### PR TITLE
maestro: fix shell escaping for paths and commands with special characters

### DIFF
--- a/Maestro/Maestro/AppState.swift
+++ b/Maestro/Maestro/AppState.swift
@@ -251,7 +251,7 @@ final class AppState {
         }
 
         if !promptArgs.isEmpty {
-            parts.append(promptArgs)
+            parts.append(shellEscape(promptArgs))
         }
 
         if runMode == .interactive {
@@ -334,5 +334,21 @@ final class AppState {
             let isDir = (try? item.resourceValues(forKeys: [.isDirectoryKey]))?.isDirectory ?? false
             return isDir
         }
+    }
+
+    private func shellEscape(_ string: String) -> String {
+        // If string contains any shell metacharacters, wrap in single quotes
+        // and escape any single quotes within
+        let needsQuoting = string.contains { char in
+            " \t\n'\"\\$`!*?[]{}()<>|&;#~".contains(char)
+        }
+
+        if needsQuoting {
+            // Use single quotes, escaping embedded single quotes as '\''
+            let escaped = string.replacingOccurrences(of: "'", with: "'\\''")
+            return "'\(escaped)'"
+        }
+
+        return string
     }
 }

--- a/Maestro/Maestro/Services/TerminalLauncher.swift
+++ b/Maestro/Maestro/Services/TerminalLauncher.swift
@@ -73,9 +73,8 @@ struct TerminalLauncher {
         let script: String
 
         if let cmd = command {
-            // Escape single quotes in the command for AppleScript
-            let escapedCmd = cmd.replacingOccurrences(of: "'", with: "'\\''")
-            let escapedPath = path.path().replacingOccurrences(of: "'", with: "'\\''")
+            let fullCommand = "cd '\(escapeShellSingleQuotes(path.path()))' && \(cmd)"
+            let escapedForAppleScript = escapeForAppleScriptString(fullCommand)
 
             script = """
             tell application "Warp"
@@ -94,13 +93,14 @@ struct TerminalLauncher {
 
             tell application "System Events"
                 tell process "Warp"
-                    keystroke "cd '\(escapedPath)' && \(escapedCmd)"
+                    keystroke "\(escapedForAppleScript)"
                     key code 36
                 end tell
             end tell
             """
         } else {
-            let escapedPath = path.path().replacingOccurrences(of: "'", with: "'\\''")
+            let fullCommand = "cd '\(escapeShellSingleQuotes(path.path()))'"
+            let escapedForAppleScript = escapeForAppleScriptString(fullCommand)
 
             script = """
             tell application "Warp"
@@ -119,7 +119,7 @@ struct TerminalLauncher {
 
             tell application "System Events"
                 tell process "Warp"
-                    keystroke "cd '\(escapedPath)'"
+                    keystroke "\(escapedForAppleScript)"
                     key code 36
                 end tell
             end tell
@@ -132,22 +132,26 @@ struct TerminalLauncher {
     private func launchITerm(at path: URL, command: String?) throws {
         let script: String
         if let cmd = command {
+            let fullCommand = "cd '\(escapeShellSingleQuotes(path.path()))' && \(cmd)"
+            let escaped = escapeForAppleScriptString(fullCommand)
             script = """
             tell application "iTerm"
                 activate
                 create window with default profile
                 tell current session of current window
-                    write text "cd '\(path.path())' && \(cmd)"
+                    write text "\(escaped)"
                 end tell
             end tell
             """
         } else {
+            let fullCommand = "cd '\(escapeShellSingleQuotes(path.path()))'"
+            let escaped = escapeForAppleScriptString(fullCommand)
             script = """
             tell application "iTerm"
                 activate
                 create window with default profile
                 tell current session of current window
-                    write text "cd '\(path.path())'"
+                    write text "\(escaped)"
                 end tell
             end tell
             """
@@ -159,17 +163,21 @@ struct TerminalLauncher {
     private func launchTerminalApp(at path: URL, command: String?) throws {
         let script: String
         if let cmd = command {
+            let fullCommand = "cd '\(escapeShellSingleQuotes(path.path()))' && \(cmd)"
+            let escaped = escapeForAppleScriptString(fullCommand)
             script = """
             tell application "Terminal"
                 activate
-                do script "cd '\(path.path())' && \(cmd)"
+                do script "\(escaped)"
             end tell
             """
         } else {
+            let fullCommand = "cd '\(escapeShellSingleQuotes(path.path()))'"
+            let escaped = escapeForAppleScriptString(fullCommand)
             script = """
             tell application "Terminal"
                 activate
-                do script "cd '\(path.path())'"
+                do script "\(escaped)"
             end tell
             """
         }
@@ -296,5 +304,17 @@ struct TerminalLauncher {
             // Fall through to return nil
         }
         return nil
+    }
+
+    /// Escape single quotes for shell: ' becomes '\''
+    private func escapeShellSingleQuotes(_ string: String) -> String {
+        string.replacingOccurrences(of: "'", with: "'\\''")
+    }
+
+    /// Escape for AppleScript double-quoted string: \ becomes \\, " becomes \"
+    private func escapeForAppleScriptString(_ string: String) -> String {
+        string
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "\"", with: "\\\"")
     }
 }

--- a/Maestro/dev
+++ b/Maestro/dev
@@ -3,13 +3,16 @@
 
 set -e
 
+DEV_APP="$HOME/Applications/Maestro Dev.app"
+
 usage() {
     echo "Usage: ./dev <command>"
     echo ""
     echo "Commands:"
     echo "  build      Build the app"
     echo "  test       Build and run tests"
-    echo "  run        Build and launch the app"
+    echo "  run        Build and launch the app (installs to ~/Applications)"
+    echo "  clean      Remove dev app and reset permissions"
     echo "  xcode      Open in Xcode"
     echo "  release    Build release .app and .dmg"
     echo "  help       Show this message"
@@ -31,14 +34,25 @@ case "${1:-help}" in
         echo "Building and running Maestro..."
         swift build
 
-        # Create proper .app bundle with Info.plist
-        APP_DIR=".build/debug/Maestro.app/Contents"
+        # Install to stable location to preserve macOS permissions across rebuilds.
+        # TCC ties permissions to app bundle path - using a fixed path means you only
+        # grant Accessibility/Automation permissions once.
+        APP_DIR="$DEV_APP/Contents"
         mkdir -p "$APP_DIR/MacOS"
         cp .build/debug/Maestro "$APP_DIR/MacOS/"
         cp Maestro/Info.plist "$APP_DIR/"
 
-        # Launch the app bundle
-        open .build/debug/Maestro.app
+        # Launch from stable location
+        open "$DEV_APP"
+        ;;
+    clean)
+        echo "Removing dev app..."
+        rm -rf "$DEV_APP"
+        echo "Resetting Accessibility permissions..."
+        tccutil reset Accessibility com.loopflow.maestro 2>/dev/null || true
+        echo "Resetting Automation permissions..."
+        tccutil reset AppleEvents com.loopflow.maestro 2>/dev/null || true
+        echo "Done. Next ./dev run will require re-granting permissions."
         ;;
     xcode)
         echo "Opening in Xcode..."


### PR DESCRIPTION
# Usage

This fixes crashes when opening terminals with paths or prompts containing special characters:

```bash
# These now work without shell injection or crashes
lf implement -w "my branch"     # spaces in branch name
lf : "what's going on?"         # quotes in prompt
cd "/path with spaces" && lf review   # spaces in working directory
```

## Summary

Fixed shell command injection vulnerabilities in terminal launching by properly escaping shell metacharacters and AppleScript strings. The app was crashing when paths contained spaces or when prompts contained quotes, backticks, or other shell special characters.

## Changes

- Add `shellEscape()` function to properly quote shell arguments with special characters
- Fix AppleScript string escaping for Warp, iTerm, and Terminal.app launchers
- Install dev app to stable path (`~/Applications/Maestro Dev.app`) to preserve macOS permissions across rebuilds
- Add `./dev clean` command to reset permissions when needed