### PR TITLE
cli: rename -p/--print to -a/--auto for autonomous execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ lf maestro start              # start tracking daemon
 lf status                     # show running sessions
 
 # In another terminal
-lf implement -p               # batch task registers automatically
+lf implement -a               # autonomous task registers automatically
 
 # Check from anywhere
 lf status                     # see all running sessions
@@ -115,10 +115,11 @@ ide:
 
 | Option | Description |
 |--------|-------------|
-| `-p, --print` | Batch mode (non-interactive) |
+| `-a, --auto` | Run autonomously without interaction |
 | `-x, --context` | Add context files |
 | `-w, --worktree` | Create worktree and run task there |
 | `-c, --copy` | Copy prompt to clipboard, show token breakdown |
+| `-v, --paste` | Include clipboard content in prompt |
 | `-m, --model` | Choose model (claude, codex) |
 | `--parallel` | Run with multiple models in parallel |
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -51,7 +51,7 @@ lf review -m codex
 
 ### push
 
-Auto-push after commits in batch mode (`-p`).
+Auto-push after commits in autonomous mode (`-a`).
 
 ```yaml
 push: true
@@ -111,7 +111,7 @@ ide:
 
 ## Pipelines
 
-Pipelines chain tasks together. Each task runs in batch mode (`-p`), with auto-commits between steps.
+Pipelines chain tasks together. Each task runs in autonomous mode (`-a`), with auto-commits between steps.
 
 ```yaml
 pipelines:

--- a/docs/patterns.md
+++ b/docs/patterns.md
@@ -45,12 +45,12 @@ Run multiple features simultaneously in separate worktrees:
 # Terminal 1
 lf wt create feature-a
 cd ../myrepo.feature-a
-lf ship -p &              # runs in background
+lf ship -a &              # runs in background
 
 # Terminal 2
 lf wt create feature-b
 cd ../myrepo.feature-b
-lf ship -p &
+lf ship -a &
 
 # Check status from anywhere
 lf status                 # shows running sessions
@@ -78,15 +78,15 @@ Compare results:
 lf wt compare implement-claude implement-codex
 ```
 
-## Batch pipeline
+## Autonomous pipeline
 
 Run a full pipeline non-interactively:
 
 ```bash
-lf ship -p                # -p for batch/print mode
+lf ship -a                # -a for autonomous mode
 ```
 
-In batch mode:
+In autonomous mode:
 - No interactive prompts
 - Auto-commits between tasks
 - Pushes if `push: true` in config
@@ -98,7 +98,7 @@ Just run review without implementation:
 
 ```bash
 lf review                 # finds issues
-lf review -p              # finds and fixes issues automatically
+lf review -a              # finds and fixes issues automatically
 ```
 
 A review task might look like:

--- a/src/loopflow/cli/run.py
+++ b/src/loopflow/cli/run.py
@@ -29,8 +29,8 @@ def _copy_to_clipboard(text: str) -> None:
 def run(
     ctx: typer.Context,
     task: str = typer.Argument(help="Task name (e.g., 'review', 'implement')"),
-    print_mode: bool = typer.Option(
-        False, "-p", "--print", help="Run non-interactively"
+    auto: bool = typer.Option(
+        False, "-a", "--auto", help="Run autonomously without interaction"
     ),
     context: list[str] = typer.Option(
         None, "-x", "--context", help="Additional files for context"
@@ -40,6 +40,9 @@ def run(
     ),
     copy: bool = typer.Option(
         False, "-c", "--copy", help="Copy prompt to clipboard and show token breakdown"
+    ),
+    paste: bool = typer.Option(
+        False, "-v", "--paste", help="Include clipboard content in prompt"
     ),
     model: ModelType = typer.Option(
         None, "-m", "--model", help="Model to use (claude, codex)"
@@ -59,7 +62,7 @@ def run(
         models = [m.strip() for m in parallel.split(",")]
         for model_name in models:
             wt_name = f"{task}-{model_name}"
-            cmd = ["lf", task, "-w", wt_name, "--model", model_name, "-p"]
+            cmd = ["lf", task, "-w", wt_name, "--model", model_name, "-a"]
             if ctx.args:
                 cmd.extend(ctx.args)
             if context:
@@ -109,7 +112,7 @@ def run(
 
     exclude = list(config.exclude) if config and config.exclude else None
     args = ctx.args or None
-    components = gather_prompt_components(repo_root, task, context=all_context or None, exclude=exclude, task_args=args)
+    components = gather_prompt_components(repo_root, task, context=all_context or None, exclude=exclude, task_args=args, paste=paste)
 
     if copy:
         prompt = format_prompt(components)
@@ -128,7 +131,7 @@ def run(
         worktree=repo_root,
         status=SessionStatus.RUNNING,
         started_at=datetime.now(),
-        pid=os.getpid() if print_mode else None,
+        pid=os.getpid() if auto else None,
     )
     maestro = connect_maestro()
     if maestro:
@@ -138,13 +141,13 @@ def run(
         prompt = format_prompt(components)
         result = runner.launch(
             prompt,
-            print_mode=print_mode,
-            stream=print_mode,
+            auto=auto,
+            stream=auto,
             skip_permissions=skip_permissions,
             cwd=repo_root,
         )
 
-        if print_mode and result.exit_code == 0:
+        if auto and result.exit_code == 0:
             autocommit(repo_root, task)
 
         if maestro:
@@ -162,14 +165,17 @@ def run(
 
 def inline(
     prompt: str = typer.Argument(help="Inline prompt to run"),
-    print_mode: bool = typer.Option(
-        False, "-p", "--print", help="Run non-interactively"
+    auto: bool = typer.Option(
+        False, "-a", "--auto", help="Run autonomously without interaction"
     ),
     context: list[str] = typer.Option(
         None, "-x", "--context", help="Additional files for context"
     ),
     copy: bool = typer.Option(
         False, "-c", "--copy", help="Copy prompt to clipboard and show token breakdown"
+    ),
+    paste: bool = typer.Option(
+        False, "-v", "--paste", help="Include clipboard content in prompt"
     ),
     model: ModelType = typer.Option(
         None, "-m", "--model", help="Model to use (claude, codex)"
@@ -201,7 +207,7 @@ def inline(
         all_context.extend(context)
 
     exclude = list(config.exclude) if config and config.exclude else None
-    components = gather_prompt_components(repo_root, task=None, inline=prompt, context=all_context or None, exclude=exclude)
+    components = gather_prompt_components(repo_root, task=None, inline=prompt, context=all_context or None, exclude=exclude, paste=paste)
 
     if copy:
         prompt_text = format_prompt(components)
@@ -220,7 +226,7 @@ def inline(
         worktree=repo_root,
         status=SessionStatus.RUNNING,
         started_at=datetime.now(),
-        pid=os.getpid() if print_mode else None,
+        pid=os.getpid() if auto else None,
     )
     maestro = connect_maestro()
     if maestro:
@@ -230,13 +236,13 @@ def inline(
         prompt_text = format_prompt(components)
         result = runner.launch(
             prompt_text,
-            print_mode=print_mode,
-            stream=print_mode,
+            auto=auto,
+            stream=auto,
             skip_permissions=skip_permissions,
             cwd=repo_root,
         )
 
-        if print_mode and result.exit_code == 0:
+        if auto and result.exit_code == 0:
             autocommit(repo_root, ":", prompt)
 
         if maestro:

--- a/src/loopflow/cli/wt.py
+++ b/src/loopflow/cli/wt.py
@@ -449,7 +449,7 @@ def compare(
     skip_permissions = config.yolo if config else False
     result = runner.launch(
         prompt,
-        print_mode=False,
+        auto=False,
         skip_permissions=skip_permissions,
         cwd=main_repo,
     )

--- a/src/loopflow/context.py
+++ b/src/loopflow/context.py
@@ -17,6 +17,7 @@ class PromptComponents:
     task: tuple[str, str] | None  # (name, content)
     context_files: list[tuple[Path, str]]
     repo_root: Path
+    clipboard: str | None = None
 
 
 def find_worktree_root(start: Optional[Path] = None) -> Path | None:
@@ -42,6 +43,14 @@ def find_worktree_root(start: Optional[Path] = None) -> Path | None:
 def _read_file_if_exists(path: Path) -> str | None:
     if path.exists() and path.is_file():
         return path.read_text()
+    return None
+
+
+def _read_clipboard() -> str | None:
+    """Read text from clipboard using pbpaste."""
+    result = subprocess.run(["pbpaste"], capture_output=True, text=True)
+    if result.returncode == 0 and result.stdout.strip():
+        return result.stdout
     return None
 
 
@@ -119,6 +128,7 @@ def gather_prompt_components(
     context: Optional[list[str]] = None,
     exclude: Optional[list[str]] = None,
     task_args: Optional[list[str]] = None,
+    paste: bool = False,
 ) -> PromptComponents:
     """Gather all prompt components without assembling them."""
     docs = gather_docs(repo_root, repo_root, exclude)
@@ -155,6 +165,7 @@ def gather_prompt_components(
             task_result = (task, f"No task file found for '{task}'.")
 
     context_files = gather_files(context, repo_root, exclude) if context else []
+    clipboard = _read_clipboard() if paste else None
 
     return PromptComponents(
         docs=docs,
@@ -162,6 +173,7 @@ def gather_prompt_components(
         task=task_result,
         context_files=context_files,
         repo_root=repo_root,
+        clipboard=clipboard,
     )
 
 
@@ -189,6 +201,9 @@ def format_prompt(components: PromptComponents) -> str:
 
     if components.context_files:
         parts.append(format_files(components.context_files, components.repo_root))
+
+    if components.clipboard:
+        parts.append(f"Content from clipboard.\n\n<lf:clipboard>\n{components.clipboard}\n</lf:clipboard>")
 
     return "\n\n".join(parts)
 

--- a/src/loopflow/launcher.py
+++ b/src/loopflow/launcher.py
@@ -24,7 +24,7 @@ class Runner(ABC):
     def launch(
         self,
         prompt: str,
-        print_mode: bool = False,
+        auto: bool = False,
         stream: bool = False,
         skip_permissions: bool = False,
         cwd: Optional[Path] = None,
@@ -44,12 +44,12 @@ class ClaudeRunner(Runner):
     def launch(
         self,
         prompt: str,
-        print_mode: bool = False,
+        auto: bool = False,
         stream: bool = False,
         skip_permissions: bool = False,
         cwd: Optional[Path] = None,
     ) -> LaunchResult:
-        exit_code, output = launch_claude(prompt, print_mode, stream, skip_permissions, cwd)
+        exit_code, output = launch_claude(prompt, auto, stream, skip_permissions, cwd)
         return LaunchResult(exit_code, output)
 
     def is_available(self) -> bool:
@@ -62,21 +62,22 @@ class CodexRunner(Runner):
     def launch(
         self,
         prompt: str,
-        print_mode: bool = False,
+        auto: bool = False,
         stream: bool = False,
         skip_permissions: bool = False,
         cwd: Optional[Path] = None,
     ) -> LaunchResult:
         cmd = ["codex"]
 
-        if print_mode:
+        if skip_permissions or auto:
+            # Never ask for approval, but sandbox to workspace
+            cmd.extend(["-a", "never", "--sandbox", "workspace-write"])
+        if auto:
             cmd.append("--quiet")
-        if skip_permissions:
-            cmd.append("--full-auto")
 
         cmd.append(prompt)
 
-        if print_mode:
+        if auto:
             result = subprocess.run(cmd, cwd=cwd, capture_output=True, text=True)
             return LaunchResult(result.returncode, result.stdout)
         else:
@@ -108,7 +109,7 @@ def get_runner(model: str) -> Runner:
 
 def launch_claude(
     prompt: str,
-    print_mode: bool = False,
+    auto: bool = False,
     stream: bool = False,
     skip_permissions: bool = False,
     cwd: Optional[Path] = None,
@@ -119,7 +120,7 @@ def launch_claude(
     """
     cmd = ["claude"]
 
-    if print_mode:
+    if auto:
         # Batch mode always skips permissions (no way to grant them interactively)
         cmd.extend(["--print", "--dangerously-skip-permissions"])
         if stream:
@@ -129,9 +130,9 @@ def launch_claude(
 
     cmd.append(prompt)
 
-    if print_mode and stream:
+    if auto and stream:
         return _run_streaming(cmd, cwd)
-    elif print_mode:
+    elif auto:
         result = subprocess.run(cmd, cwd=cwd, capture_output=True, text=True)
         return result.returncode, result.stdout
     else:

--- a/src/loopflow/pipeline.py
+++ b/src/loopflow/pipeline.py
@@ -42,7 +42,7 @@ def run_pipeline(
         prompt = build_prompt(repo_root, task_name, context=context, exclude=exclude)
         result = runner.launch(
             prompt,
-            print_mode=True,
+            auto=True,
             stream=True,
             skip_permissions=skip_permissions,
             cwd=repo_root,

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -74,25 +74,25 @@ def test_claude_runner_launch_returns_result():
         assert result.output == "output"
 
 
-def test_codex_runner_launch_print_mode():
-    """CodexRunner.launch() with print_mode captures output."""
+def test_codex_runner_launch_auto_mode():
+    """CodexRunner.launch() with auto captures output."""
     runner = CodexRunner()
 
     with patch("subprocess.run") as mock_run:
         mock_run.return_value = MagicMock(returncode=0, stdout="codex output")
-        result = runner.launch("test prompt", print_mode=True)
+        result = runner.launch("test prompt", auto=True)
 
         assert result.exit_code == 0
         assert result.output == "codex output"
 
 
 def test_codex_runner_launch_interactive():
-    """CodexRunner.launch() without print_mode runs interactively."""
+    """CodexRunner.launch() without auto runs interactively."""
     runner = CodexRunner()
 
     with patch("subprocess.run") as mock_run:
         mock_run.return_value = MagicMock(returncode=0)
-        result = runner.launch("test prompt", print_mode=False)
+        result = runner.launch("test prompt", auto=False)
 
         assert result.exit_code == 0
         assert result.output is None


### PR DESCRIPTION
## Usage

```bash
lf implement -a           # autonomous mode (was -p)
lf ship -a               # autonomous pipelines
lf : "fix the bug" -a    # autonomous inline tasks
lf review -v             # include clipboard content
```

Renames the `-p/--print` flag to `-a/--auto` for running tasks autonomously without interaction. Also adds `-v/--paste` to include clipboard content in prompts.

## Changes

- `-p/--print` becomes `-a/--auto` across all commands and docs
- New `-v/--paste` flag reads clipboard content via `pbpaste`
- Codex runner uses `--sandbox workspace-write` instead of `--full-auto`
- Updated all documentation and help text to use "autonomous" terminology