### PR TITLE
lfops land: open merged PR in browser

### DIFF
--- a/src/loopflow/lfops.py
+++ b/src/loopflow/lfops.py
@@ -1098,6 +1098,16 @@ def _land_pr(strict: bool, worktree: str | None, create_pr: bool = False) -> Non
     else:
         subprocess.run(["git", "branch", "-D", branch], cwd=main_repo, capture_output=True)
 
+    # Open merged PR in browser
+    result = subprocess.run(
+        ["gh", "pr", "view", str(pr_number), "--json", "url", "-q", ".url"],
+        cwd=main_repo,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode == 0 and result.stdout.strip():
+        subprocess.run(["open", result.stdout.strip()])
+
     typer.echo(f"Landed {branch} onto {base_branch}.")
 
     if was_in_worktree:


### PR DESCRIPTION
# Usage

After landing a PR, it automatically opens in your browser:

```bash
lf ship                      # creates and merges PR, opens in browser
lfops land                   # squash-merges current branch, opens PR
```

# Summary

When landing a PR with `lfops land`, the merged PR now opens automatically in your browser. This makes it easy to see the final merged state, check CI status, and review any post-merge actions without manually navigating to GitHub.

The implementation fetches the PR URL using `gh pr view` and opens it with the `open` command, only if the GitHub CLI call succeeds.