### PR TITLE
lf .:"@ship": ci: add ruff lint and format check

### DIFF
--- a/.design/questions.md
+++ b/.design/questions.md
@@ -1,0 +1,7 @@
+# Open Questions
+
+## Infrastructure Roadmap
+
+1. **PyPI Trusted Publishing**: Is trusted publishing already configured for `loopflowstudio/loopflow`? Need to verify in PyPI settings before implementing the automation.
+
+2. **Codecov Token**: Does the repo have Codecov configured? Need org-level setup or per-repo token.

--- a/.docs/roadmap/infra/ci-lint-check.md
+++ b/.docs/roadmap/infra/ci-lint-check.md
@@ -1,0 +1,33 @@
+# CI: Enforce Lint & Format
+
+**Status:** done
+
+## Problem
+
+Ruff is configured in `pyproject.toml` but not enforced in CI. Code can be merged without passing lint or format checks. This creates drift between what developers run locally and what CI enforces.
+
+## Proposal
+
+Add lint and format checking to the CI pipeline:
+
+```yaml
+lint:
+  runs-on: ubuntu-latest
+  steps:
+    - uses: actions/checkout@v4
+    - uses: astral-sh/setup-uv@v4
+    - run: uv sync
+    - run: uv run ruff check .
+    - run: uv run ruff format --check .
+```
+
+## Why This Matters
+
+- Ruff is already configured and rules are defined
+- Fast execution (~1-2 seconds)
+- Catches import ordering, unused variables, style issues before merge
+- Prevents accumulation of lint debt
+
+## Open Questions
+
+None. Ruff config already exists; this just enforces it.

--- a/.docs/roadmap/infra/code-coverage.md
+++ b/.docs/roadmap/infra/code-coverage.md
@@ -1,0 +1,39 @@
+# CI: Code Coverage Reporting
+
+**Status:** proposed
+
+## Problem
+
+No visibility into test coverage. Don't know which code paths are tested, which are not. Hard to assess risk when making changes.
+
+## Proposal
+
+Add pytest-cov and report to Codecov:
+
+1. Add `pytest-cov` to dev dependencies
+2. Update CI to generate coverage report
+3. Upload to Codecov for PR comments
+
+```yaml
+loopflow-test:
+  runs-on: ubuntu-latest
+  steps:
+    - uses: actions/checkout@v4
+    - uses: astral-sh/setup-uv@v4
+    - run: uv sync
+    - run: uv run pytest tests/ --cov=src/loopflow --cov-report=xml
+    - uses: codecov/codecov-action@v4
+      with:
+        files: coverage.xml
+```
+
+## Why This Matters
+
+- 506 tests exist but unknown coverage
+- PR comments show coverage delta (regression protection)
+- Visibility first, thresholds later
+
+## Open Questions
+
+- Codecov token setup for the repo
+- Whether to add coverage threshold after establishing baseline

--- a/.docs/roadmap/infra/pypi-automation.md
+++ b/.docs/roadmap/infra/pypi-automation.md
@@ -1,0 +1,50 @@
+# CI: Automate PyPI Publishing
+
+**Status:** proposed
+
+## Problem
+
+Releases require running `scripts/publish.py` locally twice—once to create the PR, once to finalize after merge. The finalize step (tag, publish to PyPI) could fail if the local environment is misconfigured.
+
+## Proposal
+
+Add a tag-triggered GitHub Actions workflow for PyPI publishing:
+
+```yaml
+name: Publish to PyPI
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write  # trusted publishing
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v4
+      - run: uv sync
+      - run: uv run python -m build
+      - uses: pypa/gh-action-pypi-publish@release/v1
+```
+
+## Why This Matters
+
+- Removes dependency on local environment for publishing
+- Tag creates release—no second manual step
+- Uses trusted publishing (no API tokens to manage)
+- Idempotent: re-running a tag push is safe
+
+## What This Doesn't Change
+
+- `scripts/publish.py` still creates the release PR
+- DMG builds still require local macOS (can't automate in GitHub Actions without macOS secrets)
+- Version bumping and release notes remain manual
+
+## Open Questions
+
+- Confirm PyPI trusted publisher is configured for `loopflowstudio/loopflow`
+- Whether to create GitHub Release from the workflow (adds changelog visibility)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,15 @@ on:
   merge_group:
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v4
+      - run: uv sync
+      - run: uv run ruff check .
+      - run: uv run ruff format --check .
+
   loopflow-test:
     runs-on: ubuntu-latest
     steps:

--- a/scripts/publish.py
+++ b/scripts/publish.py
@@ -89,7 +89,17 @@ def _tag_exists(version: str) -> bool:
 def _get_open_release_pr() -> tuple[str | None, str | None]:
     """Check for an open release PR. Returns (version, pr_url) or (None, None)."""
     result = subprocess.run(
-        ["gh", "pr", "list", "--head", "release/", "--json", "headRefName,url,state", "--limit", "10"],
+        [
+            "gh",
+            "pr",
+            "list",
+            "--head",
+            "release/",
+            "--json",
+            "headRefName,url,state",
+            "--limit",
+            "10",
+        ],
         cwd=ROOT,
         capture_output=True,
         text=True,
@@ -123,13 +133,13 @@ def _is_on_pypi(version: str) -> bool:
 def _finalize_release(version: str, skip_dmg: bool, skip_website: bool) -> int:
     """Complete release: tag, publish to PyPI, build DMG."""
     from loopflow.publish import (
+        R2_PUBLIC_URL,
         build_dmg,
         build_package,
         get_dmg_path,
         install_locally,
         publish_package,
         upload_dmg,
-        R2_PUBLIC_URL,
     )
 
     print(f"Finalizing release v{version}...")
@@ -224,6 +234,7 @@ def _finalize_release(version: str, skip_dmg: bool, skip_website: bool) -> int:
     print("https://pypi.org/project/loopflow/")
     if not skip_dmg:
         from loopflow.publish import R2_PUBLIC_URL
+
         print(f"{R2_PUBLIC_URL}/LoopflowMaestro-{version}.dmg")
     return 0
 
@@ -236,10 +247,10 @@ def _create_release_pr(
     """Create release PR with version bump."""
     from loopflow.lf.messages import generate_release_notes
     from loopflow.publish import (
-        bump_version,
         build_package,
-        check_publish_ready,
+        bump_version,
         check_ci_passed,
+        check_publish_ready,
         run_tests,
         write_version,
     )
@@ -339,11 +350,17 @@ def _create_release_pr(
     pr_body = f"Release v{new_version}\n\n{release_notes_content}"
     result = subprocess.run(
         [
-            "gh", "pr", "create",
-            "--base", "main",
-            "--head", release_branch,
-            "--title", f"release: v{new_version}",
-            "--body", pr_body,
+            "gh",
+            "pr",
+            "create",
+            "--base",
+            "main",
+            "--head",
+            release_branch,
+            "--title",
+            f"release: v{new_version}",
+            "--body",
+            pr_body,
         ],
         cwd=ROOT,
         capture_output=True,
@@ -365,8 +382,15 @@ def _create_release_pr(
     )
     if result.returncode != 0:
         error_msg = result.stderr.strip() or result.stdout.strip()
-        if "auto merge is not allowed" in error_msg.lower() or "enablepullrequestautomerge" in error_msg.lower():
-            print("Auto-merge not enabled for this repo. Merge manually after CI passes.", file=sys.stderr)
+        auto_merge_disabled = (
+            "auto merge is not allowed" in error_msg.lower()
+            or "enablepullrequestautomerge" in error_msg.lower()
+        )
+        if auto_merge_disabled:
+            print(
+                "Auto-merge not enabled for this repo. Merge manually after CI passes.",
+                file=sys.stderr,
+            )
         else:
             print(f"Warning: Could not enable auto-merge: {error_msg}")
     else:
@@ -385,14 +409,15 @@ def _create_release_pr(
 
 def main() -> int:
     parser = argparse.ArgumentParser(
-        description="Publish loopflow to PyPI and DMG to R2. Idempotent: run twice (once to create PR, once after merge)."
+        description="Publish loopflow to PyPI and DMG to R2. "
+        "Idempotent: run twice (once to create PR, once after merge)."
     )
     parser.add_argument("bump", nargs="?", choices=["patch", "minor", "major"], default="patch")
     parser.add_argument("-n", "--dry-run", action="store_true", help="Show what would be done")
-    parser.add_argument("--local", action="store_true", help="Build and install locally only (no publish)")
+    parser.add_argument("--local", action="store_true", help="Build and install locally only")
     parser.add_argument("--skip-tests", action="store_true", help="Skip test run")
     parser.add_argument("--skip-ci", action="store_true", help="Skip CI check")
-    parser.add_argument("--dmg-only", action="store_true", help="Only build and upload DMG (no PyPI)")
+    parser.add_argument("--dmg-only", action="store_true", help="Only build and upload DMG")
     parser.add_argument("--skip-dmg", action="store_true", help="Skip DMG build/upload")
     parser.add_argument("--skip-website", action="store_true", help="Skip website update/deploy")
     args = parser.parse_args()
@@ -404,11 +429,11 @@ def main() -> int:
 
     # Import here so --help works without dependencies
     from loopflow.publish import (
+        R2_PUBLIC_URL,
         build_dmg,
         get_dmg_path,
         get_version,
         upload_dmg,
-        R2_PUBLIC_URL,
     )
 
     # Handle DMG-only mode
@@ -507,6 +532,7 @@ def main() -> int:
     # State 3: No release in progress → start new release
     if args.dry_run:
         from loopflow.publish import bump_version, check_publish_ready
+
         state = check_publish_ready(ROOT)
         if not state.ready:
             print(f"Error: {state.message}", file=sys.stderr)


### PR DESCRIPTION
Enforces existing ruff config in CI. Also adds infra roadmap docs and applies ruff formatting fixes to scripts/publish.py.
