### PR TITLE
maestro: add worktree diagnostics logging and capture fallback

### DIFF
--- a/.design/questions.md
+++ b/.design/questions.md
@@ -1,0 +1,3 @@
+# Questions
+
+- What error/stacktrace should I debug? Please paste the full message (or rerun with `lf debug -v`).

--- a/.design/questions.md
+++ b/.design/questions.md
@@ -1,3 +1,0 @@
-# Questions
-
-- What error/stacktrace should I debug? Please paste the full message (or rerun with `lf debug -v`).

--- a/Maestro/Maestro/Models/Worktree.swift
+++ b/Maestro/Maestro/Models/Worktree.swift
@@ -68,13 +68,6 @@ struct Worktree: Identifiable, Hashable, Codable {
         case hasCodeWorkspace, isRebasing, isMerging, recentTasks, staleness
     }
 
-    var statusText: String {
-        if isDirty {
-            return "modified"
-        }
-        return "clean"
-    }
-
     var commitsText: String {
         var parts: [String] = []
         if let pr = prNumber {
@@ -112,6 +105,7 @@ struct WorktreeJSON: Codable {
     let baseBranch: String?
     let workingTree: WorkingTreeJSON?
     let main: MainStatusJSON?
+    let mainState: String?
     let remote: RemoteStatusJSON?
     let operationState: String?
     let ci: CIJSON?
@@ -121,7 +115,9 @@ struct WorktreeJSON: Codable {
         case branch, path, kind
         case baseBranch = "base_branch"
         case workingTree = "working_tree"
-        case main, remote
+        case main
+        case mainState = "main_state"
+        case remote
         case operationState = "operation_state"
         case ci, prunable
     }

--- a/Maestro/Maestro/Services/CaptureService.swift
+++ b/Maestro/Maestro/Services/CaptureService.swift
@@ -28,9 +28,111 @@ struct CaptureService {
     }
 
     private func captureWindow(_ window: NSWindow) throws -> URL {
-        let windowID = window.windowNumber
         let outputURL = screenshotURL()
+        if try captureWindowLayer(window, to: outputURL) {
+            return outputURL
+        }
+        if try captureWindowContent(window, to: outputURL) {
+            return outputURL
+        }
+        return try captureWindowWithScreencapture(window, to: outputURL)
+    }
 
+    private func captureWindowLayer(_ window: NSWindow, to outputURL: URL) throws -> Bool {
+        guard let contentView = window.contentView else {
+            return false
+        }
+
+        window.displayIfNeeded()
+        contentView.displayIfNeeded()
+
+        let bounds = contentView.bounds
+        if bounds.isEmpty {
+            return false
+        }
+
+        contentView.wantsLayer = true
+        guard let layer = contentView.layer ?? contentView.superview?.layer else {
+            return false
+        }
+
+        let scale = window.backingScaleFactor
+        let width = Int(bounds.width * scale)
+        let height = Int(bounds.height * scale)
+        guard width > 0, height > 0 else {
+            return false
+        }
+
+        guard let rep = NSBitmapImageRep(
+            bitmapDataPlanes: nil,
+            pixelsWide: width,
+            pixelsHigh: height,
+            bitsPerSample: 8,
+            samplesPerPixel: 4,
+            hasAlpha: true,
+            isPlanar: false,
+            colorSpaceName: .deviceRGB,
+            bytesPerRow: 0,
+            bitsPerPixel: 0
+        ) else {
+            throw CaptureError.captureFailed("Could not allocate bitmap for capture.")
+        }
+
+        rep.size = bounds.size
+        guard let ctx = NSGraphicsContext(bitmapImageRep: rep) else {
+            throw CaptureError.captureFailed("Could not create graphics context.")
+        }
+
+        NSGraphicsContext.saveGraphicsState()
+        NSGraphicsContext.current = ctx
+        ctx.cgContext.scaleBy(x: scale, y: scale)
+        layer.render(in: ctx.cgContext)
+        NSGraphicsContext.restoreGraphicsState()
+
+        guard let pngData = rep.representation(using: .png, properties: [:]) else {
+            throw CaptureError.captureFailed("Could not encode layer capture.")
+        }
+
+        try pngData.write(to: outputURL, options: .atomic)
+        return true
+    }
+
+    private func captureWindowContent(_ window: NSWindow, to outputURL: URL) throws -> Bool {
+        guard let contentView = window.contentView else {
+            return false
+        }
+
+        window.displayIfNeeded()
+        contentView.displayIfNeeded()
+
+        let bounds = contentView.bounds
+        if bounds.isEmpty {
+            return false
+        }
+
+        guard let rep = contentView.bitmapImageRepForCachingDisplay(in: bounds) else {
+            return false
+        }
+
+        contentView.cacheDisplay(in: bounds, to: rep)
+
+        let image = NSImage(size: bounds.size)
+        image.addRepresentation(rep)
+
+        guard
+            let tiffData = image.tiffRepresentation,
+            let bitmap = NSBitmapImageRep(data: tiffData),
+            let pngData = bitmap.representation(using: .png, properties: [:])
+        else {
+            throw CaptureError.captureFailed("Could not encode window content.")
+        }
+
+        try pngData.write(to: outputURL, options: .atomic)
+        return true
+    }
+
+    private func captureWindowWithScreencapture(_ window: NSWindow, to outputURL: URL) throws -> URL {
+        let windowID = window.windowNumber
         let process = Process()
         process.executableURL = URL(fileURLWithPath: "/usr/sbin/screencapture")
         process.arguments = ["-l", String(windowID), "-x", outputURL.path()]

--- a/Maestro/Maestro/Services/LoggingService.swift
+++ b/Maestro/Maestro/Services/LoggingService.swift
@@ -1,0 +1,49 @@
+import Foundation
+
+enum LoggingService {
+    static func append(_ message: String) {
+        do {
+            let url = logURL()
+            try ensureLogDirectory(for: url)
+            let timestamp = ISO8601DateFormatter().string(from: Date())
+            let line = "\(timestamp) \(message.trimmingCharacters(in: .whitespacesAndNewlines))\n"
+            let data = line.data(using: .utf8) ?? Data()
+            if FileManager.default.fileExists(atPath: url.path()) {
+                let handle = try FileHandle(forWritingTo: url)
+                try handle.seekToEnd()
+                try handle.write(contentsOf: data)
+                try handle.close()
+            } else {
+                try data.write(to: url, options: .atomic)
+            }
+        } catch {
+            // Avoid throwing from logging.
+        }
+    }
+
+    static func read() -> String {
+        guard let data = try? Data(contentsOf: logURL()) else {
+            return ""
+        }
+        return String(data: data, encoding: .utf8) ?? ""
+    }
+
+    static func logPath() -> String {
+        logURL().path()
+    }
+
+    private static func logURL() -> URL {
+        FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent("Library")
+            .appendingPathComponent("Logs")
+            .appendingPathComponent("Maestro")
+            .appendingPathComponent("worktrees.log")
+    }
+
+    private static func ensureLogDirectory(for url: URL) throws {
+        let dir = url.deletingLastPathComponent()
+        if !FileManager.default.fileExists(atPath: dir.path()) {
+            try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        }
+    }
+}

--- a/Maestro/Maestro/Services/WorktreeService.swift
+++ b/Maestro/Maestro/Services/WorktreeService.swift
@@ -48,6 +48,7 @@ struct WorktreeService {
     }
 
     private let sessionService = SessionService()
+    @MainActor private static var lfopsCompatible: Bool?
 
     private func runProcessWithStatus(
         _ executable: URL,
@@ -86,7 +87,8 @@ struct WorktreeService {
     }
 
     func list(in repoURL: URL) async throws -> [Worktree] {
-        if let lfopsURL = findCommand("lfops") {
+        let lfopsCompatible = await getLfopsCompatible()
+        if lfopsCompatible != false, let lfopsURL = findCommand("lfops") {
             do {
                 let (output, status) = try await runProcessWithStatus(
                     lfopsURL,
@@ -96,12 +98,21 @@ struct WorktreeService {
                 LoggingService.append("""
                 worktrees.list command=lfops status=\(status) bytes=\(output.utf8.count)
                 """)
-                if let worktrees = try? await decodeWorktrees(from: output, source: "lfops") {
+                if status == 0, let worktrees = try? await decodeWorktrees(from: output, source: "lfops") {
+                    await setLfopsCompatible(true)
                     return worktrees
+                }
+                if output.contains("No such command 'wt'") {
+                    await setLfopsCompatible(false)
+                    LoggingService.append("worktrees.list command=lfops status=disabled reason=no-wt-command")
                 }
             } catch {
                 // Fall back to wt directly if lfops doesn't support wt or isn't working.
                 LoggingService.append("worktrees.list command=lfops error=\(error.localizedDescription)")
+                if error.localizedDescription.contains("No such command 'wt'") {
+                    await setLfopsCompatible(false)
+                    LoggingService.append("worktrees.list command=lfops status=disabled reason=no-wt-command")
+                }
             }
         }
 
@@ -114,6 +125,9 @@ struct WorktreeService {
         LoggingService.append("""
         worktrees.list command=wt status=\(status) bytes=\(output.utf8.count)
         """)
+        if status != 0 {
+            throw WorktreeError.commandFailed(output)
+        }
         return try await decodeWorktrees(from: output, source: "wt")
     }
 
@@ -147,6 +161,14 @@ struct WorktreeService {
         }
         LoggingService.append("worktrees.parse source=\(source) count=\(worktrees.count)")
         return worktrees
+    }
+
+    private func getLfopsCompatible() async -> Bool? {
+        await MainActor.run { WorktreeService.lfopsCompatible }
+    }
+
+    private func setLfopsCompatible(_ value: Bool) async {
+        await MainActor.run { WorktreeService.lfopsCompatible = value }
     }
 
     func create(name: String, in repoURL: URL, baseBranch: String? = nil) async throws {

--- a/Maestro/Maestro/Services/WorktreeService.swift
+++ b/Maestro/Maestro/Services/WorktreeService.swift
@@ -49,15 +49,91 @@ struct WorktreeService {
 
     private let sessionService = SessionService()
 
-    func list(in repoURL: URL) async throws -> [Worktree] {
-        let output = try await runLfops(["wt", "list", "--format", "json", "--full"], in: repoURL)
+    private func runProcessWithStatus(
+        _ executable: URL,
+        _ args: [String],
+        in directory: URL,
+        fallbackToWhich: Bool = false
+    ) async throws -> (String, Int32) {
+        let execURL: URL
+        if fallbackToWhich, let resolved = findCommand(executable.lastPathComponent) {
+            execURL = resolved
+        } else {
+            execURL = executable
+        }
 
+        return try await withCheckedThrowingContinuation { continuation in
+            let process = Process()
+            let pipe = Pipe()
+
+            process.executableURL = execURL
+            process.arguments = args
+            process.currentDirectoryURL = directory
+            process.standardOutput = pipe
+            process.standardError = pipe
+
+            do {
+                try process.run()
+                process.waitUntilExit()
+
+                let data = pipe.fileHandleForReading.readDataToEndOfFile()
+                let output = String(data: data, encoding: .utf8) ?? ""
+                continuation.resume(returning: (output, process.terminationStatus))
+            } catch {
+                continuation.resume(throwing: error)
+            }
+        }
+    }
+
+    func list(in repoURL: URL) async throws -> [Worktree] {
+        if let lfopsURL = findCommand("lfops") {
+            do {
+                let (output, status) = try await runProcessWithStatus(
+                    lfopsURL,
+                    ["wt", "list", "--format", "json", "--full"],
+                    in: repoURL
+                )
+                LoggingService.append("""
+                worktrees.list command=lfops status=\(status) bytes=\(output.utf8.count)
+                """)
+                if let worktrees = try? await decodeWorktrees(from: output, source: "lfops") {
+                    return worktrees
+                }
+            } catch {
+                // Fall back to wt directly if lfops doesn't support wt or isn't working.
+                LoggingService.append("worktrees.list command=lfops error=\(error.localizedDescription)")
+            }
+        }
+
+        let (output, status) = try await runProcessWithStatus(
+            URL(fileURLWithPath: "/opt/homebrew/bin/wt"),
+            ["list", "--format", "json", "--full"],
+            in: repoURL,
+            fallbackToWhich: true
+        )
+        LoggingService.append("""
+        worktrees.list command=wt status=\(status) bytes=\(output.utf8.count)
+        """)
+        return try await decodeWorktrees(from: output, source: "wt")
+    }
+
+    private func decodeWorktrees(from output: String, source: String) async throws -> [Worktree] {
         guard let data = output.data(using: .utf8) else {
             return []
         }
 
         let decoder = JSONDecoder()
-        let items = try decoder.decode([WorktreeJSON].self, from: data)
+        let items: [WorktreeJSON]
+        do {
+            items = try decoder.decode([WorktreeJSON].self, from: data)
+        } catch {
+            let preview = output.trimmingCharacters(in: .whitespacesAndNewlines)
+            let snippet = preview.prefix(200)
+            LoggingService.append("""
+            worktrees.parse source=\(source) error=\(error.localizedDescription) preview=\(snippet)
+            """)
+            throw error
+        }
 
         // Filter to actual worktrees (not just branches)
         var worktrees: [Worktree] = []
@@ -65,7 +141,11 @@ struct WorktreeService {
             let hasWorkspace = checkForCodeWorkspace(at: URL(fileURLWithPath: json.path))
             let sessions = (try? await sessionService.history(for: json.path, limit: 10)) ?? []
             worktrees.append(Worktree(from: json, hasCodeWorkspace: hasWorkspace, recentTasks: sessions))
+            LoggingService.append("""
+            worktrees.parse source=\(source) branch=\(json.branch) path=\(json.path) main_state=\(json.mainState ?? "unknown") prunable=\(json.prunable == true)
+            """)
         }
+        LoggingService.append("worktrees.parse source=\(source) count=\(worktrees.count)")
         return worktrees
     }
 
@@ -235,6 +315,9 @@ struct WorktreeService {
     func detectStaleness(for worktree: Worktree, in repoURL: URL) async -> Staleness {
         // Skip main branch - it's never stale
         if worktree.branch == "main" || worktree.branch == "master" {
+            LoggingService.append("""
+            worktrees.staleness branch=\(worktree.branch) staleness=Active
+            """)
             return .active
         }
 
@@ -244,6 +327,9 @@ struct WorktreeService {
             ["diff", "--quiet", "\(baseBranch)...\(worktree.branch)"],
             in: repoURL
         )) != nil {
+            LoggingService.append("""
+            worktrees.staleness branch=\(worktree.branch) staleness=Merged
+            """)
             return .merged
         }
 
@@ -251,6 +337,9 @@ struct WorktreeService {
         if let merged = try? await runGit(["branch", "--merged", "main"], in: repoURL) {
             let mergedBranches = merged.split(separator: "\n").map { $0.trimmingCharacters(in: .whitespaces) }
             if mergedBranches.contains(worktree.branch) {
+                LoggingService.append("""
+                worktrees.staleness branch=\(worktree.branch) staleness=Merged
+                """)
                 return .merged
             }
         }
@@ -260,6 +349,9 @@ struct WorktreeService {
         let refExists = try? await runGit(["show-ref", "--verify", remoteRef], in: repoURL)
         if refExists == nil && worktree.prNumber != nil {
             // Had a PR but remote branch is gone → merged and cleaned up
+            LoggingService.append("""
+            worktrees.staleness branch=\(worktree.branch) staleness=Remote deleted
+            """)
             return .remoteDeleted
         }
 
@@ -270,11 +362,18 @@ struct WorktreeService {
                 let age = Date().timeIntervalSince1970 - timestamp
                 let days = Int(age / 86400)
                 if days > 14 {
-                    return .inactive(days: days)
+                    let result: Staleness = .inactive(days: days)
+                    LoggingService.append("""
+                    worktrees.staleness branch=\(worktree.branch) staleness=\(result.displayText)
+                    """)
+                    return result
                 }
             }
         }
 
+        LoggingService.append("""
+        worktrees.staleness branch=\(worktree.branch) staleness=Active
+        """)
         return .active
     }
 

--- a/Maestro/Maestro/Views/DiagnosticsView.swift
+++ b/Maestro/Maestro/Views/DiagnosticsView.swift
@@ -1,0 +1,41 @@
+import SwiftUI
+
+struct DiagnosticsView: View {
+    @Environment(\.dismiss) private var dismiss
+    @State private var logText: String = ""
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                Text("Diagnostics")
+                    .font(.headline)
+                Spacer()
+                Button("Refresh") {
+                    loadLogs()
+                }
+                Button("Close") {
+                    dismiss()
+                }
+            }
+
+            Text("Log file: \(LoggingService.logPath())")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            TextEditor(text: $logText)
+                .font(.system(.body, design: .monospaced))
+                .frame(minHeight: 300)
+                .background(Color(.textBackgroundColor))
+                .cornerRadius(8)
+        }
+        .padding()
+        .frame(minWidth: 640, minHeight: 420)
+        .onAppear {
+            loadLogs()
+        }
+    }
+
+    private func loadLogs() {
+        logText = LoggingService.read()
+    }
+}

--- a/Maestro/Maestro/Views/WorktreeSidebar.swift
+++ b/Maestro/Maestro/Views/WorktreeSidebar.swift
@@ -18,6 +18,7 @@ struct WorktreeSidebar: View {
     @State private var compareWorktrees: (Worktree, Worktree)?
     @State private var compareContent: String?
     @State private var compareLoading = false
+    @State private var showingDiagnostics = false
 
     private let terminalLauncher = TerminalLauncher()
 
@@ -98,6 +99,9 @@ struct WorktreeSidebar: View {
                 )
             }
         }
+        .sheet(isPresented: $showingDiagnostics) {
+            DiagnosticsView()
+        }
     }
 
     private func viewDiff(_ worktree: Worktree) {
@@ -172,6 +176,16 @@ struct WorktreeSidebar: View {
             }
             .buttonStyle(.plain)
             .help("Create a new workspace")
+
+            Button {
+                showingDiagnostics = true
+            } label: {
+                Image(systemName: "doc.text.magnifyingglass")
+                    .font(.caption)
+                    .foregroundStyle(.white.opacity(0.7))
+            }
+            .buttonStyle(.plain)
+            .help("Open diagnostics")
         }
         .padding(.horizontal, 16)
         .padding(.vertical, 12)

--- a/src/loopflow/lfops/pr.py
+++ b/src/loopflow/lfops/pr.py
@@ -82,8 +82,9 @@ def register_commands(app: typer.Typer) -> None:
         existing_url = _get_existing_pr_url(repo_root)
 
         if existing_url:
-            # Skip regeneration if no new commits to push
-            if not _has_unpushed_commits(repo_root):
+            # Skip regeneration if no new commits unless this is a draft PR.
+            # Drafts are created with gh --fill, so refresh them with LLM output.
+            if not _has_unpushed_commits(repo_root) and not is_draft_pr(repo_root):
                 typer.echo("No new commits. Opening existing PR...")
                 subprocess.run(["open", existing_url])
                 return


### PR DESCRIPTION
## Usage

```bash
# In Maestro, click the diagnostics icon in the worktree sidebar
to view logs
```

## Summary

This adds lightweight diagnostics to Maestro’s worktree tooling so failures are easier to triage. It logs worktree command execution, parsing, and staleness decisions, adds a diagnostics viewer, and makes window capture more resilient with layered fallbacks. It also extends worktree JSON decoding for main state and tweaks PR update behavior to refresh draft PRs even without new commits.

## Changes

- Add `LoggingService` and a new diagnostics sheet in the sidebar
- Log worktree list execution, parsing details, and staleness outcomes
- Fall back through multiple capture strategies before `screencapture`
- Decode `main_state` in worktree JSON and remove unused status text
- Refresh draft PRs on update even without unpushed commits