### PR TITLE
lfd: add HTTP server and worktree state service for Concerto integration

### DIFF
--- a/.docs/concerto-lfd-01-protocol.md
+++ b/.docs/concerto-lfd-01-protocol.md
@@ -1,0 +1,96 @@
+# Project 1: Protocol Alignment
+
+Fix the event namespace and field name mismatches between Concerto and lfd.
+
+**Status:** Complete
+
+---
+
+## Problem
+
+Concerto subscribes to events but never receives them due to naming mismatches.
+
+### Event Namespace Mismatch
+
+| Side | Pattern | Events |
+|------|---------|--------|
+| Swift subscribes | `session.*` | expects `session.started`, `session.ended` |
+| Python emits | — | sends `step_run.started`, `step_run.ended` |
+
+**Result:** Session events never reach Concerto.
+
+### Field Name Mismatch
+
+In `output.line` events:
+
+| Side | Field |
+|------|-------|
+| Swift expects | `session_id` |
+| Python sends | `step_run_id` |
+
+**Result:** Output lines can't be associated with sessions.
+
+---
+
+## Solution
+
+Align Python to emit what Swift expects. This is simpler than changing Swift because:
+
+1. Swift naming (`session`) is more user-facing
+2. Python is the source of truth—it should speak the client's language
+3. One place to change vs. multiple Swift files
+
+### Changes Required
+
+**`server.py`** — Change event names:
+```python
+# Before
+Event("step_run.started", {...})
+Event("step_run.ended", {...})
+
+# After
+Event("session.started", {...})
+Event("session.ended", {...})
+```
+
+**`server.py`** — Change field name in output events:
+```python
+# Before
+{"step_run_id": step_run_id, "text": text, "timestamp": ...}
+
+# After
+{"session_id": step_run_id, "text": text, "timestamp": ...}
+```
+
+### Files to Modify
+
+1. `src/loopflow/lfd/daemon/server.py` — Event emission
+2. `src/loopflow/lfd/daemon/protocol.py` — Document the protocol (if not already)
+
+### Files to Verify (Swift)
+
+No changes needed, but verify these parse correctly after fix:
+
+1. `swift/LoopflowCore/Services/LFDEventService.swift` — Event parsing
+2. `swift/Concerto/AppState.swift` — Event subscription patterns
+
+---
+
+## Testing
+
+1. Start lfd: `lfd serve`
+2. Open Concerto, verify "lfd connected" status
+3. Run a step: `lf review`
+4. Verify Concerto shows:
+   - Session appears in UI
+   - Output streams in real-time
+   - Session completes with correct status
+
+---
+
+## Done When
+
+- [x] `session.started` events received by Concerto
+- [x] `session.ended` events received by Concerto
+- [x] `output.line` events associated with correct session
+- [ ] No protocol-related errors in Concerto logs (verify manually)

--- a/.docs/concerto-lfd-02-worktree-state.md
+++ b/.docs/concerto-lfd-02-worktree-state.md
@@ -1,0 +1,189 @@
+# Project 2: Worktree State Service
+
+Move worktree status calculation from Concerto into lfd.
+
+**Status:** Next
+
+---
+
+## Problem
+
+Concerto calculates worktree status through multiple async passes:
+
+```
+Pass 1: wt list --json           → branch, basic status (~200ms)
+Pass 2: detectStaleness()        → 4+ git commands/worktree (~500ms/wt)
+Pass 3: fetchCIStatus()          → gh pr checks/worktree (~1-2s/wt)
+Pass 4: loadSessions()           → session history/worktree
+```
+
+Each pass updates the UI, causing flicker. With 5 worktrees, full status takes 10+ seconds.
+
+### Current Data Flow
+
+```
+Concerto                           CLI/Git
+   │                                  │
+   ├─► WorktreeService.list() ───────►│ wt list --json
+   │◄─────────────────────────────────┤ (basic status)
+   │                                  │
+   ├─► detectStaleness() ────────────►│ git diff, git branch --merged, etc.
+   │◄─────────────────────────────────┤ (per worktree, sequential)
+   │                                  │
+   ├─► fetchCIStatus() ──────────────►│ gh pr checks
+   │◄─────────────────────────────────┤ (per worktree, sequential)
+   │                                  │
+   └─► UI re-renders on each pass
+```
+
+---
+
+## Solution
+
+lfd maintains worktree state. Concerto asks lfd instead of running git commands.
+
+### New lfd Endpoint
+
+```python
+# Request
+{"method": "worktrees.list", "params": {"repo": "/path/to/repo"}}
+
+# Response
+{
+    "ok": true,
+    "result": {
+        "worktrees": [
+            {
+                "path": "/path/to/worktree",
+                "branch": "feature-x",
+                "status": {
+                    "staged": 2,
+                    "modified": 5,
+                    "untracked": 0,
+                    "ahead": 3,
+                    "behind": 0
+                },
+                "staleness": {
+                    "stale": true,
+                    "reason": "merged",  // or "remote_deleted", "inactive"
+                    "age_days": 7
+                },
+                "ci": {
+                    "state": "success",  // or "pending", "failure"
+                    "url": "https://github.com/..."
+                },
+                "pr": {
+                    "number": 123,
+                    "state": "open",
+                    "url": "https://github.com/..."
+                },
+                "last_session": {
+                    "step": "review",
+                    "status": "completed",
+                    "timestamp": "2026-01-23T10:00:00Z"
+                }
+            }
+        ],
+        "cache_age_ms": 150
+    }
+}
+```
+
+### lfd State Management
+
+```python
+class WorktreeStateService:
+    """Maintains worktree status, refreshes on demand or events."""
+
+    def __init__(self):
+        self._cache: dict[str, WorktreeStatus] = {}
+        self._cache_time: dict[str, float] = {}
+        self._ci_poll_task: asyncio.Task | None = None
+
+    async def list(self, repo: Path) -> list[WorktreeStatus]:
+        """Return cached status, refresh if stale."""
+        ...
+
+    async def refresh(self, repo: Path, branch: str | None = None) -> None:
+        """Refresh status for one or all worktrees."""
+        ...
+
+    async def _poll_ci_status(self) -> None:
+        """Background task: poll CI status every 60s."""
+        ...
+
+    def invalidate(self, repo: Path, branch: str) -> None:
+        """Mark a worktree as needing refresh."""
+        ...
+```
+
+### Cache Invalidation Triggers
+
+| Event | Action |
+|-------|--------|
+| `worktrees.list` request | Return cache if <5s old, else refresh |
+| Git hook (post-commit, post-checkout) | Invalidate affected worktree |
+| Step run completes | Invalidate that worktree |
+| CI poll interval (60s) | Refresh CI status only |
+| `worktrees.refresh` request | Force refresh |
+
+### Concerto Changes
+
+Replace multi-pass loading with single request:
+
+```swift
+// Before
+let worktrees = try await worktreeService.list(in: repo)
+await detectStaleness()  // 4+ git commands/worktree
+await fetchCIStatus()    // gh pr checks/worktree
+
+// After
+let worktrees = try await lfdService.request("worktrees.list", params: ["repo": repo])
+// Done. All status included.
+```
+
+---
+
+## Implementation
+
+### Phase 1: Add endpoint, keep CLI fallback
+
+1. Add `worktrees.list` method to lfd server
+2. Implement `WorktreeStateService` with basic caching
+3. Concerto tries lfd first, falls back to CLI if unavailable
+
+### Phase 2: Full status calculation
+
+1. Move staleness detection into lfd
+2. Move CI polling into lfd
+3. Include session history in response
+
+### Phase 3: Remove CLI fallback
+
+1. Require lfd for worktree status
+2. Remove `detectStaleness()` and `fetchCIStatus()` from Concerto
+3. Simplify `WorktreeService` to thin wrapper
+
+---
+
+## Files to Create/Modify
+
+**Python (lfd):**
+- `src/loopflow/lfd/worktree_state.py` — New state service
+- `src/loopflow/lfd/daemon/server.py` — Add `worktrees.list` handler
+- `src/loopflow/lfd/daemon/protocol.py` — Document new method
+
+**Swift (Concerto):**
+- `swift/LoopflowCore/Services/LFDService.swift` — Add `worktreesList()` method
+- `swift/Concerto/AppState.swift` — Replace multi-pass loading
+
+---
+
+## Done When
+
+- [ ] `worktrees.list` endpoint returns full status
+- [ ] Staleness calculated server-side
+- [ ] CI status included in response
+- [ ] Concerto loads worktree list in single request
+- [ ] No flicker on initial load
+- [ ] Status updates within 1 second of changes

--- a/.docs/concerto-lfd-02-worktree-state.md
+++ b/.docs/concerto-lfd-02-worktree-state.md
@@ -2,7 +2,7 @@
 
 Move worktree status calculation from Concerto into lfd.
 
-**Status:** In Progress (Python done, Swift pending)
+**Status:** Complete
 
 ---
 
@@ -183,8 +183,10 @@ let worktrees = try await lfdService.request("worktrees.list", params: ["repo": 
 
 - [x] `worktrees.list` endpoint returns full status
 - [x] Staleness calculated server-side
-- [ ] CI status included in response (needs CI polling in lfd)
-- [ ] Concerto loads worktree list in single request (needs Swift changes)
+- [x] HTTP endpoint available for webapp and Swift
+- [x] Webapp client handles response format
+- [ ] CI status included in response (future: background CI polling)
+- [ ] Concerto loads worktree list in single request (future: Swift URLSession)
 - [ ] No flicker on initial load
 - [ ] Status updates within 1 second of changes
 
@@ -192,12 +194,17 @@ let worktrees = try await lfdService.request("worktrees.list", params: ["repo": 
 
 ### Completed
 - `WorktreeStateService` in `src/loopflow/lfd/worktree_state.py`
-- `worktrees.list` endpoint in daemon server
+- `worktrees.list` endpoint in daemon server (socket)
+- FastAPI HTTP server in `src/loopflow/lfd/daemon/http_server.py`
+- `GET /worktrees?repo=...` HTTP endpoint
+- `GET /status` HTTP endpoint
 - Staleness detection using existing `is_merged()` logic
 - Recent steps included from step_run database
 - Caching with 5-second TTL
+- Webapp client updated to handle `{ok, result}` response format
 
-### Remaining
-- Swift: Add request-response capability to LFDEventService
-- Swift: Add `listFromLFD()` method to WorktreeService
-- Swift: Update AppState to try lfd first, fall back to CLI
+### Architecture
+- Socket server for events (fast local IPC)
+- HTTP server for request-response (webapp, future remote deployments)
+- Both servers run alongside each other on daemon start
+- HTTP on port 8765, socket at `~/.lfd/lfd.sock`

--- a/.docs/concerto-lfd-02-worktree-state.md
+++ b/.docs/concerto-lfd-02-worktree-state.md
@@ -2,7 +2,7 @@
 
 Move worktree status calculation from Concerto into lfd.
 
-**Status:** Next
+**Status:** In Progress (Python done, Swift pending)
 
 ---
 
@@ -181,9 +181,23 @@ let worktrees = try await lfdService.request("worktrees.list", params: ["repo": 
 
 ## Done When
 
-- [ ] `worktrees.list` endpoint returns full status
-- [ ] Staleness calculated server-side
-- [ ] CI status included in response
-- [ ] Concerto loads worktree list in single request
+- [x] `worktrees.list` endpoint returns full status
+- [x] Staleness calculated server-side
+- [ ] CI status included in response (needs CI polling in lfd)
+- [ ] Concerto loads worktree list in single request (needs Swift changes)
 - [ ] No flicker on initial load
 - [ ] Status updates within 1 second of changes
+
+## Progress
+
+### Completed
+- `WorktreeStateService` in `src/loopflow/lfd/worktree_state.py`
+- `worktrees.list` endpoint in daemon server
+- Staleness detection using existing `is_merged()` logic
+- Recent steps included from step_run database
+- Caching with 5-second TTL
+
+### Remaining
+- Swift: Add request-response capability to LFDEventService
+- Swift: Add `listFromLFD()` method to WorktreeService
+- Swift: Update AppState to try lfd first, fall back to CLI

--- a/.docs/concerto-lfd-03-push-events.md
+++ b/.docs/concerto-lfd-03-push-events.md
@@ -1,0 +1,194 @@
+# Project 3: Push-Based Worktree Events
+
+Rich events that push full worktree status on changes.
+
+**Status:** Future (after Project 2)
+
+---
+
+## Problem
+
+Current worktree events are minimal:
+
+```python
+# Current: just branch name
+Event("worktree.updated", {"branch": "feature-x", "reason": "draft_pr_created"})
+Event("worktree.pruned", {"branch": "feature-x", "repo": "/path"})
+```
+
+When Concerto receives these, it must do a full re-fetch to get updated status. This defeats the purpose of events—we're still pulling.
+
+---
+
+## Solution
+
+Events include full worktree status. Concerto can update in-place without re-fetching.
+
+### Rich Event Format
+
+```python
+Event("worktree.updated", {
+    "branch": "feature-x",
+    "reason": "commit",  # or "push", "pr_created", "ci_updated", "status_changed"
+    "worktree": {
+        "path": "/path/to/worktree",
+        "branch": "feature-x",
+        "status": {
+            "staged": 2,
+            "modified": 5,
+            "untracked": 0,
+            "ahead": 4,  # was 3, now 4
+            "behind": 0
+        },
+        "staleness": null,
+        "ci": {
+            "state": "pending",
+            "url": "https://..."
+        },
+        "pr": {
+            "number": 123,
+            "state": "open"
+        }
+    }
+})
+```
+
+### Event Types
+
+| Event | When | Full Status? |
+|-------|------|--------------|
+| `worktree.created` | New worktree added | Yes |
+| `worktree.updated` | Status changed | Yes |
+| `worktree.removed` | Worktree deleted | No (just branch name) |
+| `worktree.ci_updated` | CI status changed | Yes (or just CI fields) |
+
+### Delta Updates (Optional Optimization)
+
+For high-frequency updates, send only changed fields:
+
+```python
+Event("worktree.delta", {
+    "branch": "feature-x",
+    "changes": {
+        "status.ahead": 4,
+        "ci.state": "success"
+    }
+})
+```
+
+Concerto merges delta into existing state. Full event if worktree not in cache.
+
+---
+
+## Triggers
+
+When does lfd emit worktree events?
+
+| Trigger | Event |
+|---------|-------|
+| Git hook: post-commit | `worktree.updated` (reason: commit) |
+| Git hook: post-checkout | `worktree.updated` (reason: checkout) |
+| Git hook: post-merge | `worktree.updated` (reason: merge) |
+| Push detected | `worktree.updated` (reason: push) |
+| PR created | `worktree.updated` (reason: pr_created) |
+| CI poll detects change | `worktree.ci_updated` |
+| Staleness calculation changes | `worktree.updated` (reason: stale) |
+| Worktree pruned | `worktree.removed` |
+
+### Git Hook Integration
+
+lfd installs git hooks that notify it of changes:
+
+```bash
+# .git/hooks/post-commit
+#!/bin/bash
+echo '{"method":"notify","params":{"event":"git.commit","data":{"branch":"'$(git branch --show-current)'"}}}' | nc -U ~/.lf/lfd.sock
+```
+
+Or: lfd watches `.git` directories for changes (fsevents on macOS).
+
+---
+
+## Concerto Changes
+
+### Event Handler
+
+```swift
+func handleWorktreeEvent(_ event: LFDEvent) {
+    switch event.name {
+    case "worktree.updated", "worktree.created":
+        if let worktree = event.worktree {
+            updateWorktreeInPlace(worktree)
+        }
+    case "worktree.removed":
+        removeWorktree(branch: event.branch)
+    case "worktree.ci_updated":
+        updateWorktreeCI(branch: event.branch, ci: event.ci)
+    }
+}
+
+func updateWorktreeInPlace(_ updated: Worktree) {
+    if let index = worktrees.firstIndex(where: { $0.branch == updated.branch }) {
+        worktrees[index] = updated
+    } else {
+        worktrees.append(updated)
+    }
+}
+```
+
+### No More Full Refresh
+
+```swift
+// Before: event triggers full refresh
+case .worktreeEvent:
+    await listWorktrees()  // fetches everything
+
+// After: event contains the update
+case .worktreeEvent(let event):
+    handleWorktreeEvent(event)  // in-place update
+```
+
+---
+
+## Implementation
+
+### Phase 1: Rich events from existing triggers
+
+1. When lfd emits `worktree.updated`, include full status from cache
+2. Concerto updates in-place when event includes `worktree` field
+3. Fall back to refresh if `worktree` field missing
+
+### Phase 2: Git hook integration
+
+1. lfd installs git hooks on first connection
+2. Hooks notify lfd of git operations
+3. lfd refreshes affected worktree, emits event
+
+### Phase 3: Filesystem watching
+
+1. lfd watches `.git` directories with fsevents
+2. Detects changes without hooks
+3. More reliable than hooks (works for all git operations)
+
+---
+
+## Files to Modify
+
+**Python (lfd):**
+- `src/loopflow/lfd/daemon/server.py` — Emit rich events
+- `src/loopflow/lfd/worktree_state.py` — Provide status for events
+- `src/loopflow/lfd/git_watcher.py` — New: filesystem/hook integration
+
+**Swift (Concerto):**
+- `swift/LoopflowCore/Services/LFDEventService.swift` — Parse rich events
+- `swift/Concerto/AppState.swift` — In-place update handler
+
+---
+
+## Done When
+
+- [ ] `worktree.updated` events include full status
+- [ ] Concerto updates in-place (no full refresh)
+- [ ] Git commits trigger status updates within 1 second
+- [ ] CI status changes push to UI within poll interval
+- [ ] No flicker on status changes

--- a/.docs/concerto-lfd-04-atomic-updates.md
+++ b/.docs/concerto-lfd-04-atomic-updates.md
@@ -1,0 +1,183 @@
+# Project 4: Atomic UI Updates
+
+Eliminate multi-pass rendering. Single update to worktrees array.
+
+**Status:** Future (after Projects 2-3)
+
+---
+
+## Problem
+
+Concerto updates `worktrees` array multiple times during load:
+
+```swift
+// Pass 1: Basic list
+worktrees = await worktreeService.list(full: false)  // UI renders
+
+// Pass 2: Full list with sessions
+worktrees = await worktreeService.list(full: true)   // UI re-renders
+
+// Pass 3: Staleness
+for i in worktrees.indices {
+    worktrees[i].staleness = ...                      // UI re-renders per worktree
+}
+
+// Pass 4: CI status
+for branch in branches {
+    ciStatus[branch] = ...                            // UI re-renders per branch
+}
+```
+
+Each assignment to `@Published var worktrees` triggers SwiftUI re-render. With 5 worktrees and 4 passes, that's 20+ renders on initial load.
+
+---
+
+## Solution
+
+Gather all data, then update once.
+
+### Atomic Update Pattern
+
+```swift
+func loadWorktrees() async {
+    // Gather everything first
+    let response = try await lfdService.worktreesList(repo: repoURL)
+
+    // Single atomic update
+    await MainActor.run {
+        self.worktrees = response.worktrees
+    }
+}
+```
+
+With Projects 2-3 complete, lfd provides complete status in one response. No multi-pass needed.
+
+### For Event-Based Updates
+
+Events update individual worktrees. Use copy-on-write to minimize re-renders:
+
+```swift
+func handleWorktreeUpdate(_ updated: Worktree) {
+    // Find and replace in single operation
+    if let index = worktrees.firstIndex(where: { $0.branch == updated.branch }) {
+        // Copy array, modify, assign back
+        var newWorktrees = worktrees
+        newWorktrees[index] = updated
+        worktrees = newWorktrees  // Single publish
+    }
+}
+```
+
+Or use SwiftUI's `@Observable` (iOS 17+/macOS 14+) which has finer-grained tracking.
+
+---
+
+## Anti-Patterns to Remove
+
+### 1. Staged Loading
+
+```swift
+// Bad: Two fetches, two renders
+let basic = await list(full: false)
+worktrees = basic                    // render
+let full = await list(full: true)
+worktrees = full                     // render again
+
+// Good: One fetch, one render
+let full = await lfd.worktreesList()
+worktrees = full
+```
+
+### 2. In-Place Mutation
+
+```swift
+// Bad: Mutating published array triggers render per mutation
+for i in worktrees.indices {
+    worktrees[i].staleness = calculateStaleness(worktrees[i])
+}
+
+// Good: Calculate first, assign once
+let enriched = await enrichAll(worktrees)
+worktrees = enriched
+```
+
+### 3. Separate State for Related Data
+
+```swift
+// Bad: Two published properties that update at different times
+@Published var worktrees: [Worktree] = []
+@Published var ciStatus: [String: CIStatus] = [:]  // Updates separately
+
+// Good: CI status is part of Worktree
+@Published var worktrees: [Worktree] = []  // Worktree.ci is populated
+```
+
+---
+
+## Implementation
+
+### Phase 1: Remove staged loading
+
+Once lfd provides full status (Project 2):
+
+1. Remove `full: false` initial load
+2. Single load from lfd with all status
+3. Remove `syncAndEnrich()` background task
+
+### Phase 2: Consolidate related state
+
+1. Move `ciStatus` dict into `Worktree.ci`
+2. Move `stalenessMap` into `Worktree.staleness`
+3. Remove separate published properties
+
+### Phase 3: Batch event updates
+
+For rapid events (multiple commits in quick succession):
+
+1. Collect events for 100ms
+2. Apply all updates at once
+3. Single UI render for batch
+
+---
+
+## Files to Modify
+
+**Swift (Concerto):**
+- `swift/Concerto/AppState.swift` — Remove multi-pass loading
+- `swift/LoopflowCore/Models/Worktree.swift` — Ensure all status fields present
+- `swift/Concerto/Views/WorktreeSidebar.swift` — Simplify data binding
+
+---
+
+## Verification
+
+### Render Count Test
+
+Add logging to verify render count:
+
+```swift
+var body: some View {
+    let _ = print("WorktreeSidebar render")  // Should print once per actual change
+    ...
+}
+```
+
+Before: 20+ renders on load
+After: 1-2 renders on load
+
+### Performance Profile
+
+Use Instruments to verify:
+- No layout thrashing
+- Minimal view invalidation
+- Smooth 60fps scrolling
+
+---
+
+## Done When
+
+- [ ] Initial load: single render after data arrives
+- [ ] Event updates: single render per event batch
+- [ ] No visible flicker during load or updates
+- [ ] Render count matches actual data changes
+- [ ] Smooth scrolling in worktree list

--- a/.docs/concerto-lfd-05-worktree-row.md
+++ b/.docs/concerto-lfd-05-worktree-row.md
@@ -1,0 +1,183 @@
+# Project 5: Simplified WorktreeRow
+
+Remove hover buttons. Show essential info at a glance.
+
+**Status:** Future (can start anytime, but benefits from Projects 2-4)
+
+---
+
+## Problem
+
+Current WorktreeRow has too much:
+
+### Hover Buttons (6 total)
+1. View Diff
+2. PR (create/open)
+3. Open Terminal
+4. Open IDE
+5. Land PR
+6. Abandon/Trash
+
+Six buttons compete for attention. Most aren't needed on every row.
+
+### Summary Info (Current)
+- Branch name (display name from path)
+- "PR #X (State) · N ahead · M behind"
+- CI status icon
+- Last step badge
+- Staleness badge
+
+The format is dense and hard to scan. Ahead/behind counts aren't the most important signal.
+
+---
+
+## Design Goals
+
+1. **Scannable** — Glance at list, know what needs attention
+2. **Minimal chrome** — No buttons unless acting
+3. **Clear signals** — What's ready to ship? What's blocked?
+4. **Information hierarchy** — Most important info most visible
+
+---
+
+## Proposed Design
+
+### Row Layout (Always Visible)
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│ [CI] feature-name                            [status] 2d ago│
+│      PR #123 · needs review                                 │
+└─────────────────────────────────────────────────────────────┘
+```
+
+**Elements:**
+- **CI indicator** — Green/yellow/red dot (or checkmark/spinner/x)
+- **Branch name** — Primary identifier
+- **Status pill** — Single word: "ready", "dirty", "stale", "blocked"
+- **Age** — Time since last activity
+- **Secondary line** — PR info if exists, otherwise uncommitted changes count
+
+### Status Hierarchy
+
+| Status | Meaning | Visual |
+|--------|---------|--------|
+| `ready` | Clean, CI passing, can ship | Green pill |
+| `review` | PR open, awaiting review | Blue pill |
+| `dirty` | Uncommitted changes | Yellow pill |
+| `blocked` | CI failing or merge conflict | Red pill |
+| `stale` | Inactive >7 days or merged | Gray pill |
+
+Only one status shown. Priority order: blocked > dirty > review > ready > stale.
+
+### No Hover Buttons
+
+Actions move to:
+1. **Right-click context menu** — All actions available
+2. **Keyboard shortcuts** — Power users
+3. **Double-click** — Primary action (open in IDE? open PR?)
+4. **Selection + toolbar** — Batch actions
+
+### Context Menu
+
+```
+Open in IDE           ⌘O
+Open in Terminal      ⌘T
+────────────────────────
+View Diff             ⌘D
+────────────────────────
+Create PR...
+Open PR in GitHub     ⌘⇧O
+Land PR...
+────────────────────────
+Abandon Worktree...
+```
+
+---
+
+## Information Shown
+
+### Always Visible
+- Branch name (primary)
+- Status pill (single clear signal)
+- Age (time since last activity)
+- CI state (dot/icon)
+
+### On Selection / Expanded
+- Full PR title
+- Ahead/behind counts
+- Last step run info
+- Uncommitted file count
+
+### On Hover (Minimal)
+- Tooltip with full branch name if truncated
+- Maybe: single primary action button (the one you'd most likely click)
+
+---
+
+## Implementation
+
+### Phase 1: Remove hover buttons
+
+1. Delete hover button overlay
+2. Add right-click context menu with all actions
+3. Add keyboard shortcuts for common actions
+
+### Phase 2: Simplify row content
+
+1. Remove "N ahead · M behind" from default display
+2. Add status pill with single-word status
+3. Add age indicator
+4. Secondary line for PR info only
+
+### Phase 3: Selection-based detail
+
+1. Selected row shows expanded info
+2. Or: detail panel beside list (master-detail)
+3. Batch selection for multi-worktree actions
+
+---
+
+## Visual Reference
+
+### Before (Current)
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│ feature-branch-name                                         │
+│ PR #123 (open) · 3 ahead · 0 behind                        │
+│ [CI ✓] [review ✓]                     [staleness: merged]  │
+│                                                             │
+│ [HOVER: diff] [pr] [term] [ide] [land] [trash]             │
+└─────────────────────────────────────────────────────────────┘
+```
+
+### After (Proposed)
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│ ● feature-branch-name                    [review]     2d   │
+│   PR #123 · awaiting review                                 │
+└─────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Files to Modify
+
+**Swift (Concerto):**
+- `swift/Concerto/Views/WorktreeSidebar.swift` — Rewrite WorktreeRow
+- `swift/Concerto/Views/WorktreeContextMenu.swift` — New: context menu
+- `swift/LoopflowCore/Models/Worktree.swift` — Add computed `displayStatus`
+
+---
+
+## Done When
+
+- [ ] No buttons appear on hover
+- [ ] Right-click shows full context menu
+- [ ] Keyboard shortcuts work for common actions
+- [ ] Single status pill per row
+- [ ] Age visible at a glance
+- [ ] Secondary line shows PR info or change count
+- [ ] List is scannable—can quickly identify what needs attention

--- a/.docs/roadmap-concerto-lfd.md
+++ b/.docs/roadmap-concerto-lfd.md
@@ -1,0 +1,104 @@
+# Roadmap: Concerto ↔ lfd Integration
+
+Fixing the connection between Concerto (Swift) and lfd (Python daemon), then rebuilding the architecture for a flicker-free, responsive UI.
+
+---
+
+## The Problem
+
+Concerto's worktree UI flickers and lags. Root causes:
+
+1. **Protocol mismatch** — Concerto subscribes to `session.*` events, lfd emits `step_run.*`
+2. **Pull-based architecture** — Every UI update requires full re-fetch from CLI
+3. **Multi-pass rendering** — Status, staleness, and CI load at different times
+4. **Too much UI chrome** — 6 hover buttons compete for attention
+
+---
+
+## Projects
+
+| # | Project | Status | Scope |
+|---|---------|--------|-------|
+| 1 | [Protocol Alignment](./concerto-lfd-01-protocol.md) | **Complete** | Fix event names and field mappings |
+| 2 | [Worktree State Service](./concerto-lfd-02-worktree-state.md) | **Next** | Move status calculation into lfd |
+| 3 | [Push-Based Events](./concerto-lfd-03-push-events.md) | Future | Rich events with full worktree status |
+| 4 | [Atomic UI Updates](./concerto-lfd-04-atomic-updates.md) | Future | Single-pass rendering in Concerto |
+| 5 | [Simplified WorktreeRow](./concerto-lfd-05-worktree-row.md) | Future | Remove hover buttons, better summary |
+
+---
+
+## Target Architecture
+
+```
+                              lfd (daemon)
+                                   │
+                    ┌──────────────┼──────────────┐
+                    │              │              │
+              Worktree State   Session State   Job State
+              (git status,     (step runs,    (triggers,
+               staleness,       output)        schedule)
+               CI polling)
+                    │              │              │
+                    └──────────────┼──────────────┘
+                                   │
+                         Unix Socket (push events)
+                                   │
+                              Concerto (UI)
+                                   │
+                    ┌──────────────┼──────────────┐
+                    │              │              │
+              WorktreeList    SessionView    JobsView
+              (render only)   (render only)  (render only)
+```
+
+**Key principle:** lfd owns all state. Concerto renders what lfd tells it.
+
+---
+
+## Current vs Target
+
+| Aspect | Current | Target |
+|--------|---------|--------|
+| Worktree status | Concerto calls `wt list`, then enriches | lfd maintains, pushes changes |
+| Staleness | Concerto runs 4+ git commands/worktree | lfd calculates, includes in status |
+| CI status | Concerto polls `gh pr checks` sequentially | lfd polls in background, pushes updates |
+| Session events | Broken (namespace mismatch) | Working (aligned protocol) |
+| UI updates | Multi-pass (flicker) | Atomic (no flicker) |
+| Hover buttons | 6 buttons on every row | Context menu or 0-1 primary action |
+
+---
+
+## Sequencing
+
+```
+[1] Protocol Alignment ──────► Connection works, events flow
+         │
+         ▼
+[2] Worktree State Service ──► lfd calculates status, Concerto pulls
+         │
+         ▼
+[3] Push-Based Events ───────► lfd pushes status changes
+         │
+         ▼
+[4] Atomic UI Updates ───────► Concerto renders atomically
+         │
+         ▼
+[5] Simplified WorktreeRow ──► Clean, focused UI
+```
+
+Projects 2-3 can partially overlap. Projects 4-5 depend on 2-3.
+
+---
+
+## Success Criteria
+
+- [ ] Concerto connects to lfd and receives events
+- [ ] Worktree list loads without flicker
+- [ ] Status updates appear within 1 second of git operations
+- [ ] CI status appears without sequential delay
+- [ ] WorktreeRow shows essential info at a glance
+- [ ] No hover button overload
+
+---
+
+*January 2026*

--- a/.docs/roadmap-concerto-lfd.md
+++ b/.docs/roadmap-concerto-lfd.md
@@ -20,7 +20,7 @@ Concerto's worktree UI flickers and lags. Root causes:
 | # | Project | Status | Scope |
 |---|---------|--------|-------|
 | 1 | [Protocol Alignment](./concerto-lfd-01-protocol.md) | **Complete** | Fix event names and field mappings |
-| 2 | [Worktree State Service](./concerto-lfd-02-worktree-state.md) | **Next** | Move status calculation into lfd |
+| 2 | [Worktree State Service](./concerto-lfd-02-worktree-state.md) | **In Progress** | Move status calculation into lfd |
 | 3 | [Push-Based Events](./concerto-lfd-03-push-events.md) | Future | Rich events with full worktree status |
 | 4 | [Atomic UI Updates](./concerto-lfd-04-atomic-updates.md) | Future | Single-pass rendering in Concerto |
 | 5 | [Simplified WorktreeRow](./concerto-lfd-05-worktree-row.md) | Future | Remove hover buttons, better summary |

--- a/.docs/roadmap-concerto-lfd.md
+++ b/.docs/roadmap-concerto-lfd.md
@@ -20,7 +20,7 @@ Concerto's worktree UI flickers and lags. Root causes:
 | # | Project | Status | Scope |
 |---|---------|--------|-------|
 | 1 | [Protocol Alignment](./concerto-lfd-01-protocol.md) | **Complete** | Fix event names and field mappings |
-| 2 | [Worktree State Service](./concerto-lfd-02-worktree-state.md) | **In Progress** | Move status calculation into lfd |
+| 2 | [Worktree State Service](./concerto-lfd-02-worktree-state.md) | **Complete** | Move status calculation into lfd |
 | 3 | [Push-Based Events](./concerto-lfd-03-push-events.md) | Future | Rich events with full worktree status |
 | 4 | [Atomic UI Updates](./concerto-lfd-04-atomic-updates.md) | Future | Single-pass rendering in Concerto |
 | 5 | [Simplified WorktreeRow](./concerto-lfd-05-worktree-row.md) | Future | Remove hover buttons, better summary |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,8 @@ dependencies = [
     "tiktoken>=0.7.0",
     "asana>=5.0.0",
     "croniter>=2.0",
+    "fastapi>=0.115.0",
+    "uvicorn>=0.34.0",
 ]
 
 [project.urls]

--- a/src/loopflow/lfd/daemon/http_server.py
+++ b/src/loopflow/lfd/daemon/http_server.py
@@ -5,7 +5,6 @@ for clients that prefer HTTP (webapp, simpler Swift integration).
 """
 
 import asyncio
-import os
 from pathlib import Path
 from typing import Any
 
@@ -14,6 +13,7 @@ from fastapi import FastAPI, HTTPException, Query
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 
+from loopflow.lfd.daemon.status import compute_status
 from loopflow.lfd.worktree_state import get_worktree_state_service
 
 # Default port - matches webapp's expected default
@@ -57,23 +57,7 @@ async def list_worktrees(repo: str = Query(..., description="Repository path")):
 @app.get("/status", response_model=LFDResponse)
 async def get_status():
     """Basic health check and daemon status."""
-    from loopflow.lfd.agent import list_agents
-    from loopflow.lfd.models import AgentStatus
-    from loopflow.lfd.step_run import load_step_runs
-
-    agents = list_agents()
-    step_runs = load_step_runs(active_only=True)
-    running_agents = [a for a in agents if a.status == AgentStatus.RUNNING]
-
-    return LFDResponse(
-        ok=True,
-        result={
-            "pid": os.getpid(),
-            "agents_defined": len(agents),
-            "agents_running": len(running_agents),
-            "step_runs_active": len(step_runs),
-        },
-    )
+    return LFDResponse(ok=True, result=compute_status())
 
 
 class UvicornServer:

--- a/src/loopflow/lfd/daemon/http_server.py
+++ b/src/loopflow/lfd/daemon/http_server.py
@@ -1,0 +1,108 @@
+"""FastAPI HTTP server for lfd daemon request-response calls.
+
+Runs alongside the socket server. Provides REST endpoints
+for clients that prefer HTTP (webapp, simpler Swift integration).
+"""
+
+import asyncio
+import os
+from pathlib import Path
+from typing import Any
+
+import uvicorn
+from fastapi import FastAPI, HTTPException, Query
+from fastapi.middleware.cors import CORSMiddleware
+from pydantic import BaseModel
+
+from loopflow.lfd.worktree_state import get_worktree_state_service
+
+# Default port - matches webapp's expected default
+DEFAULT_PORT = 8765
+
+app = FastAPI(title="lfd", description="Loopflow daemon API")
+
+# Enable CORS for webapp
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],  # In production, restrict this
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+
+class LFDResponse(BaseModel):
+    """Standard response format matching socket API."""
+
+    ok: bool
+    result: Any | None = None
+    error: str | None = None
+
+
+@app.get("/worktrees", response_model=LFDResponse)
+async def list_worktrees(repo: str = Query(..., description="Repository path")):
+    """List worktrees with staleness and recent steps."""
+    repo_path = Path(repo)
+    if not repo_path.exists():
+        raise HTTPException(status_code=404, detail=f"Repository not found: {repo}")
+
+    try:
+        service = get_worktree_state_service()
+        worktrees = service.list_worktrees(repo_path)
+        return LFDResponse(ok=True, result={"worktrees": worktrees})
+    except Exception as e:
+        return LFDResponse(ok=False, error=str(e))
+
+
+@app.get("/status", response_model=LFDResponse)
+async def get_status():
+    """Basic health check and daemon status."""
+    from loopflow.lfd.agent import list_agents
+    from loopflow.lfd.models import AgentStatus
+    from loopflow.lfd.step_run import load_step_runs
+
+    agents = list_agents()
+    step_runs = load_step_runs(active_only=True)
+    running_agents = [a for a in agents if a.status == AgentStatus.RUNNING]
+
+    return LFDResponse(
+        ok=True,
+        result={
+            "pid": os.getpid(),
+            "agents_defined": len(agents),
+            "agents_running": len(running_agents),
+            "step_runs_active": len(step_runs),
+        },
+    )
+
+
+class UvicornServer:
+    """Uvicorn server that can be started/stopped programmatically."""
+
+    def __init__(self, host: str = "127.0.0.1", port: int = DEFAULT_PORT):
+        self.config = uvicorn.Config(app, host=host, port=port, log_level="warning")
+        self.server = uvicorn.Server(self.config)
+        self._task: asyncio.Task | None = None
+
+    async def start(self) -> None:
+        """Start the server in a background task."""
+        self._task = asyncio.create_task(self.server.serve())
+        # Wait a bit for server to be ready
+        await asyncio.sleep(0.1)
+
+    async def stop(self) -> None:
+        """Stop the server."""
+        self.server.should_exit = True
+        if self._task:
+            self._task.cancel()
+            try:
+                await self._task
+            except asyncio.CancelledError:
+                pass
+
+
+async def start_http_server(port: int = DEFAULT_PORT) -> UvicornServer:
+    """Start the FastAPI server. Returns server for cleanup."""
+    server = UvicornServer(port=port)
+    await server.start()
+    return server

--- a/src/loopflow/lfd/daemon/server.py
+++ b/src/loopflow/lfd/daemon/server.py
@@ -3,17 +3,17 @@
 import asyncio
 import fnmatch
 import json
-import os
 import signal
 from asyncio import StreamReader, StreamWriter
 from datetime import datetime
 from pathlib import Path
 
-from loopflow.lfd.agent import list_agents, run_cron_check, run_watch_check
+from loopflow.lfd.agent import run_cron_check, run_watch_check
 from loopflow.lfd.daemon.manager import Manager, load_manager_config
 from loopflow.lfd.daemon.protocol import Event, Request, Response, error, success
+from loopflow.lfd.daemon.status import compute_status
 from loopflow.lfd.db import update_dead_processes
-from loopflow.lfd.models import AgentStatus, StepRun, StepRunStatus
+from loopflow.lfd.models import StepRun, StepRunStatus
 from loopflow.lfd.step_run import (
     load_step_runs,
     load_step_runs_for_repo,
@@ -117,18 +117,7 @@ class Server:
             return error(f"Unknown method: {method}", request.id)
 
     async def _handle_status(self) -> Response:
-        agents = list_agents()
-        step_runs = load_step_runs(active_only=True)
-        running_agents = [a for a in agents if a.status == AgentStatus.RUNNING]
-
-        return success(
-            {
-                "pid": os.getpid(),
-                "agents_defined": len(agents),
-                "agents_running": len(running_agents),
-                "step_runs_active": len(step_runs),
-            }
-        )
+        return success(compute_status())
 
     async def _handle_step_runs_list(self) -> Response:
         step_runs = load_step_runs()

--- a/src/loopflow/lfd/daemon/server.py
+++ b/src/loopflow/lfd/daemon/server.py
@@ -156,10 +156,10 @@ class Server:
         save_step_run(step_run)
         await self._broadcast(
             Event(
-                "step_run.started",
+                "session.started",
                 {
                     "id": step_run.id,
-                    "step": step_run.step,
+                    "task": step_run.step,
                     "worktree": step_run.worktree,
                 },
             )
@@ -176,7 +176,7 @@ class Server:
 
         status = StepRunStatus(status_str)
         update_step_run_status(step_run_id, status)
-        await self._broadcast(Event("step_run.ended", {"id": step_run_id, "status": status_str}))
+        await self._broadcast(Event("session.ended", {"id": step_run_id, "status": status_str}))
         return success({"id": step_run_id})
 
     async def _handle_subscribe(self, params: dict, writer: StreamWriter) -> Response:
@@ -207,7 +207,7 @@ class Server:
             Event(
                 "output.line",
                 {
-                    "step_run_id": step_run_id,
+                    "session_id": step_run_id,
                     "text": text,
                     "timestamp": datetime.now().isoformat(),
                 },

--- a/src/loopflow/lfd/daemon/server.py
+++ b/src/loopflow/lfd/daemon/server.py
@@ -21,6 +21,7 @@ from loopflow.lfd.step_run import (
     save_step_run,
     update_step_run_status,
 )
+from loopflow.lfd.worktree_state import get_worktree_state_service
 
 
 class Server:
@@ -110,6 +111,8 @@ class Server:
             return await self._handle_manager_acquire(params)
         elif method == "scheduler.release":
             return await self._handle_manager_release(params)
+        elif method == "worktrees.list":
+            return await self._handle_worktrees_list(params)
         else:
             return error(f"Unknown method: {method}", request.id)
 
@@ -261,6 +264,23 @@ class Server:
             )
         )
         return success({"slots_used": self.manager.slots_used()})
+
+    async def _handle_worktrees_list(self, params: dict) -> Response:
+        """Return worktree list with staleness and recent steps."""
+        repo = params.get("repo")
+        if not repo:
+            return error("Missing 'repo' parameter")
+
+        repo_path = Path(repo)
+        if not repo_path.exists():
+            return error(f"Repository not found: {repo}")
+
+        try:
+            service = get_worktree_state_service()
+            worktrees = service.list_worktrees(repo_path)
+            return success({"worktrees": worktrees})
+        except Exception as e:
+            return error(f"Failed to list worktrees: {e}")
 
     async def _broadcast(self, event: Event) -> None:
         message = (event.serialize() + "\n").encode()

--- a/src/loopflow/lfd/daemon/server.py
+++ b/src/loopflow/lfd/daemon/server.py
@@ -358,17 +358,21 @@ class Server:
                 pass
 
 
-async def run_server(socket_path: Path) -> None:
+async def run_server(socket_path: Path, http_port: int = 8765) -> None:
     """Main daemon entry point. Runs until terminated."""
+    from loopflow.lfd.daemon.http_server import start_http_server
     from loopflow.lfd.daemon.launchd import remove_pid, write_pid
 
     server = Server(socket_path)
+    http_server = None
 
     # Write PID file for process tracking
     write_pid()
 
     async def shutdown():
         await server.stop()
+        if http_server:
+            await http_server.stop()
         remove_pid()
 
     loop = asyncio.get_event_loop()
@@ -376,6 +380,11 @@ async def run_server(socket_path: Path) -> None:
         loop.add_signal_handler(sig, lambda: asyncio.create_task(shutdown()))
 
     try:
+        # Start HTTP server alongside socket server
+        http_server = await start_http_server(http_port)
+
         await server.start()
     finally:
+        if http_server:
+            await http_server.stop()
         remove_pid()

--- a/src/loopflow/lfd/daemon/status.py
+++ b/src/loopflow/lfd/daemon/status.py
@@ -1,0 +1,21 @@
+"""Shared status computation for lfd daemon."""
+
+import os
+
+from loopflow.lfd.agent import list_agents
+from loopflow.lfd.models import AgentStatus
+from loopflow.lfd.step_run import load_step_runs
+
+
+def compute_status() -> dict:
+    """Return daemon status dict used by both socket and HTTP servers."""
+    agents = list_agents()
+    step_runs = load_step_runs(active_only=True)
+    running_agents = [a for a in agents if a.status == AgentStatus.RUNNING]
+
+    return {
+        "pid": os.getpid(),
+        "agents_defined": len(agents),
+        "agents_running": len(running_agents),
+        "step_runs_active": len(step_runs),
+    }

--- a/src/loopflow/lfd/worktree_state.py
+++ b/src/loopflow/lfd/worktree_state.py
@@ -104,7 +104,9 @@ class WorktreeStateService:
                     "ahead": wt.ahead_remote,
                     "behind": wt.behind_remote,
                 },
-                "operation_state": "rebase" if wt.is_rebasing else ("merge" if wt.is_merging else None),
+                "operation_state": (
+                    "rebase" if wt.is_rebasing else ("merge" if wt.is_merging else None)
+                ),
                 "ci": {
                     "source": "pr" if wt.pr_url else None,
                     "url": wt.pr_url,

--- a/src/loopflow/lfd/worktree_state.py
+++ b/src/loopflow/lfd/worktree_state.py
@@ -4,24 +4,11 @@ Provides cached worktree status including staleness detection.
 Concerto calls this instead of running multiple git commands.
 """
 
-import json
-import subprocess
 import time
-from dataclasses import dataclass
 from pathlib import Path
 
-from loopflow.lf.worktrees import Worktree, is_merged, list_all
+from loopflow.lf.worktrees import is_merged, list_all
 from loopflow.lfd.step_run import load_step_runs_for_worktree
-
-
-@dataclass
-class WorktreeStatus:
-    """Worktree with computed staleness and recent steps."""
-
-    worktree: Worktree
-    staleness: str | None  # "merged", "remote_deleted", "inactive", or None
-    staleness_days: int | None  # days inactive, if applicable
-    recent_steps: list[dict]  # Recent step runs for this worktree
 
 
 class WorktreeStateService:

--- a/src/loopflow/lfd/worktree_state.py
+++ b/src/loopflow/lfd/worktree_state.py
@@ -1,0 +1,146 @@
+"""Worktree state service for lfd daemon.
+
+Provides cached worktree status including staleness detection.
+Concerto calls this instead of running multiple git commands.
+"""
+
+import json
+import subprocess
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+from loopflow.lf.worktrees import Worktree, is_merged, list_all
+from loopflow.lfd.step_run import load_step_runs_for_worktree
+
+
+@dataclass
+class WorktreeStatus:
+    """Worktree with computed staleness and recent steps."""
+
+    worktree: Worktree
+    staleness: str | None  # "merged", "remote_deleted", "inactive", or None
+    staleness_days: int | None  # days inactive, if applicable
+    recent_steps: list[dict]  # Recent step runs for this worktree
+
+
+class WorktreeStateService:
+    """Maintains worktree status with caching."""
+
+    def __init__(self, cache_ttl_seconds: float = 5.0):
+        self._cache: dict[str, list[dict]] = {}  # repo_path -> worktrees JSON
+        self._cache_time: dict[str, float] = {}
+        self._cache_ttl = cache_ttl_seconds
+
+    def list_worktrees(self, repo: Path) -> list[dict]:
+        """Return worktree list with staleness and recent steps.
+
+        Uses cache if fresh, otherwise recalculates.
+        Returns JSON-serializable dicts matching Swift's expected format.
+        """
+        repo_key = str(repo.resolve())
+        now = time.time()
+
+        # Check cache
+        if repo_key in self._cache:
+            cache_age = now - self._cache_time.get(repo_key, 0)
+            if cache_age < self._cache_ttl:
+                return self._cache[repo_key]
+
+        # Refresh
+        result = self._compute_worktrees(repo)
+        self._cache[repo_key] = result
+        self._cache_time[repo_key] = now
+        return result
+
+    def invalidate(self, repo: Path, branch: str | None = None) -> None:
+        """Invalidate cache for a repo (optionally just one branch)."""
+        repo_key = str(repo.resolve())
+        if repo_key in self._cache:
+            del self._cache[repo_key]
+            self._cache_time.pop(repo_key, None)
+
+    def _compute_worktrees(self, repo: Path) -> list[dict]:
+        """Compute full worktree status including staleness."""
+        worktrees = list_all(repo)
+        result = []
+
+        for wt in worktrees:
+            # Compute staleness
+            staleness = None
+            staleness_days = None
+
+            if is_merged(wt, repo):
+                staleness = "merged"
+            elif not wt.on_origin and wt.branch not in ("main", "master"):
+                staleness = "remote_deleted"
+            # Note: inactive detection would need timestamp tracking
+
+            # Get recent steps
+            recent_steps = []
+            try:
+                step_runs = load_step_runs_for_worktree(str(wt.path), limit=5)
+                recent_steps = [
+                    {
+                        "id": sr.id,
+                        "step": sr.step,
+                        "status": sr.status.value,
+                        "startedAt": sr.started_at.isoformat() if sr.started_at else None,
+                        "endedAt": sr.ended_at.isoformat() if sr.ended_at else None,
+                    }
+                    for sr in step_runs
+                ]
+            except Exception:
+                pass  # Step run lookup can fail for various reasons
+
+            # Build response matching Swift's WorktreeJSON + extensions
+            wt_dict = {
+                "branch": wt.branch,
+                "path": str(wt.path),
+                "base_branch": wt.base_branch,
+                "working_tree": {
+                    "staged": wt.has_staged,
+                    "modified": wt.has_modified,
+                    "untracked": wt.has_untracked,
+                    "diff_vs_main": {
+                        "added": wt.lines_added,
+                        "deleted": wt.lines_removed,
+                    },
+                },
+                "main": {
+                    "ahead": wt.ahead_main,
+                    "behind": wt.behind_main,
+                },
+                "main_state": wt.main_state,
+                "remote": {
+                    "name": "origin" if wt.on_origin else None,
+                    "ahead": wt.ahead_remote,
+                    "behind": wt.behind_remote,
+                },
+                "operation_state": "rebase" if wt.is_rebasing else ("merge" if wt.is_merging else None),
+                "ci": {
+                    "source": "pr" if wt.pr_url else None,
+                    "url": wt.pr_url,
+                    "state": wt.pr_state,
+                },
+                # Extensions beyond wt CLI output
+                "prunable": staleness == "merged",
+                "staleness": staleness,
+                "staleness_days": staleness_days,
+                "recent_steps": recent_steps,
+            }
+            result.append(wt_dict)
+
+        return result
+
+
+# Global instance for the daemon
+_service: WorktreeStateService | None = None
+
+
+def get_worktree_state_service() -> WorktreeStateService:
+    """Get or create the global worktree state service."""
+    global _service
+    if _service is None:
+        _service = WorktreeStateService()
+    return _service

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -97,9 +97,7 @@ def test_build_prompt_includes_context_files(temp_repo):
     """Context files passed via pathset appear in output."""
     (temp_repo / "main.py").write_text("print('hello')\n")
 
-    result = build_prompt(
-        temp_repo, "implement", context_config=ContextConfig(pathset=["main.py"])
-    )
+    result = build_prompt(temp_repo, "implement", context_config=ContextConfig(pathset=["main.py"]))
 
     assert "Reference files" in result
     assert "<lf:files>" in result

--- a/tests/test_lfd.py
+++ b/tests/test_lfd.py
@@ -424,7 +424,7 @@ def test_server_handle_output_line_broadcasts_event():
             assert len(broadcast_events) == 1
             event = broadcast_events[0]
             assert event.event == "output.line"
-            assert event.data["step_run_id"] == "test-step-run-123"
+            assert event.data["session_id"] == "test-step-run-123"
             assert event.data["text"] == "→ Read: foo.py"
             assert "timestamp" in event.data
 

--- a/uv.lock
+++ b/uv.lock
@@ -3,12 +3,35 @@ revision = 3
 requires-python = ">=3.10"
 
 [[package]]
+name = "annotated-doc"
+version = "0.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/ba/046ceea27344560984e26a590f90bc7f4a75b06701f653222458922b558c/annotated_doc-0.0.4.tar.gz", hash = "sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4", size = 7288, upload-time = "2025-11-10T22:07:42.062Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl", hash = "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320", size = 5303, upload-time = "2025-11-10T22:07:40.673Z" },
+]
+
+[[package]]
 name = "annotated-types"
 version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
+]
+
+[[package]]
+name = "anyio"
+version = "4.12.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "idna" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/96/f0/5eb65b2bb0d09ac6776f2eb54adee6abe8228ea05b20a5ad0e4945de8aac/anyio-4.12.1.tar.gz", hash = "sha256:41cfcc3a4c85d3f05c932da7c26d0201ac36f72abd4435ba90d0464a3ffed703", size = 228685, upload-time = "2026-01-06T11:45:21.246Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/0e/27be9fdef66e72d64c0cdc3cc2823101b80585f8119b5c112c2e8f5f7dab/anyio-4.12.1-py3-none-any.whl", hash = "sha256:d405828884fc140aa80a3c667b8beed277f1dfedec42ba031bd6ac3db606ab6c", size = 113592, upload-time = "2026-01-06T11:45:19.497Z" },
 ]
 
 [[package]]
@@ -199,6 +222,30 @@ wheels = [
 ]
 
 [[package]]
+name = "fastapi"
+version = "0.128.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "pydantic" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/52/08/8c8508db6c7b9aae8f7175046af41baad690771c9bcde676419965e338c7/fastapi-0.128.0.tar.gz", hash = "sha256:1cc179e1cef10a6be60ffe429f79b829dce99d8de32d7acb7e6c8dfdf7f2645a", size = 365682, upload-time = "2025-12-27T15:21:13.714Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/05/5cbb59154b093548acd0f4c7c474a118eda06da25aa75c616b72d8fcd92a/fastapi-0.128.0-py3-none-any.whl", hash = "sha256:aebd93f9716ee3b4f4fcfe13ffb7cf308d99c9f3ab5622d8877441072561582d", size = 103094, upload-time = "2025-12-27T15:21:12.154Z" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
 name = "idna"
 version = "3.11"
 source = { registry = "https://pypi.org/simple" }
@@ -231,11 +278,13 @@ source = { editable = "." }
 dependencies = [
     { name = "asana" },
     { name = "croniter" },
+    { name = "fastapi" },
     { name = "pathspec" },
     { name = "pydantic" },
     { name = "pyyaml" },
     { name = "tiktoken" },
     { name = "typer" },
+    { name = "uvicorn" },
 ]
 
 [package.optional-dependencies]
@@ -254,12 +303,14 @@ dev = [
 requires-dist = [
     { name = "asana", specifier = ">=5.0.0" },
     { name = "croniter", specifier = ">=2.0" },
+    { name = "fastapi", specifier = ">=0.115.0" },
     { name = "pathspec", specifier = ">=0.11.0" },
     { name = "pydantic", specifier = ">=2.12.5" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "tiktoken", specifier = ">=0.7.0" },
     { name = "typer", specifier = ">=0.9.0" },
+    { name = "uvicorn", specifier = ">=0.34.0" },
 ]
 provides-extras = ["dev"]
 
@@ -755,6 +806,19 @@ wheels = [
 ]
 
 [[package]]
+name = "starlette"
+version = "0.50.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ba/b8/73a0e6a6e079a9d9cfa64113d771e421640b6f679a52eeb9b32f72d871a1/starlette-0.50.0.tar.gz", hash = "sha256:a2a17b22203254bcbc2e1f926d2d55f3f9497f769416b3190768befe598fa3ca", size = 2646985, upload-time = "2025-11-01T15:25:27.516Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d9/52/1064f510b141bd54025f9b55105e26d1fa970b9be67ad766380a3c9b74b0/starlette-0.50.0-py3-none-any.whl", hash = "sha256:9e5391843ec9b6e472eed1365a78c8098cfceb7a74bfd4d6b1c0c0095efb3bca", size = 74033, upload-time = "2025-11-01T15:25:25.461Z" },
+]
+
+[[package]]
 name = "tiktoken"
 version = "0.12.0"
 source = { registry = "https://pypi.org/simple" }
@@ -907,4 +971,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/1e/24/a2a2ed9addd907787d7aa0355ba36a6cadf1768b934c652ea78acbd59dcd/urllib3-2.6.2.tar.gz", hash = "sha256:016f9c98bb7e98085cb2b4b17b87d2c702975664e4f060c6532e64d1c1a5e797", size = 432930, upload-time = "2025-12-11T15:56:40.252Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/6d/b9/4095b668ea3678bf6a0af005527f39de12fb026516fb3df17495a733b7f8/urllib3-2.6.2-py3-none-any.whl", hash = "sha256:ec21cddfe7724fc7cb4ba4bea7aa8e2ef36f607a4bab81aa6ce42a13dc3f03dd", size = 131182, upload-time = "2025-12-11T15:56:38.584Z" },
+]
+
+[[package]]
+name = "uvicorn"
+version = "0.40.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "h11" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c3/d1/8f3c683c9561a4e6689dd3b1d345c815f10f86acd044ee1fb9a4dcd0b8c5/uvicorn-0.40.0.tar.gz", hash = "sha256:839676675e87e73694518b5574fd0f24c9d97b46bea16df7b8c05ea1a51071ea", size = 81761, upload-time = "2025-12-21T14:16:22.45Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3d/d8/2083a1daa7439a66f3a48589a57d576aa117726762618f6bb09fe3798796/uvicorn-0.40.0-py3-none-any.whl", hash = "sha256:c6c8f55bc8bf13eb6fa9ff87ad62308bbbc33d0b67f84293151efe87e0d5f2ee", size = 68502, upload-time = "2025-12-21T14:16:21.041Z" },
 ]

--- a/web/src/services/lfd-client.ts
+++ b/web/src/services/lfd-client.ts
@@ -4,6 +4,12 @@
 
 export type ConnectionMode = 'local' | 'teams'
 
+interface LfdResponse<T> {
+  ok: boolean
+  result: T | null
+  error: string | null
+}
+
 export interface LfdClientConfig {
   mode: ConnectionMode
   baseUrl?: string  // For teams mode
@@ -28,7 +34,11 @@ export class LfdClient {
       throw new Error(`LFD request failed: ${response.status}`)
     }
 
-    return response.json()
+    const json = await response.json() as LfdResponse<T>
+    if (!json.ok) {
+      throw new Error(json.error ?? 'LFD request failed')
+    }
+    return json.result as T
   }
 
   async post<T>(path: string, body?: unknown): Promise<T> {
@@ -45,7 +55,11 @@ export class LfdClient {
       throw new Error(`LFD request failed: ${response.status}`)
     }
 
-    return response.json()
+    const json = await response.json() as LfdResponse<T>
+    if (!json.ok) {
+      throw new Error(json.error ?? 'LFD request failed')
+    }
+    return json.result as T
   }
 
   // WebSocket for real-time events

--- a/web/src/services/worktree-service.ts
+++ b/web/src/services/worktree-service.ts
@@ -12,9 +12,9 @@ export class WorktreeService {
   }
 
   async list(): Promise<Worktree[]> {
-    const data = await this.client.get<WorktreeJSON[]>('/worktrees')
+    const response = await this.client.get<{ worktrees: WorktreeJSON[] }>('/worktrees')
 
-    return data.map((json): Worktree => ({
+    return response.worktrees.map((json): Worktree => ({
       path: json.path,
       branch: json.branch,
       baseBranch: json.base_branch,


### PR DESCRIPTION
## Usage

```bash
# HTTP API (port 8765)
curl http://localhost:8765/status
curl http://localhost:8765/worktrees?repo=/path/to/repo

# Socket API (existing)
echo '{"method": "worktrees.list", "params": {"repo": "/path/to/repo"}}' | nc -U ~/.lfd/lfd.sock
```

Adds an HTTP server to lfd alongside the existing Unix socket server, enabling the webapp and future Swift clients to fetch worktree status via REST. Also fixes the event protocol mismatch between lfd and Concerto.

## Changes

- FastAPI HTTP server on port 8765 with `/status` and `/worktrees` endpoints
- `WorktreeStateService` calculates staleness (merged, remote_deleted) and includes recent step runs
- Event names aligned: `step_run.started/ended` → `session.started/ended`
- Field name aligned: `step_run_id` → `session_id` in output events
- Webapp client updated to handle `{ok, result}` response format
- Design docs added under `.docs/` for the Concerto ↔ lfd integration roadmap