### PR TITLE
config: rename exclude to ignore, fix loop branch naming and tag push

### DIFF
--- a/.lf/config.yaml
+++ b/.lf/config.yaml
@@ -9,7 +9,7 @@ skill_sources:
 context:
   - docs
   - .design
-exclude: "uv.lock"
+ignore: "uv.lock"
 push: true
 
 summary_tokens: 25000

--- a/docs/loops.md
+++ b/docs/loops.md
@@ -110,17 +110,17 @@ When the limit is reached, the loop pauses until PRs are merged or closed.
 
 ## Branching Model
 
-Each loop gets its own `loop-<goal>` branch:
+Each loop gets its own `<goal>-main` branch:
 
 ```
 main
-  └── loop-product-engineer  (accumulates iteration work)
+  └── product-engineer-main  (accumulates iteration work)
         ├── product-engineer/001
         ├── product-engineer/002
         └── product-engineer/003
 ```
 
-Iteration branches merge to `loop-<goal>` automatically. You review and land `loop-<goal>` → `main` when ready.
+Iteration branches merge to `<goal>-main` automatically. You review and land `<goal>-main` → `main` when ready.
 
 ## See Also
 

--- a/scripts/publish.py
+++ b/scripts/publish.py
@@ -152,7 +152,7 @@ def _finalize_release(version: str, skip_dmg: bool, skip_website: bool) -> int:
         if result.returncode != 0:
             print(f"Failed to create tag: {result.stderr}", file=sys.stderr)
             return 1
-        result = subprocess.run(["git", "push", "--tags"], cwd=ROOT)
+        result = subprocess.run(["git", "push", "origin", f"v{version}"], cwd=ROOT)
         if result.returncode != 0:
             print("Failed to push tags", file=sys.stderr)
             return 1


### PR DESCRIPTION
## Summary

Three small fixes:

- Rename `exclude` config key to `ignore` for consistency with gitignore terminology
- Change loop branch naming from `loop-<goal>` to `<goal>-main` for cleaner organization
- Push only the specific version tag instead of all tags to avoid pushing unrelated tags