### PR TITLE
publish: use PR workflow instead of direct push to main

### DIFF
--- a/scripts/publish.py
+++ b/scripts/publish.py
@@ -48,19 +48,160 @@ def deploy_website() -> bool:
     return True
 
 
+def _get_release_version_from_main() -> str | None:
+    """Get the version from the latest commit on origin/main if it's a release commit."""
+    result = subprocess.run(
+        ["git", "fetch", "origin", "main"],
+        cwd=ROOT,
+        capture_output=True,
+    )
+    result = subprocess.run(
+        ["git", "log", "-1", "--format=%s", "origin/main"],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        return None
+    subject = result.stdout.strip()
+    if subject.startswith("release: v"):
+        return subject.replace("release: v", "")
+    return None
+
+
+def _finalize_release(skip_dmg: bool, skip_website: bool) -> int:
+    """Complete release after PR merges: tag, publish to PyPI, build DMG."""
+    from loopflow.publish import (
+        build_dmg,
+        build_package,
+        get_dmg_path,
+        install_locally,
+        publish_package,
+        upload_dmg,
+        R2_PUBLIC_URL,
+    )
+
+    print("Finalizing release...")
+
+    # Fetch latest main and check for release commit
+    version = _get_release_version_from_main()
+    if not version:
+        print("Error: No release commit found on origin/main", file=sys.stderr)
+        print("Make sure the release PR has been merged first.", file=sys.stderr)
+        return 1
+
+    print(f"Found release v{version} on main")
+
+    # Update local main to match origin
+    result = subprocess.run(
+        ["git", "checkout", "main"],
+        cwd=ROOT,
+        capture_output=True,
+    )
+    subprocess.run(["git", "pull", "--ff-only"], cwd=ROOT, check=True)
+
+    # Tag the release
+    print(f"Tagging v{version}...")
+    result = subprocess.run(
+        ["git", "tag", f"v{version}"],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        if "already exists" in result.stderr:
+            print(f"Tag v{version} already exists")
+        else:
+            print(f"Failed to create tag: {result.stderr}", file=sys.stderr)
+            return 1
+    else:
+        result = subprocess.run(["git", "push", "--tags"], cwd=ROOT)
+        if result.returncode != 0:
+            print("Failed to push tags", file=sys.stderr)
+            return 1
+        print("Tag pushed.")
+
+    # Build package
+    print("Building package...")
+    success, output = build_package(ROOT)
+    if not success:
+        print("Build failed:", file=sys.stderr)
+        print(output, file=sys.stderr)
+        return 1
+    print("Build succeeded.")
+
+    # Publish to PyPI
+    print("Publishing to PyPI...")
+    success, output = publish_package(ROOT)
+    if not success:
+        print("Publish failed:", file=sys.stderr)
+        print(output, file=sys.stderr)
+        return 1
+    print("Published to PyPI.")
+
+    # Build and upload DMG
+    if not skip_dmg:
+        print("Building Maestro DMG...")
+        success, output = build_dmg(ROOT)
+        if not success:
+            print("DMG build failed (continuing):", file=sys.stderr)
+            print(output, file=sys.stderr)
+        else:
+            print("DMG built.")
+            print("Uploading DMG...")
+            dmg_path = get_dmg_path(ROOT)
+            success, output = upload_dmg(dmg_path, version)
+            if not success:
+                print("DMG upload failed (continuing):", file=sys.stderr)
+                print(output, file=sys.stderr)
+            else:
+                print(output)
+                if not skip_website:
+                    print("Updating website...")
+                    if not update_website_release(version, R2_PUBLIC_URL, dry_run=False):
+                        print("Website update failed.", file=sys.stderr)
+                        return 1
+
+    # Install locally
+    print("Installing locally...")
+    success, output = install_locally(ROOT)
+    if not success:
+        print("Local install failed:", file=sys.stderr)
+        print(output, file=sys.stderr)
+        return 1
+    print("Installed locally.")
+
+    # Clean up release branch if it exists
+    release_branch = f"release/v{version}"
+    subprocess.run(
+        ["git", "push", "origin", "--delete", release_branch],
+        cwd=ROOT,
+        capture_output=True,
+    )
+
+    print(f"\nReleased v{version}")
+    print("https://pypi.org/project/loopflow/")
+    if not skip_dmg:
+        print(f"{R2_PUBLIC_URL}/LoopflowMaestro-{version}.dmg")
+    return 0
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description="Publish loopflow to PyPI and DMG to R2")
     parser.add_argument("bump", nargs="?", choices=["patch", "minor", "major"])
     parser.add_argument("-n", "--dry-run", action="store_true", help="Show what would be done")
     parser.add_argument("--skip-tests", action="store_true", help="Skip test run")
-    parser.add_argument("--skip-ci", action="store_true", help="Skip CI check (don't push and wait for CI)")
+    parser.add_argument("--skip-ci", action="store_true", help="Skip CI check")
     parser.add_argument("-f", "--force", action="store_true", help="Skip main branch check")
     parser.add_argument("--dmg-only", action="store_true", help="Only build and upload DMG (no PyPI)")
     parser.add_argument("--skip-dmg", action="store_true", help="Skip DMG build/upload")
     parser.add_argument("--skip-website", action="store_true", help="Skip website update/deploy")
+    parser.add_argument("--finalize", action="store_true", help="Complete release after PR merges")
     args = parser.parse_args()
 
     # Validate args
+    if args.finalize:
+        return _finalize_release(args.skip_dmg, args.skip_website)
     if args.dmg_only and args.bump:
         print("Error: --dmg-only cannot be used with version bump", file=sys.stderr)
         return 1
@@ -77,8 +218,6 @@ def main() -> int:
         check_publish_ready,
         get_dmg_path,
         get_version,
-        install_locally,
-        publish_package,
         check_ci_passed,
         run_tests,
         upload_dmg,
@@ -147,16 +286,14 @@ def main() -> int:
         print("Would run tests" if not args.skip_tests else "Would skip tests")
         print("Would verify CI passed" if not args.skip_ci else "Would skip CI check")
         print("Would generate release notes")
+        print("Would build package (validate before committing)")
+        print(f"Would create release branch: release/v{new_version}")
         print(f"Would commit: release: v{new_version}")
-        print(f"Would tag: v{new_version}")
-        print("Would build package")
-        print("Would publish to PyPI")
-        if not args.skip_dmg:
-            print("Would build Maestro DMG")
-            print(f"Would upload DMG to {R2_PUBLIC_URL}/LoopflowMaestro-{new_version}.dmg")
-            if not args.skip_website:
-                print("Would update website release metadata and deploy")
-        print("Would install locally")
+        print("Would push release branch")
+        print("Would create PR to main")
+        print("Would enable auto-merge")
+        print(f"\nAfter CI passes and PR merges, run: python scripts/publish.py --finalize")
+        print("  --finalize would: tag, publish to PyPI, build DMG, install locally")
         return 0
 
     # Step 2: Run tests
@@ -200,10 +337,22 @@ def main() -> int:
         return 1
     print("Build succeeded.")
 
-    # Step 5: Write release notes and commit (now safe - build validated)
+    # Step 5: Write release notes, create release branch, commit, push, create PR
     changes_md = "\n".join(f"- {change}" for change in notes.changes)
     release_notes_content = f"# v{new_version}\n\n{notes.summary}\n\n## Changes\n\n{changes_md}\n"
     (ROOT / "RELEASE_NOTES.md").write_text(release_notes_content)
+
+    release_branch = f"release/v{new_version}"
+    print(f"Creating release branch {release_branch}...")
+    result = subprocess.run(
+        ["git", "checkout", "-b", release_branch],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        print(f"Failed to create release branch: {result.stderr}", file=sys.stderr)
+        return 1
 
     print("Committing release...")
     result = subprocess.run(
@@ -222,70 +371,61 @@ def main() -> int:
         print("Failed to commit", file=sys.stderr)
         return 1
 
-    result = subprocess.run(["git", "push"], cwd=ROOT)
+    print("Pushing release branch...")
+    result = subprocess.run(
+        ["git", "push", "-u", "origin", release_branch],
+        cwd=ROOT,
+    )
     if result.returncode != 0:
-        print("Failed to push", file=sys.stderr)
+        print("Failed to push release branch", file=sys.stderr)
         return 1
-    print("Committed and pushed.")
 
-    # Step 6: Tag
-    print(f"Tagging v{new_version}...")
-    result = subprocess.run(["git", "tag", f"v{new_version}"], cwd=ROOT)
+    # Create PR
+    print("Creating PR...")
+    pr_body = f"Release v{new_version}\n\n{release_notes_content}"
+    result = subprocess.run(
+        [
+            "gh", "pr", "create",
+            "--base", "main",
+            "--head", release_branch,
+            "--title", f"release: v{new_version}",
+            "--body", pr_body,
+        ],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+    )
     if result.returncode != 0:
-        print("Failed to create tag", file=sys.stderr)
+        print(f"Failed to create PR: {result.stderr}", file=sys.stderr)
         return 1
+    pr_url = result.stdout.strip()
+    print(f"Created: {pr_url}")
 
-    result = subprocess.run(["git", "push", "--tags"], cwd=ROOT)
+    # Enable auto-merge
+    print("Enabling auto-merge...")
+    result = subprocess.run(
+        ["gh", "pr", "merge", "--squash", "--auto", "--subject", f"release: v{new_version}"],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+    )
     if result.returncode != 0:
-        print("Failed to push tags", file=sys.stderr)
-        return 1
-    print("Tag pushed.")
-
-    # Step 7: Publish (package already built)
-    print("Publishing to PyPI...")
-    success, output = publish_package(ROOT)
-    if not success:
-        print("Publish failed:", file=sys.stderr)
-        print(output, file=sys.stderr)
-        return 1
-    print("Published to PyPI.")
-
-    # Step 8: Build and upload DMG
-    if not args.skip_dmg:
-        print("Building Maestro DMG...")
-        success, output = build_dmg(ROOT)
-        if not success:
-            print("DMG build failed (continuing):", file=sys.stderr)
-            print(output, file=sys.stderr)
+        error_msg = result.stderr.strip() or result.stdout.strip()
+        if "auto merge is not allowed" in error_msg.lower() or "enablepullrequestautomerge" in error_msg.lower():
+            print("Auto-merge not enabled for this repo. Merge manually after CI passes.", file=sys.stderr)
         else:
-            print("DMG built.")
-            print("Uploading DMG...")
-            dmg_path = get_dmg_path(ROOT)
-            success, output = upload_dmg(dmg_path, new_version)
-            if not success:
-                print("DMG upload failed (continuing):", file=sys.stderr)
-                print(output, file=sys.stderr)
-            else:
-                print(output)
-                if not args.skip_website:
-                    print("Updating website...")
-                    if not update_website_release(new_version, R2_PUBLIC_URL, dry_run=False):
-                        print("Website update failed.", file=sys.stderr)
-                        return 1
+            print(f"Warning: Could not enable auto-merge: {error_msg}")
+    else:
+        print("Auto-merge enabled. PR will merge when CI passes.")
 
-    # Step 9: Install locally from the built wheel
-    print("Installing locally...")
-    success, output = install_locally(ROOT)
-    if not success:
-        print("Local install failed:", file=sys.stderr)
-        print(output, file=sys.stderr)
-        return 1
-    print("Installed locally.")
+    # Open PR in browser
+    subprocess.run(["open", pr_url])
 
-    print(f"\nReleased v{new_version}")
-    print("https://pypi.org/project/loopflow/")
-    if not args.skip_dmg:
-        print(f"{R2_PUBLIC_URL}/LoopflowMaestro-{new_version}.dmg")
+    # Return to main branch
+    subprocess.run(["git", "checkout", "main"], cwd=ROOT, capture_output=True)
+
+    print(f"\nRelease PR created for v{new_version}")
+    print(f"After CI passes and PR merges, run: python scripts/publish.py --finalize")
     return 0
 
 

--- a/scripts/publish.py
+++ b/scripts/publish.py
@@ -1,5 +1,12 @@
 #!/usr/bin/env python3
-"""Publish loopflow to PyPI and/or DMG to R2."""
+"""Publish loopflow to PyPI and/or DMG to R2.
+
+Idempotent release flow:
+  1. First run: creates release PR, enables auto-merge
+  2. Second run (after merge): tags, publishes to PyPI, builds DMG
+
+Just run `python scripts/publish.py` and it figures out what to do.
+"""
 
 import argparse
 import json
@@ -48,13 +55,12 @@ def deploy_website() -> bool:
     return True
 
 
+# --- State detection ---
+
+
 def _get_release_version_from_main() -> str | None:
     """Get the version from the latest commit on origin/main if it's a release commit."""
-    result = subprocess.run(
-        ["git", "fetch", "origin", "main"],
-        cwd=ROOT,
-        capture_output=True,
-    )
+    subprocess.run(["git", "fetch", "origin", "main"], cwd=ROOT, capture_output=True)
     result = subprocess.run(
         ["git", "log", "-1", "--format=%s", "origin/main"],
         cwd=ROOT,
@@ -69,8 +75,53 @@ def _get_release_version_from_main() -> str | None:
     return None
 
 
-def _finalize_release(skip_dmg: bool, skip_website: bool) -> int:
-    """Complete release after PR merges: tag, publish to PyPI, build DMG."""
+def _tag_exists(version: str) -> bool:
+    """Check if a tag exists locally or on remote."""
+    result = subprocess.run(
+        ["git", "tag", "-l", f"v{version}"],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+    )
+    return bool(result.stdout.strip())
+
+
+def _get_open_release_pr() -> tuple[str | None, str | None]:
+    """Check for an open release PR. Returns (version, pr_url) or (None, None)."""
+    result = subprocess.run(
+        ["gh", "pr", "list", "--head", "release/", "--json", "headRefName,url,state", "--limit", "10"],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        return None, None
+    try:
+        prs = json.loads(result.stdout)
+        for pr in prs:
+            if pr.get("state") == "OPEN" and pr.get("headRefName", "").startswith("release/v"):
+                version = pr["headRefName"].replace("release/v", "")
+                return version, pr.get("url")
+    except json.JSONDecodeError:
+        pass
+    return None, None
+
+
+def _is_on_pypi(version: str) -> bool:
+    """Check if version is already on PyPI."""
+    result = subprocess.run(
+        ["pip", "index", "versions", "loopflow"],
+        capture_output=True,
+        text=True,
+    )
+    return f"({version})" in result.stdout or version in result.stdout
+
+
+# --- Release phases ---
+
+
+def _finalize_release(version: str, skip_dmg: bool, skip_website: bool) -> int:
+    """Complete release: tag, publish to PyPI, build DMG."""
     from loopflow.publish import (
         build_dmg,
         build_package,
@@ -81,63 +132,53 @@ def _finalize_release(skip_dmg: bool, skip_website: bool) -> int:
         R2_PUBLIC_URL,
     )
 
-    print("Finalizing release...")
-
-    # Fetch latest main and check for release commit
-    version = _get_release_version_from_main()
-    if not version:
-        print("Error: No release commit found on origin/main", file=sys.stderr)
-        print("Make sure the release PR has been merged first.", file=sys.stderr)
-        return 1
-
-    print(f"Found release v{version} on main")
+    print(f"Finalizing release v{version}...")
 
     # Update local main to match origin
-    result = subprocess.run(
-        ["git", "checkout", "main"],
-        cwd=ROOT,
-        capture_output=True,
-    )
+    subprocess.run(["git", "checkout", "main"], cwd=ROOT, capture_output=True)
     subprocess.run(["git", "pull", "--ff-only"], cwd=ROOT, check=True)
 
     # Tag the release
-    print(f"Tagging v{version}...")
-    result = subprocess.run(
-        ["git", "tag", f"v{version}"],
-        cwd=ROOT,
-        capture_output=True,
-        text=True,
-    )
-    if result.returncode != 0:
-        if "already exists" in result.stderr:
-            print(f"Tag v{version} already exists")
-        else:
+    if _tag_exists(version):
+        print(f"Tag v{version} already exists")
+    else:
+        print(f"Tagging v{version}...")
+        result = subprocess.run(
+            ["git", "tag", f"v{version}"],
+            cwd=ROOT,
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
             print(f"Failed to create tag: {result.stderr}", file=sys.stderr)
             return 1
-    else:
         result = subprocess.run(["git", "push", "--tags"], cwd=ROOT)
         if result.returncode != 0:
             print("Failed to push tags", file=sys.stderr)
             return 1
         print("Tag pushed.")
 
-    # Build package
-    print("Building package...")
-    success, output = build_package(ROOT)
-    if not success:
-        print("Build failed:", file=sys.stderr)
-        print(output, file=sys.stderr)
-        return 1
-    print("Build succeeded.")
+    # Check if already on PyPI
+    if _is_on_pypi(version):
+        print(f"v{version} already on PyPI")
+    else:
+        # Build package
+        print("Building package...")
+        success, output = build_package(ROOT)
+        if not success:
+            print("Build failed:", file=sys.stderr)
+            print(output, file=sys.stderr)
+            return 1
+        print("Build succeeded.")
 
-    # Publish to PyPI
-    print("Publishing to PyPI...")
-    success, output = publish_package(ROOT)
-    if not success:
-        print("Publish failed:", file=sys.stderr)
-        print(output, file=sys.stderr)
-        return 1
-    print("Published to PyPI.")
+        # Publish to PyPI
+        print("Publishing to PyPI...")
+        success, output = publish_package(ROOT)
+        if not success:
+            print("Publish failed:", file=sys.stderr)
+            print(output, file=sys.stderr)
+            return 1
+        print("Published to PyPI.")
 
     # Build and upload DMG
     if not skip_dmg:
@@ -182,122 +223,40 @@ def _finalize_release(skip_dmg: bool, skip_website: bool) -> int:
     print(f"\nReleased v{version}")
     print("https://pypi.org/project/loopflow/")
     if not skip_dmg:
+        from loopflow.publish import R2_PUBLIC_URL
         print(f"{R2_PUBLIC_URL}/LoopflowMaestro-{version}.dmg")
     return 0
 
 
-def main() -> int:
-    parser = argparse.ArgumentParser(description="Publish loopflow to PyPI and DMG to R2")
-    parser.add_argument("bump", nargs="?", choices=["patch", "minor", "major"])
-    parser.add_argument("-n", "--dry-run", action="store_true", help="Show what would be done")
-    parser.add_argument("--skip-tests", action="store_true", help="Skip test run")
-    parser.add_argument("--skip-ci", action="store_true", help="Skip CI check")
-    parser.add_argument("-f", "--force", action="store_true", help="Skip main branch check")
-    parser.add_argument("--dmg-only", action="store_true", help="Only build and upload DMG (no PyPI)")
-    parser.add_argument("--skip-dmg", action="store_true", help="Skip DMG build/upload")
-    parser.add_argument("--skip-website", action="store_true", help="Skip website update/deploy")
-    parser.add_argument("--finalize", action="store_true", help="Complete release after PR merges")
-    args = parser.parse_args()
-
-    # Validate args
-    if args.finalize:
-        return _finalize_release(args.skip_dmg, args.skip_website)
-    if args.dmg_only and args.bump:
-        print("Error: --dmg-only cannot be used with version bump", file=sys.stderr)
-        return 1
-    if args.dmg_only and args.skip_dmg:
-        print("Error: --dmg-only and --skip-dmg are mutually exclusive", file=sys.stderr)
-        return 1
-
-    # Import here so --help works without dependencies
+def _create_release_pr(
+    bump: str,
+    skip_tests: bool,
+    skip_ci: bool,
+) -> int:
+    """Create release PR with version bump."""
     from loopflow.lf.messages import generate_release_notes
     from loopflow.publish import (
-        build_dmg,
         bump_version,
         build_package,
         check_publish_ready,
-        get_dmg_path,
-        get_version,
         check_ci_passed,
         run_tests,
-        upload_dmg,
         write_version,
-        R2_PUBLIC_URL,
     )
-
-    # Handle DMG-only mode
-    if args.dmg_only:
-        version = get_version()
-        print(f"Current version: {version}")
-
-        if args.dry_run:
-            print("Would build Maestro DMG")
-            print(f"Would upload DMG to {R2_PUBLIC_URL}/LoopflowMaestro-{version}.dmg")
-            print(f"Would upload DMG to {R2_PUBLIC_URL}/LoopflowMaestro-latest.dmg")
-            if not args.skip_website:
-                print("Would update website release metadata and deploy")
-            return 0
-
-        print("Building Maestro DMG...")
-        success, output = build_dmg(ROOT)
-        if not success:
-            print("DMG build failed:", file=sys.stderr)
-            print(output, file=sys.stderr)
-            return 1
-        print("DMG built.")
-
-        print("Uploading DMG...")
-        dmg_path = get_dmg_path(ROOT)
-        success, output = upload_dmg(dmg_path, version)
-        if not success:
-            print("DMG upload failed:", file=sys.stderr)
-            print(output, file=sys.stderr)
-            return 1
-        print(output)
-
-        print(f"\nDMG published: {R2_PUBLIC_URL}/LoopflowMaestro-{version}.dmg")
-        if not args.skip_website:
-            print("Updating website...")
-            if not update_website_release(version, R2_PUBLIC_URL, dry_run=False):
-                print("Website update failed.", file=sys.stderr)
-                return 1
-        return 0
-
-    # Full release flow
-    if not args.bump:
-        args.bump = "patch"
 
     # Step 1: Preflight checks
     print("Checking publish readiness...")
     state = check_publish_ready(ROOT)
 
-    if not args.force:
-        if not state.ready:
-            print(f"Error: {state.message}", file=sys.stderr)
-            return 1
-    elif not state.on_main:
-        print(f"Warning: {state.message} (continuing due to --force)")
+    if not state.ready:
+        print(f"Error: {state.message}", file=sys.stderr)
+        return 1
 
     old_version = state.version
-    new_version = bump_version(old_version, args.bump)
-
-    if args.dry_run:
-        print(f"Would bump version: {old_version} → {new_version} ({args.bump})")
-        print("Would run tests" if not args.skip_tests else "Would skip tests")
-        print("Would verify CI passed" if not args.skip_ci else "Would skip CI check")
-        print("Would generate release notes")
-        print("Would build package (validate before committing)")
-        print(f"Would create release branch: release/v{new_version}")
-        print(f"Would commit: release: v{new_version}")
-        print("Would push release branch")
-        print("Would create PR to main")
-        print("Would enable auto-merge")
-        print(f"\nAfter CI passes and PR merges, run: python scripts/publish.py --finalize")
-        print("  --finalize would: tag, publish to PyPI, build DMG, install locally")
-        return 0
+    new_version = bump_version(old_version, bump)
 
     # Step 2: Run tests
-    if not args.skip_tests:
+    if not skip_tests:
         print("Running tests...")
         success, output = run_tests(ROOT)
         if not success:
@@ -306,8 +265,8 @@ def main() -> int:
             return 1
         print("Tests passed.")
 
-    # Step 2b: Verify CI passed
-    if not args.skip_ci:
+    # Step 3: Verify CI passed
+    if not skip_ci:
         print("Verifying CI passed...")
         success, message = check_ci_passed(ROOT)
         if not success:
@@ -315,7 +274,7 @@ def main() -> int:
             return 1
         print(message)
 
-    # Step 3: Generate release notes (before any git changes)
+    # Step 4: Generate release notes
     print("Generating release notes...")
     try:
         notes = generate_release_notes(ROOT, old_version, new_version)
@@ -324,7 +283,7 @@ def main() -> int:
         return 1
     print("Release notes generated.")
 
-    # Step 4: Bump version and build package (validate before committing)
+    # Step 5: Bump version and build package (validate before committing)
     print(f"Bumping version: {old_version} → {new_version}")
     write_version(new_version)
 
@@ -337,7 +296,7 @@ def main() -> int:
         return 1
     print("Build succeeded.")
 
-    # Step 5: Write release notes, create release branch, commit, push, create PR
+    # Step 6: Write release notes, create release branch, commit, push, create PR
     changes_md = "\n".join(f"- {change}" for change in notes.changes)
     release_notes_content = f"# v{new_version}\n\n{notes.summary}\n\n## Changes\n\n{changes_md}\n"
     (ROOT / "RELEASE_NOTES.md").write_text(release_notes_content)
@@ -355,21 +314,16 @@ def main() -> int:
         return 1
 
     print("Committing release...")
-    result = subprocess.run(
+    subprocess.run(
         ["git", "add", "src/loopflow/__init__.py", "RELEASE_NOTES.md"],
         cwd=ROOT,
+        check=True,
     )
-    if result.returncode != 0:
-        print("Failed to stage files", file=sys.stderr)
-        return 1
-
-    result = subprocess.run(
+    subprocess.run(
         ["git", "commit", "-m", f"release: v{new_version}"],
         cwd=ROOT,
+        check=True,
     )
-    if result.returncode != 0:
-        print("Failed to commit", file=sys.stderr)
-        return 1
 
     print("Pushing release branch...")
     result = subprocess.run(
@@ -425,8 +379,125 @@ def main() -> int:
     subprocess.run(["git", "checkout", "main"], cwd=ROOT, capture_output=True)
 
     print(f"\nRelease PR created for v{new_version}")
-    print(f"After CI passes and PR merges, run: python scripts/publish.py --finalize")
+    print("Run this command again after the PR merges to complete the release.")
     return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Publish loopflow to PyPI and DMG to R2. Idempotent: run twice (once to create PR, once after merge)."
+    )
+    parser.add_argument("bump", nargs="?", choices=["patch", "minor", "major"], default="patch")
+    parser.add_argument("-n", "--dry-run", action="store_true", help="Show what would be done")
+    parser.add_argument("--skip-tests", action="store_true", help="Skip test run")
+    parser.add_argument("--skip-ci", action="store_true", help="Skip CI check")
+    parser.add_argument("--dmg-only", action="store_true", help="Only build and upload DMG (no PyPI)")
+    parser.add_argument("--skip-dmg", action="store_true", help="Skip DMG build/upload")
+    parser.add_argument("--skip-website", action="store_true", help="Skip website update/deploy")
+    args = parser.parse_args()
+
+    # Validate args
+    if args.dmg_only and args.skip_dmg:
+        print("Error: --dmg-only and --skip-dmg are mutually exclusive", file=sys.stderr)
+        return 1
+
+    # Import here so --help works without dependencies
+    from loopflow.publish import (
+        build_dmg,
+        get_dmg_path,
+        get_version,
+        upload_dmg,
+        R2_PUBLIC_URL,
+    )
+
+    # Handle DMG-only mode
+    if args.dmg_only:
+        version = get_version()
+        print(f"Current version: {version}")
+
+        if args.dry_run:
+            print("Would build Maestro DMG")
+            print(f"Would upload DMG to {R2_PUBLIC_URL}/LoopflowMaestro-{version}.dmg")
+            print(f"Would upload DMG to {R2_PUBLIC_URL}/LoopflowMaestro-latest.dmg")
+            if not args.skip_website:
+                print("Would update website release metadata and deploy")
+            return 0
+
+        print("Building Maestro DMG...")
+        success, output = build_dmg(ROOT)
+        if not success:
+            print("DMG build failed:", file=sys.stderr)
+            print(output, file=sys.stderr)
+            return 1
+        print("DMG built.")
+
+        print("Uploading DMG...")
+        dmg_path = get_dmg_path(ROOT)
+        success, output = upload_dmg(dmg_path, version)
+        if not success:
+            print("DMG upload failed:", file=sys.stderr)
+            print(output, file=sys.stderr)
+            return 1
+        print(output)
+
+        print(f"\nDMG published: {R2_PUBLIC_URL}/LoopflowMaestro-{version}.dmg")
+        if not args.skip_website:
+            print("Updating website...")
+            if not update_website_release(version, R2_PUBLIC_URL, dry_run=False):
+                print("Website update failed.", file=sys.stderr)
+                return 1
+        return 0
+
+    # --- Idempotent release flow: detect state and act accordingly ---
+
+    print("Checking release state...")
+
+    # State 1: Release commit on main, not yet tagged/published → finalize
+    release_version = _get_release_version_from_main()
+    if release_version:
+        if _tag_exists(release_version) and _is_on_pypi(release_version):
+            print(f"v{release_version} already released (tagged and on PyPI)")
+            return 0
+
+        if args.dry_run:
+            print(f"Would finalize release v{release_version}:")
+            print("  - Tag and push")
+            print("  - Publish to PyPI")
+            if not args.skip_dmg:
+                print("  - Build and upload DMG")
+            print("  - Install locally")
+            return 0
+
+        return _finalize_release(release_version, args.skip_dmg, args.skip_website)
+
+    # State 2: Open release PR exists → tell user to wait
+    pr_version, pr_url = _get_open_release_pr()
+    if pr_version:
+        print(f"Release PR for v{pr_version} is open: {pr_url}")
+        print("Waiting for CI to pass and PR to merge.")
+        print("Run this command again after the PR merges.")
+        return 0
+
+    # State 3: No release in progress → start new release
+    if args.dry_run:
+        from loopflow.publish import bump_version, check_publish_ready
+        state = check_publish_ready(ROOT)
+        if not state.ready:
+            print(f"Error: {state.message}", file=sys.stderr)
+            return 1
+        new_version = bump_version(state.version, args.bump)
+        print(f"Would create release PR for v{new_version}:")
+        print(f"  - Bump version: {state.version} → {new_version}")
+        print("  - Run tests" if not args.skip_tests else "  - Skip tests")
+        print("  - Verify CI passed" if not args.skip_ci else "  - Skip CI check")
+        print("  - Generate release notes")
+        print("  - Build package")
+        print(f"  - Create branch release/v{new_version}")
+        print("  - Create PR with auto-merge")
+        print("\nAfter PR merges, run again to finalize (tag, publish, DMG).")
+        return 0
+
+    return _create_release_pr(args.bump, args.skip_tests, args.skip_ci)
 
 
 if __name__ == "__main__":

--- a/src/loopflow/lf/messages.py
+++ b/src/loopflow/lf/messages.py
@@ -232,6 +232,34 @@ def _get_commits_since_tag(repo_root: Path, tag: str) -> str | None:
     return result.stdout
 
 
+def _get_base_tag_for_release(old_version: str, new_version: str) -> str:
+    """Determine the base tag for release notes based on bump type.
+
+    For patch bumps: use old_version (e.g., 0.6.5 → 0.6.6 uses v0.6.5)
+    For minor bumps: use first patch of old minor (e.g., 0.6.5 → 0.7.0 uses v0.6.1)
+    For major bumps: use first patch of old major (e.g., 0.6.5 → 1.0.0 uses v0.1.0)
+    """
+    old_parts = [int(x) for x in old_version.split(".")]
+    new_parts = [int(x) for x in new_version.split(".")]
+
+    if len(old_parts) != 3 or len(new_parts) != 3:
+        return f"v{old_version}"
+
+    old_major, old_minor, _ = old_parts
+    new_major, new_minor, _ = new_parts
+
+    # Major bump: summarize all changes since start of old major version
+    if new_major > old_major:
+        return f"v{old_major}.1.0"
+
+    # Minor bump: summarize all changes since start of old minor version
+    if new_minor > old_minor:
+        return f"v{old_major}.{old_minor}.1"
+
+    # Patch bump: just changes since old version
+    return f"v{old_version}"
+
+
 def _parse_release_notes(output: str) -> ReleaseNotes:
     """Parse release notes from CLI output."""
     payload = _extract_json_payload(output)
@@ -249,10 +277,13 @@ def _parse_release_notes(output: str) -> ReleaseNotes:
 
 def generate_release_notes(repo_root: Path, old_version: str, new_version: str) -> ReleaseNotes:
     """Generate release notes from commits since last tag via CLI."""
-    commits = _get_commits_since_tag(repo_root, f"v{old_version}")
+    base_tag = _get_base_tag_for_release(old_version, new_version)
+    commits = _get_commits_since_tag(repo_root, base_tag)
     task_prompt = get_builtin_prompt("release_notes")
 
     parts = [f"Version bump: {old_version} → {new_version}"]
+    if base_tag != f"v{old_version}":
+        parts.append(f"This is a {'major' if new_version.split('.')[0] > old_version.split('.')[0] else 'minor'} release summarizing all changes since {base_tag}.")
     if commits:
         parts.append(f"<commits>\n{commits}\n</commits>")
     parts.append(f"<task>\n{task_prompt}\n</task>")


### PR DESCRIPTION
## Usage

```bash
# Start a release (creates PR with auto-merge)
python scripts/publish.py patch

# After PR merges, finalize (tag, publish, build DMG)
python scripts/publish.py --finalize
```

## Summary

Releases now go through a PR workflow instead of pushing directly to main. Running `publish.py` creates a release branch, opens a PR, and enables auto-merge. After CI passes and the PR merges, `--finalize` completes the release by tagging, publishing to PyPI, and building the DMG.

## Changes

- Create `release/vX.Y.Z` branch instead of committing to main
- Open PR with release notes in body and enable auto-merge
- New `--finalize` flag to complete release after PR merges (tag, PyPI, DMG)
- Build package before committing to validate the release
- Clean up release branch after finalization