### PR TITLE
lfops pr: add --refresh flag and use pr base diff

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
   merge_group:
 
 jobs:
-  test:
+  loopflow-test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -15,14 +15,14 @@ jobs:
       - run: uv sync
       - run: uv run pytest tests/
 
-  maestro-tests:
+  maestro-test:
     runs-on: macos-15
     steps:
       - uses: actions/checkout@v4
       - name: Run Maestro SwiftUI tests
         run: swift test --package-path Maestro
 
-  maestro-ui-tests:
+  maestro-ui-test:
     runs-on: macos-15
     steps:
       - uses: actions/checkout@v4

--- a/.lf/config.yaml
+++ b/.lf/config.yaml
@@ -1,4 +1,4 @@
-agent_model: codex 
+agent_model: claude:opus 
 yolo: true 
 chrome: true
 

--- a/.lf/config.yaml
+++ b/.lf/config.yaml
@@ -1,4 +1,4 @@
-agent_model: claude:opus 
+agent_model: codex 
 yolo: true 
 chrome: true
 

--- a/.lf/config.yaml
+++ b/.lf/config.yaml
@@ -1,5 +1,5 @@
 agent_model: claude:opus 
-yolo: true
+yolo: false
 chrome: true
 
 skill_sources:

--- a/.lf/config.yaml
+++ b/.lf/config.yaml
@@ -1,5 +1,5 @@
 agent_model: claude:opus 
-yolo: false
+yolo: true 
 chrome: true
 
 skill_sources:

--- a/src/loopflow/lf/builtins/pr_message.txt
+++ b/src/loopflow/lf/builtins/pr_message.txt
@@ -1,6 +1,6 @@
 Generate a PR title and body for the changes on this branch.
 
-Review the diff against main and summarize what changed and why.
+Review the diff against the PR base and summarize what changed and why.
 
 Do not ask questions. If anything is unclear, make the best assumption and proceed.
 

--- a/src/loopflow/lf/context.py
+++ b/src/loopflow/lf/context.py
@@ -240,8 +240,12 @@ def gather_task(repo_root: Path | None, name: str, config=None) -> TaskFile | No
     return None
 
 
-def gather_diff(repo_root: Path, exclude: Optional[list[str]] = None) -> str | None:
-    """Get diff against main branch. Returns None if on main or no diff."""
+def gather_diff(
+    repo_root: Path,
+    exclude: Optional[list[str]] = None,
+    base_ref: str | None = None,
+) -> str | None:
+    """Get diff against base branch. Returns None if on main or no diff."""
     # Get current branch
     result = subprocess.run(
         ["git", "branch", "--show-current"],
@@ -253,8 +257,12 @@ def gather_diff(repo_root: Path, exclude: Optional[list[str]] = None) -> str | N
     if not branch or branch == "main":
         return None
 
-    # Get diff against main, excluding specified patterns
-    cmd = ["git", "diff", "main...HEAD"]
+    # Get diff against base, excluding specified patterns
+    if base_ref is None:
+        from loopflow.lf.git import get_default_base_ref
+
+        base_ref = get_default_base_ref(repo_root)
+    cmd = ["git", "diff", f"{base_ref}...HEAD"]
     if exclude:
         cmd.append("--")
         cmd.extend(f":(exclude){pattern}" for pattern in exclude)
@@ -271,8 +279,8 @@ def gather_diff(repo_root: Path, exclude: Optional[list[str]] = None) -> str | N
     return result.stdout
 
 
-def gather_diff_files(repo_root: Path) -> list[str]:
-    """Return file paths touched by this branch vs main.
+def gather_diff_files(repo_root: Path, base_ref: str | None = None) -> list[str]:
+    """Return file paths touched by this branch vs base branch.
 
     Filters out deleted files (can't load those).
     Exclude patterns are applied later when files are loaded via gather_files().
@@ -288,8 +296,13 @@ def gather_diff_files(repo_root: Path) -> list[str]:
     if not branch or branch == "main":
         return []
 
+    if base_ref is None:
+        from loopflow.lf.git import get_default_base_ref
+
+        base_ref = get_default_base_ref(repo_root)
+
     result = subprocess.run(
-        ["git", "diff", "--name-only", "main...HEAD"],
+        ["git", "diff", "--name-only", f"{base_ref}...HEAD"],
         cwd=repo_root,
         capture_output=True,
         text=True,

--- a/src/loopflow/lf/git.py
+++ b/src/loopflow/lf/git.py
@@ -120,6 +120,18 @@ def get_current_branch(repo_root: Path) -> str | None:
     return branch if branch else None
 
 
+def get_default_base_ref(repo_root: Path) -> str:
+    """Return default base ref (origin/HEAD), falling back to main."""
+    result = subprocess.run(
+        ["git", "rev-parse", "--abbrev-ref", "origin/HEAD"],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+    )
+    base_ref = result.stdout.strip() if result.returncode == 0 else ""
+    return base_ref or "main"
+
+
 
 
 def open_pr(

--- a/src/loopflow/lf/messages.py
+++ b/src/loopflow/lf/messages.py
@@ -212,6 +212,13 @@ def generate_pr_message(repo_root: Path) -> CommitMessage:
     return _generate_message(repo_root, prompt, "pr message")
 
 
+def generate_pr_message_from_diff(repo_root: Path, diff: str | None) -> CommitMessage:
+    """Generate PR title and body from a provided diff."""
+    task_prompt = get_builtin_prompt("pr_message")
+    prompt = _build_message_prompt(repo_root, diff, task_prompt)
+    return _generate_message(repo_root, prompt, "pr message")
+
+
 def _get_commits_since_tag(repo_root: Path, tag: str) -> str | None:
     """Get commit log since a tag."""
     result = subprocess.run(

--- a/src/loopflow/lfops/_helpers.py
+++ b/src/loopflow/lfops/_helpers.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 import typer
 
-from loopflow.lf.git import ensure_draft_pr
+from loopflow.lf.git import ensure_draft_pr, get_current_branch
 from loopflow.lf.messages import generate_commit_message
 
 
@@ -63,6 +63,16 @@ def get_default_branch(repo_root: Path) -> str:
     return "main"
 
 
+def is_repo_clean(repo_root: Path) -> bool:
+    result = subprocess.run(
+        ["git", "status", "--porcelain"],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+    )
+    return result.returncode == 0 and not result.stdout.strip()
+
+
 def resolve_base_ref(repo_root: Path, base_branch: str) -> str:
     origin_ref = f"origin/{base_branch}"
     result = subprocess.run(
@@ -97,18 +107,17 @@ def sync_main_repo(main_repo: Path, base_branch: str) -> bool:
         return False
 
     # If base_branch is checked out here, update it to match origin
-    result = subprocess.run(
-        ["git", "rev-parse", "--abbrev-ref", "HEAD"],
-        cwd=main_repo,
-        capture_output=True,
-        text=True,
-    )
-    if result.returncode == 0 and result.stdout.strip() == base_branch:
-        subprocess.run(
+    current_branch = get_current_branch(main_repo)
+    if current_branch == base_branch:
+        if not is_repo_clean(main_repo):
+            return False
+        result = subprocess.run(
             ["git", "reset", "--hard", f"origin/{base_branch}"],
             cwd=main_repo,
             capture_output=True,
         )
+        if result.returncode != 0:
+            return False
 
     # origin/base_branch is now up-to-date, which is sufficient for merge-base checks
     return True

--- a/src/loopflow/lfops/pr.py
+++ b/src/loopflow/lfops/pr.py
@@ -6,9 +6,9 @@ import subprocess
 import typer
 
 from loopflow.lf.context import find_worktree_root
-from loopflow.lf.git import GitError, ensure_ready_pr, is_draft_pr, open_pr
-from loopflow.lf.messages import generate_pr_message
-from loopflow.lfops._helpers import add_commit_push
+from loopflow.lf.git import GitError, ensure_ready_pr, find_main_repo, is_draft_pr, open_pr
+from loopflow.lf.messages import generate_pr_message, generate_pr_message_from_diff
+from loopflow.lfops._helpers import add_commit_push, get_default_branch, sync_main_repo
 
 
 def _get_existing_pr_url(repo_root) -> str | None:
@@ -39,6 +39,19 @@ def _has_unpushed_commits(repo_root) -> bool:
     return count > 0
 
 
+def _get_pr_diff(repo_root) -> str | None:
+    """Fetch PR diff via gh for accuracy against the PR base."""
+    result = subprocess.run(
+        ["gh", "pr", "diff", "--patch"],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0 or not result.stdout.strip():
+        return None
+    return result.stdout
+
+
 def _update_pr(repo_root, title: str, body: str) -> str:
     """Update existing PR title and body. Returns URL."""
     subprocess.run(
@@ -55,6 +68,16 @@ def _update_pr(repo_root, title: str, body: str) -> str:
     if result.returncode != 0:
         raise GitError(result.stderr.strip() or "Failed to update PR")
     return _get_existing_pr_url(repo_root) or ""
+
+
+def _sync_main_repo(repo_root) -> None:
+    main_repo = find_main_repo(repo_root) or repo_root
+    base_branch = get_default_branch(main_repo)
+    if not sync_main_repo(main_repo, base_branch):
+        typer.echo(
+            f"Warning: failed to sync {base_branch}; diff may be stale",
+            err=True,
+        )
 
 
 def register_commands(app: typer.Typer) -> None:
@@ -75,6 +98,8 @@ def register_commands(app: typer.Typer) -> None:
             typer.echo("Error: 'gh' CLI not found. Install with: brew install gh", err=True)
             raise typer.Exit(1)
 
+        _sync_main_repo(repo_root)
+
         # Always auto-commit and push any pending changes
         add_commit_push(repo_root)
 
@@ -90,7 +115,11 @@ def register_commands(app: typer.Typer) -> None:
                 return
 
             typer.echo("Updating existing PR...")
-            message = generate_pr_message(repo_root)
+            diff = _get_pr_diff(repo_root)
+            if diff:
+                message = generate_pr_message_from_diff(repo_root, diff)
+            else:
+                message = generate_pr_message(repo_root)
             typer.echo(f"\n{message.title}\n")
             typer.echo(message.body)
             typer.echo("")

--- a/src/loopflow/lfops/pr.py
+++ b/src/loopflow/lfops/pr.py
@@ -40,9 +40,9 @@ def _has_unpushed_commits(repo_root) -> bool:
 
 
 def _get_pr_diff(repo_root) -> str | None:
-    """Fetch PR diff via gh for accuracy against the PR base."""
+    """Fetch combined PR diff via gh for accuracy against the PR base."""
     result = subprocess.run(
-        ["gh", "pr", "diff", "--patch"],
+        ["gh", "pr", "diff"],
         cwd=repo_root,
         capture_output=True,
         text=True,
@@ -84,7 +84,11 @@ def register_commands(app: typer.Typer) -> None:
     """Register PR command on the app."""
 
     @app.command("pr")
-    def pr() -> None:
+    def pr(
+        refresh: bool = typer.Option(
+            False, "--refresh", "-r", help="Force regenerate PR title and body"
+        ),
+    ) -> None:
         """Create or update a GitHub PR, then open it in browser.
 
         Auto-commits any uncommitted changes before creating/updating the PR.
@@ -107,9 +111,9 @@ def register_commands(app: typer.Typer) -> None:
         existing_url = _get_existing_pr_url(repo_root)
 
         if existing_url:
-            # Skip regeneration if no new commits unless this is a draft PR.
+            # Skip regeneration if no new commits unless refresh flag or draft PR.
             # Drafts are created with gh --fill, so refresh them with LLM output.
-            if not _has_unpushed_commits(repo_root) and not is_draft_pr(repo_root):
+            if not refresh and not _has_unpushed_commits(repo_root) and not is_draft_pr(repo_root):
                 typer.echo("No new commits. Opening existing PR...")
                 subprocess.run(["open", existing_url])
                 return

--- a/src/loopflow/lfops/sync.py
+++ b/src/loopflow/lfops/sync.py
@@ -3,7 +3,8 @@
 import typer
 
 from loopflow.lf.context import find_worktree_root
-from loopflow.lfops._helpers import get_default_branch, sync_main_repo
+from loopflow.lf.git import get_current_branch
+from loopflow.lfops._helpers import get_default_branch, is_repo_clean, sync_main_repo
 
 
 def register_commands(app: typer.Typer) -> None:
@@ -16,6 +17,8 @@ def register_commands(app: typer.Typer) -> None:
             raise typer.Exit(1)
 
         base_branch = get_default_branch(repo_root)
+        current_branch = get_current_branch(repo_root)
+        is_clean = is_repo_clean(repo_root)
 
         typer.echo(f"Fetching origin/{base_branch}...")
         success = sync_main_repo(repo_root, base_branch)
@@ -23,5 +26,11 @@ def register_commands(app: typer.Typer) -> None:
         if success:
             typer.echo(f"Updated {base_branch} to origin/{base_branch}")
         else:
-            typer.echo(f"Failed to update {base_branch}", err=True)
+            if current_branch == base_branch and not is_clean:
+                typer.echo(
+                    f"Refusing to reset {base_branch} with uncommitted changes",
+                    err=True,
+                )
+            else:
+                typer.echo(f"Failed to update {base_branch}", err=True)
             raise typer.Exit(1)


### PR DESCRIPTION
## Usage

```bash
# Force regenerate PR title and body
lfops pr --refresh
lfops pr -r
```

## Summary

Improves PR message generation accuracy by using `gh pr diff` to get the actual diff against the PR base branch, rather than computing a local diff against main. This ensures the generated title and body reflect what GitHub will show in the PR.

Also adds a `--refresh` flag to force regeneration of the PR title and body, even when there are no new commits.

## Changes

- Add `--refresh/-r` flag to `lfops pr` for forcing title/body regeneration
- Use `gh pr diff` for accurate PR diff when updating existing PRs
- Add `get_default_base_ref()` to resolve base branch from `origin/HEAD`
- Sync main repo before PR operations to ensure fresh merge-base
- Refuse to reset base branch when there are uncommitted changes (with clear error message)
- Standardize CI job names (`loopflow-test`, `maestro-test`, `maestro-ui-test`)