### PR TITLE
cli: improve error handling and worktree workflow

### DIFF
--- a/STYLE.md
+++ b/STYLE.md
@@ -234,3 +234,5 @@ and open Warp + Cursor. Reuses existing worktree if branch exists.
 ```
 
 Keep messages short—one sentence to one paragraph.
+
+Do not add AI attribution footers like "Generated with Claude Code" or "Co-Authored-By: Claude" to commits. The git history should read the same whether written by a human or AI.

--- a/src/loopflow/cli/__init__.py
+++ b/src/loopflow/cli/__init__.py
@@ -57,8 +57,12 @@ def main():
 
                 if has_pipeline:
                     sys.argv.insert(1, "pipeline")
-                else:
+                elif has_task:
                     sys.argv.insert(1, "run")
+                else:
+                    typer.echo(f"Error: No task or pipeline named '{name}'", err=True)
+                    typer.echo(f"Create .lf/{name}.lf or add '{name}' to pipelines in .lf/config.yaml", err=True)
+                    raise SystemExit(1)
 
         app()
     except ConfigError as e:

--- a/src/loopflow/cli/pr.py
+++ b/src/loopflow/cli/pr.py
@@ -7,7 +7,7 @@ import subprocess
 import typer
 
 from loopflow.context import find_worktree_root
-from loopflow.git import GitError, open_pr, update_pr
+from loopflow.git import GitError, find_main_repo, open_pr, update_pr
 from loopflow.llm_http import generate_commit_message, generate_pr_message
 
 app = typer.Typer(help="Pull request workflow.")
@@ -125,6 +125,12 @@ def land(
         typer.echo("Error: Not in a git repository", err=True)
         raise typer.Exit(1)
 
+    # Get main repo (different from repo_root when in a worktree)
+    main_repo = find_main_repo(repo_root)
+    if not main_repo:
+        typer.echo("Error: Could not find main repository", err=True)
+        raise typer.Exit(1)
+
     if not shutil.which("gh"):
         typer.echo("Error: 'gh' CLI not found. Install with: brew install gh", err=True)
         raise typer.Exit(1)
@@ -215,11 +221,17 @@ def land(
     if body:
         commit_msg += f"\n\n{body}"
 
-    # Land it
-    subprocess.run(["git", "checkout", "main"], cwd=repo_root, check=True)
-    subprocess.run(["git", "merge", "--squash", branch], cwd=repo_root, check=True)
-    subprocess.run(["git", "commit", "-m", commit_msg], cwd=repo_root, check=True)
-    subprocess.run(["git", "branch", "-D", branch], cwd=repo_root, check=True)
-    subprocess.run(["git", "push"], cwd=repo_root, check=True)
+    # Land it (operations happen in main repo where main is checked out)
+    subprocess.run(["git", "fetch", "origin", branch], cwd=main_repo, check=True)
+    subprocess.run(["git", "merge", "--squash", f"origin/{branch}"], cwd=main_repo, check=True)
+    subprocess.run(["git", "commit", "-m", commit_msg], cwd=main_repo, check=True)
+    subprocess.run(["git", "push"], cwd=main_repo, check=True)
+
+    # Clean up: remove worktree and branch
+    from loopflow.git import remove_worktree
+    if repo_root != main_repo:
+        remove_worktree(main_repo, branch)
+    else:
+        subprocess.run(["git", "branch", "-D", branch], cwd=main_repo, check=True)
 
     typer.echo(f"Landed {branch} to main and pushed.")

--- a/src/loopflow/cli/wt.py
+++ b/src/loopflow/cli/wt.py
@@ -117,6 +117,9 @@ def clean(
         typer.echo("Error: Not in a git repository", err=True)
         raise typer.Exit(1)
 
+    # Prune stale remote-tracking branches
+    subprocess.run(["git", "fetch", "--prune"], cwd=main_repo, capture_output=True)
+
     worktrees = list_worktrees(main_repo)
     to_remove = [wt for wt in worktrees if not wt.on_origin and not wt.is_dirty]
 

--- a/src/loopflow/git.py
+++ b/src/loopflow/git.py
@@ -202,12 +202,42 @@ def autocommit(
     return True
 
 
+def _sync_main(repo_root: Path) -> None:
+    """Fetch origin/main and fast-forward main to match. Raises GitError if main is dirty."""
+    # Check if main repo is dirty
+    result = subprocess.run(
+        ["git", "status", "--porcelain"],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+    )
+    if result.stdout.strip():
+        raise GitError("Main repo has uncommitted changes. Commit or stash them first.")
+
+    # Fetch latest
+    subprocess.run(
+        ["git", "fetch", "origin", "main"],
+        cwd=repo_root,
+        capture_output=True,
+    )
+
+    # Reset main to origin/main
+    subprocess.run(
+        ["git", "reset", "--hard", "origin/main"],
+        cwd=repo_root,
+        capture_output=True,
+    )
+
+
 def create_worktree(repo_root: Path, name: str) -> Path:
-    """Create a worktree with a new branch. Raises GitError on failure."""
+    """Create a worktree with a new branch from latest main. Raises GitError on failure."""
     worktree_path = repo_root / ".lf" / "worktrees" / name
 
     if worktree_path.exists():
         return worktree_path
+
+    # Sync main with origin before branching
+    _sync_main(repo_root)
 
     worktree_path.parent.mkdir(parents=True, exist_ok=True)
 


### PR DESCRIPTION
## Usage

```bash
lf nonexistent-task    # now shows helpful error instead of crashing
lf wt create feature   # creates branch from latest main
lf wt clean            # removes stale remote-tracking branches
```

Better error messages when tasks don't exist, and worktree operations now sync with origin to avoid conflicts.

## Changes

- Show helpful error when task/pipeline doesn't exist instead of falling through to typer
- Sync main with origin/main before creating worktrees to ensure branches start from latest
- Prune stale remote-tracking branches during `lf wt clean`
- Add AI attribution guidelines to style guide