### PR TITLE
land: delete remote branch after landing

### DIFF
--- a/src/loopflow/cli/land.py
+++ b/src/loopflow/cli/land.py
@@ -203,6 +203,13 @@ def land(
         cmd.append(base_branch)
     subprocess.run(cmd, cwd=repo_root, check=True)
 
+    # Delete remote branch if it exists
+    subprocess.run(
+        ["git", "push", "origin", "--delete", branch],
+        cwd=main_repo,
+        capture_output=True,
+    )
+
     # Output main repo path for shell cd integration when we removed a worktree
     if was_in_worktree:
         typer.echo(str(main_repo))


### PR DESCRIPTION
## Usage

```bash
lf ops land
# Now automatically deletes the remote branch after landing locally
```

When landing a branch, the remote branch is now automatically deleted after the local merge completes. This keeps the remote repo clean by removing feature branches that have been successfully landed.

## Changes

- Add `git push origin --delete` step after worktrunk land completes
- Uses capture_output=True to suppress deletion errors (e.g. if branch doesn't exist remotely)