### PR TITLE
maestro: live update on worktree events, main branch protection

### DIFF
--- a/.design/liveupdate.md
+++ b/.design/liveupdate.md
@@ -1,0 +1,215 @@
+# Live Update
+
+## What to build
+
+Enhance Maestro SwiftUI app with live-refreshing worktree list and main branch protection.
+
+**Location**: `loopflow.uiexplorations/Maestro/` (SwiftUI macOS app)
+
+## User quotes
+
+> "as soon as the wt remove happens we should somehow notify the maestro app, probably via lfd"
+
+> "it's a little more robust to react to wt than lf since users could invoke wt manually"
+
+> "the app is hierarchical, and the prompter is basically 'inside' the worktree, so which files specifically we are parsing is well defined"
+
+> "the frontmatter is for `lf x` but the user's toggle should just override the default. However we can use the frontmatter to set the initial selection"
+
+## Existing Architecture
+
+```
+Maestro/Maestro/
+├── Views/
+│   ├── WorktreeSidebar.swift    ← left panel, worktree list
+│   ├── PromptLauncher.swift     ← right panel, task selection + run
+│   └── ...
+├── Models/
+│   ├── Worktree.swift           ← worktree data model
+│   └── PromptCard.swift         ← task with defaultMode
+├── Services/
+│   ├── WorktreeService.swift    ← calls `wt list`
+│   └── TerminalLauncher.swift   ← AppleScript to terminals
+└── AppState.swift               ← central state, runMode, selectedWorktree
+```
+
+**PromptLauncher** already:
+- Has task selector with `defaultMode` from frontmatter
+- Has Auto/Interactive segmented control bound to `appState.runMode`
+- Builds command with explicit `-a`/`-i` via `appState.buildCommand()`
+- Launches via `TerminalLauncher`
+
+## Main Branch Protection
+
+Never run prompts directly in main. When main is selected:
+
+1. User clicks Run
+2. Generate random worktree name from magical/musical words
+3. Create worktree: `wt switch --create <random-name>`
+4. Launch task in new worktree
+5. UI refreshes worktree list, selects new worktree
+
+```swift
+// Maestro/Maestro/Services/NameGenerator.swift
+let magicalWords = ["aurora", "cascade", "drift", "echo", "flume", "grove", ...]
+let musicalWords = ["allegro", "cadence", "forte", "harmony", "lyric", "tempo", ...]
+
+func generateWorktreeName() -> String {
+    let magical = magicalWords.randomElement()!
+    let musical = musicalWords.randomElement()!
+    return "\(magical)-\(musical)"
+}
+```
+
+**In PromptLauncher.launchInTerminal():**
+```swift
+// Check if launching from main
+if appState.selectedWorktree == nil || appState.selectedWorktree?.branch == "main" {
+    let name = generateWorktreeName()
+    try await appState.createWorktree(name: name)
+    // Select the new worktree
+    appState.selectedWorktree = appState.worktrees.first { $0.branch == name }
+}
+// Then launch...
+```
+
+## Changes Required
+
+### 1. Live worktree refresh (WorktreeSidebar.swift)
+
+Currently `appState.refreshWorktrees()` is called manually. Need to poll or subscribe to changes.
+
+**Option A: Poll** (simplest)
+```swift
+// In WorktreeSidebar or AppState
+.task {
+    while !Task.isCancelled {
+        await appState.refreshWorktrees()
+        try? await Task.sleep(for: .seconds(2))
+    }
+}
+```
+
+**Option B: File system events** (FSEvents)
+Watch for changes to worktree directories.
+
+**Option C: lfd subscription** (requires Python changes)
+Connect to lfd Unix socket, subscribe to `worktree.*` events.
+
+### 2. Main branch protection (PromptLauncher.swift)
+
+Add to `launchInTerminal()`:
+```swift
+private func launchInTerminal() async {
+    guard let repo = appState.currentRepo else { return }
+
+    // Main branch protection
+    let isMain = appState.selectedWorktree?.branch == "main"
+              || appState.selectedWorktree == nil
+
+    var workPath: URL
+    if isMain {
+        let name = NameGenerator.generate()
+        do {
+            try await appState.createWorktree(name: name)
+            await appState.refreshWorktrees()
+            appState.selectedWorktree = appState.worktrees.first { $0.branch == name }
+            workPath = URL(fileURLWithPath: appState.selectedWorktree!.path)
+        } catch {
+            launchError = error.localizedDescription
+            showingLaunchError = true
+            return
+        }
+    } else {
+        workPath = URL(fileURLWithPath: appState.selectedWorktree!.path)
+    }
+
+    // Rest of launch logic...
+}
+```
+
+### 3. Name generator (new file)
+
+```swift
+// Maestro/Maestro/Services/NameGenerator.swift
+enum NameGenerator {
+    static let magical = [
+        "aurora", "cascade", "crystal", "drift", "echo", "ember",
+        "fern", "flume", "frost", "glade", "grove", "haze",
+        "ivy", "jade", "luna", "mist", "nova", "opal",
+        "petal", "prism", "rain", "ripple", "sage", "shade",
+        "spark", "star", "stone", "storm", "tide", "vale",
+        "wave", "wisp", "wren", "zephyr"
+    ]
+
+    static let musical = [
+        "allegro", "aria", "ballad", "cadence", "canon", "chord",
+        "coda", "duet", "forte", "fugue", "harmony", "hymn",
+        "lilt", "lyric", "melody", "motif", "opus", "prelude",
+        "refrain", "rondo", "sonata", "tempo", "trill", "tune",
+        "verse", "waltz"
+    ]
+
+    static func generate() -> String {
+        let m = magical.randomElement()!
+        let n = musical.randomElement()!
+        return "\(m)-\(n)"
+    }
+}
+```
+
+## Launch flow (already works)
+
+```
+1. User selects worktree in sidebar
+2. User selects task → appState.runMode = prompt.defaultMode
+3. User may flip Auto/Interactive toggle
+4. User clicks Run:
+   - If main: create new worktree with random name, refresh, select it
+   - Launch: `lf <task> -a` or `lf <task> -i` (explicit flag)
+```
+
+The `-a`/`-i` flag is already explicit in `buildCommand()`.
+
+## Live updates (optional enhancement)
+
+**Option A: Simple polling** in WorktreeSidebar
+- Poll every 2 seconds
+- Minimal code change
+- Good enough for now
+
+**Option B: worktrunk hooks + lfd** (future)
+User hook in `~/.config/worktrunk/config.toml`:
+```toml
+[pre-remove]
+notify = "lf notify worktree-changed removed '{{ worktree_path }}' '{{ branch }}' || true"
+```
+Then Maestro subscribes to lfd socket for instant updates.
+
+## Constraints
+
+- **Never run in main**: Launching from main creates a new worktree first
+- **Explicit flags**: `buildCommand()` already passes `-a` or `-i`
+- **Worktree-scoped**: Tasks come from selected worktree's `.lf/`
+
+## Open questions
+
+1. Polling interval for live refresh? (2s feels responsive, 5s is lighter)
+2. Should we add FSEvents watching instead of polling?
+
+## Done when
+
+```
+# 1. Worktree list updates after wt remove
+wt remove some-feature
+# → Within 2-5 seconds, Maestro UI removes it from sidebar
+
+# 2. Auto/Interactive toggle already works
+# (verify: select task, check toggle matches defaultMode, flip it, run, see correct flag)
+
+# 3. Main branch protection
+# In Maestro: no worktree selected (or main selected) → select task → click Run
+# → New worktree created (e.g., "aurora-cadence")
+# → Sidebar shows new worktree, selected
+# → Task runs in new worktree
+```

--- a/.design/liveupdate.md
+++ b/.design/liveupdate.md
@@ -2,9 +2,11 @@
 
 ## What to build
 
-Enhance Maestro SwiftUI app with live-refreshing worktree list and main branch protection.
+Enhance Maestro SwiftUI app with live-refreshing worktree list via push notifications from lfd, plus main branch protection.
 
-**Location**: `loopflow.uiexplorations/Maestro/` (SwiftUI macOS app)
+**Location**:
+- `Maestro/` (SwiftUI macOS app)
+- `src/loopflow/lfd/` (daemon additions)
 
 ## User quotes
 
@@ -12,204 +14,263 @@ Enhance Maestro SwiftUI app with live-refreshing worktree list and main branch p
 
 > "it's a little more robust to react to wt than lf since users could invoke wt manually"
 
-> "the app is hierarchical, and the prompter is basically 'inside' the worktree, so which files specifically we are parsing is well defined"
+> "Why are we using polling vs push notifications? I think its good to respond to wt generally, but doesnt wt have hooks?"
 
-> "the frontmatter is for `lf x` but the user's toggle should just override the default. However we can use the frontmatter to set the initial selection"
-
-## Existing Architecture
+## Architecture
 
 ```
-Maestro/Maestro/
-├── Views/
-│   ├── WorktreeSidebar.swift    ← left panel, worktree list
-│   ├── PromptLauncher.swift     ← right panel, task selection + run
-│   └── ...
-├── Models/
-│   ├── Worktree.swift           ← worktree data model
-│   └── PromptCard.swift         ← task with defaultMode
-├── Services/
-│   ├── WorktreeService.swift    ← calls `wt list`
-│   └── TerminalLauncher.swift   ← AppleScript to terminals
-└── AppState.swift               ← central state, runMode, selectedWorktree
+┌─────────────────┐    post-create     ┌─────────────────┐
+│   worktrunk     │ ─────────────────► │  lfd notify     │
+│   (wt switch)   │    pre-remove      │  CLI command    │
+└─────────────────┘                    └────────┬────────┘
+                                                │
+                                                ▼
+                                       ┌─────────────────┐
+                                       │   lfd daemon    │
+                                       │  Unix socket    │
+                                       │  ~/.lf/lfd.sock │
+                                       └────────┬────────┘
+                                                │ broadcast
+                                                ▼
+                                       ┌─────────────────┐
+                                       │    Maestro      │
+                                       │  (subscribed)   │
+                                       └─────────────────┘
 ```
 
-**PromptLauncher** already:
-- Has task selector with `defaultMode` from frontmatter
-- Has Auto/Interactive segmented control bound to `appState.runMode`
-- Builds command with explicit `-a`/`-i` via `appState.buildCommand()`
-- Launches via `TerminalLauncher`
+## Data structures
 
-## Main Branch Protection
+### lfd protocol (existing)
 
-Never run prompts directly in main. When main is selected:
-
-1. User clicks Run
-2. Generate random worktree name from magical/musical words
-3. Create worktree: `wt switch --create <random-name>`
-4. Launch task in new worktree
-5. UI refreshes worktree list, selects new worktree
-
-```swift
-// Maestro/Maestro/Services/NameGenerator.swift
-let magicalWords = ["aurora", "cascade", "drift", "echo", "flume", "grove", ...]
-let musicalWords = ["allegro", "cadence", "forte", "harmony", "lyric", "tempo", ...]
-
-func generateWorktreeName() -> String {
-    let magical = magicalWords.randomElement()!
-    let musical = musicalWords.randomElement()!
-    return "\(magical)-\(musical)"
-}
+```python
+# src/loopflow/lfd/protocol.py (existing)
+@dataclass
+class Event:
+    event: str          # e.g. "worktree.created"
+    data: dict[str, Any]
 ```
 
-**In PromptLauncher.launchInTerminal():**
-```swift
-// Check if launching from main
-if appState.selectedWorktree == nil || appState.selectedWorktree?.branch == "main" {
-    let name = generateWorktreeName()
-    try await appState.createWorktree(name: name)
-    // Select the new worktree
-    appState.selectedWorktree = appState.worktrees.first { $0.branch == name }
-}
-// Then launch...
+### Worktree events (new)
+
+```python
+# Event types
+Event("worktree.created", {"branch": "feature-x", "path": "/path/to/worktree"})
+Event("worktree.removed", {"branch": "feature-x"})
 ```
 
-## Changes Required
+## Key functions
 
-### 1. Live worktree refresh (WorktreeSidebar.swift)
+### 1. lfd server: add `notify` method
 
-Currently `appState.refreshWorktrees()` is called manually. Need to poll or subscribe to changes.
+```python
+# src/loopflow/lfd/server.py
 
-**Option A: Poll** (simplest)
-```swift
-// In WorktreeSidebar or AppState
-.task {
-    while !Task.isCancelled {
-        await appState.refreshWorktrees()
-        try? await Task.sleep(for: .seconds(2))
-    }
-}
+async def _handle_notify(self, params: dict) -> Response:
+    """Accept external events and broadcast to subscribers."""
+    event_name = params.get("event")
+    event_data = params.get("data", {})
+
+    if not event_name:
+        return error("Missing 'event' parameter")
+
+    await self._broadcast(Event(event_name, event_data))
+    return success({"event": event_name})
 ```
 
-**Option B: File system events** (FSEvents)
-Watch for changes to worktree directories.
-
-**Option C: lfd subscription** (requires Python changes)
-Connect to lfd Unix socket, subscribe to `worktree.*` events.
-
-### 2. Main branch protection (PromptLauncher.swift)
-
-Add to `launchInTerminal()`:
-```swift
-private func launchInTerminal() async {
-    guard let repo = appState.currentRepo else { return }
-
-    // Main branch protection
-    let isMain = appState.selectedWorktree?.branch == "main"
-              || appState.selectedWorktree == nil
-
-    var workPath: URL
-    if isMain {
-        let name = NameGenerator.generate()
-        do {
-            try await appState.createWorktree(name: name)
-            await appState.refreshWorktrees()
-            appState.selectedWorktree = appState.worktrees.first { $0.branch == name }
-            workPath = URL(fileURLWithPath: appState.selectedWorktree!.path)
-        } catch {
-            launchError = error.localizedDescription
-            showingLaunchError = true
-            return
-        }
-    } else {
-        workPath = URL(fileURLWithPath: appState.selectedWorktree!.path)
-    }
-
-    // Rest of launch logic...
-}
+Add to `_dispatch()`:
+```python
+elif method == "notify":
+    return await self._handle_notify(params)
 ```
 
-### 3. Name generator (new file)
+### 2. lfd CLI: add `notify` command
 
-```swift
-// Maestro/Maestro/Services/NameGenerator.swift
-enum NameGenerator {
-    static let magical = [
-        "aurora", "cascade", "crystal", "drift", "echo", "ember",
-        "fern", "flume", "frost", "glade", "grove", "haze",
-        "ivy", "jade", "luna", "mist", "nova", "opal",
-        "petal", "prism", "rain", "ripple", "sage", "shade",
-        "spark", "star", "stone", "storm", "tide", "vale",
-        "wave", "wisp", "wren", "zephyr"
-    ]
+```python
+# src/loopflow/lfd/__init__.py
 
-    static let musical = [
-        "allegro", "aria", "ballad", "cadence", "canon", "chord",
-        "coda", "duet", "forte", "fugue", "harmony", "hymn",
-        "lilt", "lyric", "melody", "motif", "opus", "prelude",
-        "refrain", "rondo", "sonata", "tempo", "trill", "tune",
-        "verse", "waltz"
-    ]
+@app.command()
+def notify(
+    event: str = typer.Argument(help="Event name (e.g. worktree.created)"),
+    branch: str = typer.Option(None, "--branch", "-b", help="Branch name"),
+    path: str = typer.Option(None, "--path", "-p", help="Worktree path"),
+):
+    """Send an event to lfd for broadcast to subscribers."""
+    if not is_running():
+        return  # Silently fail if daemon not running
 
-    static func generate() -> String {
-        let m = magical.randomElement()!
-        let n = musical.randomElement()!
-        return "\(m)-\(n)"
-    }
-}
+    data = {}
+    if branch:
+        data["branch"] = branch
+    if path:
+        data["path"] = path
+
+    client = DaemonClient()
+    try:
+        asyncio.run(client.call("notify", {"event": event, "data": data}))
+    except Exception:
+        pass  # Best effort - don't fail hooks
 ```
 
-## Launch flow (already works)
+### 3. worktrunk user hooks
 
-```
-1. User selects worktree in sidebar
-2. User selects task → appState.runMode = prompt.defaultMode
-3. User may flip Auto/Interactive toggle
-4. User clicks Run:
-   - If main: create new worktree with random name, refresh, select it
-   - Launch: `lf <task> -a` or `lf <task> -i` (explicit flag)
-```
-
-The `-a`/`-i` flag is already explicit in `buildCommand()`.
-
-## Live updates (optional enhancement)
-
-**Option A: Simple polling** in WorktreeSidebar
-- Poll every 2 seconds
-- Minimal code change
-- Good enough for now
-
-**Option B: worktrunk hooks + lfd** (future)
-User hook in `~/.config/worktrunk/config.toml`:
 ```toml
+# ~/.config/worktrunk/config.toml
+
+[post-create]
+lfd-notify = "lfd notify worktree.created --branch '{{ branch }}' --path '{{ worktree_path }}'"
+
 [pre-remove]
-notify = "lf notify worktree-changed removed '{{ worktree_path }}' '{{ branch }}' || true"
+lfd-notify = "lfd notify worktree.removed --branch '{{ branch }}'"
 ```
-Then Maestro subscribes to lfd socket for instant updates.
+
+### 4. Maestro: LFDEventService
+
+```swift
+// Maestro/Maestro/Services/LFDEventService.swift
+
+import Foundation
+import Network
+
+actor LFDEventService {
+    private var connection: NWConnection?
+    private let socketPath = FileManager.default.homeDirectoryForCurrentUser
+        .appendingPathComponent(".lf/lfd.sock")
+
+    func subscribe(
+        to patterns: [String],
+        onEvent: @escaping (String, [String: Any]) -> Void
+    ) async throws {
+        let params = NWParameters()
+        let endpoint = NWEndpoint.unix(path: socketPath.path)
+        connection = NWConnection(to: endpoint, using: params)
+
+        connection?.start(queue: .main)
+
+        // Send subscribe request
+        let request = """
+        {"method":"subscribe","params":{"events":\(patterns)}}
+
+        """
+        connection?.send(content: request.data(using: .utf8), completion: .idempotent)
+
+        // Read events
+        receiveLoop(onEvent: onEvent)
+    }
+
+    private func receiveLoop(onEvent: @escaping (String, [String: Any]) -> Void) {
+        connection?.receive(minimumIncompleteLength: 1, maximumLength: 65536) { [weak self] data, _, _, _ in
+            if let data = data,
+               let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+               let event = json["event"] as? String,
+               let eventData = json["data"] as? [String: Any] {
+                onEvent(event, eventData)
+            }
+            self?.receiveLoop(onEvent: onEvent)
+        }
+    }
+
+    func disconnect() {
+        connection?.cancel()
+        connection = nil
+    }
+}
+```
+
+### 5. Maestro: integrate in AppState
+
+```swift
+// Maestro/Maestro/AppState.swift
+
+@MainActor
+@Observable
+final class AppState {
+    // ... existing properties ...
+
+    private var eventService: LFDEventService?
+
+    func startEventSubscription() {
+        eventService = LFDEventService()
+
+        Task {
+            try? await eventService?.subscribe(to: ["worktree.*"]) { [weak self] event, data in
+                Task { @MainActor in
+                    self?.handleWorktreeEvent(event, data: data)
+                }
+            }
+        }
+    }
+
+    private func handleWorktreeEvent(_ event: String, data: [String: Any]) {
+        // Refresh worktree list on any worktree event
+        Task {
+            await refreshWorktrees()
+        }
+    }
+}
+```
+
+### 6. Remove polling from WorktreeSidebar
+
+```swift
+// Maestro/Maestro/Views/WorktreeSidebar.swift
+
+// DELETE this .task block:
+// .task {
+//     while !Task.isCancelled {
+//         await appState.refreshWorktrees()
+//         try? await Task.sleep(for: .seconds(2))
+//     }
+// }
+```
+
+## Main branch protection (already implemented)
+
+When main is selected and user clicks Run:
+1. Generate random name from magical/musical words
+2. Create worktree via `wt switch --create`
+3. Refresh worktree list (will get push notification)
+4. Select new worktree
+5. Launch task
 
 ## Constraints
 
-- **Never run in main**: Launching from main creates a new worktree first
-- **Explicit flags**: `buildCommand()` already passes `-a` or `-i`
-- **Worktree-scoped**: Tasks come from selected worktree's `.lf/`
-
-## Open questions
-
-1. Polling interval for live refresh? (2s feels responsive, 5s is lighter)
-2. Should we add FSEvents watching instead of polling?
+- **Silent failures**: `lfd notify` must not fail worktrunk hooks - catch all errors
+- **No daemon = no events**: If lfd isn't running, Maestro won't get updates (acceptable)
+- **Idempotent refresh**: Multiple events may arrive close together; `refreshWorktrees()` should be debounced or idempotent
 
 ## Done when
 
-```
-# 1. Worktree list updates after wt remove
-wt remove some-feature
-# → Within 2-5 seconds, Maestro UI removes it from sidebar
+```bash
+# 1. Setup worktrunk hooks
+cat >> ~/.config/worktrunk/config.toml << 'EOF'
+[post-create]
+lfd-notify = "lfd notify worktree.created --branch '{{ branch }}' --path '{{ worktree_path }}'"
 
-# 2. Auto/Interactive toggle already works
-# (verify: select task, check toggle matches defaultMode, flip it, run, see correct flag)
+[pre-remove]
+lfd-notify = "lfd notify worktree.removed --branch '{{ branch }}'"
+EOF
 
-# 3. Main branch protection
-# In Maestro: no worktree selected (or main selected) → select task → click Run
-# → New worktree created (e.g., "aurora-cadence")
-# → Sidebar shows new worktree, selected
+# 2. Create worktree - Maestro updates instantly
+wt switch --create test-push
+# → Maestro sidebar shows "test-push" immediately (no 2s delay)
+
+# 3. Remove worktree - Maestro updates instantly
+wt remove test-push
+# → Maestro sidebar removes "test-push" immediately
+
+# 4. Main branch protection still works
+# In Maestro: select main → select task → click Run
+# → New worktree created with random name
+# → Sidebar updates instantly
 # → Task runs in new worktree
 ```
+
+## Files to modify
+
+| File | Change |
+|------|--------|
+| `src/loopflow/lfd/server.py` | Add `_handle_notify()` method |
+| `src/loopflow/lfd/__init__.py` | Add `notify` CLI command |
+| `Maestro/Maestro/Services/LFDEventService.swift` | New file - Unix socket client |
+| `Maestro/Maestro/AppState.swift` | Add event subscription |
+| `Maestro/Maestro/Views/WorktreeSidebar.swift` | Remove polling `.task` |

--- a/.design/liveupdate.md
+++ b/.design/liveupdate.md
@@ -1,20 +1,10 @@
 # Live Update
 
-## What to build
+Live-refreshing worktree list via push notifications from lfd, plus main branch protection.
 
-Enhance Maestro SwiftUI app with live-refreshing worktree list via push notifications from lfd, plus main branch protection.
+## Summary
 
-**Location**:
-- `Maestro/` (SwiftUI macOS app)
-- `src/loopflow/lfd/` (daemon additions)
-
-## User quotes
-
-> "as soon as the wt remove happens we should somehow notify the maestro app, probably via lfd"
-
-> "it's a little more robust to react to wt than lf since users could invoke wt manually"
-
-> "Why are we using polling vs push notifications? I think its good to respond to wt generally, but doesnt wt have hooks?"
+Maestro now receives push notifications from lfd when worktrees are created or removed, instead of polling. When running from the main branch, Maestro auto-creates a new worktree with a random name.
 
 ## Architecture
 
@@ -38,80 +28,35 @@ Enhance Maestro SwiftUI app with live-refreshing worktree list via push notifica
                                        └─────────────────┘
 ```
 
-## Data structures
+## What was built
 
-### lfd protocol (existing)
+### Python: lfd notify command
 
-```python
-# src/loopflow/lfd/protocol.py (existing)
-@dataclass
-class Event:
-    event: str          # e.g. "worktree.created"
-    data: dict[str, Any]
-```
+`lfd notify <event> [--branch] [--path]` sends events to the daemon for broadcast to subscribers. Fails silently if daemon not running (safe for use in hooks).
 
-### Worktree events (new)
+### Python: lfd server notify handler
 
-```python
-# Event types
-Event("worktree.created", {"branch": "feature-x", "path": "/path/to/worktree"})
-Event("worktree.removed", {"branch": "feature-x"})
-```
+The daemon's `_handle_notify()` method accepts external events and broadcasts them to subscribed clients.
 
-## Key functions
+### Swift: LFDEventService
 
-### 1. lfd server: add `notify` method
+Unix socket client that subscribes to worktree events and calls a callback when events arrive. Uses Network framework's `NWConnection` for async socket communication.
 
-```python
-# src/loopflow/lfd/server.py
+### Swift: AppState integration
 
-async def _handle_notify(self, params: dict) -> Response:
-    """Accept external events and broadcast to subscribers."""
-    event_name = params.get("event")
-    event_data = params.get("data", {})
+`startEventSubscription()` connects to lfd on repo open and refreshes worktrees on any `worktree.*` event.
 
-    if not event_name:
-        return error("Missing 'event' parameter")
+### Swift: Main branch protection
 
-    await self._broadcast(Event(event_name, event_data))
-    return success({"event": event_name})
-```
+`PromptLauncher.launchInTerminal()` detects when main is selected and auto-creates a worktree with a random name (e.g. "aurora-allegro") before launching the task.
 
-Add to `_dispatch()`:
-```python
-elif method == "notify":
-    return await self._handle_notify(params)
-```
+### Swift: Selection preservation
 
-### 2. lfd CLI: add `notify` command
+`refreshWorktrees()` now preserves the selected worktree by matching on branch name after refresh.
 
-```python
-# src/loopflow/lfd/__init__.py
+## Setup required
 
-@app.command()
-def notify(
-    event: str = typer.Argument(help="Event name (e.g. worktree.created)"),
-    branch: str = typer.Option(None, "--branch", "-b", help="Branch name"),
-    path: str = typer.Option(None, "--path", "-p", help="Worktree path"),
-):
-    """Send an event to lfd for broadcast to subscribers."""
-    if not is_running():
-        return  # Silently fail if daemon not running
-
-    data = {}
-    if branch:
-        data["branch"] = branch
-    if path:
-        data["path"] = path
-
-    client = DaemonClient()
-    try:
-        asyncio.run(client.call("notify", {"event": event, "data": data}))
-    except Exception:
-        pass  # Best effort - don't fail hooks
-```
-
-### 3. worktrunk user hooks
+Users must configure worktrunk hooks to send notifications:
 
 ```toml
 # ~/.config/worktrunk/config.toml
@@ -123,154 +68,20 @@ lfd-notify = "lfd notify worktree.created --branch '{{ branch }}' --path '{{ wor
 lfd-notify = "lfd notify worktree.removed --branch '{{ branch }}'"
 ```
 
-### 4. Maestro: LFDEventService
-
-```swift
-// Maestro/Maestro/Services/LFDEventService.swift
-
-import Foundation
-import Network
-
-actor LFDEventService {
-    private var connection: NWConnection?
-    private let socketPath = FileManager.default.homeDirectoryForCurrentUser
-        .appendingPathComponent(".lf/lfd.sock")
-
-    func subscribe(
-        to patterns: [String],
-        onEvent: @escaping (String, [String: Any]) -> Void
-    ) async throws {
-        let params = NWParameters()
-        let endpoint = NWEndpoint.unix(path: socketPath.path)
-        connection = NWConnection(to: endpoint, using: params)
-
-        connection?.start(queue: .main)
-
-        // Send subscribe request
-        let request = """
-        {"method":"subscribe","params":{"events":\(patterns)}}
-
-        """
-        connection?.send(content: request.data(using: .utf8), completion: .idempotent)
-
-        // Read events
-        receiveLoop(onEvent: onEvent)
-    }
-
-    private func receiveLoop(onEvent: @escaping (String, [String: Any]) -> Void) {
-        connection?.receive(minimumIncompleteLength: 1, maximumLength: 65536) { [weak self] data, _, _, _ in
-            if let data = data,
-               let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-               let event = json["event"] as? String,
-               let eventData = json["data"] as? [String: Any] {
-                onEvent(event, eventData)
-            }
-            self?.receiveLoop(onEvent: onEvent)
-        }
-    }
-
-    func disconnect() {
-        connection?.cancel()
-        connection = nil
-    }
-}
-```
-
-### 5. Maestro: integrate in AppState
-
-```swift
-// Maestro/Maestro/AppState.swift
-
-@MainActor
-@Observable
-final class AppState {
-    // ... existing properties ...
-
-    private var eventService: LFDEventService?
-
-    func startEventSubscription() {
-        eventService = LFDEventService()
-
-        Task {
-            try? await eventService?.subscribe(to: ["worktree.*"]) { [weak self] event, data in
-                Task { @MainActor in
-                    self?.handleWorktreeEvent(event, data: data)
-                }
-            }
-        }
-    }
-
-    private func handleWorktreeEvent(_ event: String, data: [String: Any]) {
-        // Refresh worktree list on any worktree event
-        Task {
-            await refreshWorktrees()
-        }
-    }
-}
-```
-
-### 6. Remove polling from WorktreeSidebar
-
-```swift
-// Maestro/Maestro/Views/WorktreeSidebar.swift
-
-// DELETE this .task block:
-// .task {
-//     while !Task.isCancelled {
-//         await appState.refreshWorktrees()
-//         try? await Task.sleep(for: .seconds(2))
-//     }
-// }
-```
-
-## Main branch protection (already implemented)
-
-When main is selected and user clicks Run:
-1. Generate random name from magical/musical words
-2. Create worktree via `wt switch --create`
-3. Refresh worktree list (will get push notification)
-4. Select new worktree
-5. Launch task
-
 ## Constraints
 
-- **Silent failures**: `lfd notify` must not fail worktrunk hooks - catch all errors
-- **No daemon = no events**: If lfd isn't running, Maestro won't get updates (acceptable)
-- **Idempotent refresh**: Multiple events may arrive close together; `refreshWorktrees()` should be debounced or idempotent
+- **Silent failures**: `lfd notify` catches all errors to avoid breaking worktrunk hooks
+- **No daemon = no events**: If lfd isn't running, Maestro won't get live updates
+- **Idempotent refresh**: Multiple events may arrive; `refreshWorktrees()` is safe to call repeatedly
 
-## Done when
-
-```bash
-# 1. Setup worktrunk hooks
-cat >> ~/.config/worktrunk/config.toml << 'EOF'
-[post-create]
-lfd-notify = "lfd notify worktree.created --branch '{{ branch }}' --path '{{ worktree_path }}'"
-
-[pre-remove]
-lfd-notify = "lfd notify worktree.removed --branch '{{ branch }}'"
-EOF
-
-# 2. Create worktree - Maestro updates instantly
-wt switch --create test-push
-# → Maestro sidebar shows "test-push" immediately (no 2s delay)
-
-# 3. Remove worktree - Maestro updates instantly
-wt remove test-push
-# → Maestro sidebar removes "test-push" immediately
-
-# 4. Main branch protection still works
-# In Maestro: select main → select task → click Run
-# → New worktree created with random name
-# → Sidebar updates instantly
-# → Task runs in new worktree
-```
-
-## Files to modify
+## Files changed
 
 | File | Change |
 |------|--------|
 | `src/loopflow/lfd/server.py` | Add `_handle_notify()` method |
 | `src/loopflow/lfd/__init__.py` | Add `notify` CLI command |
-| `Maestro/Maestro/Services/LFDEventService.swift` | New file - Unix socket client |
-| `Maestro/Maestro/AppState.swift` | Add event subscription |
-| `Maestro/Maestro/Views/WorktreeSidebar.swift` | Remove polling `.task` |
+| `Maestro/Maestro/Services/LFDEventService.swift` | New - Unix socket client |
+| `Maestro/Maestro/Services/NameGenerator.swift` | New - Random name generator |
+| `Maestro/Maestro/AppState.swift` | Event subscription, selection preservation |
+| `Maestro/Maestro/Views/PromptLauncher.swift` | Main branch protection |
+| `Maestro/Maestro/Views/WorktreeSidebar.swift` | Removed polling (now uses push) |

--- a/.design/questions.md
+++ b/.design/questions.md
@@ -1,0 +1,7 @@
+# Questions
+
+## Pre-existing test failures
+
+The Swift tests in `MaestroTests/ConfigLoaderTests.swift` were already failing before these changes - they need to be updated to include the `docs`, `diff`, `paste` parameters that were added to `LoopflowConfig`.
+
+This is out of scope for the liveupdate feature.

--- a/Maestro/Maestro.xcodeproj/project.pbxproj
+++ b/Maestro/Maestro.xcodeproj/project.pbxproj
@@ -28,6 +28,8 @@
 		A0000015 /* RecentRepo.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0000015; };
 		A0000016 /* WelcomeWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0000016; };
 		A0000017 /* RepoWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0000017; };
+		A0000018 /* NameGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0000018; };
+		A0000019 /* LFDEventService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0000019; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -54,6 +56,8 @@
 		B0000015 /* RecentRepo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentRepo.swift; sourceTree = "<group>"; };
 		B0000016 /* WelcomeWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WelcomeWindow.swift; sourceTree = "<group>"; };
 		B0000017 /* RepoWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepoWindow.swift; sourceTree = "<group>"; };
+		B0000018 /* NameGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NameGenerator.swift; sourceTree = "<group>"; };
+		B0000019 /* LFDEventService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LFDEventService.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -118,6 +122,8 @@
 			children = (
 				B0000013 /* AgentService.swift */,
 				B0000009 /* ConfigLoader.swift */,
+				B0000019 /* LFDEventService.swift */,
+				B0000018 /* NameGenerator.swift */,
 				B000000A /* PromptService.swift */,
 				B0000014 /* RecentsService.swift */,
 				B000000B /* TerminalLauncher.swift */,
@@ -209,6 +215,8 @@
 				A0000015 /* RecentRepo.swift in Sources */,
 				A0000016 /* WelcomeWindow.swift in Sources */,
 				A0000017 /* RepoWindow.swift in Sources */,
+				A0000018 /* NameGenerator.swift in Sources */,
+				A0000019 /* LFDEventService.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Maestro/Maestro/AppState.swift
+++ b/Maestro/Maestro/AppState.swift
@@ -138,17 +138,11 @@ final class AppState {
         eventService = LFDEventService()
 
         Task {
-            try? await eventService?.subscribe(to: ["worktree.*"]) { [weak self] event in
+            try? await eventService?.subscribe(to: ["worktree.*"]) { [weak self] _ in
                 Task { @MainActor in
-                    self?.handleWorktreeEvent(event)
+                    await self?.refreshWorktrees()
                 }
             }
-        }
-    }
-
-    private func handleWorktreeEvent(_ event: WorktreeEvent) {
-        Task {
-            await refreshWorktrees()
         }
     }
 

--- a/Maestro/Maestro/AppState.swift
+++ b/Maestro/Maestro/AppState.swift
@@ -87,7 +87,13 @@ final class AppState {
         guard let repo = currentRepo else { return }
 
         do {
+            let previousSelection = selectedWorktree?.branch
             worktrees = try await worktreeService.list(in: repo)
+
+            // Preserve selection by matching on branch name
+            if let branch = previousSelection {
+                selectedWorktree = worktrees.first { $0.branch == branch }
+            }
         } catch {
             errorMessage = error.localizedDescription
         }

--- a/Maestro/Maestro/AppState.swift
+++ b/Maestro/Maestro/AppState.swift
@@ -36,6 +36,7 @@ final class AppState {
     private let configLoader = ConfigLoader()
     private let promptService = PromptService()
     private let agentService = AgentService()
+    private var eventService: LFDEventService?
 
     func openRepo(_ url: URL) async {
         currentRepo = url
@@ -46,6 +47,8 @@ final class AppState {
         let setupService = SetupService()
         do {
             try await setupService.ensureDaemonRunning()
+            // Start event subscription after daemon is running
+            startEventSubscription()
         } catch {
             // Non-fatal - daemon setup failed but app can still work
         }
@@ -123,6 +126,24 @@ final class AppState {
         let worktreeURL = URL(fileURLWithPath: worktree.path)
         try await worktreeService.landPR(in: worktreeURL)
         await refreshWorktrees()
+    }
+
+    func startEventSubscription() {
+        eventService = LFDEventService()
+
+        Task {
+            try? await eventService?.subscribe(to: ["worktree.*"]) { [weak self] event in
+                Task { @MainActor in
+                    self?.handleWorktreeEvent(event)
+                }
+            }
+        }
+    }
+
+    private func handleWorktreeEvent(_ event: WorktreeEvent) {
+        Task {
+            await refreshWorktrees()
+        }
     }
 
     func refreshAgents() async {

--- a/Maestro/Maestro/AppState.swift
+++ b/Maestro/Maestro/AppState.swift
@@ -76,6 +76,12 @@ final class AppState {
             }
 
             await refreshWorktrees()
+
+            // Auto-select first worktree so launch button always has a target
+            if selectedWorktree == nil {
+                selectedWorktree = worktrees.first
+            }
+
             prompts = try promptService.loadPrompts(from: url, config: config)
             await estimateTokens()
             await refreshAgents()

--- a/Maestro/Maestro/Services/LFDEventService.swift
+++ b/Maestro/Maestro/Services/LFDEventService.swift
@@ -1,0 +1,86 @@
+// Service for subscribing to lfd events via Unix socket.
+
+import Foundation
+import Network
+
+struct WorktreeEvent: Sendable {
+    let name: String
+    let branch: String?
+    let path: String?
+}
+
+actor LFDEventService {
+    private var connection: NWConnection?
+    private let socketPath = FileManager.default.homeDirectoryForCurrentUser
+        .appendingPathComponent(".lf/lfd.sock")
+    private var onEvent: (@Sendable (WorktreeEvent) -> Void)?
+
+    func subscribe(
+        to patterns: [String],
+        onEvent: @escaping @Sendable (WorktreeEvent) -> Void
+    ) async throws {
+        self.onEvent = onEvent
+
+        let params = NWParameters()
+        let endpoint = NWEndpoint.unix(path: socketPath.path)
+        connection = NWConnection(to: endpoint, using: params)
+
+        connection?.stateUpdateHandler = { [weak self] state in
+            if case .failed = state {
+                Task { await self?.disconnect() }
+            }
+        }
+
+        connection?.start(queue: .main)
+
+        // Wait briefly for connection to establish
+        try await Task.sleep(for: .milliseconds(100))
+
+        // Send subscribe request
+        let patternsJson = patterns.map { "\"\($0)\"" }.joined(separator: ",")
+        let request = "{\"method\":\"subscribe\",\"params\":{\"events\":[\(patternsJson)]}}\n"
+        connection?.send(content: request.data(using: .utf8), completion: .idempotent)
+
+        // Start receiving events
+        receiveLoop()
+    }
+
+    private func receiveLoop() {
+        connection?.receive(minimumIncompleteLength: 1, maximumLength: 65536) { [weak self] data, _, _, error in
+            guard let self = self else { return }
+
+            if let data = data {
+                // lfd sends newline-delimited JSON
+                if let text = String(data: data, encoding: .utf8) {
+                    for line in text.split(separator: "\n") {
+                        if let lineData = line.data(using: .utf8),
+                           let json = try? JSONSerialization.jsonObject(with: lineData) as? [String: Any],
+                           let eventName = json["event"] as? String,
+                           let eventData = json["data"] as? [String: Any] {
+                            let event = WorktreeEvent(
+                                name: eventName,
+                                branch: eventData["branch"] as? String,
+                                path: eventData["path"] as? String
+                            )
+                            Task { await self.handleEvent(event) }
+                        }
+                    }
+                }
+            }
+
+            if error == nil {
+                Task { await self.receiveLoop() }
+            }
+        }
+    }
+
+    private func handleEvent(_ event: WorktreeEvent) {
+        onEvent?(event)
+    }
+
+    func disconnect() {
+        connection?.cancel()
+        connection = nil
+        onEvent = nil
+    }
+}

--- a/Maestro/Maestro/Services/NameGenerator.swift
+++ b/Maestro/Maestro/Services/NameGenerator.swift
@@ -1,0 +1,28 @@
+// Generates random worktree names from magical and musical word pairs.
+
+import Foundation
+
+enum NameGenerator {
+    static let magical = [
+        "aurora", "cascade", "crystal", "drift", "echo", "ember",
+        "fern", "flume", "frost", "glade", "grove", "haze",
+        "ivy", "jade", "luna", "mist", "nova", "opal",
+        "petal", "prism", "rain", "ripple", "sage", "shade",
+        "spark", "star", "stone", "storm", "tide", "vale",
+        "wave", "wisp", "wren", "zephyr"
+    ]
+
+    static let musical = [
+        "allegro", "aria", "ballad", "cadence", "canon", "chord",
+        "coda", "duet", "forte", "fugue", "harmony", "hymn",
+        "lilt", "lyric", "melody", "motif", "opus", "prelude",
+        "refrain", "rondo", "sonata", "tempo", "trill", "tune",
+        "verse", "waltz"
+    ]
+
+    static func generate() -> String {
+        let m = magical.randomElement()!
+        let n = musical.randomElement()!
+        return "\(m)-\(n)"
+    }
+}

--- a/Maestro/Maestro/Views/PromptLauncher.swift
+++ b/Maestro/Maestro/Views/PromptLauncher.swift
@@ -12,6 +12,7 @@ struct PromptLauncher: View {
     @State private var launchError: String?
     @State private var showingLaunchError = false
     @FocusState private var isInputFocused: Bool
+    @State private var isCreatingWorktree = false
 
     private let terminalLauncher = TerminalLauncher()
 
@@ -646,15 +647,46 @@ struct PromptLauncher: View {
         appState.selectedPrompt = selectedPrompt
         appState.promptArgs = parsedInput.args
 
+        // Check if on main branch - if so, create new worktree first
+        let isMain = appState.selectedWorktree?.branch == "main"
+                  || appState.selectedWorktree == nil
+
+        if isMain {
+            isCreatingWorktree = true
+            Task {
+                await launchWithNewWorktree(repo: repo)
+                isCreatingWorktree = false
+            }
+        } else {
+            launchCommand(repo: repo, workPath: URL(fileURLWithPath: appState.selectedWorktree!.path))
+        }
+    }
+
+    private func launchWithNewWorktree(repo: URL) async {
+        let name = NameGenerator.generate()
+
+        do {
+            try await appState.createWorktree(name: name)
+            await appState.refreshWorktrees()
+
+            // Select the newly created worktree
+            if let newWorktree = appState.worktrees.first(where: { $0.branch == name }) {
+                appState.selectedWorktree = newWorktree
+                let workPath = URL(fileURLWithPath: newWorktree.path)
+                launchCommand(repo: repo, workPath: workPath)
+            } else {
+                launchError = "Failed to find newly created worktree"
+                showingLaunchError = true
+            }
+        } catch {
+            launchError = "Failed to create worktree: \(error.localizedDescription)"
+            showingLaunchError = true
+        }
+    }
+
+    private func launchCommand(repo: URL, workPath: URL) {
         let terminal = appState.config?.terminalApp ?? .warp
         let command = appState.buildCommand()
-
-        let workPath: URL
-        if let wt = appState.selectedWorktree {
-            workPath = URL(fileURLWithPath: wt.path)
-        } else {
-            workPath = repo
-        }
 
         do {
             try terminalLauncher.launchTerminal(terminal, at: workPath, command: command)

--- a/Maestro/Maestro/Views/WorktreeSidebar.swift
+++ b/Maestro/Maestro/Views/WorktreeSidebar.swift
@@ -52,13 +52,6 @@ struct WorktreeSidebar: View {
         } message: {
             Text(actionError ?? "An error occurred")
         }
-        .task {
-            // Poll for worktree changes every 2 seconds
-            while !Task.isCancelled {
-                await appState.refreshWorktrees()
-                try? await Task.sleep(for: .seconds(2))
-            }
-        }
     }
 
     private var header: some View {

--- a/Maestro/Maestro/Views/WorktreeSidebar.swift
+++ b/Maestro/Maestro/Views/WorktreeSidebar.swift
@@ -52,6 +52,13 @@ struct WorktreeSidebar: View {
         } message: {
             Text(actionError ?? "An error occurred")
         }
+        .task {
+            // Poll for worktree changes every 2 seconds
+            while !Task.isCancelled {
+                await appState.refreshWorktrees()
+                try? await Task.sleep(for: .seconds(2))
+            }
+        }
     }
 
     private var header: some View {

--- a/src/loopflow/lfd/__init__.py
+++ b/src/loopflow/lfd/__init__.py
@@ -81,6 +81,29 @@ def uninstall():
         raise typer.Exit(1)
 
 
+@app.command()
+def notify(
+    event: str = typer.Argument(help="Event name (e.g. worktree.created)"),
+    branch: str = typer.Option(None, "--branch", "-b", help="Branch name"),
+    path: str = typer.Option(None, "--path", "-p", help="Worktree path"),
+):
+    """Send an event to lfd for broadcast to subscribers."""
+    if not is_running():
+        return  # Silently fail if daemon not running
+
+    data = {}
+    if branch:
+        data["branch"] = branch
+    if path:
+        data["path"] = path
+
+    client = DaemonClient()
+    try:
+        asyncio.run(client.call("notify", {"event": event, "data": data}))
+    except Exception:
+        pass  # Best effort - don't fail hooks
+
+
 # Agent commands
 
 

--- a/src/loopflow/lfd/server.py
+++ b/src/loopflow/lfd/server.py
@@ -95,6 +95,8 @@ class Server:
             return await self._handle_sessions_list()
         elif method == "subscribe":
             return await self._handle_subscribe(params, writer)
+        elif method == "notify":
+            return await self._handle_notify(params)
         else:
             return error(f"Unknown method: {method}", request.id)
 
@@ -160,6 +162,17 @@ class Server:
         events = params.get("events", [])
         self.subscriptions[writer] = events
         return success({"subscribed": events})
+
+    async def _handle_notify(self, params: dict) -> Response:
+        """Accept external events and broadcast to subscribers."""
+        event_name = params.get("event")
+        event_data = params.get("data", {})
+
+        if not event_name:
+            return error("Missing 'event' parameter")
+
+        await self._broadcast(Event(event_name, event_data))
+        return success({"event": event_name})
 
     async def _broadcast(self, event: Event) -> None:
         message = (event.serialize() + "\n").encode()


### PR DESCRIPTION
# Usage

Configure worktrunk hooks to enable live updates:

```bash
# ~/.config/worktrunk/config.toml
[post-create]
lfd-notify = "lfd notify worktree.created --branch '{{ branch }}' --path '{{ worktree_path }}'"

[pre-remove]
lfd-notify = "lfd notify worktree.removed --branch '{{ branch }}'"
```

Maestro now refreshes its worktree list instantly when you create/remove worktrees. Running tasks from main automatically creates a new worktree with a random name.

## Summary

Maestro now receives push notifications from lfd when worktrees change, replacing polling with real-time updates. When launching tasks from the main branch, Maestro auto-creates a worktree with a generated name to protect the main branch from direct commits.

## Changes

- Added `lfd notify` CLI command for external event injection
- Built Unix socket event service in Maestro using Network framework
- Integrated event subscription into AppState with selection preservation
- Added main branch protection with random worktree names (e.g. "aurora-allegro")
- Enhanced lfd server to handle notify requests and broadcast events
- Removed polling in favor of push-based updates