### PR TITLE
lfops sync: resolve main repo before syncing

### DIFF
--- a/src/loopflow/lfops/sync.py
+++ b/src/loopflow/lfops/sync.py
@@ -2,8 +2,7 @@
 
 import typer
 
-from loopflow.lf.context import find_worktree_root
-from loopflow.lf.git import get_current_branch
+from loopflow.lf.git import find_main_repo, get_current_branch
 from loopflow.lfops._helpers import get_default_branch, is_repo_clean, sync_main_repo
 
 
@@ -11,7 +10,7 @@ def register_commands(app: typer.Typer) -> None:
     @app.command()
     def sync() -> None:
         """Fetch origin and update local main to match origin/main."""
-        repo_root = find_worktree_root()
+        repo_root = find_main_repo()
         if not repo_root:
             typer.echo("Error: Not in a git repository", err=True)
             raise typer.Exit(1)


### PR DESCRIPTION
## Usage

```bash
lf ops sync
```

## Summary

`lf ops sync` now resolves the main repo root directly before syncing, so it updates the correct repository even when run from a worktree. This aligns the sync behavior with how other git-aware commands locate the primary repo.

## Changes

- Use `find_main_repo()` when locating the repo root for sync operations
- Keep existing error handling for non-git directories