### PR TITLE
lf src/loopflow/:"@ship": roadmap: add proposed items for cli, daemon, and maestro

### DIFF
--- a/.design/questions.md
+++ b/.design/questions.md
@@ -1,0 +1,16 @@
+# Open Questions
+
+## Roadmap Prioritization
+
+1. **Which item should be approved first?**
+   - `roadmap-cli` - Quick win, enables the agent workflow
+   - `context-profiles` - Competitive advantage per vision
+   - `loop-metrics` - Visibility into what loops do
+   - `model-racing` - Differentiating feature
+   - `maestro-mvp` - Vision centerpiece but biggest effort
+
+2. **Is the area structure right?** Created `cli/`, `daemon/`, `maestro/`. Should there be other areas?
+
+3. **Model racing scope:** Support >2 models? The cost scales fast.
+
+4. **Maestro form factor:** Menu bar app vs full window vs hybrid?

--- a/.docs/roadmap/cli/context-profiles.md
+++ b/.docs/roadmap/cli/context-profiles.md
@@ -1,0 +1,64 @@
+---
+status: proposed
+area: cli
+created_at: 2026-01-20T15:31:00
+---
+
+# Context Profiles: Structured Context for Large Codebases
+
+Vision says "Context management is the hard problem—better context management = competitive advantage."
+
+## The Problem
+
+Current context assembly is basic: gather files from `context:` frontmatter, diff, clipboard. For large codebases, this either:
+- Includes too much (overwhelming the model, hitting token limits)
+- Includes too little (model lacks necessary context)
+
+Users manually curate context. This knowledge disappears after the session.
+
+## Proposed Solution
+
+Introduce context profiles in `.lf/context/`:
+
+```yaml
+# .lf/context/auth.yaml
+name: auth
+description: Authentication system context
+files:
+  - src/auth/**/*.py
+  - src/middleware/auth.py
+symbols:
+  - class:AuthService
+  - function:verify_token
+related: [api, database]
+```
+
+Steps can reference profiles:
+
+```yaml
+---
+context: auth
+# or
+context: [auth, api]
+---
+```
+
+## Implementation
+
+1. `@dataclass ContextProfile` in `src/loopflow/lf/context.py`
+2. `load_context_profile()` function
+3. Update context assembly in `run.py` to resolve profiles
+4. `lf context list` to show available profiles
+5. `lf context show auth` to preview what files would be included
+
+## Why This Matters
+
+- Reproducible context across sessions
+- Team can share context knowledge
+- Scales to large codebases without manual curation
+- Profiles evolve with the codebase (versioned in git)
+
+## Open Questions
+
+1. Should profiles support dynamic queries (files changed in last N commits)?
+2. How to handle profile size estimation for token budgets?

--- a/.docs/roadmap/cli/model-racing.md
+++ b/.docs/roadmap/cli/model-racing.md
@@ -1,0 +1,46 @@
+---
+status: proposed
+area: cli
+created_at: 2026-01-20T15:30:00
+---
+
+# Model Racing: Run Same Task with Multiple Models
+
+Race Claude vs Codex on the same task, pick the winner.
+
+## The Problem
+
+The `RaceConfig` structure exists in `flows.py` but there's no actual racing implementation. Users can't run the same prompt against multiple models in parallel and compare results.
+
+## Proposed Solution
+
+Add `lf race` command:
+
+```bash
+# Race two models on the same task
+lf race debug -v --models claude:sonnet,codex:o3
+
+# Race with custom judge
+lf race implement --models claude:opus,claude:sonnet --judge review
+```
+
+Each model runs in its own worktree. Results are compared via `@compare` step or custom judge.
+
+## Implementation
+
+1. Create worktrees for each model: `feature-race-1`, `feature-race-2`
+2. Run step in parallel across worktrees
+3. After all complete, run judge step that sees both diffs
+4. Output recommendation, let user pick winner
+
+## Files to Change
+
+- `src/loopflow/lf/run.py` - Add race execution logic
+- `src/loopflow/lf/__init__.py` - Add `race` command
+- `src/loopflow/lf/worktrees.py` - Support race worktree creation
+
+## Open Questions
+
+1. How to handle races where one model fails? Continue with survivors?
+2. Should races support >2 models? Gets expensive quickly.
+3. Auto-cleanup losing worktrees, or let user review first?

--- a/.docs/roadmap/cli/roadmap-cli.md
+++ b/.docs/roadmap/cli/roadmap-cli.md
@@ -1,0 +1,52 @@
+---
+status: proposed
+area: cli
+created_at: 2026-01-20T15:34:00
+---
+
+# Roadmap CLI: Manage Work Items from Terminal
+
+## The Problem
+
+The roadmap infrastructure exists (`roadmap.py`) but there's no CLI to interact with it. Users must manually create markdown files and remember the frontmatter format.
+
+## Proposed Solution
+
+Add `lf roadmap` commands:
+
+```bash
+# List all roadmap items
+lf roadmap
+
+# List items for an area
+lf roadmap --area cli
+
+# Create a new item
+lf roadmap add cli "Model Racing" --body "Race models against each other"
+
+# Approve an item for work
+lf roadmap approve cli/model-racing
+
+# Mark item complete (moves to _done/)
+lf roadmap done cli/model-racing
+```
+
+## Implementation
+
+Most of the logic already exists in `roadmap.py`:
+- `load_roadmap()` - ✓
+- `create_item()` - ✓
+- `approve_item()` - ✓
+- `complete_item()` - ✓
+
+Just need CLI wiring:
+
+1. Add `roadmap` command group to `lf/__init__.py`
+2. Wire to existing `roadmap.py` functions
+3. Add formatted output using `format_roadmap_list()`
+
+## Why This Matters
+
+- Faster workflow for managing roadmap items
+- Consistent frontmatter (no manual YAML errors)
+- Integrates with adaptive mode flow (agents can propose items, humans approve)

--- a/.docs/roadmap/daemon/loop-metrics.md
+++ b/.docs/roadmap/daemon/loop-metrics.md
@@ -1,0 +1,57 @@
+---
+status: proposed
+area: daemon
+created_at: 2026-01-20T15:32:00
+---
+
+# Loop Metrics: Track What Loops Are Actually Doing
+
+## The Problem
+
+`lfd status` shows loop state (running/idle/waiting) but not:
+- How many iterations have run
+- What they produced (commits, PRs)
+- Why they stopped
+- Cost tracking
+
+Users can't tell if loops are productive or spinning.
+
+## Proposed Solution
+
+Add metrics collection to loop execution:
+
+```python
+@dataclass
+class LoopMetrics:
+    iterations: int
+    commits_created: int
+    prs_opened: int
+    prs_landed: int
+    errors: int
+    last_error: str | None
+    started_at: datetime
+    last_iteration_at: datetime | None
+    estimated_cost_usd: float
+```
+
+Expose via `lfd status --metrics`:
+
+```
+area       status   iters  commits  PRs   cost    last run
+api        running  47     12       3     $2.40   2m ago
+tests      waiting  23     8        2     $1.10   (1 outstanding)
+```
+
+## Implementation
+
+1. Add `LoopMetrics` to `lfd/models.py`
+2. Collect metrics in `loop_runner.py`
+3. Store in SQLite alongside loop state
+4. Add `--metrics` flag to `lfd status`
+5. Consider: `lfd metrics <loop>` for detailed view
+
+## Future
+
+- Daily/weekly summaries
+- Cost alerts when loops exceed budget
+- Productivity trends over time

--- a/.docs/roadmap/maestro/maestro-mvp.md
+++ b/.docs/roadmap/maestro/maestro-mvp.md
@@ -1,0 +1,58 @@
+---
+status: proposed
+area: maestro
+created_at: 2026-01-20T15:33:00
+---
+
+# Maestro MVP: The Podium for Conducting Agents
+
+Vision: "Maestro is where you conduct from—launch tasks, watch progress, ship when ready."
+
+## The Problem
+
+Today, agent orchestration requires:
+- Multiple terminal windows
+- Manual `lfd status` polling
+- Switching between worktrees with shell commands
+- No unified view of all running work
+
+## What Maestro Does (MVP)
+
+Native macOS app showing:
+
+1. **Worktree list** - All worktrees in the repo, their branches, status
+2. **Loop status** - Running loops with live indicator
+3. **Quick actions** - Open in terminal, open in Cursor, ship (PR + land)
+4. **Notifications** - When loops complete or need attention
+
+## What Maestro Doesn't Do (MVP)
+
+- No embedded terminal (launch in your terminal app)
+- No streaming output (check terminal for details)
+- No IDE integration (works alongside Cursor/VS Code)
+
+## Implementation Path
+
+1. **Start with SwiftUI** - Native macOS, menu bar presence
+2. **IPC via lfd** - Maestro talks to daemon for status
+3. **Launch protocol** - `maestro://open?worktree=feature-auth`
+4. **Minimal state** - All truth in lfd database
+
+## Protocol Between Maestro and lfd
+
+```
+lfd serve --maestro-socket /tmp/maestro.sock
+
+Commands:
+- list-worktrees
+- list-loops
+- loop-status <id>
+- start-loop <id>
+- stop-loop <id>
+```
+
+## Open Questions
+
+1. Menu bar app vs full window app vs hybrid?
+2. How to handle multi-repo workflows?
+3. Should Maestro manage terminal app preferences?


### PR DESCRIPTION
Drafts context-profiles, model-racing, roadmap-cli, loop-metrics, and maestro-mvp. Adds questions.md to track open decisions on prioritization and scope.
