### PR TITLE
context: handle binary content in git diffs

### DIFF
--- a/src/loopflow/lf/context.py
+++ b/src/loopflow/lf/context.py
@@ -476,7 +476,8 @@ def gather_diff(
         cmd,
         cwd=repo_root,
         capture_output=True,
-        text=True,
+        encoding="utf-8",
+        errors="replace",  # Handle binary content in diffs
     )
     if result.returncode != 0 or not result.stdout.strip():
         return None


### PR DESCRIPTION
## Summary

Fixes crashes when gathering context from diffs that contain binary content. The subprocess now uses `errors="replace"` to handle non-UTF-8 bytes gracefully instead of failing.

## Changes

- Replace `text=True` with explicit `encoding="utf-8"` and `errors="replace"` in diff subprocess call