### PR TITLE
worktrees: push to create remote branch on worktree creation

### DIFF
--- a/src/loopflow/lf/worktrees.py
+++ b/src/loopflow/lf/worktrees.py
@@ -270,6 +270,14 @@ def create_with_schema(
         error = result.stderr.strip() or result.stdout.strip() or "Failed to create worktree"
         raise WorktreeError(error)
 
+    # Push to create remote branch with tracking
+    subprocess.run(
+        ["git", "push", "-u", "origin", branch_name],
+        cwd=worktree_path,
+        capture_output=True,
+        text=True,
+    )
+
     return worktree_path
 
 


### PR DESCRIPTION
## Usage

```bash
lf wt create feature-name
```

Creating a worktree now automatically pushes the new branch to origin with upstream tracking enabled. The remote branch is created immediately so the worktree starts with `on_origin: true`.

## Summary

When `create_with_schema` creates a new worktree, it now runs `git push -u origin <branch>` to establish the remote branch. This eliminates the manual step of pushing before the first commit and ensures the branch is visible on GitHub right away. The push is fire-and-forget—failures are silently ignored since a missing remote shouldn't block local development.