### PR TITLE
roadmap/infra: add pre-commit hooks and daemon health check proposals

### DIFF
--- a/.design/choices/ship.md
+++ b/.design/choices/ship.md
@@ -1,0 +1,7 @@
+---
+choice: add_to_roadmap
+reason: No roadmap exists to scope from
+options: [add_to_roadmap, scope_from_roadmap]
+---
+
+The `.docs/roadmap` directory does not exist, and `.design/` contains no design documents. Without a roadmap entry, the `scope_from_roadmap` branch cannot run. The `add_to_roadmap` branch should be used to create a roadmap entry first.

--- a/.design/joins/ship.md
+++ b/.design/joins/ship.md
@@ -1,0 +1,8 @@
+# Join Summary
+
+Merged two infra roadmap proposals from parallel forks:
+
+1. **pre-commit-hooks** - Fast local feedback via ruff lint/format and file hygiene checks
+2. **lfd-health-checks** - Daemon observability with heartbeat, status file, and watchdog recovery
+
+Both are independent proposed items ready for review.

--- a/.design/questions.md
+++ b/.design/questions.md
@@ -1,0 +1,6 @@
+# Open Questions
+
+## Pre-commit hooks (infra)
+
+- Should `lf init` automatically run `pre-commit install`, or just prompt the user?
+- The codebase already has ruff 0.9.0 in dev dependencies. Should we match that version exactly in the pre-commit config, or allow them to drift?

--- a/.docs/roadmap/infra/lfd-health-checks.md
+++ b/.docs/roadmap/infra/lfd-health-checks.md
@@ -1,0 +1,23 @@
+---
+status: proposed
+area: infra
+---
+
+# Daemon health checks and self-heal
+
+Background agents are core to Loopflow, but the current daemon behavior has no explicit health contract. Add a lightweight health-check and recovery path so loops are observable, failures are surfaced, and stuck daemons can be recovered without manual cleanup. This improves reliability for headless runs and reduces developer toil.
+
+## Scope
+
+- Define a health check for `lfd` (last heartbeat, active loops, last error)
+- Persist daemon state to a single on-disk status file for `lfd status` and future UI
+- Add a watchdog path that can detect a stalled daemon and restart cleanly
+- Emit a clear notification on failure and on automatic recovery
+- Add tests around heartbeat updates and status parsing
+
+- Not included: full metrics/telemetry backend, remote monitoring service
+- Not included: changes to loop scheduling semantics or run mode behavior
+
+## Approach
+
+Create a small `DaemonStatus` record (json) stored under `~/.lf/state/lfd.status.json` with timestamped heartbeat, active loop IDs, and last error. Update it on daemon start, loop start/stop, and on a fixed heartbeat interval. Add `lfd status --health` to report OK/warn/stale based on configurable thresholds. Implement a watchdog in `lfd` startup that checks for an existing pid + stale heartbeat; if stale, archive the old status and start fresh. Use the existing notification mechanism to surface failure/recovery. Tests should mock time and file IO to validate stale detection and status parsing logic.

--- a/.docs/roadmap/infra/pre-commit-hooks.md
+++ b/.docs/roadmap/infra/pre-commit-hooks.md
@@ -1,0 +1,65 @@
+---
+status: proposed
+area: infra
+created_at: 2026-01-21T02:35:00
+---
+
+# Pre-commit hooks for fast local feedback
+
+Add pre-commit hooks that catch common issues before they reach CI. Developers get immediate feedback on lint errors, formatting issues, and basic sanity checks without waiting for GitHub Actions.
+
+## Scope
+
+**Included:**
+- `.pre-commit-config.yaml` with ruff (lint + format)
+- Basic file hygiene checks (trailing whitespace, end-of-file, no debug statements)
+- `pyproject.toml` integration (hooks respect existing ruff config)
+- Documentation in CLAUDE.md about running/skipping hooks
+
+**Not included:**
+- Type checking (mypy/pyright) - too slow for pre-commit
+- Test running - that's CI's job
+- macOS-specific hooks for Maestro (Swift has different tooling)
+- Security scanning - separate roadmap item
+
+## Approach
+
+Use the `pre-commit` framework. Configure hooks that run in under 2 seconds for typical commits.
+
+```yaml
+# .pre-commit-config.yaml
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.9.0
+    hooks:
+      - id: ruff
+        args: [--fix]
+      - id: ruff-format
+
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-added-large-files
+```
+
+Add `pre-commit` to dev dependencies:
+
+```toml
+# pyproject.toml
+[project.optional-dependencies]
+dev = ["pre-commit>=4.0.0"]
+```
+
+Install on clone:
+
+```bash
+uv sync --extra dev
+uv run pre-commit install
+```
+
+The `lf init` command should offer to install pre-commit hooks during setup.
+
+**Why ruff over black/isort:** Already using ruff for linting. Single tool means single version to track, faster execution.


### PR DESCRIPTION
Two new roadmap items for infrastructure reliability:
- pre-commit-hooks: ruff lint/format + file hygiene for fast local feedback
- lfd-health-checks: daemon observability with heartbeat and watchdog recovery
