### PR TITLE
swift: add LoopflowCore shared framework

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@ __pycache__/
 .build/
 xcuserdata/
 .swiftpm/xcode/
-swift/Concerto.xcodeproj/
+swift/*.xcodeproj/
 swift/dist/
 
 # Claude Code (personal state)

--- a/swift/LoopflowCore/Info.plist
+++ b/swift/LoopflowCore/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/swift/project.yml
+++ b/swift/project.yml
@@ -15,6 +15,19 @@ packages:
     from: 0.10.0
 
 targets:
+  LoopflowCore:
+    type: framework
+    platform: macOS
+    sources:
+      - path: LoopflowCore
+        excludes:
+          - Info.plist
+    settings:
+      base:
+        INFOPLIST_FILE: LoopflowCore/Info.plist
+        PRODUCT_BUNDLE_IDENTIFIER: com.loopflow.core
+        DEFINES_MODULE: YES
+
   Concerto:
     type: application
     platform: macOS
@@ -22,6 +35,8 @@ targets:
       - path: Concerto
         excludes:
           - Info.plist
+    dependencies:
+      - target: LoopflowCore
     settings:
       base:
         INFOPLIST_FILE: Concerto/Info.plist


### PR DESCRIPTION
## Usage

```bash
cd swift && xcodegen generate && open Concerto.xcodeproj
```

Adds a new `LoopflowCore` framework target that Concerto depends on. This sets up a shared code layer for Swift apps in the repo.

## Changes

- New `LoopflowCore` framework target in `project.yml`
- Concerto now depends on LoopflowCore
- Updated `.gitignore` to exclude all generated Xcode projects under `swift/`