### PR TITLE
infra: add CI linting and daemon health check roadmap items

### DIFF
--- a/.design/choices/ship.md
+++ b/.design/choices/ship.md
@@ -1,0 +1,7 @@
+---
+choice: add_to_roadmap
+reason: No roadmap exists yet - need to create one before scoping
+options: [add_to_roadmap, scope_from_roadmap]
+---
+
+The `.docs/roadmap` directory does not exist and `.design` is empty. Since `scope_from_roadmap` requires an existing roadmap to scope work from, we must first run `add_to_roadmap` to create roadmap items that can later be scoped and implemented.

--- a/.design/joins/ship.md
+++ b/.design/joins/ship.md
@@ -1,0 +1,23 @@
+# Join: Infrastructure Roadmap Items
+
+Synthesized from 2 forked worktrees that ran in roadmap mode.
+
+## Merged
+
+**From roadmap fork:**
+- `.docs/roadmap/infra/ci-linting.md` - Add ruff check/format to CI
+- `.design/questions.md` - Open questions from analysis
+
+**From roadmap:3 fork:**
+- `.docs/roadmap/infra/lfd-health-checks.md` - Daemon health monitoring
+
+## Consolidation
+
+- Standardized area naming to `infra` (fork 2 used `infra-engineer`)
+- Both items placed under `.docs/roadmap/infra/`
+
+## Result
+
+Two proposed infra improvements ready for review:
+1. **CI Linting** - Low effort, immediate value, catches formatting drift
+2. **LFD Health Checks** - Higher effort, addresses daemon reliability gap

--- a/.design/questions.md
+++ b/.design/questions.md
@@ -1,0 +1,9 @@
+# Open Questions
+
+## From infra-engineer roadmap analysis (2026-01-21)
+
+1. **Daemon error handling**: `server.py:314-315` swallows all exceptions in `_periodic_check`. Should this log errors? Surface them via the status API? This makes debugging daemon issues hard.
+
+2. **Expanded lint rules**: Ruff is currently configured with E/F/W/I only. There are 30 blind exceptions (`BLE001`) and other issues. Worth expanding rules, or is the current minimal set intentional?
+
+3. **Pre-commit hooks**: Should `ruff check` and `ruff format` run before commit locally, or is CI-only sufficient? Trade-off: faster local commits vs catching issues earlier.

--- a/.docs/roadmap/infra/ci-linting.md
+++ b/.docs/roadmap/infra/ci-linting.md
@@ -1,0 +1,42 @@
+---
+status: proposed
+area: infra
+---
+
+# Add linting to CI
+
+Ruff is configured locally but CI only runs pytest. Failed lints get caught in local dev (if you remember to run them) but can slip through PRs.
+
+## Scope
+
+- Add `ruff check src/` to CI workflow
+- Add `ruff format --check src/` to CI workflow
+- Keep it as a separate job so test failures and lint failures are distinguishable
+
+## Not included
+
+- Expanding ruff rules beyond current E/F/W/I selection
+- Pre-commit hooks (different item)
+- Fixing existing lint issues on stricter rules
+
+## Approach
+
+Add a `lint` job to `.github/workflows/ci.yml`:
+
+```yaml
+lint:
+  runs-on: ubuntu-latest
+  steps:
+    - uses: actions/checkout@v4
+    - uses: astral-sh/setup-uv@v4
+    - run: uv sync
+    - run: uv run ruff check src/
+    - run: uv run ruff format --check src/
+```
+
+This catches:
+- Import sorting issues
+- Syntax errors
+- Formatting drift
+
+Fast (<10s), no false positives with current rules.

--- a/.docs/roadmap/infra/lfd-health-checks.md
+++ b/.docs/roadmap/infra/lfd-health-checks.md
@@ -1,0 +1,21 @@
+---
+status: proposed
+area: infra
+---
+
+# LFD Health Checks and Stuck-Loop Recovery
+
+The background daemon is core to Loopflow's promise of tight, reliable loops. Today, when a loop stalls or a worktree becomes inconsistent, the failure mode is silent and requires manual cleanup. Add explicit health checks and automatic recovery so long-running loops stay trustworthy and operators get fast signal when intervention is needed.
+
+## Scope
+
+- Add daemon heartbeat tracking and a health status snapshot on disk
+- Detect stalled loops and surface clear status in `lfd status`
+- Provide a safe auto-recovery path (retry with backoff, then halt and report)
+- Document rollback and manual recovery steps for operators
+
+- Not included: Maestro UI changes, notifications routing, or cloud-hosted daemon
+
+## Approach
+
+Introduce a lightweight health registry under `~/.lf/state/` that records per-loop heartbeat timestamps, last successful step, and retry state. Extend `lfd status` to read this registry and flag stalled loops with actionable messages. Implement a recovery policy: on missed heartbeats, retry the last step up to N times with exponential backoff, then mark the loop halted and emit a log entry with a clear remediation hint. Keep the policy configurable in `.lf/config.yaml` with conservative defaults and ensure all new failure states are surfaced in logs for observability.


### PR DESCRIPTION
Two proposed infrastructure improvements:
- ci-linting.md: Add ruff check/format to GitHub Actions
- lfd-health-checks.md: Heartbeat tracking and stuck-loop recovery

Synthesized from forked roadmap exploration sessions.
