### PR TITLE
lf init: use lf command directly in run_lint

### DIFF
--- a/src/loopflow/lfops/_helpers.py
+++ b/src/loopflow/lfops/_helpers.py
@@ -1,7 +1,6 @@
 """Shared helpers for lfops commands."""
 
 import subprocess
-import sys
 from pathlib import Path
 
 import typer
@@ -14,7 +13,7 @@ def run_lint(repo_root: Path) -> bool:
     """Run lf lint in auto mode. Returns True if successful."""
     typer.echo("Running lint...")
     result = subprocess.run(
-        [sys.executable, "-m", "loopflow.lf", "lint", "-a"],
+        ["lf", "lint", "-a"],
         cwd=repo_root,
     )
     return result.returncode == 0


### PR DESCRIPTION
## Summary

Simplifies the lint invocation in `run_lint()` by calling `lf lint -a` directly instead of `sys.executable -m loopflow.lf lint -a`.

This assumes `lf` is available on the PATH, which is the expected installation method via `uv tool install loopflow`. Using the command directly is cleaner and matches how users invoke lf from the command line.