### PR TITLE
ops subcommand: move management commands under lf ops

### DIFF
--- a/.claude/commands/design.md
+++ b/.claude/commands/design.md
@@ -1,6 +1,6 @@
 This task produces a short implementation spec that another LLM session can use to write a first draft of a feature.
 
-The design doc is scaffolding. It's a checkpoint for recovery, not documentation for posterity. If a session crashes, the spec lets a fresh session pick up where things left off. After implementation, `lf review` writes the review under `.design/`. `lf pr land` removes the `.design/` contents.
+The design doc is scaffolding. It's a checkpoint for recovery, not documentation for posterity. If a session crashes, the spec lets a fresh session pick up where things left off. After implementation, `lf review` writes the review under `.design/`. `lf ops pr land` removes the `.design/` contents.
 
 ## Workflow
 

--- a/.claude/commands/draft_commit.md
+++ b/.claude/commands/draft_commit.md
@@ -8,7 +8,7 @@ Draft a commit message for landing this branch.
    - First line: concise summary (50 chars or less)
    - Blank line
    - Body: what this branch accomplished and why
-4. Done. Tell the user to review `.lf/COMMIT` and run `lf land` when ready.
+4. Done. Tell the user to review `.lf/COMMIT` and run `lf ops land` when ready.
 
 ## Style
 

--- a/.claude/commands/implement.md
+++ b/.claude/commands/implement.md
@@ -18,7 +18,7 @@ Run the "done when" check from the design doc to verify the implementation works
 
 **Stay in scope.** Implement what the design doc describes, nothing more. Note anything that should be added, but don't build it.
 
-**Leave the design doc.** Don't delete `.design/*.md`—`lf review` writes its assessment under `.design/`, and `lf pr land` removes the `.design/` contents.
+**Leave the design doc.** Don't delete `.design/*.md`—`lf review` writes its assessment under `.design/`, and `lf ops pr land` removes the `.design/` contents.
 
 **Add documentation per the style guide.** The best documentation is simple code—descriptive names, type hints, clear APIs. Skip obvious docstrings. If a module needs explanation, add a brief comment at the top of the file, not a separate doc. Update existing READMEs when user-facing behavior changes. Document new CLI commands or user-facing features in the appropriate README.
 

--- a/.claude/commands/reduce.md
+++ b/.claude/commands/reduce.md
@@ -1,0 +1,28 @@
+Refactor and simplify code while preserving user behavior.
+
+Focus on trimming complexity, deleting unused code, and clarifying the intent
+without changing what users can do.
+
+## Priorities
+
+1. Remove dead code, unused branches, or obsolete options.
+2. Collapse duplication and tighten APIs that are overly broad.
+3. Replace brittle or complex logic with clearer, smaller flows.
+4. Keep outputs, CLI flags, and user workflows the same.
+
+## Guardrails
+
+- Do not add features or change behavior.
+- If behavior must change to simplify, document the tradeoff and keep it minimal.
+- Avoid large refactors that touch unrelated areas.
+- Prefer deleting code over rewriting it.
+
+## Output
+
+Make the refactor directly. If any assumptions were required, append them to
+`.design/questions.md`.
+
+## Auto mode
+
+In auto/headless runs, do not pause to ask questions. Make the best assumption
+you can and append any open questions to `.design/questions.md`.

--- a/.design/feature-spec.md
+++ b/.design/feature-spec.md
@@ -1,7 +1,8 @@
 # Ops Subcommand Split
 
-## What to build
-Keep `lf` as the single CLI, but move all non-task commands under a single `ops` subcommand (e.g., `lf ops pr`, `lf ops land`, `lf ops status`).
+## What exists
+`lf` now exposes only run/inline/pipeline plus the shorthand task/pipeline resolution.
+All non-task commands live under a single `ops` subcommand (`lf ops ...`).
 
 ## User intent (quotes)
 > "I want to separate lf run and the other commanders."
@@ -22,12 +23,7 @@ Keep `lf` as the single CLI, but move all non-task commands under a single `ops`
 > "i think maybe just makes ops a single special sub command which can then be subdivided"
 > — user
 
-## Data structures
-```python
-# No new data structures expected; rewire existing Typer apps/commands.
-```
-
-## CLI layout (sketch)
+## CLI layout (implemented)
 ```python
 # lf (minimal)
 app = typer.Typer(name="lf", ...)
@@ -37,8 +33,13 @@ app.command(name="pipeline")(run.pipeline)
 
 ops = typer.Typer(name="ops", help="Management and maintenance commands.")
 ops.add_typer(pr.app, name="pr")
-ops.add_typer(meta.app, name="meta")
 ops.add_typer(maestro.app, name="maestro")
+
+# Flat ops commands
+ops.command()(meta.init)
+ops.command()(meta.install)
+ops.command()(meta.doctor)
+ops.command()(meta.version)
 ops.command()(status.status)
 ops.command()(sessions.stop)
 ops.command()(sessions.prune)
@@ -52,25 +53,17 @@ def main():
     ...
 ```
 
-## APIs
-```python
-# Add ops subcommand wiring in src/loopflow/cli/__init__.py
-# Possibly introduce a new module: src/loopflow/cli/ops.py
-```
+## Decisions
+- `meta` remains a module but its commands are flat under `lf ops` rather than `lf ops meta`.
 
-## Constraints
-- Preserve existing `lf` shorthand behavior for `lf :`, `lf <task>`, and `lf <pipeline>`.
-- Keep Typer conventions and subcommand names unchanged; only relocate them.
-- Avoid breaking existing task/pipeline resolution logic in `lf` main.
-- No backward compatibility for old `lf <subcommand>` names; move everything immediately.
-- `lf ops` is the management namespace.
+## Constraints met
+- Shorthand behavior preserved for `lf :`, `lf <task>`, and `lf <pipeline>`.
+- Non-task commands moved under `lf ops` without backward compatibility.
 
-## Done when
-- `lf` only exposes run/inline/pipeline + shorthand behavior for tasks/pipelines.
-- `lf ops` exposes pr/meta/maestro/status/sessions/compare/land.
-- `lf --help` lists `ops` as a single subcommand.
-- `lf ops --help` shows management commands.
-- Existing commands still function under their new namespace.
+## Verification
+- `lf --help` lists only `ops` plus run/inline/pipeline.
+- `lf ops --help` lists `pr`, `maestro`, `init`, `install`, `doctor`, `version`, `status`, `stop`, `prune`, `compare`, `land`.
+- Commands documented in `README.md`, `docs/index.md`, and `docs/patterns.md`.
 
-## Open questions
-- Where should help text and docs be updated (README, docs/index.md, docs/patterns.md)?
+## Remaining work
+- None.

--- a/.design/feature-spec.md
+++ b/.design/feature-spec.md
@@ -1,0 +1,76 @@
+# Ops Subcommand Split
+
+## What to build
+Keep `lf` as the single CLI, but move all non-task commands under a single `ops` subcommand (e.g., `lf ops pr`, `lf ops land`, `lf ops status`).
+
+## User intent (quotes)
+> "I want to separate lf run and the other commanders."
+> — user
+
+> "I think we want two sepaate commands maybe"
+> — user
+
+> "lf is just the lf : and lf <command> functinoality"
+> — user
+
+> "Then we can have ... lander? that has all the other stuff"
+> — user
+
+> "should it all just be lf lander ?"
+> — user
+
+> "i think maybe just makes ops a single special sub command which can then be subdivided"
+> — user
+
+## Data structures
+```python
+# No new data structures expected; rewire existing Typer apps/commands.
+```
+
+## CLI layout (sketch)
+```python
+# lf (minimal)
+app = typer.Typer(name="lf", ...)
+app.command()(run.run)         # lf run
+app.command()(run.inline)      # lf :
+app.command(name="pipeline")(run.pipeline)
+
+ops = typer.Typer(name="ops", help="Management and maintenance commands.")
+ops.add_typer(pr.app, name="pr")
+ops.add_typer(meta.app, name="meta")
+ops.add_typer(maestro.app, name="maestro")
+ops.command()(status.status)
+ops.command()(sessions.stop)
+ops.command()(sessions.prune)
+ops.command()(compare.compare)
+ops.command()(land.land)
+
+app.add_typer(ops, name="ops")
+
+def main():
+    # keep shorthand behavior: lf <task>, lf <pipeline>, lf :
+    ...
+```
+
+## APIs
+```python
+# Add ops subcommand wiring in src/loopflow/cli/__init__.py
+# Possibly introduce a new module: src/loopflow/cli/ops.py
+```
+
+## Constraints
+- Preserve existing `lf` shorthand behavior for `lf :`, `lf <task>`, and `lf <pipeline>`.
+- Keep Typer conventions and subcommand names unchanged; only relocate them.
+- Avoid breaking existing task/pipeline resolution logic in `lf` main.
+- No backward compatibility for old `lf <subcommand>` names; move everything immediately.
+- `lf ops` is the management namespace.
+
+## Done when
+- `lf` only exposes run/inline/pipeline + shorthand behavior for tasks/pipelines.
+- `lf ops` exposes pr/meta/maestro/status/sessions/compare/land.
+- `lf --help` lists `ops` as a single subcommand.
+- `lf ops --help` shows management commands.
+- Existing commands still function under their new namespace.
+
+## Open questions
+- Where should help text and docs be updated (README, docs/index.md, docs/patterns.md)?

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ macOS only. Supports Claude Code and OpenAI Codex via configuration.
 
 ```bash
 pip install loopflow
-lf ops meta install    # installs Claude Code + worktrunk
+lf ops install    # installs Claude Code + worktrunk
 ```
 
 ## Why Worktrees?
@@ -165,9 +165,9 @@ lf implement &         # background (shell handles it)
 | `lf ops pr create` | Open GitHub PR |
 | `lf ops pr land [-a]` | Squash-merge to main |
 | `lf ops land [--no-pr] [--force] [--base]` | Land locally via worktrunk |
-| `lf ops meta init` | Initialize repo with prompts and config |
-| `lf ops meta install` | Install Claude Code |
-| `lf ops meta doctor` | Check dependencies |
+| `lf ops init` | Initialize repo with prompts and config |
+| `lf ops install` | Install Claude Code |
+| `lf ops doctor` | Check dependencies |
 | `lf ops maestro start` | Start session tracking daemon |
 | `lf ops maestro stop` | Stop session tracking daemon |
 | `lf ops status` | Show running sessions |

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ macOS only. Supports Claude Code and OpenAI Codex via configuration.
 
 ```bash
 pip install loopflow
-lf meta install    # installs Claude Code + worktrunk
+lf ops meta install    # installs Claude Code + worktrunk
 ```
 
 ## Why Worktrees?
@@ -96,14 +96,14 @@ wt remove auth                # remove worktree + branch
 Track running tasks across multiple terminals (maestro is optional):
 
 ```bash
-lf maestro start              # optional web UI (tails logs)
-lf status                     # show running sessions (reads SQLite)
+lf ops maestro start              # optional web UI (tails logs)
+lf ops status                     # show running sessions (reads SQLite)
 
 # In another terminal
 lf implement                  # auto mode task registers automatically
 
 # Check from anywhere
-lf status                     # see all running sessions
+lf ops status                     # see all running sessions
 ```
 
 Sessions write to SQLite in auto mode; the maestro UI reads the same database.
@@ -160,14 +160,14 @@ lf implement &         # background (shell handles it)
 | `lf <task>` | Run a task from `.lf/` |
 | `lf <pipeline>` | Run a pipeline |
 | `lf : "prompt"` | Inline prompt |
-| `lf compare a b` | Compare two worktree implementations |
+| `lf ops compare a b` | Compare two worktree implementations |
 | `wt <subcommand>` | Worktree management (worktrunk) |
-| `lf pr create` | Open GitHub PR |
-| `lf pr land [-a]` | Squash-merge to main |
-| `lf land [--no-pr] [--force] [--base]` | Land locally via worktrunk |
-| `lf meta init` | Initialize repo with prompts and config |
-| `lf meta install` | Install Claude Code |
-| `lf meta doctor` | Check dependencies |
-| `lf maestro start` | Start session tracking daemon |
-| `lf maestro stop` | Stop session tracking daemon |
-| `lf status` | Show running sessions |
+| `lf ops pr create` | Open GitHub PR |
+| `lf ops pr land [-a]` | Squash-merge to main |
+| `lf ops land [--no-pr] [--force] [--base]` | Land locally via worktrunk |
+| `lf ops meta init` | Initialize repo with prompts and config |
+| `lf ops meta install` | Install Claude Code |
+| `lf ops meta doctor` | Check dependencies |
+| `lf ops maestro start` | Start session tracking daemon |
+| `lf ops maestro stop` | Stop session tracking daemon |
+| `lf ops status` | Show running sessions |

--- a/STYLE.md
+++ b/STYLE.md
@@ -9,7 +9,7 @@ This is the governing document of the loopflow codebase. Humans and LLMs alike a
 - Return `None` for "not found"; raise exceptions for "shouldn't happen"
 - No `Args:`/`Returns:` docstrings—if types are clear, skip the docstring
 - Mock side effects, but don't test mock wiring
-- Design docs go under `.design/`; `lf pr land` removes `.design/*` contents
+- Design docs go under `.design/`; `lf ops pr land` removes `.design/*` contents
 - Auto runs are headless: make best-effort assumptions and append open questions to `.design/questions.md`
 
 ## File-Type Guidelines
@@ -38,7 +38,7 @@ When editing `README.md` files:
 When editing docs in `.design/`:
 - Focus on what's left to build, not what's done
 - `lf review` writes its assessment under `.design/`
-- `lf pr land` removes `.design/*` contents automatically
+- `lf ops pr land` removes `.design/*` contents automatically
 
 # Goals
 
@@ -162,7 +162,7 @@ def open_warp(path: Path) -> None:
 
 Give each module a `README.md` for users. Use inline comments for maintainers. Don't duplicate what's in the code.
 
-Start features with a design doc under `.design/`. After implementation, `lf review` writes its assessment under `.design/`. `lf pr land` removes `.design/*` contents—by then, the code and its README should speak for themselves.
+Start features with a design doc under `.design/`. After implementation, `lf review` writes its assessment under `.design/`. `lf ops pr land` removes `.design/*` contents—by then, the code and its README should speak for themselves.
 
 # Testing
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -117,7 +117,7 @@ exclude:
 
 ### ide
 
-Configure which IDEs loopflow installs (used by `lf meta install`).
+Configure which IDEs loopflow installs (used by `lf ops meta install`).
 
 ```yaml
 ide:

--- a/docs/config.md
+++ b/docs/config.md
@@ -117,7 +117,7 @@ exclude:
 
 ### ide
 
-Configure which IDEs loopflow installs (used by `lf ops meta install`).
+Configure which IDEs loopflow installs (used by `lf ops install`).
 
 ```yaml
 ide:

--- a/docs/index.md
+++ b/docs/index.md
@@ -36,7 +36,7 @@ uv tool install loopflow
 pip install loopflow
 
 # Install Claude Code + worktrunk if needed
-lf meta install
+lf ops meta install
 ```
 
 ## Quick start
@@ -45,7 +45,7 @@ Initialize a repo with example tasks:
 
 ```bash
 cd your-repo
-lf meta init
+lf ops meta init
 ```
 
 This creates `.lf/` with starter prompts and config.
@@ -79,8 +79,8 @@ lf ship                  # agents work here
 When done:
 
 ```bash
-lf pr create             # open PR from worktree
-lf land                  # local merge via worktrunk
+lf ops pr create             # open PR from worktree
+lf ops land                  # local merge via worktrunk
 wt remove my-feature     # remove worktree + branch
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -36,7 +36,7 @@ uv tool install loopflow
 pip install loopflow
 
 # Install Claude Code + worktrunk if needed
-lf ops meta install
+lf ops install
 ```
 
 ## Quick start
@@ -45,7 +45,7 @@ Initialize a repo with example tasks:
 
 ```bash
 cd your-repo
-lf ops meta init
+lf ops init
 ```
 
 This creates `.lf/` with starter prompts and config.

--- a/docs/patterns.md
+++ b/docs/patterns.md
@@ -53,13 +53,13 @@ cd ../myrepo.feature-b
 lf ship &
 
 # Check status from anywhere
-lf status                 # shows running sessions
+lf ops status                 # shows running sessions
 ```
 
 With maestro running, you'll get notifications when tasks complete:
 
 ```bash
-lf maestro start          # start once, runs in background
+lf ops maestro start          # start once, runs in background
 ```
 
 ## Model comparison
@@ -178,20 +178,20 @@ wt remove feature-a      # remove a worktree + branch
 Open a PR from a worktree:
 
 ```bash
-lf pr create             # opens PR on GitHub
+lf ops pr create             # opens PR on GitHub
 ```
 
 Land a PR (squash-merge to main):
 
 ```bash
-lf pr land               # merges and cleans up
-lf pr land -a            # auto-merge when checks pass
+lf ops pr land               # merges and cleans up
+lf ops pr land -a            # auto-merge when checks pass
 ```
 
 Land locally (no PR required):
 
 ```bash
-lf land                  # squash + merge via worktrunk
+lf ops land                  # squash + merge via worktrunk
 ```
 
 ## Commit message generation

--- a/src/loopflow/builtins/__init__.py
+++ b/src/loopflow/builtins/__init__.py
@@ -1,6 +1,6 @@
 """Builtin prompts for loopflow commands.
 
-These are prompts used by loopflow's own commands (lf pr create, etc.),
+These are prompts used by loopflow's own commands (lf ops pr create, etc.),
 not user-defined tasks in .lf/.
 """
 

--- a/src/loopflow/builtins/pr_message.txt
+++ b/src/loopflow/builtins/pr_message.txt
@@ -35,8 +35,8 @@ Example body:
 ## Usage
 
 \`\`\`bash
-lf pr create -a
-lf pr update -a
+lf ops pr create -a
+lf ops pr update -a
 \`\`\`
 
 PR create and update now generate title/body via Claude API instead of reading from .lf/COMMIT. The -a flag adds, commits, and pushes before creating/updating.

--- a/src/loopflow/cli/__init__.py
+++ b/src/loopflow/cli/__init__.py
@@ -15,21 +15,14 @@ app = typer.Typer(
 
 # Import and register subcommands
 from loopflow.cli import run as run_module
-from loopflow.cli import pr, meta, maestro, status, compare as compare_module, land as land_module, sessions
+from loopflow.cli import ops
 
-app.add_typer(pr.app, name="pr")
-app.add_typer(meta.app, name="meta")
-app.add_typer(maestro.app, name="maestro")
+app.add_typer(ops.app, name="ops")
 
 # Register top-level commands
 app.command(context_settings={"allow_extra_args": True, "allow_interspersed_args": True})(run_module.run)
 app.command()(run_module.inline)
 app.command(name="pipeline")(run_module.pipeline)
-app.command()(status.status)
-app.command()(sessions.stop)
-app.command()(sessions.prune)
-app.command()(compare_module.compare)
-app.command()(land_module.land)
 
 
 def main():
@@ -38,14 +31,7 @@ def main():
         "run",
         "pipeline",
         "inline",
-        "pr",
-        "meta",
-        "maestro",
-        "status",
-        "compare",
-        "land",
-        "stop",
-        "prune",
+        "ops",
         "--help",
         "-h",
     }

--- a/src/loopflow/cli/compare.py
+++ b/src/loopflow/cli/compare.py
@@ -111,9 +111,9 @@ def compare(
     The analysis is written to a markdown file in the current directory.
 
     Examples:
-        lf compare impl-claude impl-codex
-        lf compare feature-a feature-b -p
-        lf compare auth-v1 auth-v2 -o comparison.md
+        lf ops compare impl-claude impl-codex
+        lf ops compare feature-a feature-b -p
+        lf ops compare auth-v1 auth-v2 -o comparison.md
     """
     # Find main repo
     main_repo = find_main_repo()

--- a/src/loopflow/cli/land.py
+++ b/src/loopflow/cli/land.py
@@ -79,10 +79,6 @@ def _ensure_clean(repo_root: Path) -> None:
         raise typer.Exit(1)
 
 
-def _clear_design_artifacts(repo_root: Path) -> bool:
-    return clear_design_artifacts(repo_root)
-
-
 def _squash_commits(repo_root: Path, base_ref: str, commit_msg: str) -> None:
     original_head = subprocess.run(
         ["git", "rev-parse", "HEAD"],
@@ -185,7 +181,7 @@ def land(
             )
             raise typer.Exit(1)
     else:
-        _clear_design_artifacts(repo_root)
+        clear_design_artifacts(repo_root)
 
     base_ref = _resolve_base_ref(repo_root, base_branch)
     diff = _get_diff(repo_root, base_ref)

--- a/src/loopflow/cli/land.py
+++ b/src/loopflow/cli/land.py
@@ -133,7 +133,7 @@ def land(
         raise typer.Exit(1)
 
     if not shutil.which("wt"):
-        typer.echo("Error: 'wt' CLI not found. Run: lf meta install", err=True)
+        typer.echo("Error: 'wt' CLI not found. Run: lf ops meta install", err=True)
         raise typer.Exit(1)
 
     main_repo = find_main_repo(repo_root) or repo_root
@@ -143,14 +143,14 @@ def land(
     pr_exists = _get_pr_status(repo_root)
     if pr_exists is True and not force:
         if pr_enabled:
-            typer.echo("Warning: PR exists, use 'lf pr land'", err=True)
+            typer.echo("Warning: PR exists, use 'lf ops pr land'", err=True)
         else:
-            typer.echo("Warning: PR exists, use 'lf pr land' or --force", err=True)
+            typer.echo("Warning: PR exists, use 'lf ops pr land' or --force", err=True)
         raise typer.Exit(1)
 
     if pr_exists is False and pr_enabled and not no_pr:
         typer.echo(
-            "Warning: PR workflow enabled, use 'lf pr create' first or --no-pr",
+            "Warning: PR workflow enabled, use 'lf ops pr create' first or --no-pr",
             err=True,
         )
         raise typer.Exit(1)

--- a/src/loopflow/cli/land.py
+++ b/src/loopflow/cli/land.py
@@ -133,7 +133,7 @@ def land(
         raise typer.Exit(1)
 
     if not shutil.which("wt"):
-        typer.echo("Error: 'wt' CLI not found. Run: lf ops meta install", err=True)
+        typer.echo("Error: 'wt' CLI not found. Run: lf ops install", err=True)
         raise typer.Exit(1)
 
     main_repo = find_main_repo(repo_root) or repo_root

--- a/src/loopflow/cli/meta.py
+++ b/src/loopflow/cli/meta.py
@@ -244,13 +244,13 @@ def doctor():
     if check_claude_available():
         typer.echo("✓ claude")
     else:
-        typer.echo("✗ claude - Run: lf ops meta install")
+        typer.echo("✗ claude - Run: lf ops install")
         all_ok = False
 
     if shutil.which("wt"):
         typer.echo("✓ wt")
     else:
-        typer.echo("✗ wt - Run: lf ops meta install")
+        typer.echo("✗ wt - Run: lf ops install")
         all_ok = False
 
     # IDE tools (based on config)
@@ -258,14 +258,14 @@ def doctor():
         if shutil.which("warp"):
             typer.echo("✓ warp")
         else:
-            typer.echo("✗ warp - Run: lf ops meta install")
+            typer.echo("✗ warp - Run: lf ops install")
             all_ok = False
 
     if not ide or ide.cursor:
         if shutil.which("cursor"):
             typer.echo("✓ cursor")
         else:
-            typer.echo("✗ cursor - Run: lf ops meta install")
+            typer.echo("✗ cursor - Run: lf ops install")
             all_ok = False
 
     # Optional: gh for PR creation

--- a/src/loopflow/cli/meta.py
+++ b/src/loopflow/cli/meta.py
@@ -88,7 +88,17 @@ def init(
         commands_dir = repo_root / ".claude" / "commands"
         commands_dir.mkdir(parents=True, exist_ok=True)
 
-        for prompt_name in ["review.md", "implement.md", "design.md", "polish.md", "debug.md", "publish.md", "iterate.md", "expand.md"]:
+        for prompt_name in [
+            "review.md",
+            "implement.md",
+            "design.md",
+            "polish.md",
+            "debug.md",
+            "publish.md",
+            "iterate.md",
+            "expand.md",
+            "reduce.md",
+        ]:
             src = commands_src / prompt_name
             dst = commands_dir / prompt_name
 

--- a/src/loopflow/cli/meta.py
+++ b/src/loopflow/cli/meta.py
@@ -244,13 +244,13 @@ def doctor():
     if check_claude_available():
         typer.echo("✓ claude")
     else:
-        typer.echo("✗ claude - Run: lf meta install")
+        typer.echo("✗ claude - Run: lf ops meta install")
         all_ok = False
 
     if shutil.which("wt"):
         typer.echo("✓ wt")
     else:
-        typer.echo("✗ wt - Run: lf meta install")
+        typer.echo("✗ wt - Run: lf ops meta install")
         all_ok = False
 
     # IDE tools (based on config)
@@ -258,14 +258,14 @@ def doctor():
         if shutil.which("warp"):
             typer.echo("✓ warp")
         else:
-            typer.echo("✗ warp - Run: lf meta install")
+            typer.echo("✗ warp - Run: lf ops meta install")
             all_ok = False
 
     if not ide or ide.cursor:
         if shutil.which("cursor"):
             typer.echo("✓ cursor")
         else:
-            typer.echo("✗ cursor - Run: lf meta install")
+            typer.echo("✗ cursor - Run: lf ops meta install")
             all_ok = False
 
     # Optional: gh for PR creation

--- a/src/loopflow/cli/ops.py
+++ b/src/loopflow/cli/ops.py
@@ -9,9 +9,12 @@ from loopflow.cli import maestro, meta, pr, sessions, status
 app = typer.Typer(name="ops", help="Management and maintenance commands.")
 
 app.add_typer(pr.app, name="pr")
-app.add_typer(meta.app, name="meta")
 app.add_typer(maestro.app, name="maestro")
 
+app.command()(meta.init)
+app.command()(meta.install)
+app.command()(meta.doctor)
+app.command()(meta.version)
 app.command()(status.status)
 app.command()(sessions.stop)
 app.command()(sessions.prune)

--- a/src/loopflow/cli/ops.py
+++ b/src/loopflow/cli/ops.py
@@ -1,0 +1,19 @@
+"""Management and maintenance subcommands."""
+
+import typer
+
+from loopflow.cli import compare as compare_module
+from loopflow.cli import land as land_module
+from loopflow.cli import maestro, meta, pr, sessions, status
+
+app = typer.Typer(name="ops", help="Management and maintenance commands.")
+
+app.add_typer(pr.app, name="pr")
+app.add_typer(meta.app, name="meta")
+app.add_typer(maestro.app, name="maestro")
+
+app.command()(status.status)
+app.command()(sessions.stop)
+app.command()(sessions.prune)
+app.command()(compare_module.compare)
+app.command()(land_module.land)

--- a/src/loopflow/cli/pr.py
+++ b/src/loopflow/cli/pr.py
@@ -231,7 +231,7 @@ def land(
         text=True,
     )
     if result.returncode != 0:
-        typer.echo("Error: No PR found. Run 'lf pr create' first.", err=True)
+        typer.echo("Error: No PR found. Run 'lf ops pr create' first.", err=True)
         raise typer.Exit(1)
 
     pr_data = json.loads(result.stdout)

--- a/src/loopflow/files.py
+++ b/src/loopflow/files.py
@@ -50,17 +50,31 @@ def _load_gitignore(gitignore_path: Path) -> pathspec.PathSpec | None:
     return pathspec.PathSpec.from_lines("gitwildmatch", patterns)
 
 
-def _matches_glob_pattern(path: Path, pattern: str, repo_root: Path) -> bool:
-    """Check if path matches a glob pattern using Path.glob semantics."""
-    matching_paths = set(repo_root.glob(pattern))
-    return path in matching_paths
+def _compile_exclude_patterns(patterns: list[str], repo_root: Path) -> set[Path]:
+    """Pre-compute all paths matching exclude patterns.
+
+    Runs glob once per pattern instead of once per file, giving O(patterns)
+    instead of O(patterns * files) glob operations.
+    """
+    excluded: set[Path] = set()
+    for pattern in patterns:
+        excluded.update(repo_root.glob(pattern))
+    return excluded
 
 
-def is_ignored(path: Path, repo_root: Path, exclude: Optional[list[str]] = None) -> bool:
+def is_ignored(
+    path: Path,
+    repo_root: Path,
+    exclude: Optional[list[str]] = None,
+    _excluded_paths: Optional[set[Path]] = None,
+) -> bool:
     """Check if path should be excluded from context.
 
     Excludes .git, .lf (prompt config), gitignored paths, and paths matching exclude patterns.
     Exclude patterns use Path.glob semantics (*.md = root only, **/*.md = recursive).
+
+    For performance, pass _excluded_paths (from _compile_exclude_patterns) to avoid
+    re-globbing on every call.
     """
     rel_path = path.relative_to(repo_root)
 
@@ -72,11 +86,15 @@ def is_ignored(path: Path, repo_root: Path, exclude: Optional[list[str]] = None)
     if rel_path.parts and rel_path.parts[0] == ".lf":
         return True
 
-    # Check exclude patterns (Path.glob style)
-    if exclude:
-        for pattern in exclude:
-            if _matches_glob_pattern(path, pattern, repo_root):
-                return True
+    # Check pre-compiled exclude patterns (fast path)
+    if _excluded_paths is not None:
+        if path in _excluded_paths:
+            return True
+    elif exclude:
+        # Fallback: compile on demand (slower, for backwards compatibility)
+        excluded = _compile_exclude_patterns(exclude, repo_root)
+        if path in excluded:
+            return True
 
     # Check .gitignore files from repo root down to path's parent
     # Each .gitignore matches paths relative to its own directory
@@ -94,7 +112,12 @@ def is_ignored(path: Path, repo_root: Path, exclude: Optional[list[str]] = None)
     return False
 
 
-def gather_docs(path: Path, repo_root: Path, exclude: Optional[list[str]] = None) -> list[tuple[Path, str]]:
+def gather_docs(
+    path: Path,
+    repo_root: Path,
+    exclude: Optional[list[str]] = None,
+    _excluded_paths: Optional[set[Path]] = None,
+) -> list[tuple[Path, str]]:
     """Gather .md files from path up to repo root.
 
     If path is a file, starts from its parent directory.
@@ -106,7 +129,7 @@ def gather_docs(path: Path, repo_root: Path, exclude: Optional[list[str]] = None
     while current >= repo_root:
         dir_docs = []
         for md_file in sorted(current.glob("*.md")):
-            if md_file.is_file() and not is_ignored(md_file, repo_root, exclude):
+            if md_file.is_file() and not is_ignored(md_file, repo_root, exclude, _excluded_paths):
                 dir_docs.append((md_file, md_file.read_text()))
         if dir_docs:
             docs_by_dir.append(dir_docs)
@@ -119,13 +142,18 @@ def gather_docs(path: Path, repo_root: Path, exclude: Optional[list[str]] = None
     return result
 
 
-def gather_file(path: Path, repo_root: Path, exclude: Optional[list[str]] = None) -> tuple[Path, str] | None:
+def gather_file(
+    path: Path,
+    repo_root: Path,
+    exclude: Optional[list[str]] = None,
+    _excluded_paths: Optional[set[Path]] = None,
+) -> tuple[Path, str] | None:
     """Gather a single file if it exists, isn't ignored, and isn't binary."""
     if not path.exists():
         return None
     if not path.is_file():
         return None
-    if is_ignored(path, repo_root, exclude):
+    if is_ignored(path, repo_root, exclude, _excluded_paths):
         return None
     if is_binary(path):
         return None
@@ -163,18 +191,21 @@ def gather_files(paths: list[str], repo_root: Path, exclude: Optional[list[str]]
     seen: set[Path] = set()
     results: list[tuple[Path, str]] = []
 
+    # Pre-compile exclude patterns once for the entire gather operation
+    excluded_paths = _compile_exclude_patterns(exclude, repo_root) if exclude else None
+
     for path_str in paths:
         expanded = _expand_path(path_str, repo_root)
 
         for path in expanded:
             # Gather parent documentation first
-            for doc_path, content in gather_docs(path, repo_root, exclude):
+            for doc_path, content in gather_docs(path, repo_root, exclude, excluded_paths):
                 if doc_path not in seen:
                     seen.add(doc_path)
                     results.append((doc_path, content))
 
             # Gather the file itself
-            file_result = gather_file(path, repo_root, exclude)
+            file_result = gather_file(path, repo_root, exclude, excluded_paths)
             if file_result and file_result[0] not in seen:
                 seen.add(file_result[0])
                 results.append(file_result)

--- a/src/loopflow/files.py
+++ b/src/loopflow/files.py
@@ -62,6 +62,15 @@ def _compile_exclude_patterns(patterns: list[str], repo_root: Path) -> set[Path]
     return excluded
 
 
+def _is_excluded_by_paths(path: Path, excluded: set[Path]) -> bool:
+    if path in excluded:
+        return True
+    for parent in path.parents:
+        if parent in excluded:
+            return True
+    return False
+
+
 def is_ignored(
     path: Path,
     repo_root: Path,
@@ -88,12 +97,12 @@ def is_ignored(
 
     # Check pre-compiled exclude patterns (fast path)
     if _excluded_paths is not None:
-        if path in _excluded_paths:
+        if _is_excluded_by_paths(path, _excluded_paths):
             return True
     elif exclude:
         # Fallback: compile on demand (slower, for backwards compatibility)
         excluded = _compile_exclude_patterns(exclude, repo_root)
-        if path in excluded:
+        if _is_excluded_by_paths(path, excluded):
             return True
 
     # Check .gitignore files from repo root down to path's parent

--- a/src/loopflow/files.py
+++ b/src/loopflow/files.py
@@ -71,19 +71,15 @@ def _is_excluded_by_paths(path: Path, excluded: set[Path]) -> bool:
     return False
 
 
-def is_ignored(
+def _is_ignored(
     path: Path,
     repo_root: Path,
-    exclude: Optional[list[str]] = None,
-    _excluded_paths: Optional[set[Path]] = None,
+    excluded_paths: set[Path] | None,
 ) -> bool:
     """Check if path should be excluded from context.
 
     Excludes .git, .lf (prompt config), gitignored paths, and paths matching exclude patterns.
     Exclude patterns use Path.glob semantics (*.md = root only, **/*.md = recursive).
-
-    For performance, pass _excluded_paths (from _compile_exclude_patterns) to avoid
-    re-globbing on every call.
     """
     rel_path = path.relative_to(repo_root)
 
@@ -95,15 +91,9 @@ def is_ignored(
     if rel_path.parts and rel_path.parts[0] == ".lf":
         return True
 
-    # Check pre-compiled exclude patterns (fast path)
-    if _excluded_paths is not None:
-        if _is_excluded_by_paths(path, _excluded_paths):
-            return True
-    elif exclude:
-        # Fallback: compile on demand (slower, for backwards compatibility)
-        excluded = _compile_exclude_patterns(exclude, repo_root)
-        if _is_excluded_by_paths(path, excluded):
-            return True
+    # Check pre-compiled exclude patterns.
+    if excluded_paths is not None and _is_excluded_by_paths(path, excluded_paths):
+        return True
 
     # Check .gitignore files from repo root down to path's parent
     # Each .gitignore matches paths relative to its own directory
@@ -121,11 +111,10 @@ def is_ignored(
     return False
 
 
-def gather_docs(
+def _gather_docs(
     path: Path,
     repo_root: Path,
-    exclude: Optional[list[str]] = None,
-    _excluded_paths: Optional[set[Path]] = None,
+    excluded_paths: set[Path] | None,
 ) -> list[tuple[Path, str]]:
     """Gather .md files from path up to repo root.
 
@@ -138,7 +127,7 @@ def gather_docs(
     while current >= repo_root:
         dir_docs = []
         for md_file in sorted(current.glob("*.md")):
-            if md_file.is_file() and not is_ignored(md_file, repo_root, exclude, _excluded_paths):
+            if md_file.is_file() and not _is_ignored(md_file, repo_root, excluded_paths):
                 dir_docs.append((md_file, md_file.read_text()))
         if dir_docs:
             docs_by_dir.append(dir_docs)
@@ -151,22 +140,39 @@ def gather_docs(
     return result
 
 
-def gather_file(
+def gather_docs(
     path: Path,
     repo_root: Path,
     exclude: Optional[list[str]] = None,
-    _excluded_paths: Optional[set[Path]] = None,
+) -> list[tuple[Path, str]]:
+    excluded_paths = _compile_exclude_patterns(exclude, repo_root) if exclude else None
+    return _gather_docs(path, repo_root, excluded_paths)
+
+
+def _gather_file(
+    path: Path,
+    repo_root: Path,
+    excluded_paths: set[Path] | None,
 ) -> tuple[Path, str] | None:
     """Gather a single file if it exists, isn't ignored, and isn't binary."""
     if not path.exists():
         return None
     if not path.is_file():
         return None
-    if is_ignored(path, repo_root, exclude, _excluded_paths):
+    if _is_ignored(path, repo_root, excluded_paths):
         return None
     if is_binary(path):
         return None
     return (path, path.read_text())
+
+
+def gather_file(
+    path: Path,
+    repo_root: Path,
+    exclude: Optional[list[str]] = None,
+) -> tuple[Path, str] | None:
+    excluded_paths = _compile_exclude_patterns(exclude, repo_root) if exclude else None
+    return _gather_file(path, repo_root, excluded_paths)
 
 
 def _expand_path(path_str: str, repo_root: Path) -> list[Path]:
@@ -208,13 +214,13 @@ def gather_files(paths: list[str], repo_root: Path, exclude: Optional[list[str]]
 
         for path in expanded:
             # Gather parent documentation first
-            for doc_path, content in gather_docs(path, repo_root, exclude, excluded_paths):
+            for doc_path, content in _gather_docs(path, repo_root, excluded_paths):
                 if doc_path not in seen:
                     seen.add(doc_path)
                     results.append((doc_path, content))
 
             # Gather the file itself
-            file_result = gather_file(path, repo_root, exclude, excluded_paths)
+            file_result = _gather_file(path, repo_root, excluded_paths)
             if file_result and file_result[0] not in seen:
                 seen.add(file_result[0])
                 results.append(file_result)

--- a/src/loopflow/worktrees.py
+++ b/src/loopflow/worktrees.py
@@ -46,7 +46,7 @@ def _run_wt(args: list[str], repo_root: Path) -> str:
     try:
         result = subprocess.run(cmd, cwd=repo_root, capture_output=True, text=True)
     except FileNotFoundError:
-        raise WorktreeError("Worktree CLI not found. Run: lf meta install")
+        raise WorktreeError("Worktree CLI not found. Run: lf ops meta install")
 
     if result.returncode != 0:
         error = result.stderr.strip() or result.stdout.strip() or "Worktree operation failed"

--- a/src/loopflow/worktrees.py
+++ b/src/loopflow/worktrees.py
@@ -46,7 +46,7 @@ def _run_wt(args: list[str], repo_root: Path) -> str:
     try:
         result = subprocess.run(cmd, cwd=repo_root, capture_output=True, text=True)
     except FileNotFoundError:
-        raise WorktreeError("Worktree CLI not found. Run: lf ops meta install")
+        raise WorktreeError("Worktree CLI not found. Run: lf ops install")
 
     if result.returncode != 0:
         error = result.stderr.strip() or result.stdout.strip() or "Worktree operation failed"

--- a/tests/test_cli_ops.py
+++ b/tests/test_cli_ops.py
@@ -62,10 +62,13 @@ def test_ops_help_lists_management_commands():
     assert result.exit_code == 0
     commands = _get_command_names(result.output)
     assert "pr" in commands
-    assert "meta" in commands
     assert "maestro" in commands
     assert "status" in commands
     assert "stop" in commands
     assert "prune" in commands
     assert "compare" in commands
     assert "land" in commands
+    assert "init" in commands
+    assert "install" in commands
+    assert "doctor" in commands
+    assert "version" in commands

--- a/tests/test_cli_ops.py
+++ b/tests/test_cli_ops.py
@@ -1,0 +1,56 @@
+"""Tests for ops subcommand wiring."""
+
+from typer.testing import CliRunner
+
+from loopflow.cli import app
+
+
+def _get_command_names(output: str) -> list[str]:
+    lines = output.splitlines()
+    try:
+        start = lines.index("Commands:")
+    except ValueError:
+        return []
+
+    commands = []
+    for line in lines[start + 1 :]:
+        if not line.strip():
+            break
+        if line.startswith("  "):
+            commands.append(line.split()[0])
+    return commands
+
+
+def test_top_level_help_lists_ops_only():
+    runner = CliRunner()
+
+    result = runner.invoke(app, ["--help"])
+
+    assert result.exit_code == 0
+    commands = _get_command_names(result.output)
+    assert "ops" in commands
+    assert "pr" not in commands
+    assert "meta" not in commands
+    assert "maestro" not in commands
+    assert "status" not in commands
+    assert "compare" not in commands
+    assert "land" not in commands
+    assert "stop" not in commands
+    assert "prune" not in commands
+
+
+def test_ops_help_lists_management_commands():
+    runner = CliRunner()
+
+    result = runner.invoke(app, ["ops", "--help"])
+
+    assert result.exit_code == 0
+    commands = _get_command_names(result.output)
+    assert "pr" in commands
+    assert "meta" in commands
+    assert "maestro" in commands
+    assert "status" in commands
+    assert "stop" in commands
+    assert "prune" in commands
+    assert "compare" in commands
+    assert "land" in commands

--- a/tests/test_cli_ops.py
+++ b/tests/test_cli_ops.py
@@ -6,18 +6,33 @@ from loopflow.cli import app
 
 
 def _get_command_names(output: str) -> list[str]:
+    """Extract command names from Typer help output.
+
+    Handles both plain text "Commands:" and Rich-formatted "╭─ Commands ─..."
+    """
     lines = output.splitlines()
-    try:
-        start = lines.index("Commands:")
-    except ValueError:
+
+    # Find the commands section (handles Rich box formatting)
+    start = None
+    for i, line in enumerate(lines):
+        if "Commands" in line:
+            start = i
+            break
+
+    if start is None:
         return []
 
     commands = []
     for line in lines[start + 1 :]:
-        if not line.strip():
+        # Stop at section end (Rich box border or empty line)
+        if line.startswith("╰") or (not line.strip() and commands):
             break
-        if line.startswith("  "):
-            commands.append(line.split()[0])
+        # Extract command name from lines like "│ run        description │"
+        stripped = line.strip().lstrip("│").strip()
+        if stripped and not stripped.startswith("─"):
+            parts = stripped.split()
+            if parts:
+                commands.append(parts[0])
     return commands
 
 

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -188,6 +188,16 @@ def test_gather_files_exclude_directory(temp_repo):
     assert temp_repo / "src" / "README.md" not in paths
 
 
+def test_gather_files_exclude_directory_name(temp_repo):
+    """Exclude patterns match directories without globbing."""
+    results = gather_files(["."], temp_repo, exclude=["src"])
+    paths = [p for p, _ in results]
+
+    assert temp_repo / "main.py" in paths
+    assert temp_repo / "src" / "app.py" not in paths
+    assert temp_repo / "src" / "README.md" not in paths
+
+
 def test_gather_files_exclude_glob_root_only(temp_repo):
     """Exclude *.md only matches root level (Path.glob semantics)."""
     results = gather_files(["."], temp_repo, exclude=["*.md"])

--- a/tests/test_worktrees.py
+++ b/tests/test_worktrees.py
@@ -104,7 +104,7 @@ def test_create_worktree_missing_wt_raises(tmp_path):
     with patch("loopflow.worktrees.list_all") as mock_list:
         mock_list.return_value = []
         with patch("subprocess.run", side_effect=FileNotFoundError()):
-            with pytest.raises(WorktreeError, match="lf ops meta install"):
+            with pytest.raises(WorktreeError, match="lf ops install"):
                 create(repo_root, "feature")
 
 

--- a/tests/test_worktrees.py
+++ b/tests/test_worktrees.py
@@ -104,7 +104,7 @@ def test_create_worktree_missing_wt_raises(tmp_path):
     with patch("loopflow.worktrees.list_all") as mock_list:
         mock_list.return_value = []
         with patch("subprocess.run", side_effect=FileNotFoundError()):
-            with pytest.raises(WorktreeError, match="lf meta install"):
+            with pytest.raises(WorktreeError, match="lf ops meta install"):
                 create(repo_root, "feature")
 
 


### PR DESCRIPTION
## Usage

```bash
lf ops pr create
lf ops meta install
lf ops status
lf ops land
```

All management commands are now under the `ops` subcommand. The main `lf` command only handles tasks, pipelines, and inline prompts.

This separates the core task runner (`lf implement`, `lf ship`) from maintenance operations (`lf ops pr`, `lf ops land`). Makes the interface cleaner and groups related functionality together.

## Changes

- Created `src/loopflow/cli/ops.py` to consolidate all management commands
- Moved pr, meta, maestro, status, compare, land, stop, prune under `lf ops`
- Updated all documentation to use new command paths
- Core `lf` command now only exposes run/pipeline/inline plus shorthand behavior