### PR TITLE
lfops init: remove style guide and prompts scaffolding

### DIFF
--- a/src/loopflow/lfops.py
+++ b/src/loopflow/lfops.py
@@ -185,16 +185,6 @@ def _scaffold_repo(repo_root: Path, all_prompts: bool = False) -> None:
         shutil.copy(config_src, config_dst)
         typer.echo("  ✓ .lf/config.yaml")
 
-    # Style guide and PROMPTS.md
-    for name in ["STYLE.md", "PROMPTS.md"]:
-        src = templates / name
-        dst = config_dir / name
-        if dst.exists():
-            typer.echo(f"  - .lf/{name} (already exists)")
-        else:
-            shutil.copy(src, dst)
-            typer.echo(f"  ✓ .lf/{name}")
-
     # Commit templates
     for template_name in ["COMMIT_MESSAGE.md", "CHECKPOINT_MESSAGE.md"]:
         src = prompts_dir / template_name


### PR DESCRIPTION
## Usage

```bash
lf ops init    # now only creates config.yaml and commit templates
```

This change simplifies `lf ops init` by removing automatic scaffolding of `STYLE.md` and `PROMPTS.md` files into `.lf/`. The command now focuses on essential configuration: creating `.lf/config.yaml` and commit message templates.

Repos can still add their own style guides and prompt documentation as needed, but they're no longer automatically copied from templates during initialization. This reduces clutter and lets teams decide what documentation they actually need.

## Changes

- Remove `STYLE.md` and `PROMPTS.md` copying from `_scaffold_repo()`
- Keep config and commit template scaffolding unchanged