### PR TITLE
lf lint: tests: fix line formatting in test_context

### DIFF
--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -97,9 +97,7 @@ def test_build_prompt_includes_context_files(temp_repo):
     """Context files passed via pathset appear in output."""
     (temp_repo / "main.py").write_text("print('hello')\n")
 
-    result = build_prompt(
-        temp_repo, "implement", context_config=ContextConfig(pathset=["main.py"])
-    )
+    result = build_prompt(temp_repo, "implement", context_config=ContextConfig(pathset=["main.py"]))
 
     assert "Reference files" in result
     assert "<lf:files>" in result


### PR DESCRIPTION
## Summary

Fixes line formatting in `test_context.py` to match the codebase style. The `build_prompt` function call was split across multiple lines unnecessarily when it fits on a single line.

## Changes

- Consolidate multi-line function call to single line in `test_build_prompt_includes_context_files`