### PR TITLE
onboarding: improve `lf ops init` with dependency checking

### DIFF
--- a/.design/docs-revision.md
+++ b/.design/docs-revision.md
@@ -1,0 +1,691 @@
+# Documentation Revision
+
+Revise docs/ to reflect current state: maestro app, evolved prompts, research positioning.
+
+## What to build
+
+New documentation structure inspired by Stripe (upfront caveats, quick start first), Notion (progressive disclosure), Cursor (role-based entry points), and Linear (workflow-focused).
+
+## Current problems
+
+1. **Missing maestro** — UI layer not documented at all
+2. **Prompts live in .claude/commands/** — docs still say `.lf/`
+3. **No limitations section** — Stripe-style honesty missing
+4. **Buried quick start** — install comes before "try this command"
+5. **Research insights not reflected** — positioning doc explains value prop better than current docs
+
+## New structure
+
+```
+docs/
+├── index.md          # Quick start at top, what it is, install, 30-second demo
+├── tasks.md          # Tasks and prompts (NEW - extracted from config)
+├── pipelines.md      # Pipelines and chaining (NEW - extracted from config)
+├── configuration.md  # Config reference only, no conceptual content
+├── maestro.md        # Session tracking + UI (NEW)
+├── cli.md            # Command reference (NEW - extracted from README)
+├── limitations.md    # Upfront caveats (NEW)
+└── patterns.md       # Recipes (keep, but trim)
+```
+
+## index.md
+
+```markdown
+---
+layout: default
+title: Loopflow
+---
+
+# Loopflow
+
+Run LLM coding tasks from reusable prompt files.
+
+\`\`\`bash
+pip install loopflow && lf ops init && lf review
+\`\`\`
+
+## 30-second demo
+
+\`\`\`bash
+# Review current branch
+lf review
+
+# Implement a feature
+lf implement: add user auth
+
+# Run full pipeline: implement → review → test → commit → PR
+lf ship
+\`\`\`
+
+## What it is
+
+Prompts as files. Pipelines chain them. Worktrees keep work isolated.
+
+- **Tasks** — Prompt files in `.claude/commands/` or `.lf/`
+- **Pipelines** — Chain tasks: `ship: [implement, review, test, commit]`
+- **Session tracking** — See what's running across terminals
+
+Supports Claude Code, OpenAI Codex, Google Gemini CLI. macOS only.
+
+## Install
+
+\`\`\`bash
+# With uv (recommended)
+uv tool install loopflow
+
+# Or pip
+pip install loopflow
+
+# Install Claude Code + worktrunk
+lf ops install
+\`\`\`
+
+Then initialize your repo:
+
+\`\`\`bash
+cd your-repo
+lf ops init
+\`\`\`
+
+## Why worktrees?
+
+Agents commit to branches. If an agent commits to the branch you're editing, you have a problem.
+
+Worktrees give each feature its own directory. You work in main, agents work in `repo.feature-name`.
+
+\`\`\`bash
+wt switch --create my-feature
+cd ../myrepo.my-feature
+lf ship                        # agents work here
+\`\`\`
+
+When done: `lf ops pr create` to open PR, `lf ops land` to merge.
+
+## Next
+
+- [Tasks](tasks.md) — Writing and running prompts
+- [Pipelines](pipelines.md) — Chaining tasks together
+- [Configuration](configuration.md) — All options
+- [Maestro](maestro.md) — Session tracking UI
+- [Limitations](limitations.md) — What loopflow can't do
+```
+
+## tasks.md
+
+```markdown
+---
+layout: default
+title: Tasks
+---
+
+# Tasks
+
+A task is a prompt file. Run it by name:
+
+\`\`\`bash
+lf review              # runs .claude/commands/review.md or .lf/review.lf
+lf implement: add auth # pass arguments after the colon
+lf : "fix typo"        # inline prompt, no file
+\`\`\`
+
+## Where tasks live
+
+Loopflow searches in order:
+
+1. `.claude/commands/{name}.md` — Claude Code standard location
+2. `.lf/{name}.lf` — Loopflow-specific
+3. `.lf/{name}.md` — Fallback
+
+Use `.claude/commands/` if you want tasks to work with both loopflow and Claude Code directly.
+
+## Task file format
+
+Tasks are markdown. The filename (minus extension) is the task name.
+
+\`\`\`markdown
+# .claude/commands/review.md
+
+Review the diff on the current branch against main.
+
+Fix any issues you find. The deliverable is the fixes, not a written review.
+
+## What to look for
+
+- Style guide violations (see STYLE.md)
+- Bugs and edge cases
+- Unnecessary complexity
+\`\`\`
+
+## Arguments
+
+Pass arguments after a colon. Use `{args}` as placeholder:
+
+\`\`\`markdown
+# .lf/implement.lf
+
+Implement the following feature:
+
+{args}
+
+Follow the existing code style.
+\`\`\`
+
+\`\`\`bash
+lf implement: add OAuth login
+\`\`\`
+
+## Task frontmatter
+
+Override per-task settings with YAML frontmatter:
+
+\`\`\`markdown
+---
+interactive: true
+model: claude:opus
+include:
+  - tests/**
+exclude:
+  - "*.test.ts"
+---
+
+# Design
+
+Explore how to implement {args}...
+\`\`\`
+
+Frontmatter options:
+- `interactive: true` — Run in interactive mode
+- `model: backend:variant` — Override default model
+- `include: [patterns]` — Additional context files
+- `exclude: [patterns]` — Files to exclude
+
+## Auto-included context
+
+Every task automatically gets:
+
+1. All `.md` files at repo root (README, STYLE, etc.)
+2. Current git diff (staged + unstaged)
+3. Files in `context` config
+4. Files passed with `-x` flag
+
+## Run modes
+
+Tasks run in **auto mode** by default: non-interactive, streaming output, logs to `~/.lf/logs/`.
+
+\`\`\`bash
+lf implement           # auto mode (default)
+lf design              # interactive if configured
+lf implement -i        # force interactive
+lf design -a           # force auto
+\`\`\`
+
+Configure default interactive tasks in `.lf/config.yaml`:
+
+\`\`\`yaml
+interactive:
+  - design
+  - iterate
+\`\`\`
+
+## Built-in tasks
+
+Loopflow includes prompts for common workflows. Run `lf ops init --prompts` to install them:
+
+| Task | Purpose |
+|------|---------|
+| design | Explore approach before coding |
+| implement | Build what's in .design/ |
+| review | Find and fix issues |
+| polish | Run tests, clean up |
+| iterate | Improve code on branch |
+| reduce | Simplify without changing behavior |
+| draft_commit | Generate commit message |
+| rebase | Rebase onto main |
+
+See [PROMPTS.md](https://github.com/user/loopflow/blob/main/PROMPTS.md) for how they chain together.
+```
+
+## pipelines.md
+
+```markdown
+---
+layout: default
+title: Pipelines
+---
+
+# Pipelines
+
+Pipelines chain tasks. Each runs in auto mode with auto-commits between.
+
+\`\`\`yaml
+# .lf/config.yaml
+pipelines:
+  ship:
+    tasks: [implement, review, test, commit]
+    pr: true
+\`\`\`
+
+\`\`\`bash
+lf ship    # runs the pipeline
+\`\`\`
+
+## How pipelines work
+
+1. Run first task
+2. If changes exist, commit them
+3. Run next task
+4. Repeat until done
+5. If `pr: true`, open PR
+
+## Pipeline options
+
+| Option | Description |
+|--------|-------------|
+| `tasks` | List of task names to run |
+| `push` | Push after commits (overrides global) |
+| `pr` | Open PR when done |
+
+## Example pipelines
+
+\`\`\`yaml
+pipelines:
+  # Full workflow
+  ship:
+    tasks: [implement, review, test, commit]
+    pr: true
+
+  # Fast iteration
+  quick:
+    tasks: [implement, commit]
+    push: true
+
+  # Cleanup pass
+  polish:
+    tasks: [review, test]
+\`\`\`
+
+## Commit behavior
+
+Commits between tasks include:
+- Task name in message
+- Model used
+- Prompt content hash (for reproducibility)
+
+Set `push: true` to auto-push after each commit.
+```
+
+## maestro.md
+
+```markdown
+---
+layout: default
+title: Maestro
+---
+
+# Maestro
+
+Maestro tracks running sessions and provides a visual UI for managing loopflow tasks.
+
+## Session tracking
+
+Every auto-mode task registers with the session database:
+
+\`\`\`bash
+lf ops status          # show running sessions
+\`\`\`
+
+Output shows task name, repo, worktree, duration, and status.
+
+## The Maestro app (optional)
+
+Maestro is a macOS app that provides:
+
+- Visual session list
+- Worktree sidebar
+- Prompt launcher
+- Log tailing
+
+### Start the daemon
+
+\`\`\`bash
+lf ops maestro start   # start background daemon
+lf ops maestro stop    # stop daemon
+\`\`\`
+
+The daemon runs on `localhost:8420` and the Maestro app connects to it.
+
+### Requirements
+
+- macOS 15+
+- Claude Code installed
+- Daemon running
+
+## Without Maestro
+
+Session tracking works without the app:
+
+\`\`\`bash
+# Check what's running
+lf ops status
+
+# View logs directly
+tail -f ~/.lf/logs/<worktree>/<task>.log
+\`\`\`
+
+## Parallel sessions
+
+Run multiple tasks across worktrees:
+
+\`\`\`bash
+# Terminal 1
+cd ../myrepo.feature-a && lf ship &
+
+# Terminal 2
+cd ../myrepo.feature-b && lf ship &
+
+# Check both
+lf ops status
+\`\`\`
+
+Maestro shows all sessions in one view.
+```
+
+## limitations.md
+
+```markdown
+---
+layout: default
+title: Limitations
+---
+
+# Limitations
+
+Be aware of these constraints before using loopflow.
+
+## macOS only
+
+Loopflow requires macOS. The session tracking daemon uses launchd, and the Maestro app is a native macOS application.
+
+Linux and Windows are not supported. `lf ops install` will fail on other platforms.
+
+## Requires Claude Code, Codex, or Gemini CLI
+
+Loopflow wraps existing AI coding CLIs. You need at least one installed:
+
+\`\`\`bash
+lf ops install         # installs Claude Code via npm
+\`\`\`
+
+Loopflow does not provide its own AI capabilities.
+
+## No IDE integration
+
+Loopflow runs in the terminal. There's no VS Code extension, no Cursor plugin, no editor integration.
+
+If you want IDE features, use Claude Code or Codex directly.
+
+## Worktrees recommended
+
+Without worktrees, agents commit to your current branch. This can conflict with your own work.
+
+We strongly recommend using worktrees:
+
+\`\`\`bash
+wt switch --create feature
+cd ../repo.feature
+lf ship
+\`\`\`
+
+## Session tracking is local
+
+The SQLite database lives at `~/.lf/maestro.db`. Sessions aren't shared across machines or users.
+
+## No remote execution
+
+Tasks run locally. There's no cloud execution, no queue system, no distributed agents.
+
+## Model rate limits apply
+
+Loopflow doesn't manage rate limits. If Claude or Codex throttles you, tasks will fail or slow down.
+
+## Auto mode skips confirmation
+
+In auto mode (the default), tasks run without asking permission. Use `yolo: false` in config if you want Claude Code to prompt before file changes.
+
+## Pipeline failures leave state
+
+If a pipeline fails mid-way, you'll have partial commits. Check `git log` and decide whether to continue or reset.
+```
+
+## configuration.md
+
+Trim to reference only:
+
+```markdown
+---
+layout: default
+title: Configuration
+---
+
+# Configuration
+
+Config lives in `.lf/config.yaml`.
+
+## Full example
+
+\`\`\`yaml
+agent_model: claude:opus
+push: true
+pr: false
+yolo: true
+
+interactive:
+  - design
+  - iterate
+
+context:
+  - src/schema.py
+  - docs/api.md
+
+exclude:
+  - "*.test.ts"
+  - node_modules
+
+ide:
+  warp: true
+  cursor: true
+
+pipelines:
+  ship:
+    tasks: [implement, review, test, commit]
+    pr: true
+\`\`\`
+
+## Options reference
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `agent_model` | string | `claude` | Default model (backend:variant) |
+| `push` | bool | `false` | Auto-push after commits |
+| `pr` | bool | `false` | Open PR after pipelines |
+| `yolo` | bool | `false` | Skip permission prompts |
+| `interactive` | list | `[]` | Tasks that default to interactive |
+| `context` | list | `[]` | Always-included context files |
+| `exclude` | list | `[]` | Glob patterns to exclude |
+| `ide.warp` | bool | `false` | Install Warp terminal |
+| `ide.cursor` | bool | `false` | Install Cursor editor |
+
+## Pipelines
+
+\`\`\`yaml
+pipelines:
+  name:
+    tasks: [task1, task2]    # required
+    push: true               # optional, overrides global
+    pr: true                 # optional, open PR when done
+\`\`\`
+
+## Per-task overrides
+
+Use frontmatter in task files. See [Tasks](tasks.md#task-frontmatter).
+
+## CLI overrides
+
+| Flag | Description |
+|------|-------------|
+| `-i, --interactive` | Force interactive mode |
+| `-a, --auto` | Force auto mode |
+| `-m, --model` | Override model |
+| `-x, --context` | Add context files |
+```
+
+## cli.md
+
+```markdown
+---
+layout: default
+title: CLI Reference
+---
+
+# CLI Reference
+
+## Running tasks
+
+\`\`\`bash
+lf <task>              # run task from .claude/commands/ or .lf/
+lf <task>: args        # pass arguments
+lf : "prompt"          # inline prompt
+lf <pipeline>          # run pipeline from config
+\`\`\`
+
+## Options
+
+| Option | Description |
+|--------|-------------|
+| `-i, --interactive` | Run interactively |
+| `-a, --auto` | Run in auto mode |
+| `-x, --context FILE` | Add context file |
+| `-m, --model MODEL` | Choose model |
+| `-c, --copy` | Copy prompt to clipboard |
+| `-v, --paste` | Include clipboard in prompt |
+| `--parallel a,b` | Run with multiple models |
+
+## Operations
+
+\`\`\`bash
+lf ops init            # initialize repo
+lf ops install         # install dependencies
+lf ops doctor          # check installation
+lf ops status          # show running sessions
+\`\`\`
+
+## Maestro
+
+\`\`\`bash
+lf ops maestro start   # start daemon
+lf ops maestro stop    # stop daemon
+\`\`\`
+
+## Pull requests
+
+\`\`\`bash
+lf ops pr create       # open PR from branch
+lf ops pr land         # merge PR
+lf ops pr land -a      # auto-merge when checks pass
+lf ops land            # local merge via worktrunk
+\`\`\`
+
+## Worktrees
+
+Loopflow uses worktrunk for worktree management:
+
+\`\`\`bash
+wt list                # show worktrees
+wt switch --create X   # create or switch
+wt remove X            # remove worktree + branch
+\`\`\`
+```
+
+## patterns.md
+
+Keep but trim to essentials:
+
+```markdown
+---
+layout: default
+title: Patterns
+---
+
+# Patterns
+
+## Design-first
+
+\`\`\`bash
+wt switch --create auth
+cd ../myrepo.auth
+lf design: add OAuth
+lf implement
+lf review
+\`\`\`
+
+## Parallel features
+
+\`\`\`bash
+cd ../myrepo.feature-a && lf ship &
+cd ../myrepo.feature-b && lf ship &
+lf ops status
+\`\`\`
+
+## Model comparison
+
+\`\`\`bash
+lf implement --parallel claude,codex: add caching
+# Creates two worktrees, runs both
+\`\`\`
+
+## Review-only
+
+\`\`\`bash
+lf review              # find issues
+lf review -a           # find and fix
+\`\`\`
+
+## Inline prompts
+
+\`\`\`bash
+lf : "fix the typo"
+lf : "add type hints to utils.py"
+\`\`\`
+```
+
+## Constraints
+
+- Don't duplicate info between pages—reference instead
+- Quick start must work with copy-paste (no placeholders)
+- Limitations before features (Stripe pattern)
+- Task file location is `.claude/commands/` first, not `.lf/`
+- Maestro is optional, CLI works without it
+- macOS only—be explicit
+
+## Done when
+
+```bash
+# Docs render locally
+cd docs && bundle exec jekyll serve
+
+# Quick start works from scratch
+pip install loopflow
+lf ops init
+lf review
+# Should work
+
+# Limitations page exists and loads
+open http://localhost:4000/limitations
+
+# All internal links resolve
+# No broken references to old structure
+```
+
+## Open questions
+
+None—structure is clear from research.

--- a/.design/onboarding.md
+++ b/.design/onboarding.md
@@ -1,148 +1,222 @@
 # Onboarding
 
-Improve the first-run experience for new loopflow users.
+Improve `lf ops init` to be a unified first-run experience.
 
 ## What to build
 
-A guided setup flow that helps users go from `pip install loopflow` to running their first task, with clear feedback at each step.
+Enhance `lf ops init` to check dependencies, offer to install missing ones, and scaffold the repo—all in one command. Users run one command to go from zero to ready.
 
-## Current state
+## Decisions
 
-Today's onboarding is manual:
-1. User installs loopflow
-2. User runs `lf ops install` (if they know to)
-3. User runs `lf ops init` to scaffold `.lf/`
-4. User runs a task like `lf review`
+Based on codebase exploration:
 
-Problems:
-- No feedback when dependencies are missing
-- No guidance on what to do next
-- `lf ops doctor` exists but users don't know to run it
+1. **Option B: Improved `lf ops init`** — The explicit approach. Don't intercept arbitrary commands (Option A adds complexity, can annoy experienced users). Don't just hint in help (Option C is too passive).
 
-## Proposed approach
+2. **Prompt before installing** — Ask "Install missing dependencies? [Y/n]" rather than auto-installing. Respects user control. Use `--yes` flag for CI/scripts.
 
-### Option A: First-run wizard
+3. **macOS only** — Fail gracefully with "macOS required" message on other platforms. Don't attempt partial support.
 
-When user runs any `lf` command and setup is incomplete, prompt them through setup:
+## Current state (from code)
 
-```
-$ lf review
-
-Welcome to loopflow! Let's get you set up.
-
-Checking dependencies...
-  ✓ Node.js
-  ✗ Claude Code — installing...
-  ✓ worktrunk
-  ✓ Warp
-  ✓ Cursor
-
-Initialize this repo? [Y/n]
-  ✓ Created .lf/config.yaml
-  ✓ Created .claude/commands/
-
-Ready! Running 'lf review'...
-```
-
-### Option B: Explicit init command
-
-Keep current behavior but improve `lf ops init`:
-
-```
-$ lf ops init
-
-Checking dependencies...
-  ✓ Node.js
-  ✗ Claude Code
-
-Some dependencies are missing. Install them? [Y/n]
-  Installing Claude Code...
-  ✓ Claude Code installed
-
-Creating .lf/ structure...
-  ✓ .lf/config.yaml
-  ✓ .claude/commands/review.md
-  ...
-
-Next steps:
-  1. Run 'lf design' to start a new feature
-  2. Or 'lf review' to review current changes
-```
-
-### Option C: Status-aware help
-
-`lf --help` detects missing setup and shows relevant guidance:
-
-```
-$ lf --help
-
-⚠️  Setup incomplete. Run 'lf ops init' to get started.
-
-Usage: lf [OPTIONS] COMMAND [ARGS]...
-...
-```
+- `init()` in `meta.py:63-150` scaffolds `.lf/` and `.claude/commands/`
+- `install()` in `meta.py:160-264` installs deps via Homebrew/npm
+- `doctor()` in `meta.py:266-327` checks what's installed
+- These are separate commands with no integration
 
 ## Data structures
 
 ```python
 @dataclass
 class SetupStatus:
-    """Current setup state for a repo."""
+    """What's installed and what's missing."""
+    node: bool
+    claude: bool
+    worktrunk: bool
+    warp: bool      # IDE, optional per config
+    cursor: bool    # IDE, optional per config
+    codex: bool     # optional
+    gemini: bool    # optional
     has_config: bool
     has_prompts: bool
-    dependencies: dict[str, bool]  # name -> installed
 
     @property
-    def is_complete(self) -> bool:
-        return (
-            self.has_config
-            and self.has_prompts
-            and all(self.dependencies.values())
-        )
+    def ready(self) -> bool:
+        """Can run tasks (required deps + repo setup)."""
+        return self.node and self.claude and self.worktrunk and self.has_config
 
-def check_setup(repo_root: Path) -> SetupStatus:
-    """Check what's configured and what's missing."""
+    @property
+    def missing_required(self) -> list[str]:
+        """Names of missing required dependencies."""
+        missing = []
+        if not self.node:
+            missing.append("node")
+        if not self.claude:
+            missing.append("claude")
+        if not self.worktrunk:
+            missing.append("worktrunk")
+        return missing
+```
+
+## Key functions
+
+```python
+def check_setup(repo_root: Path | None = None) -> SetupStatus:
+    """Check all dependencies and repo state. Fast (no network)."""
+    ...
+
+def run_init(
+    repo_root: Path,
+    install_deps: bool = True,
+    yes: bool = False,
+) -> SetupStatus:
+    """
+    Unified init flow:
+    1. Check dependencies
+    2. Offer to install missing (if install_deps and not yes, prompt)
+    3. Scaffold .lf/ and .claude/commands/
+    4. Print next steps
+    """
     ...
 ```
 
-## APIs
+## Changes to meta.py
+
+### Modify `init()` command
 
 ```python
-def check_setup(repo_root: Path | None) -> SetupStatus:
-    """Check setup status for repo (or globally if None)."""
-    ...
+@app.command()
+def init(
+    prompts: bool = typer.Option(False, "--prompts", help="Only install prompts"),
+    style: bool = typer.Option(False, "--style", help="Only install style guide"),
+    yes: bool = typer.Option(False, "--yes", "-y", help="Auto-confirm prompts"),
+):
+    """Initialize repo with loopflow. Checks deps, installs missing, scaffolds config."""
+    repo_root = find_worktree_root()
+    if not repo_root:
+        print("Not in a git repository")
+        raise typer.Exit(1)
 
-def run_setup(
-    repo_root: Path,
-    interactive: bool = True,
-    install_deps: bool = True,
-) -> SetupStatus:
-    """Run setup flow, optionally interactive."""
-    ...
+    # If specific flags, use existing behavior
+    if prompts or style:
+        _install_subset(repo_root, prompts=prompts, style=style)
+        return
+
+    # Full init flow
+    status = check_setup(repo_root)
+
+    # Show current state
+    _print_status(status)
+
+    # Handle missing deps
+    if status.missing_required:
+        if yes or typer.confirm("Install missing dependencies?", default=True):
+            _install_missing(status)
+            status = check_setup(repo_root)  # recheck
+        else:
+            print("\nRun 'lf ops install' to install dependencies manually.")
+            raise typer.Exit(1)
+
+    # Scaffold repo
+    _scaffold_repo(repo_root)
+
+    # Success message
+    print("\n✓ Ready! Try 'lf review' or 'lf design'")
+```
+
+### Add `check_setup()` function
+
+Reuse existing check logic from `doctor()`:
+
+```python
+def check_setup(repo_root: Path | None = None) -> SetupStatus:
+    """Check dependencies and repo state."""
+    return SetupStatus(
+        node=_check_available("npm"),
+        claude=check_claude_available(),
+        worktrunk=_check_available("wt"),
+        warp=_check_available("warp"),
+        cursor=_check_available("cursor"),
+        codex=check_codex_available(),
+        gemini=check_gemini_available(),
+        has_config=repo_root and (repo_root / ".lf" / "config.yaml").exists(),
+        has_prompts=repo_root and (repo_root / ".claude" / "commands").exists(),
+    )
+
+def _check_available(cmd: str) -> bool:
+    """Check if command exists (no --version call, just which)."""
+    return shutil.which(cmd) is not None
+```
+
+### Add `_print_status()` helper
+
+```python
+def _print_status(status: SetupStatus) -> None:
+    """Print dependency check results."""
+    print("Checking dependencies...")
+
+    def icon(ok: bool) -> str:
+        return "✓" if ok else "✗"
+
+    print(f"  {icon(status.node)} Node.js")
+    print(f"  {icon(status.claude)} Claude Code")
+    print(f"  {icon(status.worktrunk)} worktrunk")
+
+    if status.missing_required:
+        print(f"\nMissing: {', '.join(status.missing_required)}")
+```
+
+### Refactor `install()` to be callable
+
+Extract the install logic so `init` can call it:
+
+```python
+def _install_missing(status: SetupStatus) -> None:
+    """Install missing required dependencies."""
+    if not status.node:
+        _install_node()
+    if not status.claude:
+        _run(["npm", "install", "-g", "@anthropic-ai/claude-code"])
+    if not status.worktrunk:
+        _install_worktrunk()
 ```
 
 ## Constraints
 
-- macOS only (per README)
-- Should work without API keys (uses CLI subscriptions)
-- Don't block experienced users who know what they're doing
-- Keep it fast—don't check network on every command
+- macOS only—check `sys.platform` early, exit with message on other platforms
+- No network calls in `check_setup()`—just `shutil.which()` checks
+- Keep `install` and `doctor` commands working as before (don't break existing users)
+- `--yes` flag for non-interactive use
 
 ## Done when
 
 ```bash
-# Fresh repo, no prior setup
+# Fresh repo, no prior loopflow setup
 cd /tmp/test-repo && git init
-lf ops init
-# Shows dependency check, installs missing, creates .lf/
 
+# Single command does everything
+lf ops init
+# Output:
+# Checking dependencies...
+#   ✓ Node.js
+#   ✗ Claude Code
+#   ✓ worktrunk
+#
+# Missing: claude
+# Install missing dependencies? [Y/n] y
+#   Installing Claude Code...
+#   ✓ Claude Code installed
+#
+# Creating .lf/...
+#   ✓ .lf/config.yaml
+#   ✓ .claude/commands/
+#
+# ✓ Ready! Try 'lf review' or 'lf design'
+
+# Verify
 lf ops doctor
 # All green
 
-lf review
-# Runs without additional prompts
+# Non-interactive
+lf ops init --yes
+# Skips prompts, auto-installs
 ```
-
-## Open questions
-
-See `.design/questions.md`

--- a/.design/onboarding.md
+++ b/.design/onboarding.md
@@ -1,0 +1,148 @@
+# Onboarding
+
+Improve the first-run experience for new loopflow users.
+
+## What to build
+
+A guided setup flow that helps users go from `pip install loopflow` to running their first task, with clear feedback at each step.
+
+## Current state
+
+Today's onboarding is manual:
+1. User installs loopflow
+2. User runs `lf ops install` (if they know to)
+3. User runs `lf ops init` to scaffold `.lf/`
+4. User runs a task like `lf review`
+
+Problems:
+- No feedback when dependencies are missing
+- No guidance on what to do next
+- `lf ops doctor` exists but users don't know to run it
+
+## Proposed approach
+
+### Option A: First-run wizard
+
+When user runs any `lf` command and setup is incomplete, prompt them through setup:
+
+```
+$ lf review
+
+Welcome to loopflow! Let's get you set up.
+
+Checking dependencies...
+  ✓ Node.js
+  ✗ Claude Code — installing...
+  ✓ worktrunk
+  ✓ Warp
+  ✓ Cursor
+
+Initialize this repo? [Y/n]
+  ✓ Created .lf/config.yaml
+  ✓ Created .claude/commands/
+
+Ready! Running 'lf review'...
+```
+
+### Option B: Explicit init command
+
+Keep current behavior but improve `lf ops init`:
+
+```
+$ lf ops init
+
+Checking dependencies...
+  ✓ Node.js
+  ✗ Claude Code
+
+Some dependencies are missing. Install them? [Y/n]
+  Installing Claude Code...
+  ✓ Claude Code installed
+
+Creating .lf/ structure...
+  ✓ .lf/config.yaml
+  ✓ .claude/commands/review.md
+  ...
+
+Next steps:
+  1. Run 'lf design' to start a new feature
+  2. Or 'lf review' to review current changes
+```
+
+### Option C: Status-aware help
+
+`lf --help` detects missing setup and shows relevant guidance:
+
+```
+$ lf --help
+
+⚠️  Setup incomplete. Run 'lf ops init' to get started.
+
+Usage: lf [OPTIONS] COMMAND [ARGS]...
+...
+```
+
+## Data structures
+
+```python
+@dataclass
+class SetupStatus:
+    """Current setup state for a repo."""
+    has_config: bool
+    has_prompts: bool
+    dependencies: dict[str, bool]  # name -> installed
+
+    @property
+    def is_complete(self) -> bool:
+        return (
+            self.has_config
+            and self.has_prompts
+            and all(self.dependencies.values())
+        )
+
+def check_setup(repo_root: Path) -> SetupStatus:
+    """Check what's configured and what's missing."""
+    ...
+```
+
+## APIs
+
+```python
+def check_setup(repo_root: Path | None) -> SetupStatus:
+    """Check setup status for repo (or globally if None)."""
+    ...
+
+def run_setup(
+    repo_root: Path,
+    interactive: bool = True,
+    install_deps: bool = True,
+) -> SetupStatus:
+    """Run setup flow, optionally interactive."""
+    ...
+```
+
+## Constraints
+
+- macOS only (per README)
+- Should work without API keys (uses CLI subscriptions)
+- Don't block experienced users who know what they're doing
+- Keep it fast—don't check network on every command
+
+## Done when
+
+```bash
+# Fresh repo, no prior setup
+cd /tmp/test-repo && git init
+lf ops init
+# Shows dependency check, installs missing, creates .lf/
+
+lf ops doctor
+# All green
+
+lf review
+# Runs without additional prompts
+```
+
+## Open questions
+
+See `.design/questions.md`

--- a/.design/questions.md
+++ b/.design/questions.md
@@ -1,0 +1,30 @@
+# Open Questions
+
+Questions that need answers before implementation.
+
+## Scope
+
+1. **What does "onboarding" mean here?** I've assumed it's about improving the first-run experience. Is this correct, or is there a specific feature you have in mind?
+
+2. **Which option?** The design proposes three approaches:
+   - A: First-run wizard (intercepts any command)
+   - B: Improved `lf ops init` (explicit)
+   - C: Status-aware help (passive hints)
+
+   Which direction do you prefer?
+
+## Behavior
+
+3. **Should setup be automatic or prompted?** When dependencies are missing, should we:
+   - Automatically install them (current `lf ops install` behavior)
+   - Ask first ("Install missing dependencies? [Y/n]")
+   - Just report what's missing and tell them to run `lf ops install`
+
+4. **What about non-macOS?** Current code is macOS-only. Should onboarding:
+   - Fail gracefully with instructions for manual setup
+   - Try to work with whatever's available
+   - Something else
+
+## Context
+
+5. **Is there prior art or a specific workflow you're modeling?** Understanding what inspired this would help nail the UX.

--- a/.design/questions.md
+++ b/.design/questions.md
@@ -1,30 +1,3 @@
 # Open Questions
 
-Questions that need answers before implementation.
-
-## Scope
-
-1. **What does "onboarding" mean here?** I've assumed it's about improving the first-run experience. Is this correct, or is there a specific feature you have in mind?
-
-2. **Which option?** The design proposes three approaches:
-   - A: First-run wizard (intercepts any command)
-   - B: Improved `lf ops init` (explicit)
-   - C: Status-aware help (passive hints)
-
-   Which direction do you prefer?
-
-## Behavior
-
-3. **Should setup be automatic or prompted?** When dependencies are missing, should we:
-   - Automatically install them (current `lf ops install` behavior)
-   - Ask first ("Install missing dependencies? [Y/n]")
-   - Just report what's missing and tell them to run `lf ops install`
-
-4. **What about non-macOS?** Current code is macOS-only. Should onboarding:
-   - Fail gracefully with instructions for manual setup
-   - Try to work with whatever's available
-   - Something else
-
-## Context
-
-5. **Is there prior art or a specific workflow you're modeling?** Understanding what inspired this would help nail the UX.
+No open questions—decisions made in onboarding.md.

--- a/.lf/CHECKPOINT_MESSAGE.md
+++ b/.lf/CHECKPOINT_MESSAGE.md
@@ -1,0 +1,29 @@
+Generate a PR title and body for the changes on this branch.
+
+Review the diff against main and summarize what changed and why.
+
+## Output format
+
+Return a structured response with:
+- **title**: lowercase, with optional area prefix (e.g. `llm_http: add structured output`)
+- **body**: markdown with headers, code blocks for commands, and bullet lists
+
+## Title style
+
+Titles are lowercase and concise. Use an area prefix when changes are focused on a specific module or feature area. The area can be new or existing.
+
+Examples:
+- `llm_http: add structured output for pr messages`
+- `pr workflow: add -a flag to commit and push`
+- `fix worktree cleanup on branch delete`
+
+## Body style
+
+Use markdown headers to organize the body. Open with a "Usage" or "Try it" section showing commands in code blocks. Then explain what changed.
+
+Structure:
+1. **Usage section** (header + code block) - how to try it, run it, or see it in action
+2. **Summary** - one paragraph explaining what this PR does and why
+3. **Changes** (optional) - bullet list of notable changes if helpful
+
+Keep it medium length. Stay high-level; don't enumerate every file.

--- a/.lf/COMMIT_MESSAGE.md
+++ b/.lf/COMMIT_MESSAGE.md
@@ -1,0 +1,24 @@
+Generate a commit message for the changes on this branch.
+
+Review the diff and write a concise commit message.
+
+## Output format
+
+Return a structured response with:
+- **title**: lowercase, with optional area prefix (e.g. `llm_http: add structured output`)
+- **body**: brief explanation if needed, otherwise empty string
+
+## Title style
+
+Titles are lowercase and concise. Use an area prefix when changes are focused on a specific module or feature area.
+
+Examples:
+- `llm_http: add structured output for pr messages`
+- `pr workflow: add -a flag to commit and push`
+- `fix typo in readme`
+
+## Body style
+
+Keep it brief—one sentence or a few bullets if the change needs explanation. Empty string is fine for self-explanatory changes.
+
+Most commits don't need a body. Only add one if the "why" isn't obvious from the title.

--- a/.lf/LOOPFLOW_STYLE.md
+++ b/.lf/LOOPFLOW_STYLE.md
@@ -1,0 +1,130 @@
+# Style Guide
+
+This is the governing document for this codebase. Humans and LLMs alike are expected to follow it.
+
+## Quick Reference
+
+- Prefix private functions with `_`
+- Return `None` for "not found"; raise exceptions for "shouldn't happen"
+- No `Args:`/`Returns:` docstrings—if types are clear, skip the docstring
+- Mock side effects, but don't test mock wiring
+
+# Goals
+
+## Clarity
+
+Design around data structures and public APIs. Aim for a 1:1 mapping between real-world concepts and their representation in code.
+
+Write code that demonstrates its own correctness. If a feature exists, write a test that proves it works. Assume you won't finish everything you start—make it easy to see what's done and what's broken.
+
+## Simplicity
+
+Every line of code must earn its place. Readable code is not terse code; don't sacrifice clarity for brevity. But recognize that lines can be net-negative:
+
+* Unused code
+* Comments that restate the obvious
+* Checks for impossible conditions
+
+Start with minimal data structures and APIs. If the core is right, trimming excess at the edges is straightforward.
+
+# Code Organization
+
+Consistency with existing code matters more than any specific rule.
+
+Keep information in one place. Version numbers, configuration, documentation—each piece of information should have a single source of truth. Don't duplicate versions in multiple files. If something needs to appear in multiple places, generate it or reference the source.
+
+Put imports at the top of the file, not inline.
+
+Keep one implementation. Avoid `v2_`, `_old`, `_new`, `_backup` prefixes and suffixes—look up old versions in git. If you're tempted to keep both old and new code around, delete the old version and commit. You can always get it back from git if needed.
+
+Don't maintain backwards compatibility unless explicitly required. If a config format or API changes, migrate everything to the new format—don't write code that handles both old and new. Backwards compatibility is for production databases and published APIs with external users, not internal config files.
+
+## Naming
+
+Use verb-first names for action functions: `find_user()`, `load_config()`, `create_session()`.
+
+Prefix private functions with underscore: `_validate()`, `_parse_line()`.
+
+Name things after what they are, not what they're for: `Document`, `Session`, `Target`—not `DocumentHelper`, `SessionManager`, `OutputHandler`.
+
+## Error Handling
+
+Errors are for users; exceptions are for programmers.
+
+Return errors when the caller should handle them—invalid input, missing files, failed requests. Raise exceptions for bugs: violated invariants, impossible states, programming mistakes.
+
+```python
+# Error: caller decides what to do
+def find_config(path: Path) -> Optional[Config]:
+    if not path.exists():
+        return None
+    return load(path)
+
+# Exception: this shouldn't happen
+def get_target(name: str) -> Target:
+    if name not in TARGETS:
+        raise ValueError(f"Unknown target: {name}")
+    return TARGETS[name]
+```
+
+When in doubt: if you'd write an `assert`, raise an exception instead—it's easier for callers to catch.
+
+# Documentation
+
+The best documentation is simple code. Descriptive names, type hints, and clear APIs often suffice.
+
+The worst documentation is wrong documentation. If it can drift from the code, it will. Update docs when you change code—or delete them.
+
+Put documentation next to code. A few paragraphs at the top of a key file beats a separate doc that nobody maintains.
+
+Skip obvious docstrings. If the function name and types tell the whole story, don't repeat it in prose.
+
+# Testing
+
+Test user behavior, not implementation details. A good test proves that something users care about actually works. Most tests don't meet that bar. Delete them.
+
+Aim for a mix:
+- **Smoke tests**: Does the system run without crashing?
+- **Edge case tests**: What happens at boundaries?
+- **Value tests**: Does this feature do what users expect?
+
+## When to Mock
+
+Mock to isolate your code from things that shouldn't be part of unit tests:
+- **External systems**: Network calls, databases, file systems (when testing logic, not I/O)
+- **Side effects**: Sending emails, writing logs, spawning processes
+- **Slow operations**: Anything that would make tests take seconds instead of milliseconds
+
+Don't mock to verify internal wiring. If a test's assertions are just "did we call the mock with the right args?"—that's testing implementation, not behavior. The test will break when you refactor, even if the feature still works.
+
+```python
+# Bad: testing that we called the mock correctly
+def test_send_notification():
+    with patch("app.email.send") as mock_send:
+        notify_user(user)
+        mock_send.assert_called_once_with(user.email, ANY)
+
+# Good: mock the side effect, test the behavior
+def test_notify_user_returns_success():
+    with patch("app.email.send"):  # prevent actual email
+        result = notify_user(user)
+        assert result.success
+
+# Better: if possible, test without mocking
+def test_notification_message_format():
+    msg = build_notification(user)
+    assert user.name in msg.body
+```
+
+If a test requires elaborate mock setup, it's usually a sign that either:
+1. The code under test does too much (refactor it)
+2. You're testing implementation rather than behavior (test something else)
+3. This should be an integration test, not a unit test (move it)
+
+# Git
+
+Commit messages are documentation. Explain what changed and why, not line-by-line what you did.
+
+Keep messages short—one sentence to one paragraph.
+
+Do not add AI attribution footers like "Generated with Claude Code" or "Co-Authored-By: Claude" to commits. The git history should read the same whether written by a human or AI.

--- a/src/loopflow/cli/meta.py
+++ b/src/loopflow/cli/meta.py
@@ -36,17 +36,6 @@ class SetupStatus:
     node: bool
     claude: bool
     worktrunk: bool
-    warp: bool
-    cursor: bool
-    codex: bool
-    gemini: bool
-    has_config: bool
-    has_prompts: bool
-
-    @property
-    def ready(self) -> bool:
-        """Can run tasks (required deps + repo setup)."""
-        return self.node and self.claude and self.worktrunk and self.has_config
 
     @property
     def missing_required(self) -> list[str]:
@@ -61,18 +50,12 @@ class SetupStatus:
         return missing
 
 
-def check_setup(repo_root: Path | None = None) -> SetupStatus:
-    """Check all dependencies and repo state. Fast (no network)."""
+def check_setup() -> SetupStatus:
+    """Check required dependencies. Fast (no network)."""
     return SetupStatus(
         node=shutil.which("npm") is not None,
         claude=shutil.which("claude") is not None,
         worktrunk=shutil.which("wt") is not None,
-        warp=shutil.which("warp") is not None,
-        cursor=shutil.which("cursor") is not None,
-        codex=shutil.which("codex") is not None,
-        gemini=shutil.which("gemini") is not None,
-        has_config=repo_root is not None and (repo_root / ".lf" / "config.yaml").exists(),
-        has_prompts=repo_root is not None and (repo_root / ".claude" / "commands").exists(),
     )
 
 
@@ -274,14 +257,13 @@ def init(
         return
 
     # Full init flow
-    status = check_setup(repo_root)
+    status = check_setup()
     _print_setup_status(status)
 
     # Handle missing deps
     if status.missing_required:
         if yes or typer.confirm("Install missing dependencies?", default=True):
             _install_missing(status)
-            status = check_setup(repo_root)  # recheck
         else:
             typer.echo("\nRun 'lf ops install' to install dependencies manually.")
             raise typer.Exit(1)

--- a/src/loopflow/cli/meta.py
+++ b/src/loopflow/cli/meta.py
@@ -3,6 +3,8 @@
 import platform
 import shutil
 import subprocess
+import sys
+from dataclasses import dataclass
 from pathlib import Path
 
 import typer
@@ -12,6 +14,53 @@ from loopflow.context import find_worktree_root
 from loopflow.launcher import check_claude_available, check_codex_available, check_gemini_available
 
 app = typer.Typer(help="Setup and diagnostics.")
+
+
+@dataclass
+class SetupStatus:
+    """What's installed and what's missing."""
+
+    node: bool
+    claude: bool
+    worktrunk: bool
+    warp: bool
+    cursor: bool
+    codex: bool
+    gemini: bool
+    has_config: bool
+    has_prompts: bool
+
+    @property
+    def ready(self) -> bool:
+        """Can run tasks (required deps + repo setup)."""
+        return self.node and self.claude and self.worktrunk and self.has_config
+
+    @property
+    def missing_required(self) -> list[str]:
+        """Names of missing required dependencies."""
+        missing = []
+        if not self.node:
+            missing.append("node")
+        if not self.claude:
+            missing.append("claude")
+        if not self.worktrunk:
+            missing.append("worktrunk")
+        return missing
+
+
+def check_setup(repo_root: Path | None = None) -> SetupStatus:
+    """Check all dependencies and repo state. Fast (no network)."""
+    return SetupStatus(
+        node=shutil.which("npm") is not None,
+        claude=shutil.which("claude") is not None,
+        worktrunk=shutil.which("wt") is not None,
+        warp=shutil.which("warp") is not None,
+        cursor=shutil.which("cursor") is not None,
+        codex=shutil.which("codex") is not None,
+        gemini=shutil.which("gemini") is not None,
+        has_config=repo_root is not None and (repo_root / ".lf" / "config.yaml").exists(),
+        has_prompts=repo_root is not None and (repo_root / ".claude" / "commands").exists(),
+    )
 
 
 def _install_node() -> bool:
@@ -60,31 +109,121 @@ def _install_worktrunk() -> bool:
     return False
 
 
-@app.command()
-def init(
-    prompts_only: bool = typer.Option(False, "--prompts", help="Only install prompts"),
-    style_only: bool = typer.Option(False, "--style", help="Only install style guide"),
-):
-    """Initialize a repository with loopflow prompts, style guide, and config."""
-    repo_root = find_worktree_root()
-    if not repo_root:
-        typer.echo("Error: Not in a git repository", err=True)
-        raise typer.Exit(1)
+def _print_setup_status(status: SetupStatus) -> None:
+    """Print dependency check results."""
+    typer.echo("Checking dependencies...")
 
-    # Determine what to install
-    install_prompts = prompts_only or not style_only
-    install_style = style_only or not prompts_only
-    install_config = not prompts_only and not style_only
+    def icon(ok: bool) -> str:
+        return "✓" if ok else "✗"
 
-    # Get bundled assets path
+    typer.echo(f"  {icon(status.node)} Node.js")
+    typer.echo(f"  {icon(status.claude)} Claude Code")
+    typer.echo(f"  {icon(status.worktrunk)} worktrunk")
+
+    if status.missing_required:
+        typer.echo(f"\nMissing: {', '.join(status.missing_required)}")
+
+
+def _install_missing(status: SetupStatus) -> None:
+    """Install missing required dependencies."""
+    if not status.node:
+        typer.echo("  Installing Node.js...")
+        if _install_node() and shutil.which("npm"):
+            typer.echo("  ✓ Node.js installed")
+        else:
+            typer.echo("  ✗ Could not install Node.js", err=True)
+            raise typer.Exit(1)
+
+    if not status.claude:
+        typer.echo("  Installing Claude Code...")
+        result = subprocess.run(
+            ["npm", "install", "-g", "@anthropic-ai/claude-code"],
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode == 0:
+            typer.echo("  ✓ Claude Code installed")
+        else:
+            typer.echo(f"  ✗ Could not install Claude Code: {result.stderr}", err=True)
+            raise typer.Exit(1)
+
+    if not status.worktrunk:
+        typer.echo("  Installing worktrunk...")
+        if _install_worktrunk() and shutil.which("wt"):
+            typer.echo("  ✓ worktrunk installed")
+        else:
+            typer.echo("  ✗ Could not install worktrunk", err=True)
+            raise typer.Exit(1)
+
+
+def _scaffold_repo(repo_root: Path) -> None:
+    """Create .lf/ config and .claude/commands/ prompts."""
     bundled_dir = Path(__file__).parent.parent
     commands_src = bundled_dir / "commands"
     prompts_dir = bundled_dir / "prompts"
     style_template = bundled_dir / "LOOPFLOW_STYLE.md"
     config_template = bundled_dir / "config_template.yaml"
 
-    # Install prompts to .claude/commands/ (accessible via raw claude too)
-    if install_prompts:
+    typer.echo("\nCreating .lf/...")
+
+    # Config
+    config_dir = repo_root / ".lf"
+    config_dir.mkdir(exist_ok=True)
+    config_dst = config_dir / "config.yaml"
+
+    if config_dst.exists():
+        typer.echo("  - .lf/config.yaml (already exists)")
+    else:
+        shutil.copy(config_template, config_dst)
+        typer.echo("  ✓ .lf/config.yaml")
+
+    # Style guide
+    style_dst = config_dir / "LOOPFLOW_STYLE.md"
+    if style_dst.exists():
+        typer.echo("  - .lf/LOOPFLOW_STYLE.md (already exists)")
+    else:
+        shutil.copy(style_template, style_dst)
+        typer.echo("  ✓ .lf/LOOPFLOW_STYLE.md")
+
+    # Commit templates
+    for template_name in ["COMMIT_MESSAGE.md", "CHECKPOINT_MESSAGE.md"]:
+        src = prompts_dir / template_name
+        dst = config_dir / template_name
+        if dst.exists():
+            typer.echo(f"  - .lf/{template_name} (already exists)")
+        else:
+            shutil.copy(src, dst)
+            typer.echo(f"  ✓ .lf/{template_name}")
+
+    # Prompts
+    commands_dir = repo_root / ".claude" / "commands"
+    commands_dir.mkdir(parents=True, exist_ok=True)
+    typer.echo("  ✓ .claude/commands/")
+
+    for prompt_name in [
+        "review.md",
+        "implement.md",
+        "design.md",
+        "polish.md",
+        "debug.md",
+        "publish.md",
+        "iterate.md",
+        "expand.md",
+        "reduce.md",
+    ]:
+        src = commands_src / prompt_name
+        dst = commands_dir / prompt_name
+        if not dst.exists():
+            shutil.copy(src, dst)
+
+
+def _install_subset(repo_root: Path, prompts: bool, style: bool) -> None:
+    """Install just prompts or style guide (legacy behavior for --prompts/--style flags)."""
+    bundled_dir = Path(__file__).parent.parent
+    commands_src = bundled_dir / "commands"
+    style_template = bundled_dir / "LOOPFLOW_STYLE.md"
+
+    if prompts:
         commands_dir = repo_root / ".claude" / "commands"
         commands_dir.mkdir(parents=True, exist_ok=True)
 
@@ -108,8 +247,7 @@ def init(
                 shutil.copy(src, dst)
                 typer.echo(f"✓ Created .claude/commands/{prompt_name}")
 
-    # Install style guide to .lf/ (only included in lf sessions, not raw claude/codex)
-    if install_style:
+    if style:
         lf_dir = repo_root / ".lf"
         lf_dir.mkdir(exist_ok=True)
         style_dst = lf_dir / "LOOPFLOW_STYLE.md"
@@ -119,34 +257,47 @@ def init(
             shutil.copy(style_template, style_dst)
             typer.echo("✓ Created .lf/LOOPFLOW_STYLE.md")
 
-    # Install config
-    if install_config:
-        config_dir = repo_root / ".lf"
-        config_dir.mkdir(exist_ok=True)
-        config_dst = config_dir / "config.yaml"
 
-        if config_dst.exists():
-            typer.echo("- .lf/config.yaml (already exists)")
+@app.command()
+def init(
+    prompts_only: bool = typer.Option(False, "--prompts", help="Only install prompts"),
+    style_only: bool = typer.Option(False, "--style", help="Only install style guide"),
+    yes: bool = typer.Option(False, "--yes", "-y", help="Auto-confirm prompts"),
+):
+    """Initialize repo with loopflow. Checks deps, installs missing, scaffolds config."""
+    # macOS only
+    if sys.platform != "darwin":
+        typer.echo("Error: loopflow requires macOS", err=True)
+        raise typer.Exit(1)
+
+    repo_root = find_worktree_root()
+    if not repo_root:
+        typer.echo("Error: Not in a git repository", err=True)
+        raise typer.Exit(1)
+
+    # If specific flags, use subset behavior
+    if prompts_only or style_only:
+        _install_subset(repo_root, prompts=prompts_only, style=style_only)
+        return
+
+    # Full init flow
+    status = check_setup(repo_root)
+    _print_setup_status(status)
+
+    # Handle missing deps
+    if status.missing_required:
+        if yes or typer.confirm("Install missing dependencies?", default=True):
+            _install_missing(status)
+            status = check_setup(repo_root)  # recheck
         else:
-            shutil.copy(config_template, config_dst)
-            typer.echo("✓ Created .lf/config.yaml")
+            typer.echo("\nRun 'lf ops install' to install dependencies manually.")
+            raise typer.Exit(1)
 
-        for template_name in ["COMMIT_MESSAGE.md", "CHECKPOINT_MESSAGE.md"]:
-            src = prompts_dir / template_name
-            dst = config_dir / template_name
+    # Scaffold repo
+    _scaffold_repo(repo_root)
 
-            if dst.exists():
-                typer.echo(f"- .lf/{template_name} (already exists)")
-            else:
-                shutil.copy(src, dst)
-                typer.echo(f"✓ Created .lf/{template_name}")
-
-    if install_prompts and not prompts_only:
-        typer.echo("\nYou can now use:")
-        typer.echo("  lf design        # or: claude /design")
-        typer.echo("  lf implement")
-        typer.echo("  lf review")
-        typer.echo("  lf polish")
+    # Success message
+    typer.echo("\n✓ Ready! Try 'lf review' or 'lf design'")
 
 
 @app.command()

--- a/src/loopflow/cli/meta.py
+++ b/src/loopflow/cli/meta.py
@@ -15,6 +15,19 @@ from loopflow.launcher import check_claude_available, check_codex_available, che
 
 app = typer.Typer(help="Setup and diagnostics.")
 
+# Prompts installed by `lf ops init`
+_BUNDLED_PROMPTS = [
+    "review.md",
+    "implement.md",
+    "design.md",
+    "polish.md",
+    "debug.md",
+    "publish.md",
+    "iterate.md",
+    "expand.md",
+    "reduce.md",
+]
+
 
 @dataclass
 class SetupStatus:
@@ -200,17 +213,7 @@ def _scaffold_repo(repo_root: Path) -> None:
     commands_dir.mkdir(parents=True, exist_ok=True)
     typer.echo("  ✓ .claude/commands/")
 
-    for prompt_name in [
-        "review.md",
-        "implement.md",
-        "design.md",
-        "polish.md",
-        "debug.md",
-        "publish.md",
-        "iterate.md",
-        "expand.md",
-        "reduce.md",
-    ]:
+    for prompt_name in _BUNDLED_PROMPTS:
         src = commands_src / prompt_name
         dst = commands_dir / prompt_name
         if not dst.exists():
@@ -227,17 +230,7 @@ def _install_subset(repo_root: Path, prompts: bool, style: bool) -> None:
         commands_dir = repo_root / ".claude" / "commands"
         commands_dir.mkdir(parents=True, exist_ok=True)
 
-        for prompt_name in [
-            "review.md",
-            "implement.md",
-            "design.md",
-            "polish.md",
-            "debug.md",
-            "publish.md",
-            "iterate.md",
-            "expand.md",
-            "reduce.md",
-        ]:
+        for prompt_name in _BUNDLED_PROMPTS:
             src = commands_src / prompt_name
             dst = commands_dir / prompt_name
 


### PR DESCRIPTION
# Try it

```bash
# From a fresh repo (no prior loopflow setup)
cd your-repo
lf ops init

# Single command now checks deps, offers to install missing ones, and scaffolds config
# Output shows what's installed/missing, prompts to install, then creates .lf/ and .claude/
```

## Summary

Enhances `lf ops init` to be a unified first-run experience. Instead of requiring separate `lf ops install` and `lf ops init` commands, the new init flow checks dependencies, offers to install missing ones, and scaffolds the repo—all in one command. Users can go from zero to ready with a single command.

## Changes

- Add `SetupStatus` dataclass and `check_setup()` to assess what's installed
- Add `_print_setup_status()` to show dependency check results with ✓/✗ icons
- Add `_install_missing()` to install required deps (node, claude, worktrunk)
- Enhance `init()` command to run full dependency check + install flow by default
- Add `--yes` flag for non-interactive use (CI/scripts)
- Preserve existing `--prompts`/`--style` behavior for subset installs
- Add macOS-only check with clear error message on other platforms
- Create design docs outlining the enhanced onboarding experience