### PR TITLE
gemini: add google gemini cli provider support

### DIFF
--- a/.design/gemini.md
+++ b/.design/gemini.md
@@ -1,0 +1,155 @@
+# Gemini Provider Support
+
+Add Gemini CLI as a third model provider alongside Claude Code and Codex.
+
+## What to build
+
+A `GeminiRunner` class and supporting command builders that let users run `lf review -m gemini` or configure `agent_model: gemini:2.5-pro` in config.
+
+## Data structures
+
+No new data structures needed. The existing `Runner` ABC and `LaunchResult` dataclass work unchanged.
+
+## Key functions
+
+All in `src/loopflow/launcher.py`:
+
+```python
+class GeminiRunner(Runner):
+    """Google Gemini CLI runner."""
+
+    def launch(
+        self,
+        prompt: str,
+        auto: bool = False,
+        stream: bool = False,
+        skip_permissions: bool = False,
+        session_id: str | None = None,
+        cwd: Optional[Path] = None,
+    ) -> LaunchResult:
+        """Launch using build_gemini_command + prompt as positional arg."""
+        ...
+
+    def is_available(self) -> bool:
+        """Check for `gemini --version`."""
+        ...
+
+
+def build_gemini_command(
+    auto: bool,
+    stream: bool,
+    skip_permissions: bool,
+    model_variant: str | None = None,
+    sandbox_root: Path | None = None,
+    workdir: Path | None = None,
+) -> list[str]:
+    """Build Gemini CLI command.
+
+    auto mode: uses positional prompt (no -p flag needed)
+    stream mode: --output-format stream-json
+    skip_permissions: --yolo or --approval-mode yolo
+    model_variant: -m <variant>
+    sandbox_root: not used (Gemini has different sandbox model)
+    workdir: run from this directory
+    """
+    ...
+
+
+def build_gemini_interactive_command(
+    skip_permissions: bool,
+    model_variant: str | None = None,
+    sandbox_root: Path | None = None,
+    workdir: Path | None = None,
+) -> list[str]:
+    """Build Gemini CLI command for interactive mode.
+
+    Uses -i/--prompt-interactive to accept prompt then continue interactively.
+    """
+    ...
+
+
+def normalize_gemini_event(event: dict) -> list[dict]:
+    """Normalize Gemini stream-json events to common schema."""
+    ...
+```
+
+Update `get_runner()`:
+
+```python
+def get_runner(model: str) -> Runner:
+    runners = {
+        "claude": ClaudeRunner,
+        "codex": CodexRunner,
+        "gemini": GeminiRunner,
+    }
+    ...
+```
+
+Update `build_model_command()` and `build_model_interactive_command()`:
+
+```python
+def build_model_command(...) -> list[str]:
+    if model == "claude":
+        return build_claude_command(...)
+    if model == "gemini":
+        return build_gemini_command(...)
+    return build_codex_command(...)
+```
+
+## Gemini CLI flags mapping
+
+| Loopflow concept | Gemini CLI flag |
+|------------------|-----------------|
+| auto mode | Positional prompt (no flag needed) |
+| stream output | `--output-format stream-json` |
+| skip permissions | `--yolo` or `--approval-mode yolo` |
+| model variant | `-m <model>` (e.g., `gemini-2.5-pro`) |
+| interactive + prompt | `-i <prompt>` (prompt-interactive) |
+| sandbox | `-s` (optional, different model than Codex) |
+
+## stream-json event normalization
+
+Gemini's `stream-json` output needs mapping to the common schema used by `_format_normalized_event()`. The normalizer should handle:
+
+- Tool use events → `{"type": "tool_use", "tool": ..., "input": ...}`
+- Text output → `{"type": "text", "content": ...}`
+- Completion → `{"type": "result", "status": "success"|"error"}`
+
+Exact event schema TBD during implementation - inspect actual output with `gemini "test" --output-format stream-json`.
+
+## Constraints
+
+- **CLI availability**: Gemini CLI requires Node.js 20+. The `is_available()` check must verify `gemini --version` works.
+- **Prompt passing**: Gemini uses positional args for prompts in non-interactive mode, not stdin. This matches how Claude and Codex work in loopflow.
+- **Interactive mode**: Use `-i` flag which accepts the initial prompt then continues interactively.
+- **Sandbox model**: Gemini's `-s` sandbox flag works differently from Codex's workspace sandboxing. For now, don't pass sandbox flags - let users configure via Gemini's own settings.
+
+## Files to modify
+
+1. `src/loopflow/launcher.py` - Add GeminiRunner, build functions, normalizer
+2. `src/loopflow/cli/meta.py` - Add gemini to `doctor` and `install` commands
+3. `README.md` - Update to mention Gemini support
+4. `tests/test_backend.py` - Add test for gemini runner
+
+## Done when
+
+```bash
+# Verify gemini runner exists and is selectable
+uv run python -c "from loopflow.launcher import get_runner; r = get_runner('gemini'); print(type(r).__name__)"
+# Output: GeminiRunner
+
+# Verify command building
+uv run python -c "
+from loopflow.launcher import build_gemini_command
+cmd = build_gemini_command(auto=True, stream=True, skip_permissions=True, model_variant='2.5-pro')
+print(' '.join(cmd))
+"
+# Output should include: gemini -m 2.5-pro --output-format stream-json --yolo
+
+# If gemini CLI installed, verify is_available
+uv run python -c "from loopflow.launcher import get_runner; print(get_runner('gemini').is_available())"
+# Output: True (if installed) or False
+
+# Run tests
+uv run pytest tests/test_backend.py -v
+```

--- a/README.md
+++ b/README.md
@@ -10,13 +10,13 @@ lf ship
 
 Run LLM coding tasks from reusable prompt files.
 
-macOS only. Supports Claude Code and OpenAI Codex via configuration.
+macOS only. Supports Claude Code, OpenAI Codex, and Google Gemini CLI via configuration.
 
 ## Install
 
 ```bash
 pip install loopflow
-lf ops install    # installs Claude Code + worktrunk
+lf ops install    # installs Claude Code, Codex, Gemini CLI, worktrunk
 ```
 
 ## Why Worktrees?
@@ -112,7 +112,7 @@ Sessions write to SQLite in auto mode; the maestro UI reads the same database.
 
 ```yaml
 # .lf/config.yaml
-agent_model: claude:opus     # Model to use (backend or backend:variant)
+agent_model: claude:opus     # Model: claude, codex, gemini (or backend:variant)
 push: true        # auto-push after commits
 pr: false         # open PR after pipelines
 
@@ -166,7 +166,7 @@ lf implement &         # background (shell handles it)
 | `lf ops pr land [-a]` | Squash-merge to main |
 | `lf ops land [--no-pr] [--force] [--base]` | Land locally via worktrunk |
 | `lf ops init` | Initialize repo with prompts and config |
-| `lf ops install` | Install Claude Code |
+| `lf ops install` | Install Claude Code, Codex, Gemini CLI |
 | `lf ops doctor` | Check dependencies |
 | `lf ops maestro start` | Start session tracking daemon |
 | `lf ops maestro stop` | Stop session tracking daemon |

--- a/src/loopflow/cli/meta.py
+++ b/src/loopflow/cli/meta.py
@@ -9,7 +9,7 @@ import typer
 
 from loopflow.config import load_config
 from loopflow.context import find_worktree_root
-from loopflow.launcher import check_claude_available
+from loopflow.launcher import check_claude_available, check_codex_available, check_gemini_available
 
 app = typer.Typer(help="Setup and diagnostics.")
 
@@ -185,7 +185,7 @@ def install():
     else:
         typer.echo("✓ Node.js")
 
-    # Claude Code (always required)
+    # Claude Code
     if check_claude_available():
         typer.echo("✓ Claude Code")
     else:
@@ -199,7 +199,36 @@ def install():
             typer.echo("✓ Claude Code installed")
         else:
             typer.echo(f"✗ Could not install Claude Code: {result.stderr}", err=True)
-            raise typer.Exit(1)
+
+    # Codex
+    if check_codex_available():
+        typer.echo("✓ Codex")
+    else:
+        typer.echo("Installing Codex...")
+        result = subprocess.run(
+            ["npm", "install", "-g", "@openai/codex"],
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode == 0:
+            typer.echo("✓ Codex installed")
+        else:
+            typer.echo(f"✗ Could not install Codex: {result.stderr}", err=True)
+
+    # Gemini CLI
+    if check_gemini_available():
+        typer.echo("✓ Gemini CLI")
+    else:
+        typer.echo("Installing Gemini CLI...")
+        result = subprocess.run(
+            ["npm", "install", "-g", "@google/gemini-cli"],
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode == 0:
+            typer.echo("✓ Gemini CLI installed")
+        else:
+            typer.echo("- Gemini CLI: npm install -g @google/gemini-cli")
 
     # Worktrunk (required for worktree operations)
     if shutil.which("wt"):
@@ -277,6 +306,17 @@ def doctor():
         else:
             typer.echo("✗ cursor - Run: lf ops install")
             all_ok = False
+
+    # Optional model backends
+    if check_codex_available():
+        typer.echo("✓ codex (optional)")
+    else:
+        typer.echo("- codex (optional): npm install -g @openai/codex")
+
+    if check_gemini_available():
+        typer.echo("✓ gemini (optional)")
+    else:
+        typer.echo("- gemini (optional): npm install -g @google/gemini-cli")
 
     # Optional: gh for PR creation
     if shutil.which("gh"):

--- a/src/loopflow/cli/meta.py
+++ b/src/loopflow/cli/meta.py
@@ -228,7 +228,7 @@ def install():
         if result.returncode == 0:
             typer.echo("✓ Gemini CLI installed")
         else:
-            typer.echo("- Gemini CLI: npm install -g @google/gemini-cli")
+            typer.echo(f"✗ Could not install Gemini CLI: {result.stderr}", err=True)
 
     # Worktrunk (required for worktree operations)
     if shutil.which("wt"):

--- a/src/loopflow/config.py
+++ b/src/loopflow/config.py
@@ -21,10 +21,21 @@ class PipelineConfig(BaseModel):
 
 
 def parse_model(model: str) -> tuple[str, str | None]:
-    """Parse model string like 'claude:opus' into (backend, variant)."""
+    """Parse model string like 'claude:opus' into (backend, variant).
+
+    Applies smart defaults when no variant is specified:
+    - claude -> opus (Claude Opus 4.5)
+    - codex -> o3 (latest reasoning model)
+    - gemini -> 2.5-pro (Gemini 2.5 Pro)
+    """
+    defaults = {
+        "claude": "opus",
+        "codex": "o3",
+        "gemini": "2.5-pro",
+    }
     parts = model.split(":", 1)
     backend = parts[0]
-    variant = parts[1] if len(parts) > 1 else None
+    variant = parts[1] if len(parts) > 1 else defaults.get(backend)
     return backend, variant
 
 

--- a/src/loopflow/config.py
+++ b/src/loopflow/config.py
@@ -25,12 +25,11 @@ def parse_model(model: str) -> tuple[str, str | None]:
 
     Applies smart defaults when no variant is specified:
     - claude -> opus (Claude Opus 4.5)
-    - codex -> o3 (latest reasoning model)
     - gemini -> 2.5-pro (Gemini 2.5 Pro)
+    - codex -> None (let Codex CLI pick its default)
     """
     defaults = {
         "claude": "opus",
-        "codex": "o3",
         "gemini": "2.5-pro",
     }
     parts = model.split(":", 1)

--- a/src/loopflow/launcher.py
+++ b/src/loopflow/launcher.py
@@ -117,11 +117,52 @@ class CodexRunner(Runner):
             return False
 
 
+class GeminiRunner(Runner):
+    """Google Gemini CLI runner."""
+
+    def launch(
+        self,
+        prompt: str,
+        auto: bool = False,
+        stream: bool = False,
+        skip_permissions: bool = False,
+        session_id: str | None = None,
+        cwd: Optional[Path] = None,
+    ) -> LaunchResult:
+        cmd = build_gemini_command(
+            auto=auto,
+            stream=stream,
+            skip_permissions=skip_permissions,
+            workdir=cwd,
+        )
+
+        cmd_with_prompt = cmd + [prompt]
+
+        if auto and stream:
+            exit_code, output = _run_streaming_json(
+                cmd_with_prompt,
+                cwd=cwd,
+                normalize_fn=normalize_gemini_event,
+                session_id=session_id,
+            )
+            return LaunchResult(exit_code, output)
+        if auto:
+            result = subprocess.run(cmd_with_prompt, cwd=cwd, capture_output=True, text=True, env=get_model_env())
+            return LaunchResult(result.returncode, result.stdout)
+
+        result = subprocess.run(cmd_with_prompt, cwd=cwd, text=True, env=get_model_env())
+        return LaunchResult(result.returncode, None)
+
+    def is_available(self) -> bool:
+        return check_gemini_available()
+
+
 def get_runner(model: str) -> Runner:
     """Get a runner instance for the given model."""
     runners = {
         "claude": ClaudeRunner,
         "codex": CodexRunner,
+        "gemini": GeminiRunner,
     }
     if model not in runners:
         raise ValueError(f"Unknown model: {model}. Available: {list(runners.keys())}")
@@ -266,6 +307,60 @@ def build_codex_interactive_command(
     return cmd
 
 
+def build_gemini_command(
+    auto: bool,
+    stream: bool,
+    skip_permissions: bool,
+    model_variant: str | None = None,
+    sandbox_root: Path | None = None,
+    workdir: Path | None = None,
+) -> list[str]:
+    """Build Gemini CLI command.
+
+    auto mode: uses positional prompt (no -p flag needed)
+    stream mode: --output-format stream-json
+    skip_permissions: --yolo
+    model_variant: -m <variant>
+    sandbox_root: not used (Gemini has different sandbox model)
+    workdir: not used as CLI arg (handled via cwd in subprocess)
+    """
+    cmd = ["gemini"]
+
+    if model_variant:
+        cmd.extend(["-m", model_variant])
+
+    if stream:
+        cmd.extend(["--output-format", "stream-json"])
+
+    if skip_permissions:
+        cmd.append("--yolo")
+
+    return cmd
+
+
+def build_gemini_interactive_command(
+    skip_permissions: bool,
+    model_variant: str | None = None,
+    sandbox_root: Path | None = None,
+    workdir: Path | None = None,
+) -> list[str]:
+    """Build Gemini CLI command for interactive mode.
+
+    Uses -i to accept prompt then continue interactively.
+    """
+    cmd = ["gemini"]
+
+    if model_variant:
+        cmd.extend(["-m", model_variant])
+
+    if skip_permissions:
+        cmd.append("--yolo")
+
+    cmd.append("-i")
+
+    return cmd
+
+
 def build_model_command(
     model: str,
     auto: bool,
@@ -281,6 +376,15 @@ def build_model_command(
     """
     if model == "claude":
         return build_claude_command(auto=auto, stream=stream, skip_permissions=skip_permissions, model_variant=model_variant)
+    if model == "gemini":
+        return build_gemini_command(
+            auto=auto,
+            stream=stream,
+            skip_permissions=skip_permissions,
+            model_variant=model_variant,
+            sandbox_root=sandbox_root,
+            workdir=workdir,
+        )
     return build_codex_command(
         auto=auto,
         stream=stream,
@@ -304,6 +408,13 @@ def build_model_interactive_command(
     """
     if model == "claude":
         return build_claude_command(auto=False, stream=False, skip_permissions=skip_permissions, model_variant=model_variant)
+    if model == "gemini":
+        return build_gemini_interactive_command(
+            skip_permissions=skip_permissions,
+            model_variant=model_variant,
+            sandbox_root=sandbox_root,
+            workdir=workdir,
+        )
     return build_codex_interactive_command(
         skip_permissions=skip_permissions,
         model_variant=model_variant,
@@ -405,6 +516,32 @@ def normalize_codex_event(event: dict) -> list[dict]:
     return [event] if event else []
 
 
+def normalize_gemini_event(event: dict) -> list[dict]:
+    """Normalize Gemini stream-json events to common schema."""
+    event_type = event.get("type")
+    results = []
+
+    if event_type == "text":
+        text = event.get("content", "")
+        if text:
+            results.append({"type": "text", "content": text})
+
+    elif event_type == "tool_use":
+        results.append({
+            "type": "tool_use",
+            "tool": event.get("name", "unknown"),
+            "input": event.get("input", {}),
+        })
+
+    elif event_type == "result":
+        results.append({
+            "type": "result",
+            "status": event.get("status", "unknown"),
+        })
+
+    return results
+
+
 def _format_normalized_event(event: dict) -> str | None:
     """Format a normalized event in unified format."""
     event_type = event.get("type")
@@ -437,6 +574,32 @@ def check_claude_available() -> bool:
     try:
         subprocess.run(
             ["claude", "--version"],
+            capture_output=True,
+            check=True,
+        )
+        return True
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return False
+
+
+def check_codex_available() -> bool:
+    """Check if the codex CLI is available."""
+    try:
+        subprocess.run(
+            ["codex", "--version"],
+            capture_output=True,
+            check=True,
+        )
+        return True
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return False
+
+
+def check_gemini_available() -> bool:
+    """Check if the gemini CLI is available."""
+    try:
+        subprocess.run(
+            ["gemini", "--version"],
             capture_output=True,
             check=True,
         )

--- a/src/loopflow/launcher.py
+++ b/src/loopflow/launcher.py
@@ -106,15 +106,7 @@ class CodexRunner(Runner):
         return LaunchResult(result.returncode, None)
 
     def is_available(self) -> bool:
-        try:
-            subprocess.run(
-                ["codex", "--version"],
-                capture_output=True,
-                check=True,
-            )
-            return True
-        except (subprocess.CalledProcessError, FileNotFoundError):
-            return False
+        return check_codex_available()
 
 
 class GeminiRunner(Runner):
@@ -576,40 +568,29 @@ def _print_status(msg: str) -> None:
     print(f"\033[90m{msg}\033[0m", file=sys.stderr)
 
 
-def check_claude_available() -> bool:
-    """Check if the claude CLI is available."""
+def _check_cli_available(cli_name: str) -> bool:
+    """Check if a CLI tool is available by running --version."""
     try:
         subprocess.run(
-            ["claude", "--version"],
+            [cli_name, "--version"],
             capture_output=True,
             check=True,
         )
         return True
     except (subprocess.CalledProcessError, FileNotFoundError):
         return False
+
+
+def check_claude_available() -> bool:
+    """Check if the claude CLI is available."""
+    return _check_cli_available("claude")
 
 
 def check_codex_available() -> bool:
     """Check if the codex CLI is available."""
-    try:
-        subprocess.run(
-            ["codex", "--version"],
-            capture_output=True,
-            check=True,
-        )
-        return True
-    except (subprocess.CalledProcessError, FileNotFoundError):
-        return False
+    return _check_cli_available("codex")
 
 
 def check_gemini_available() -> bool:
     """Check if the gemini CLI is available."""
-    try:
-        subprocess.run(
-            ["gemini", "--version"],
-            capture_output=True,
-            check=True,
-        )
-        return True
-    except (subprocess.CalledProcessError, FileNotFoundError):
-        return False
+    return _check_cli_available("gemini")

--- a/src/loopflow/launcher.py
+++ b/src/loopflow/launcher.py
@@ -133,6 +133,7 @@ class GeminiRunner(Runner):
             auto=auto,
             stream=stream,
             skip_permissions=skip_permissions,
+            sandbox_root=cwd.parent if cwd else None,
             workdir=cwd,
         )
 
@@ -321,7 +322,7 @@ def build_gemini_command(
     stream mode: --output-format stream-json
     skip_permissions: --yolo
     model_variant: -m <variant>
-    sandbox_root: not used (Gemini has different sandbox model)
+    sandbox_root: included via --include-directories for git access
     workdir: not used as CLI arg (handled via cwd in subprocess)
     """
     cmd = ["gemini"]
@@ -334,6 +335,9 @@ def build_gemini_command(
 
     if skip_permissions:
         cmd.append("--yolo")
+
+    if sandbox_root:
+        cmd.extend(["--include-directories", str(sandbox_root)])
 
     return cmd
 
@@ -355,6 +359,9 @@ def build_gemini_interactive_command(
 
     if skip_permissions:
         cmd.append("--yolo")
+
+    if sandbox_root:
+        cmd.extend(["--include-directories", str(sandbox_root)])
 
     cmd.append("-i")
 

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -3,7 +3,7 @@
 import pytest
 from unittest.mock import patch, MagicMock
 
-from loopflow.launcher import get_runner, ClaudeRunner, CodexRunner, LaunchResult
+from loopflow.launcher import get_runner, ClaudeRunner, CodexRunner, GeminiRunner, LaunchResult
 
 
 def test_get_runner_returns_claude():
@@ -16,6 +16,12 @@ def test_get_runner_returns_codex():
     """get_runner returns CodexRunner instance for 'codex'."""
     runner = get_runner("codex")
     assert isinstance(runner, CodexRunner)
+
+
+def test_get_runner_returns_gemini():
+    """get_runner returns GeminiRunner instance for 'gemini'."""
+    runner = get_runner("gemini")
+    assert isinstance(runner, GeminiRunner)
 
 
 def test_get_runner_raises_on_unknown():
@@ -89,6 +95,42 @@ def test_codex_runner_launch_auto_mode():
 def test_codex_runner_launch_interactive():
     """CodexRunner.launch() without auto runs interactively."""
     runner = CodexRunner()
+
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(returncode=0)
+        result = runner.launch("test prompt", auto=False)
+
+        assert result.exit_code == 0
+        assert result.output is None
+
+
+def test_gemini_runner_is_available():
+    """GeminiRunner.is_available() checks for gemini CLI."""
+    runner = GeminiRunner()
+
+    with patch("loopflow.launcher.check_gemini_available") as mock_check:
+        mock_check.return_value = True
+        assert runner.is_available() is True
+
+        mock_check.return_value = False
+        assert runner.is_available() is False
+
+
+def test_gemini_runner_launch_auto_mode():
+    """GeminiRunner.launch() with auto captures output."""
+    runner = GeminiRunner()
+
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(returncode=0, stdout="gemini output")
+        result = runner.launch("test prompt", auto=True)
+
+        assert result.exit_code == 0
+        assert result.output == "gemini output"
+
+
+def test_gemini_runner_launch_interactive():
+    """GeminiRunner.launch() without auto runs interactively."""
+    runner = GeminiRunner()
 
     with patch("subprocess.run") as mock_run:
         mock_run.return_value = MagicMock(returncode=0)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -288,7 +288,7 @@ def test_parse_model_with_variant():
 def test_parse_model_default_variants():
     """parse_model applies smart defaults when no variant specified."""
     assert parse_model("claude") == ("claude", "opus")
-    assert parse_model("codex") == ("codex", "o3")
+    assert parse_model("codex") == ("codex", None)  # let Codex CLI pick
     assert parse_model("gemini") == ("gemini", "2.5-pro")
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from loopflow.config import load_config, PipelineConfig, ConfigError
+from loopflow.config import load_config, parse_model, PipelineConfig, ConfigError
 
 
 @pytest.fixture
@@ -276,3 +276,22 @@ def test_load_config_agent_model_setting(temp_repo):
 
     assert config is not None
     assert config.agent_model == "codex:o3"
+
+
+def test_parse_model_with_variant():
+    """parse_model extracts backend and variant."""
+    assert parse_model("claude:opus") == ("claude", "opus")
+    assert parse_model("codex:o3") == ("codex", "o3")
+    assert parse_model("gemini:2.5-pro") == ("gemini", "2.5-pro")
+
+
+def test_parse_model_default_variants():
+    """parse_model applies smart defaults when no variant specified."""
+    assert parse_model("claude") == ("claude", "opus")
+    assert parse_model("codex") == ("codex", "o3")
+    assert parse_model("gemini") == ("gemini", "2.5-pro")
+
+
+def test_parse_model_unknown_backend():
+    """parse_model returns None variant for unknown backends."""
+    assert parse_model("unknown") == ("unknown", None)


### PR DESCRIPTION
## Usage

```bash
lf review -m gemini                    # run with gemini
lf implement -m gemini:2.5-pro         # specific model variant
```

Or configure in `.lf/config.yaml`:

```yaml
agent_model: gemini:2.5-pro
```

Loopflow now supports Google Gemini CLI as a third model provider alongside Claude Code and Codex. Users can select gemini via `-m` flag or config file.

## Changes

- New `GeminiRunner` class in launcher.py with streaming JSON support
- Gemini CLI installation in `lf ops install` and health checks in `lf ops doctor`
- Command builders for auto/interactive modes with proper flag mapping
- Stream event normalization for consistent output formatting
- Updated README and meta commands to include Gemini support