### PR TITLE
diffload: add diff_files context source, flip diff default to off

### DIFF
--- a/.claude/commands/design.md
+++ b/.claude/commands/design.md
@@ -46,14 +46,15 @@ def create_worktree(name: str) -> Worktree:
 - **What to build** — One sentence. What exists after this that doesn't exist now.
 - **Data structures** — Core types, sketched in code.
 - **Key functions** — Signatures with one-line intent.
+- **UI changes** — If adding config options or CLI flags, specify the Maestro UI updates. Skip only if explicitly infrastructure-only.
 - **Constraints** — What would require rewriting if guessed wrong.
-- **Done when** — Verification command and expected output.
+- **Done when** — Verification command and expected output. Include UI verification if applicable.
 
 ## Loopflow design principles
 
 When designing for this codebase:
 
-- **End-to-end changes.** Features should be complete from CLI to UI. If you add a config option or context flag, include corresponding Maestro UI updates (under `Maestro/`). Infrastructure-only changes are okay when explicitly spec'd as prep for future product work.
+- **End-to-end by default.** Every feature that adds config options, CLI flags, or context sources must include Maestro UI updates. The Maestro app (under `Maestro/`) is the primary user interface—if users can't access a feature from the UI, it's incomplete. Infrastructure-only changes require explicit justification in the design doc (e.g., "Phase 1 of 2: backend only, UI in follow-up").
 - **Worktrees are first-class.** Features should work across isolated worktrees. Don't assume a single working directory.
 - **Prompts are files, not config.** Task definitions live in `.claude/commands/` or `.lf/`. Don't design template systems or prompt builders.
 - **Design for auto mode.** Most tasks run headless. Don't require interactive confirmation for core flows.

--- a/.claude/commands/design.md
+++ b/.claude/commands/design.md
@@ -53,6 +53,7 @@ def create_worktree(name: str) -> Worktree:
 
 When designing for this codebase:
 
+- **End-to-end changes.** Features should be complete from CLI to UI. If you add a config option or context flag, include corresponding Maestro UI updates (under `Maestro/`). Infrastructure-only changes are okay when explicitly spec'd as prep for future product work.
 - **Worktrees are first-class.** Features should work across isolated worktrees. Don't assume a single working directory.
 - **Prompts are files, not config.** Task definitions live in `.claude/commands/` or `.lf/`. Don't design template systems or prompt builders.
 - **Design for auto mode.** Most tasks run headless. Don't require interactive confirmation for core flows.

--- a/.claude/commands/implement.md
+++ b/.claude/commands/implement.md
@@ -44,6 +44,7 @@ These are specific to this codebase:
 - **Return `None` for "not found"**, raise exceptions for "shouldn't happen"
 - **Prefer functions over classes** when you don't need state
 - **No backwards-compatibility shims** unless explicitly required
+- **End-to-end changes.** If you add CLI flags or config options, update the Maestro UI too (under `Maestro/`). Check `Maestro/Maestro/Models/LoopflowConfig.swift` for config parsing, `AppState.swift` for state, and `Views/PromptLauncher.swift` for the launch UI.
 
 ## If something's wrong
 

--- a/.claude/commands/implement.md
+++ b/.claude/commands/implement.md
@@ -44,7 +44,18 @@ These are specific to this codebase:
 - **Return `None` for "not found"**, raise exceptions for "shouldn't happen"
 - **Prefer functions over classes** when you don't need state
 - **No backwards-compatibility shims** unless explicitly required
-- **End-to-end changes.** If you add CLI flags or config options, update the Maestro UI too (under `Maestro/`). Check `Maestro/Maestro/Models/LoopflowConfig.swift` for config parsing, `AppState.swift` for state, and `Views/PromptLauncher.swift` for the launch UI.
+
+## End-to-end implementation
+
+If the design adds config options, CLI flags, or context sources, the implementation is incomplete without Maestro UI updates. Check the design doc for a "UI changes" section.
+
+Key Maestro files:
+- `Maestro/Maestro/Models/LoopflowConfig.swift` — Config model and YAML parsing
+- `Maestro/Maestro/AppState.swift` — App state, including toggle defaults
+- `Maestro/Maestro/Views/PromptLauncher.swift` — Launch UI with toggles and options
+- `Maestro/Maestro/Services/TokenEstimator.swift` — Token counting (if new context sources)
+
+If the design doc explicitly marks the feature as infrastructure-only, skip UI updates.
 
 ## If something's wrong
 

--- a/.design/diffload.md
+++ b/.design/diffload.md
@@ -1,177 +1,24 @@
-# diffload: Two context sources from branch changes
+# diffload
 
-## What to build
+Add `diff_files` context source (full file content for files touched by branch) and flip `diff` default to off.
 
-Add `diff_files` as a new context source (files touched by the branch). Change `diff` default to off. Both are independent toggles like `docs` and `paste`.
+## Review
 
-## Problem
+**Verdict:** Ready to ship
 
-"It seems like the LLMs do not realize they have the whole diff in their context."
+Implementation is clean and complete. All touched files follow the existing patterns. The design spec is fully implemented:
 
-A diff shows changes but lacks surrounding context. Loading the actual files touched by the branch gives the LLM the full picture—it can see the whole function, the class hierarchy, the imports.
+- `diff_files` field added to `Config` (default: True), `PromptComponents`, and `AgentFile`
+- `gather_diff_files()` correctly filters deleted files and returns paths for `gather_files()` to load
+- CLI flags `--diff-files/--no-diff-files` added to `run()`, `inline()`, `cp()`
+- Token analysis shows `diff_files` as separate category
+- Files merge with `context_files` in `<lf:files>` section, deduplicated by path
+- `docs/config.md` updated with new options
 
-## The two options
+No issues found.
 
-| Option | What it loads | Default | CLI flags |
-|--------|--------------|---------|-----------|
-| `diff_files` | Full content of files touched by branch | ON | `--diff-files/--no-diff-files` |
-| `diff` | Raw `git diff main...HEAD` output | OFF | `--diff/--no-diff` |
+## Design notes
 
-Both can be on, both can be off, or either one. They're independent context sources, same as `docs`, `paste`, `clipboard`.
+**Why two options?** `diff_files` loads complete file content—lets the LLM see surrounding context, imports, full functions. `diff` shows exactly what changed but lacks context. Most tasks work better with files; some may want both or neither.
 
-## Data structures
-
-Add to `PromptComponents`:
-
-```python
-@dataclass
-class PromptComponents:
-    run_mode: str | None
-    docs: list[tuple[Path, str]]
-    diff: str | None
-    diff_files: list[tuple[Path, str]]  # NEW
-    task: tuple[str, str] | None
-    context_files: list[tuple[Path, str]]
-    # ...
-```
-
-Add to `Config`:
-
-```python
-class Config(BaseModel):
-    # ...
-    diff: bool = False        # CHANGED: was True
-    diff_files: bool = True   # NEW
-```
-
-## Key functions
-
-```python
-def gather_diff_files(repo_root: Path, exclude: list[str] | None = None) -> list[str]:
-    """Return file paths touched by this branch vs main.
-
-    Uses git diff --name-only main...HEAD.
-    Filters out deleted files (can't load those).
-    Respects exclude patterns.
-    """
-```
-
-## Changes by file
-
-### `src/loopflow/config.py`
-
-```python
-class Config(BaseModel):
-    # ...
-    diff: bool = False        # change default
-    diff_files: bool = True   # add new field
-```
-
-### `src/loopflow/context.py`
-
-Add `gather_diff_files()`:
-
-```python
-def gather_diff_files(repo_root: Path, exclude: list[str] | None = None) -> list[str]:
-    result = subprocess.run(
-        ["git", "diff", "--name-only", "main...HEAD"],
-        cwd=repo_root,
-        capture_output=True,
-        text=True,
-    )
-    if result.returncode != 0:
-        return []
-
-    paths = []
-    for line in result.stdout.strip().split("\n"):
-        if not line:
-            continue
-        path = repo_root / line
-        if path.exists():  # filter deleted files
-            paths.append(line)
-    return paths
-```
-
-Update `PromptComponents`:
-
-```python
-@dataclass
-class PromptComponents:
-    # ...
-    diff_files: list[tuple[Path, str]] = field(default_factory=list)
-```
-
-Update `gather_prompt_components()` to call `gather_diff_files()` and pass to `gather_files()`.
-
-Update `format_prompt()` to include diff_files in `<lf:files>` section (they merge with context_files).
-
-### `src/loopflow/cli/run.py`
-
-Add CLI flag to `run()`, `inline()`, `cp()`:
-
-```python
-diff_files: Optional[bool] = typer.Option(
-    None, "--diff-files/--no-diff-files", help="Include files touched by branch"
-),
-```
-
-Same pattern as existing `--diff/--no-diff`, `--docs/--no-docs`.
-
-### `src/loopflow/tokens.py`
-
-Update `analyze_prompt_tokens()` to show diff_files in token breakdown:
-
-```python
-def analyze_prompt_tokens(
-    # ...
-    diff_files: Optional[list[tuple[Path, str]]] = None,
-) -> TokenTree:
-    # ...
-    if diff_files:
-        for file_path, content in diff_files:
-            tokens = count_tokens(content)
-            tree.add("diff_files", file_path.name, tokens)
-```
-
-### `src/loopflow/maestro/markdown.py`
-
-Add to `AgentFile`:
-
-```python
-@dataclass
-class AgentFile:
-    # ...
-    diff: bool = False        # change default
-    diff_files: bool = True   # add field
-```
-
-Update `parse_agent_file()` and `create_agent_file()`.
-
-### `docs/config.md`
-
-Document both options with their defaults and CLI flags.
-
-## Constraints
-
-- **Filter deleted files.** `git diff --name-only` includes deleted files—can't load those.
-- **Respect exclude patterns.** If `exclude: ["*.test.ts"]` is set, don't load test files even if they're in the diff.
-- **Merge with context_files.** diff_files should appear in the same `<lf:files>` section as explicit `-x` context, deduplicated.
-
-## Done when
-
-```bash
-# On a feature branch with changes
-lf : "list files in lf:files" -c 2>&1 | head -20
-```
-
-Should show:
-- `diff_files` category in token breakdown (not `diff`)
-- Changed files in `<lf:files>` section
-
-With flags:
-
-```bash
-lf : "test" --no-diff-files --diff -c   # old behavior
-lf : "test" --diff-files --no-diff -c   # new default
-lf : "test" --diff-files --diff -c      # both
-```
+**Exclude patterns applied at load time.** `gather_diff_files()` returns raw paths; exclusions happen when `gather_files()` loads content. This keeps the function simple and consistent with how `-x` context works.

--- a/.design/diffload.md
+++ b/.design/diffload.md
@@ -14,6 +14,8 @@ Implementation is clean and complete. All touched files follow the existing patt
 - Token analysis shows `diff_files` as separate category
 - Files merge with `context_files` in `<lf:files>` section, deduplicated by path
 - `docs/config.md` updated with new options
+- **Maestro UI updated:** `LoopflowConfig.swift`, `AppState.swift`, `PromptLauncher.swift`, `TokenEstimator.swift` all support `diff_files`
+- Design/implement prompts updated with end-to-end guidance
 
 No issues found.
 

--- a/.design/diffload.md
+++ b/.design/diffload.md
@@ -1,0 +1,86 @@
+# diffload: Extract files from diff for context
+
+## What to build
+
+Replace auto-loaded diff with auto-loaded file context for files touched by the branch.
+
+## Problem
+
+"It seems like the LLMs do not realize they have the whole diff in their context."
+
+A diff shows changes but lacks surrounding context. When an LLM sees:
+
+```diff
+@@ -121,5 +121,8 @@
+-    old_line()
++    new_line()
++    another_line()
+```
+
+It knows what changed but not what's around it. Three context lines isn't enough to understand the file's structure, imports, or how functions fit together.
+
+Loading the actual files gives the LLM the full picture—it can see the whole function, the class hierarchy, the imports. The diff becomes redundant because the LLM can read the current state directly.
+
+## Data structures
+
+No new types. The change is in `gather_prompt_components()`.
+
+```python
+# Current behavior
+diff = gather_diff(repo_root, exclude)
+context_files = gather_files(context, repo_root, context_exclude) if context else []
+
+# New behavior
+diff_files = gather_diff_files(repo_root, exclude)  # List of paths from diff
+context_files = gather_files(context + diff_files, repo_root, context_exclude)
+diff = None  # Or keep as option, default off
+```
+
+## Key functions
+
+```python
+def gather_diff_files(repo_root: Path, exclude: list[str] | None = None) -> list[str]:
+    """Return list of file paths touched by this branch vs main.
+
+    Uses git diff --name-only main...HEAD.
+    Filters out deleted files (they don't exist to load).
+    """
+```
+
+Modification to `gather_prompt_components()`:
+- Call `gather_diff_files()`
+- Merge result with explicit `-x` context
+- Pass combined list to `gather_files()`
+
+## Constraints
+
+- **Must filter deleted files.** `git diff --name-only` includes deleted files—can't load those.
+- **Must respect exclude patterns.** If `exclude: ["*.test.ts"]` is set, don't load test files even if they're in the diff.
+- **Config toggle for backwards compat.** Some users may prefer the diff. Add `diff_as_files: bool = True` (default on) to config. When false, loads raw diff as before.
+
+## Config
+
+```yaml
+# .lf/config.yaml
+diff_as_files: true   # default: load files instead of diff
+```
+
+The existing `diff: bool` controls whether to include diff context at all. The new `diff_as_files` controls the format when diff is enabled.
+
+## Done when
+
+```bash
+# On a feature branch with changes to src/loopflow/context.py
+lf : "list the files in lf:files" -c 2>&1 | grep "context.py"
+```
+
+Should show `src/loopflow/context.py` in the `<lf:files>` section, not in `<lf:diff>`.
+
+Alternative verification:
+```bash
+lf : "what files are in your context?" -c | pbpaste | grep -A5 "lf:files"
+```
+
+## Open questions
+
+None blocking. The smallest useful version is clear: parse diff for filenames, load those files instead of raw diff.

--- a/.design/diffload.md
+++ b/.design/diffload.md
@@ -1,86 +1,177 @@
-# diffload: Extract files from diff for context
+# diffload: Two context sources from branch changes
 
 ## What to build
 
-Replace auto-loaded diff with auto-loaded file context for files touched by the branch.
+Add `diff_files` as a new context source (files touched by the branch). Change `diff` default to off. Both are independent toggles like `docs` and `paste`.
 
 ## Problem
 
 "It seems like the LLMs do not realize they have the whole diff in their context."
 
-A diff shows changes but lacks surrounding context. When an LLM sees:
+A diff shows changes but lacks surrounding context. Loading the actual files touched by the branch gives the LLM the full picture—it can see the whole function, the class hierarchy, the imports.
 
-```diff
-@@ -121,5 +121,8 @@
--    old_line()
-+    new_line()
-+    another_line()
-```
+## The two options
 
-It knows what changed but not what's around it. Three context lines isn't enough to understand the file's structure, imports, or how functions fit together.
+| Option | What it loads | Default | CLI flags |
+|--------|--------------|---------|-----------|
+| `diff_files` | Full content of files touched by branch | ON | `--diff-files/--no-diff-files` |
+| `diff` | Raw `git diff main...HEAD` output | OFF | `--diff/--no-diff` |
 
-Loading the actual files gives the LLM the full picture—it can see the whole function, the class hierarchy, the imports. The diff becomes redundant because the LLM can read the current state directly.
+Both can be on, both can be off, or either one. They're independent context sources, same as `docs`, `paste`, `clipboard`.
 
 ## Data structures
 
-No new types. The change is in `gather_prompt_components()`.
+Add to `PromptComponents`:
 
 ```python
-# Current behavior
-diff = gather_diff(repo_root, exclude)
-context_files = gather_files(context, repo_root, context_exclude) if context else []
+@dataclass
+class PromptComponents:
+    run_mode: str | None
+    docs: list[tuple[Path, str]]
+    diff: str | None
+    diff_files: list[tuple[Path, str]]  # NEW
+    task: tuple[str, str] | None
+    context_files: list[tuple[Path, str]]
+    # ...
+```
 
-# New behavior
-diff_files = gather_diff_files(repo_root, exclude)  # List of paths from diff
-context_files = gather_files(context + diff_files, repo_root, context_exclude)
-diff = None  # Or keep as option, default off
+Add to `Config`:
+
+```python
+class Config(BaseModel):
+    # ...
+    diff: bool = False        # CHANGED: was True
+    diff_files: bool = True   # NEW
 ```
 
 ## Key functions
 
 ```python
 def gather_diff_files(repo_root: Path, exclude: list[str] | None = None) -> list[str]:
-    """Return list of file paths touched by this branch vs main.
+    """Return file paths touched by this branch vs main.
 
     Uses git diff --name-only main...HEAD.
-    Filters out deleted files (they don't exist to load).
+    Filters out deleted files (can't load those).
+    Respects exclude patterns.
     """
 ```
 
-Modification to `gather_prompt_components()`:
-- Call `gather_diff_files()`
-- Merge result with explicit `-x` context
-- Pass combined list to `gather_files()`
+## Changes by file
+
+### `src/loopflow/config.py`
+
+```python
+class Config(BaseModel):
+    # ...
+    diff: bool = False        # change default
+    diff_files: bool = True   # add new field
+```
+
+### `src/loopflow/context.py`
+
+Add `gather_diff_files()`:
+
+```python
+def gather_diff_files(repo_root: Path, exclude: list[str] | None = None) -> list[str]:
+    result = subprocess.run(
+        ["git", "diff", "--name-only", "main...HEAD"],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        return []
+
+    paths = []
+    for line in result.stdout.strip().split("\n"):
+        if not line:
+            continue
+        path = repo_root / line
+        if path.exists():  # filter deleted files
+            paths.append(line)
+    return paths
+```
+
+Update `PromptComponents`:
+
+```python
+@dataclass
+class PromptComponents:
+    # ...
+    diff_files: list[tuple[Path, str]] = field(default_factory=list)
+```
+
+Update `gather_prompt_components()` to call `gather_diff_files()` and pass to `gather_files()`.
+
+Update `format_prompt()` to include diff_files in `<lf:files>` section (they merge with context_files).
+
+### `src/loopflow/cli/run.py`
+
+Add CLI flag to `run()`, `inline()`, `cp()`:
+
+```python
+diff_files: Optional[bool] = typer.Option(
+    None, "--diff-files/--no-diff-files", help="Include files touched by branch"
+),
+```
+
+Same pattern as existing `--diff/--no-diff`, `--docs/--no-docs`.
+
+### `src/loopflow/tokens.py`
+
+Update `analyze_prompt_tokens()` to show diff_files in token breakdown:
+
+```python
+def analyze_prompt_tokens(
+    # ...
+    diff_files: Optional[list[tuple[Path, str]]] = None,
+) -> TokenTree:
+    # ...
+    if diff_files:
+        for file_path, content in diff_files:
+            tokens = count_tokens(content)
+            tree.add("diff_files", file_path.name, tokens)
+```
+
+### `src/loopflow/maestro/markdown.py`
+
+Add to `AgentFile`:
+
+```python
+@dataclass
+class AgentFile:
+    # ...
+    diff: bool = False        # change default
+    diff_files: bool = True   # add field
+```
+
+Update `parse_agent_file()` and `create_agent_file()`.
+
+### `docs/config.md`
+
+Document both options with their defaults and CLI flags.
 
 ## Constraints
 
-- **Must filter deleted files.** `git diff --name-only` includes deleted files—can't load those.
-- **Must respect exclude patterns.** If `exclude: ["*.test.ts"]` is set, don't load test files even if they're in the diff.
-- **Config toggle for backwards compat.** Some users may prefer the diff. Add `diff_as_files: bool = True` (default on) to config. When false, loads raw diff as before.
-
-## Config
-
-```yaml
-# .lf/config.yaml
-diff_as_files: true   # default: load files instead of diff
-```
-
-The existing `diff: bool` controls whether to include diff context at all. The new `diff_as_files` controls the format when diff is enabled.
+- **Filter deleted files.** `git diff --name-only` includes deleted files—can't load those.
+- **Respect exclude patterns.** If `exclude: ["*.test.ts"]` is set, don't load test files even if they're in the diff.
+- **Merge with context_files.** diff_files should appear in the same `<lf:files>` section as explicit `-x` context, deduplicated.
 
 ## Done when
 
 ```bash
-# On a feature branch with changes to src/loopflow/context.py
-lf : "list the files in lf:files" -c 2>&1 | grep "context.py"
+# On a feature branch with changes
+lf : "list files in lf:files" -c 2>&1 | head -20
 ```
 
-Should show `src/loopflow/context.py` in the `<lf:files>` section, not in `<lf:diff>`.
+Should show:
+- `diff_files` category in token breakdown (not `diff`)
+- Changed files in `<lf:files>` section
 
-Alternative verification:
+With flags:
+
 ```bash
-lf : "what files are in your context?" -c | pbpaste | grep -A5 "lf:files"
+lf : "test" --no-diff-files --diff -c   # old behavior
+lf : "test" --diff-files --no-diff -c   # new default
+lf : "test" --diff-files --diff -c      # both
 ```
-
-## Open questions
-
-None blocking. The smallest useful version is clear: parse diff for filenames, load those files instead of raw diff.

--- a/Maestro/Maestro/AppState.swift
+++ b/Maestro/Maestro/AppState.swift
@@ -16,7 +16,8 @@ final class AppState {
     var selectedPrompt: PromptCard?
     var promptArgs: String = ""
     var includeDocs: Bool = true
-    var includeDiff: Bool = true
+    var includeDiff: Bool = false
+    var includeDiffFiles: Bool = true
     var includePaste: Bool = false
     var selectedContextFolders: Set<URL> = []
     var attachedFiles: [URL] = []  // Files dropped or added via UI
@@ -58,7 +59,8 @@ final class AppState {
 
             // Initialize toggles from config
             includeDocs = config?.docs ?? true
-            includeDiff = config?.diff ?? true
+            includeDiff = config?.diff ?? false
+            includeDiffFiles = config?.diffFiles ?? true
             includePaste = config?.paste ?? false
 
             // Initialize context folders from config
@@ -177,6 +179,7 @@ final class AppState {
             args: promptArgs,
             context: Array(selectedContextFolders),
             includeDiff: includeDiff,
+            includeDiffFiles: includeDiffFiles,
             in: repo
         )
     }
@@ -228,8 +231,11 @@ final class AppState {
         if !includeDocs {
             parts.append("--no-docs")
         }
-        if !includeDiff {
-            parts.append("--no-diff")
+        if includeDiff {
+            parts.append("--diff")
+        }
+        if !includeDiffFiles {
+            parts.append("--no-diff-files")
         }
         if includePaste {
             parts.append("--paste")

--- a/Maestro/Maestro/Models/LoopflowConfig.swift
+++ b/Maestro/Maestro/Models/LoopflowConfig.swift
@@ -15,10 +15,12 @@ struct LoopflowConfig: Codable {
     let yolo: Bool?
     let docs: Bool?
     let diff: Bool?
+    let diffFiles: Bool?
     let paste: Bool?
 
     enum CodingKeys: String, CodingKey {
         case agentModel = "agent_model"
+        case diffFiles = "diff_files"
         case interactive, terminal, ide, workspace, context, exclude, push, pr, yolo, docs, diff, paste
     }
 

--- a/Maestro/Maestro/Services/ConfigLoader.swift
+++ b/Maestro/Maestro/Services/ConfigLoader.swift
@@ -39,6 +39,7 @@ struct ConfigLoader {
         var yolo: Bool?
         var docs: Bool?
         var diff: Bool?
+        var diffFiles: Bool?
         var paste: Bool?
 
         let lines = contents.components(separatedBy: .newlines)
@@ -100,6 +101,7 @@ struct ConfigLoader {
                 case "yolo": yolo = value == "true"
                 case "docs": docs = value == "true"
                 case "diff": diff = value == "true"
+                case "diff_files": diffFiles = value == "true"
                 case "paste": paste = value == "true"
                 default: break
                 }
@@ -119,6 +121,7 @@ struct ConfigLoader {
             yolo: yolo,
             docs: docs,
             diff: diff,
+            diffFiles: diffFiles,
             paste: paste
         )
     }

--- a/Maestro/Maestro/Services/TokenEstimator.swift
+++ b/Maestro/Maestro/Services/TokenEstimator.swift
@@ -8,6 +8,7 @@ struct TokenEstimator {
         args: String,
         context: [URL],
         includeDiff: Bool,
+        includeDiffFiles: Bool,
         in repoURL: URL
     ) async -> Int {
         var cmdArgs = ["lf"]
@@ -28,8 +29,15 @@ struct TokenEstimator {
             cmdArgs.append(relativePath)
         }
 
+        // Include diff flags to match actual command
+        if includeDiff {
+            cmdArgs.append("--diff")
+        }
+        if !includeDiffFiles {
+            cmdArgs.append("--no-diff-files")
+        }
+
         cmdArgs.append("-c")
-        cmdArgs.append("--json")
 
         do {
             let output = try await run(cmdArgs, in: repoURL)

--- a/Maestro/Maestro/Views/PromptLauncher.swift
+++ b/Maestro/Maestro/Views/PromptLauncher.swift
@@ -436,6 +436,9 @@ struct PromptLauncher: View {
         .onChange(of: appState.includeDiff) {
             Task { await appState.estimateTokens() }
         }
+        .onChange(of: appState.includeDiffFiles) {
+            Task { await appState.estimateTokens() }
+        }
         .onChange(of: appState.includePaste) {
             Task { await appState.estimateTokens() }
         }
@@ -453,11 +456,19 @@ struct PromptLauncher: View {
                 }
                 .toggleStyle(.checkbox)
 
+                Toggle(isOn: $appState.includeDiffFiles) {
+                    Text("Files")
+                        .font(.caption)
+                }
+                .toggleStyle(.checkbox)
+                .help("Include full content of files touched by this branch")
+
                 Toggle(isOn: $appState.includeDiff) {
                     Text("Diff")
                         .font(.caption)
                 }
                 .toggleStyle(.checkbox)
+                .help("Include raw diff output")
 
                 Toggle(isOn: $appState.includePaste) {
                     Text("Clipboard")
@@ -585,19 +596,25 @@ struct PromptLauncher: View {
                     if appState.includeDocs {
                         Rectangle()
                             .fill(Color.blue.opacity(0.7))
+                            .frame(width: geometry.size.width * 0.25)
+                    }
+                    // Diff files
+                    if appState.includeDiffFiles {
+                        Rectangle()
+                            .fill(Color.teal.opacity(0.7))
                             .frame(width: geometry.size.width * 0.3)
                     }
                     // Diff
                     if appState.includeDiff {
                         Rectangle()
                             .fill(Color.green.opacity(0.7))
-                            .frame(width: geometry.size.width * 0.2)
+                            .frame(width: geometry.size.width * 0.15)
                     }
                     // Context files
                     if !appState.selectedContextFolders.isEmpty {
                         Rectangle()
                             .fill(Color.orange.opacity(0.7))
-                            .frame(width: geometry.size.width * 0.4)
+                            .frame(width: geometry.size.width * 0.2)
                     }
                     // Clipboard
                     if appState.includePaste {
@@ -618,13 +635,18 @@ struct PromptLauncher: View {
                         .font(.caption2)
                         .foregroundStyle(Color.blue.opacity(0.7))
                 }
+                if appState.includeDiffFiles {
+                    Label("Files", systemImage: "circle.fill")
+                        .font(.caption2)
+                        .foregroundStyle(Color.teal.opacity(0.7))
+                }
                 if appState.includeDiff {
                     Label("Diff", systemImage: "circle.fill")
                         .font(.caption2)
                         .foregroundStyle(Color.green.opacity(0.7))
                 }
                 if !appState.selectedContextFolders.isEmpty {
-                    Label("Files", systemImage: "circle.fill")
+                    Label("Context", systemImage: "circle.fill")
                         .font(.caption2)
                         .foregroundStyle(Color.orange.opacity(0.7))
                 }

--- a/docs/config.md
+++ b/docs/config.md
@@ -118,6 +118,39 @@ exclude:
   - dist
 ```
 
+### diff_files
+
+Include the full content of files touched by the current branch. Default: `true`.
+
+```yaml
+diff_files: true
+```
+
+This is the primary way agents see what's changed on the branch. Instead of just seeing the diff output, the agent gets the complete file content for every modified file.
+
+Override per-run with `--diff-files/--no-diff-files`:
+
+```bash
+lf review --no-diff-files     # skip loading changed files
+```
+
+### diff
+
+Include raw `git diff main...HEAD` output. Default: `false`.
+
+```yaml
+diff: false
+```
+
+The raw diff shows exactly what lines changed but lacks context. Most tasks work better with `diff_files` enabled instead.
+
+Override per-run with `--diff/--no-diff`:
+
+```bash
+lf review --diff              # include raw diff
+lf review --diff --diff-files # both: files + diff
+```
+
 ### ide
 
 Configure which IDEs loopflow installs (used by `lf ops install`).
@@ -248,6 +281,8 @@ No environment variable overrides are supported yet.
 Every task automatically includes:
 
 1. All `.md` files at repository root (README, STYLE, etc.)
-2. Current git diff (staged and unstaged)
+2. Files touched by the current branch (if `diff_files: true`, the default)
 3. Files specified in `context` config
 4. Files passed with `-x` flag
+
+Raw diff output is not included by default. Enable with `diff: true` or `--diff` flag.

--- a/src/loopflow/cli/run.py
+++ b/src/loopflow/cli/run.py
@@ -178,7 +178,10 @@ def run(
         None, "--docs/--no-docs", help="Include repo documentation (.md files)"
     ),
     diff: Optional[bool] = typer.Option(
-        None, "--diff/--no-diff", help="Include branch diff against main"
+        None, "--diff/--no-diff", help="Include raw branch diff against main"
+    ),
+    diff_files: Optional[bool] = typer.Option(
+        None, "--diff-files/--no-diff-files", help="Include files touched by branch"
     ),
     model: ModelType = typer.Option(
         None, "-m", "--model", help="Model to use (backend or backend:variant)"
@@ -270,10 +273,11 @@ def run(
         if pattern in exclude_patterns:
             exclude_patterns.remove(pattern)
 
-    # Resolve paste/docs/diff flags (CLI overrides config)
+    # Resolve paste/docs/diff/diff_files flags (CLI overrides config)
     include_paste = paste if paste is not None else (config.paste if config else False)
     include_docs = docs if docs is not None else (config.docs if config else True)
-    include_diff = diff if diff is not None else (config.diff if config else True)
+    include_diff = diff if diff is not None else (config.diff if config else False)
+    include_diff_files = diff_files if diff_files is not None else (config.diff_files if config else True)
 
     args = ctx.args or None
     try:
@@ -287,16 +291,16 @@ def run(
             run_mode="interactive" if is_interactive else "auto",
             include_loopflow_doc=config.include_loopflow_doc if config else True,
             voices=resolved.voice or None,
+            include_diff=include_diff,
+            include_diff_files=include_diff_files,
         )
     except VoiceNotFoundError as e:
         typer.echo(f"Error: {e}", err=True)
         raise typer.Exit(1)
 
-    # Apply docs/diff flags
+    # Apply docs flag
     if not include_docs:
         components.docs = []
-    if not include_diff:
-        components.diff = None
 
     if copy:
         prompt = format_prompt(components)
@@ -343,7 +347,10 @@ def inline(
         None, "--docs/--no-docs", help="Include repo documentation (.md files)"
     ),
     diff: Optional[bool] = typer.Option(
-        None, "--diff/--no-diff", help="Include branch diff against main"
+        None, "--diff/--no-diff", help="Include raw branch diff against main"
+    ),
+    diff_files: Optional[bool] = typer.Option(
+        None, "--diff-files/--no-diff-files", help="Include files touched by branch"
     ),
     model: ModelType = typer.Option(
         None, "-m", "--model", help="Model to use (backend or backend:variant)"
@@ -396,10 +403,11 @@ def inline(
         if pattern in exclude_patterns:
             exclude_patterns.remove(pattern)
 
-    # Resolve paste/docs/diff flags (CLI overrides config)
+    # Resolve paste/docs/diff/diff_files flags (CLI overrides config)
     include_paste = paste if paste is not None else (config.paste if config else False)
     include_docs = docs if docs is not None else (config.docs if config else True)
-    include_diff = diff if diff is not None else (config.diff if config else True)
+    include_diff = diff if diff is not None else (config.diff if config else False)
+    include_diff_files = diff_files if diff_files is not None else (config.diff_files if config else True)
 
     try:
         components = gather_prompt_components(
@@ -412,16 +420,16 @@ def inline(
             run_mode="interactive" if is_interactive else "auto",
             include_loopflow_doc=config.include_loopflow_doc if config else True,
             voices=resolved.voice or None,
+            include_diff=include_diff,
+            include_diff_files=include_diff_files,
         )
     except VoiceNotFoundError as e:
         typer.echo(f"Error: {e}", err=True)
         raise typer.Exit(1)
 
-    # Apply docs/diff flags
+    # Apply docs flag
     if not include_docs:
         components.docs = []
-    if not include_diff:
-        components.diff = None
 
     if copy:
         prompt_text = format_prompt(components)
@@ -454,11 +462,14 @@ def cp(
     paste: bool = typer.Option(
         False, "-v", "--paste", help="Include clipboard content"
     ),
-    docs: bool = typer.Option(
-        True, "--docs/--no-docs", help="Include repo documentation (.md files)"
+    docs: Optional[bool] = typer.Option(
+        None, "--docs/--no-docs", help="Include repo documentation (.md files)"
     ),
-    diff: bool = typer.Option(
-        True, "--diff/--no-diff", help="Include branch diff"
+    diff: Optional[bool] = typer.Option(
+        None, "--diff/--no-diff", help="Include raw branch diff"
+    ),
+    diff_files: Optional[bool] = typer.Option(
+        None, "--diff-files/--no-diff-files", help="Include files touched by branch"
     ),
 ):
     """Copy file context to clipboard."""
@@ -479,6 +490,11 @@ def cp(
     if config and config.exclude:
         exclude_patterns.extend(config.exclude)
 
+    # Resolve flags (CLI overrides config)
+    include_docs = docs if docs is not None else (config.docs if config else True)
+    include_diff = diff if diff is not None else (config.diff if config else False)
+    include_diff_files = diff_files if diff_files is not None else (config.diff_files if config else True)
+
     components = gather_prompt_components(
         repo_root,
         task=None,
@@ -487,13 +503,13 @@ def cp(
         paste=paste,
         run_mode=None,
         include_loopflow_doc=config.include_loopflow_doc if config else True,
+        include_diff=include_diff,
+        include_diff_files=include_diff_files,
     )
 
-    # Apply docs/diff flags
-    if not docs:
+    # Apply docs flag
+    if not include_docs:
         components.docs = []
-    if not diff:
-        components.diff = None
 
     prompt = format_prompt(components)
     _copy_to_clipboard(prompt)
@@ -569,6 +585,8 @@ def pipeline(
             exclude=exclude,
             include_tests_for=config.include_tests_for if config else None,
             include_loopflow_doc=config.include_loopflow_doc,
+            include_diff=config.diff,
+            include_diff_files=config.diff_files,
         )
         prompt = format_prompt(components)
         _copy_to_clipboard(prompt)

--- a/src/loopflow/config.py
+++ b/src/loopflow/config.py
@@ -53,7 +53,8 @@ class Config(BaseModel):
     interactive: list[str] = Field(default_factory=list)  # Tasks that default to interactive
     include_loopflow_doc: bool = True  # Include bundled LOOPFLOW.md in prompts
     docs: bool = True  # Include repo documentation (.md files)
-    diff: bool = True  # Include branch diff against main
+    diff: bool = False  # Include raw branch diff against main
+    diff_files: bool = True  # Include full content of files touched by branch
     paste: bool = False  # Include clipboard content by default
     voice: Optional[list[str]] = None  # Default voices for all tasks
 

--- a/src/loopflow/context.py
+++ b/src/loopflow/context.py
@@ -19,6 +19,7 @@ class PromptComponents:
     run_mode: str | None
     docs: list[tuple[Path, str]]
     diff: str | None
+    diff_files: list[tuple[Path, str]]
     task: tuple[str, str] | None  # (name, content)
     context_files: list[tuple[Path, str]]
     repo_root: Path
@@ -149,6 +150,42 @@ def gather_diff(repo_root: Path, exclude: Optional[list[str]] = None) -> str | N
     return result.stdout
 
 
+def gather_diff_files(repo_root: Path) -> list[str]:
+    """Return file paths touched by this branch vs main.
+
+    Filters out deleted files (can't load those).
+    Exclude patterns are applied later when files are loaded via gather_files().
+    """
+    # Get current branch
+    result = subprocess.run(
+        ["git", "branch", "--show-current"],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+    )
+    branch = result.stdout.strip()
+    if not branch or branch == "main":
+        return []
+
+    result = subprocess.run(
+        ["git", "diff", "--name-only", "main...HEAD"],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        return []
+
+    paths = []
+    for line in result.stdout.strip().split("\n"):
+        if not line:
+            continue
+        path = repo_root / line
+        if path.exists():  # filter deleted files
+            paths.append(line)
+    return paths
+
+
 def _load_loopflow_doc() -> str:
     """Load LOOPFLOW.md from the package."""
     return resources.files("loopflow").joinpath("LOOPFLOW.md").read_text()
@@ -166,6 +203,8 @@ def gather_prompt_components(
     run_mode: Optional[str] = None,
     include_loopflow_doc: bool = True,
     voices: Optional[list[str]] = None,
+    include_diff: bool = False,
+    include_diff_files: bool = True,
 ) -> PromptComponents:
     """Gather all prompt components without assembling them."""
     docs = gather_docs(repo_root, repo_root, exclude)
@@ -178,7 +217,7 @@ def gather_prompt_components(
     if design_docs:
         docs[0:0] = design_docs
 
-    diff = gather_diff(repo_root, exclude)
+    diff = gather_diff(repo_root, exclude) if include_diff else None
 
     task_result = None
     if inline:
@@ -211,6 +250,10 @@ def gather_prompt_components(
         if not include_tests and "tests/**" not in context_exclude:
             context_exclude.append("tests/**")
 
+    # Gather files touched by diff
+    diff_file_paths = gather_diff_files(repo_root) if include_diff_files else []
+    diff_files_content = gather_files(diff_file_paths, repo_root, context_exclude) if diff_file_paths else []
+
     context_files = (
         gather_files(context, repo_root, context_exclude) if context else []
     )
@@ -223,6 +266,7 @@ def gather_prompt_components(
         run_mode=run_mode,
         docs=docs,
         diff=diff,
+        diff_files=diff_files_content,
         task=task_result,
         context_files=context_files,
         repo_root=repo_root,
@@ -277,8 +321,16 @@ def format_prompt(components: PromptComponents) -> str:
     if components.diff:
         parts.append(f"Changes on this branch (diff against main).\n\n<lf:diff>\n{components.diff}\n</lf:diff>")
 
-    if components.context_files:
-        parts.append(format_files(components.context_files, components.repo_root))
+    # Merge diff_files and context_files, deduplicating by path
+    all_files = list(components.diff_files)
+    seen_paths = {path for path, _ in all_files}
+    for path, content in components.context_files:
+        if path not in seen_paths:
+            all_files.append((path, content))
+            seen_paths.add(path)
+
+    if all_files:
+        parts.append(format_files(all_files, components.repo_root))
 
     if components.clipboard:
         parts.append(f"Content from clipboard.\n\n<lf:clipboard>\n{components.clipboard}\n</lf:clipboard>")

--- a/src/loopflow/maestro/markdown.py
+++ b/src/loopflow/maestro/markdown.py
@@ -32,6 +32,8 @@ class AgentFile:
     prompt: str
     interval_seconds: int | None = None
     fresh: bool = False  # force fresh worktree each run
+    diff: bool = False  # include raw branch diff
+    diff_files: bool = True  # include files touched by branch
 
 
 _FRONTMATTER_PATTERN = re.compile(r"^---\s*\n(.*?)\n---\s*\n?", re.DOTALL)
@@ -64,6 +66,8 @@ def parse_agent_file(path: Path) -> AgentFile | None:
         prompt=prompt,
         interval_seconds=config.get("interval"),
         fresh=config.get("fresh", False),
+        diff=config.get("diff", False),
+        diff_files=config.get("diff_files", True),
     )
 
 
@@ -149,6 +153,8 @@ def create_agent_file(
     prompt: str = "",
     interval_seconds: int | None = None,
     agents_dir: Path | None = None,
+    diff: bool = False,
+    diff_files: bool = True,
 ) -> Path:
     """Create a new agent markdown file."""
     if agents_dir is None:
@@ -165,6 +171,10 @@ def create_agent_file(
         lines.append(f"interval: {interval_seconds}")
     if context:
         lines.append(f"context: [{', '.join(context)}]")
+    if diff:
+        lines.append("diff: true")
+    if not diff_files:
+        lines.append("diff_files: false")
     lines.append("---")
     lines.append("")
     lines.append(prompt or "Describe what this agent should do.")

--- a/src/loopflow/tokens.py
+++ b/src/loopflow/tokens.py
@@ -163,6 +163,7 @@ class TokenTree:
 def analyze_prompt_tokens(
     docs: Optional[list[tuple[Path, str]]] = None,
     diff: Optional[str] = None,
+    diff_files: Optional[list[tuple[Path, str]]] = None,
     task: Optional[tuple[str, str]] = None,
     context_files: Optional[list[tuple[Path, str]]] = None,
     repo_root: Optional[Path] = None,
@@ -184,6 +185,16 @@ def analyze_prompt_tokens(
     if diff:
         tokens = count_tokens(diff)
         tree.add("diff", "branch diff", tokens)
+
+    if diff_files and repo_root:
+        for file_path, content in diff_files:
+            tokens = count_tokens(content)
+            try:
+                rel = file_path.relative_to(repo_root)
+                parts = list(rel.parts[:-1])  # directory parts
+                tree.add("diff_files", rel.name, tokens, path=parts)
+            except ValueError:
+                tree.add("diff_files", file_path.name, tokens)
 
     if task:
         name, content = task
@@ -212,6 +223,7 @@ def analyze_components(components) -> TokenTree:
     return analyze_prompt_tokens(
         docs=components.docs,
         diff=components.diff,
+        diff_files=components.diff_files,
         task=components.task,
         context_files=components.context_files,
         repo_root=components.repo_root,


### PR DESCRIPTION
# Usage

```bash
# Default: get full files touched by branch, no raw diff
lf review

# Include raw diff too
lf review --diff

# Skip diff files, just raw diff
lf review --no-diff-files --diff
```

Adds `diff_files` context source that loads complete file content for files touched by the current branch. This gives LLMs better context than raw diffs alone—they see imports, surrounding functions, and full file structure.

The `diff` option (raw diff output) is now off by default. Most tasks work better with complete files (`diff_files`) than line-by-line diffs. Both can be used together when needed.

## Changes

- Add `diff_files` config option (default: true) and `--diff-files/--no-diff-files` flags
- Change `diff` default from true to false 
- Update Maestro UI with separate toggles for "Files" and "Diff"
- Add token analysis for diff files as separate category
- Files from diff and context merge in `<lf:files>` section, deduplicated by path
- Update design/implement prompts with end-to-end guidance for UI changes