### PR TITLE
lfops install: clone superpowers if configured

### DIFF
--- a/src/loopflow/lf/skills.py
+++ b/src/loopflow/lf/skills.py
@@ -88,12 +88,14 @@ def _find_skill_prompt_path(source_path: Path, skill_name: str) -> Path | None:
 def discover_skill_sources(
     config_sources: "list[SkillSourceConfig] | None" = None,
     repo_root: Path | None = None,
+    *,
+    auto_detect: bool = True,
 ) -> list[SkillSource]:
     """Find configured skill libraries.
 
     Checks:
     1. Explicit config sources
-    2. Auto-detection at ~/.superpowers or ./superpowers
+    2. Auto-detection at ~/.superpowers or ./superpowers (if auto_detect=True)
     """
     sources = []
     seen_prefixes = set()
@@ -114,7 +116,7 @@ def discover_skill_sources(
             seen_prefixes.add(source_config.prefix)
 
     # Auto-detect superpowers if not explicitly configured
-    if "sp" not in seen_prefixes:
+    if auto_detect and "sp" not in seen_prefixes:
         # Check repo-local first
         if repo_root:
             local_path = repo_root / "superpowers"

--- a/src/loopflow/lfops/init.py
+++ b/src/loopflow/lfops/init.py
@@ -100,6 +100,42 @@ def _install_worktrunk() -> bool:
     return False
 
 
+def _install_superpowers(config) -> bool:
+    """Clone superpowers skill library if configured and not present."""
+    if not config or not config.skill_sources:
+        return False
+
+    # Check if superpowers is configured
+    sp_source = None
+    for source in config.skill_sources:
+        if source.name == "superpowers" or source.prefix == "sp":
+            sp_source = source
+            break
+
+    if not sp_source:
+        return False
+
+    # Expand path and check if it exists
+    sp_path = Path(sp_source.path).expanduser()
+    if sp_path.exists():
+        typer.echo("✓ superpowers")
+        return True
+
+    # Clone superpowers
+    typer.echo("Installing superpowers skill library...")
+    result = subprocess.run(
+        ["git", "clone", "https://github.com/obra/superpowers", str(sp_path)],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode == 0:
+        typer.echo("✓ superpowers installed")
+        return True
+
+    typer.echo(f"✗ Could not clone superpowers: {result.stderr}", err=True)
+    return False
+
+
 def _print_setup_status(status: SetupStatus) -> None:
     """Print dependency check results."""
     typer.echo("Checking dependencies...")
@@ -329,6 +365,9 @@ def register_commands(app: typer.Typer) -> None:
                 else:
                     typer.echo("✗ Could not install Cursor", err=True)
 
+        # Superpowers skill library (if configured)
+        _install_superpowers(config)
+
     @app.command()
     def doctor() -> None:
         """Check loopflow dependencies and repo status."""
@@ -382,6 +421,17 @@ def register_commands(app: typer.Typer) -> None:
             else:
                 typer.echo("✗ cursor - Run: lfops install")
                 all_ok = False
+
+        # Skill libraries (if configured)
+        if config and config.skill_sources:
+            for source in config.skill_sources:
+                if source.name == "superpowers" or source.prefix == "sp":
+                    sp_path = Path(source.path).expanduser()
+                    if sp_path.exists():
+                        typer.echo("✓ superpowers")
+                    else:
+                        typer.echo("✗ superpowers - Run: lfops install")
+                        all_ok = False
 
         # Optional model backends
         if check_codex_available():

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -1,5 +1,7 @@
 """Tests for loopflow.context module."""
 
+from unittest.mock import patch
+
 import pytest
 
 from loopflow.lf.context import (
@@ -320,6 +322,7 @@ def test_list_user_tasks_returns_user_tasks(tmp_path):
     assert "config" not in tasks  # config.yaml should be excluded
 
 
+@patch("loopflow.lf.skills._SUPERPOWERS_PATHS", [])
 def test_list_all_tasks_separates_user_and_builtin(tmp_path):
     """list_all_tasks returns user tasks, builtin-only tasks, and external skills."""
     (tmp_path / ".git").mkdir()
@@ -347,6 +350,7 @@ def test_list_all_tasks_separates_user_and_builtin(tmp_path):
     assert external_skills == []
 
 
+@patch("loopflow.lf.skills._SUPERPOWERS_PATHS", [])
 def test_list_all_tasks_without_repo():
     """list_all_tasks works without a repo root (returns only builtins)."""
     user_tasks, builtin_only, external_skills = list_all_tasks(None)

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -123,7 +123,7 @@ def test_discover_skill_sources_skips_nonexistent_path(tmp_path):
     config_sources = [
         SkillSourceConfig(name="missing", prefix="ms", path=str(tmp_path / "nonexistent"))
     ]
-    sources = discover_skill_sources(config_sources)
+    sources = discover_skill_sources(config_sources, auto_detect=False)
     assert len(sources) == 0
 
 
@@ -149,7 +149,7 @@ def test_discover_skill_sources_multiple_sources(tmp_path):
         SkillSourceConfig(name="source1", prefix="s1", path=str(sp1)),
         SkillSourceConfig(name="source2", prefix="s2", path=str(sp2)),
     ]
-    sources = discover_skill_sources(config_sources)
+    sources = discover_skill_sources(config_sources, auto_detect=False)
 
     assert len(sources) == 2
     prefixes = {s.prefix for s in sources}


### PR DESCRIPTION
## Summary
- Add `_install_superpowers()` to clone superpowers skill library when `skill_sources` config includes superpowers
- Show superpowers status in `lfops doctor`
- Add `auto_detect` param to `discover_skill_sources` for test isolation

## Test plan
- [x] All 411 tests pass
- [x] `lfops install` clones superpowers if configured and not present
- [x] `lfops doctor` shows superpowers status when configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)