### PR TITLE
context: add voices parameter to build_prompt

### DIFF
--- a/src/loopflow/lf/context.py
+++ b/src/loopflow/lf/context.py
@@ -573,6 +573,7 @@ def build_prompt(
     include_tests_for: Optional[list[str]] = None,
     run_mode: Optional[str] = None,
     include_loopflow_doc: bool = True,
+    voices: Optional[list[str]] = None,
 ) -> str:
     """Build the full prompt for an LLM session."""
     components = gather_prompt_components(
@@ -584,5 +585,6 @@ def build_prompt(
         include_tests_for=include_tests_for,
         run_mode=run_mode,
         include_loopflow_doc=include_loopflow_doc,
+        voices=voices,
     )
     return format_prompt(components)

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -77,6 +77,18 @@ def test_build_prompt_handles_missing_task(temp_repo):
     assert "No task file found" in result
 
 
+def test_build_prompt_with_voices(temp_repo):
+    """build_prompt passes voices through to formatting."""
+    voices_dir = temp_repo / ".lf" / "voices"
+    voices_dir.mkdir(parents=True, exist_ok=True)
+    (voices_dir / "concise.md").write_text("Be concise.")
+
+    result = build_prompt(temp_repo, "implement", voices=["concise"])
+
+    assert "<lf:voice:concise>" in result
+    assert "Be concise." in result
+
+
 def test_build_prompt_includes_context_files(temp_repo):
     """Context files passed via -c appear in output."""
     (temp_repo / "main.py").write_text("print('hello')\n")


### PR DESCRIPTION
## Usage

```python
from loopflow.lf.context import build_prompt

prompt = build_prompt(
    repo_root,
    task="review",
    voices=["concise", "technical"],
)
```

The `build_prompt` function now accepts a `voices` parameter, allowing callers to include voice customizations in the generated prompt. Previously, voices could only be specified through the lower-level `gather_prompt_components` function.

## Changes

- Add `voices: Optional[list[str]]` parameter to `build_prompt`
- Pass `voices` through to `gather_prompt_components`