### PR TITLE
lf lint: lfd: make agent mode explicit in data model

### DIFF
--- a/scratch/expansion-opportunities.md
+++ b/scratch/expansion-opportunities.md
@@ -1,0 +1,121 @@
+# Expansion Opportunities
+
+## Current state
+
+Loopflow solves prompt and context construction for coding agents. The core value: assemble context (docs, diffs, files, clipboard), pair it with reusable prompts, pass to Claude/Codex/Gemini. Prompts are versioned artifacts. Flows chain prompts. Agents run flows in the background.
+
+Target users are "softwarists"—engineers who want craft *and* throughput, co-creation *and* delegation. They use AI constantly but hit limits when code goes off the rails or lacks judgment.
+
+What loopflow does well:
+- Context assembly with token management
+- Prompts as files, not chat logs
+- Multi-model portability
+- Background agents with triggers (loop, watch, cron)
+- Native macOS app for visual control
+
+---
+
+## Direction 1: Execution Memory
+
+**What**: Learn from every step execution. When steps succeed, fail, or get edited by humans—feed that back into prompt selection and context assembly.
+
+**Why**: Currently prompts are static. Run `lf implement` twice with the same context, get the same prompt. But the system already logs every execution (step_runs table), tracks outcomes, and knows when humans intervene. This data is sitting unused.
+
+With execution memory:
+- Prompts that produced failed tests could trigger different follow-up prompts
+- Voice selection could adapt based on what worked for similar tasks
+- Context assembly could learn which files matter for which step types
+- Error patterns could surface as warnings before you hit them again
+
+**Builds on**:
+- `step_runs` table with status, started_at, ended_at
+- `flow_runs` tracking full execution chains
+- Existing summary/cache infrastructure in `~/.lf/lfd.db`
+- Token counting already tracks what went in
+
+**Implementation path**:
+1. Add outcome tagging to step_runs (success, failure, human_edit, timeout)
+2. Build a retrieval layer: "find similar past executions"
+3. Surface insights: "last 3 times implement ran on auth code, review caught X"
+4. Eventually: auto-adjust voice/context based on learned patterns
+
+**Open questions**:
+- Privacy: should execution history sync across machines/repos?
+- Granularity: per-step learning vs per-flow vs per-repo?
+- Cold start: how much data before patterns emerge?
+
+---
+
+## Direction 2: Verification Layer
+
+**What**: Structured verification that step output matches intent. Not just "did it run" but "did it do what the design doc said."
+
+**Why**: The gap between autonomous agents and trusted agents is verification. Current flows chain steps, but nothing checks whether the output is correct—you're trusting the agent or reviewing everything manually. This is why the "craft over vibes" principle exists.
+
+With a verification layer:
+- Flows could include `verify` steps that check output against specs
+- Design docs (`scratch/<branch>.md`) become testable contracts
+- Autonomous loops gain confidence: the agent self-checks before creating PRs
+- Regression detection: "this change affects X, but the spec said Y"
+
+**Builds on**:
+- Flow DAG already supports conditional branching (`choose`)
+- Design docs in `scratch/` already capture intent
+- Review step already assesses code quality
+- Polish step already runs tests
+
+**Implementation path**:
+1. Define a verification protocol: what does a "spec" look like? (structured design docs)
+2. Add `verify` as a flow construct: `{"verify": "spec_path", "on_fail": "iterate"}`
+3. Build spec comparison: diff design intent vs actual changes
+4. Connect to test runner: verify includes "tests pass" as baseline
+
+**Open questions**:
+- Spec format: structured YAML vs natural language in markdown?
+- Failure modes: retry, escalate to human, or abort?
+- How to verify non-functional requirements (style, architecture)?
+
+---
+
+## Direction 3: Context Intelligence
+
+**What**: Make context assembly task-aware. Instead of "include these files," understand "what's relevant for this task."
+
+**Why**: Context is the hard problem. Too little and the agent hallucinates. Too much and you hit token limits. Current assembly is rule-based: include diff_files, include summaries, exclude patterns. But relevance depends on the task.
+
+Asking "add caching to the API" needs different context than "fix the auth bug." The system knows both the task (step + args) and the codebase (summaries, file structure). It should connect them.
+
+With context intelligence:
+- Token budget goes further: less irrelevant code in context
+- Agents see what matters: relevant imports, related tests, similar patterns
+- Summaries become searchable: "find code that handles caching"
+- New codebases become navigable faster
+
+**Builds on**:
+- Summary system already generates codebase overviews
+- Token trimming already drops components by size
+- Skills discovery already searches for relevant prompts
+- Context gathering already walks the file tree
+
+**Implementation path**:
+1. Index summaries for semantic search (embeddings or keyword)
+2. Extract task keywords from step + args
+3. Score file relevance: "this file mentions caching, include it"
+4. Replace greedy trimming with relevance-weighted trimming
+
+**Open questions**:
+- Embedding model: local (fast, private) vs API (better quality)?
+- Update frequency: rebuild index on every commit? Lazy?
+- Explainability: why was this file included?
+
+---
+
+## Not yet
+
+**Multi-agent collaboration**: Multiple specialized agents working together—one designs, one implements, one reviews, with handoffs. The architecture hints at this (subagents in Claude Code, flow DAGs), but it requires rethinking what an "agent" is. Current agents are solo: one flow, one area, one worktree. True collaboration needs shared state, conflict resolution, and coordination protocols. Worth exploring after the single-agent experience is solid.
+
+**Prompt marketplace**: Share prompts beyond the repo. The skills system already supports external libraries (superpowers, SkillRegistry), but a true marketplace needs trust, versioning, and discovery. The infrastructure isn't wrong—it's just early. Let patterns emerge from local usage before building distribution.
+
+**Cross-project learning**: Apply lessons from one repo to another. "This pattern worked in project A, try it in project B." Compelling but requires solving: data privacy (not all repos should share), semantic translation (different codebases have different idioms), and trust (why should I trust what worked elsewhere?). Execution memory within a repo comes first.
+
+**Rust lfd rewrite**: The daemon works. Python asyncio has overhead, but it's not the bottleneck. Rewriting in Rust adds maintenance burden and build complexity for benefits that aren't proven. If the daemon becomes a stability problem, revisit. Until then, invest in reliability features (the roadmap already covers this) rather than rewrites.

--- a/scratch/simplification-opportunities.md
+++ b/scratch/simplification-opportunities.md
@@ -1,0 +1,155 @@
+# Simplification Opportunities
+
+## Product intent
+
+Loopflow is a tight, focused tool for prompt and context assembly. The core value: gather context, store prompts as markdown files, pass to coding agents. "Tight loops. Do one thing, hand off cleanly."
+
+An agent is **flow × area × voice**—three multiplied concepts, not a complex hierarchy.
+
+---
+
+## Opportunity 1: Agent mode as discriminated union, not nullable columns
+
+**Misalignment**: The product describes three distinct agent modes (Loop, Watch, Cron) as equals, but the architecture stores mode implicitly via nullable columns (`watch_paths`, `cron`) on a single Agent table.
+
+**Symptom**: The `mode` property computes what should be explicit data:
+
+```python
+# models.py:98-104
+@property
+def mode(self) -> str:
+    if self.watch_paths:
+        return "watch"
+    if self.cron:
+        return "cron"
+    return "loop"
+```
+
+The migration `m_2025_01_22_unified_agents.py` had to consolidate three separate tables (loops, subscriptions, schedules) into one by adding nullable columns. This suggests the original intuition was right—modes are distinct—but the consolidation went too far.
+
+**Realignment**: Make mode explicit in the data model:
+
+```python
+class AgentMode(str, Enum):
+    LOOP = "loop"
+    WATCH = "watch"
+    CRON = "cron"
+
+class Agent(LfdModel):
+    mode: AgentMode
+    trigger_config: str | None  # watch_paths for WATCH, cron expression for CRON, None for LOOP
+```
+
+Or use three tables again with a shared base—but with explicit naming this time (`loop_agents`, `watch_agents`, `cron_agents`) rather than the previous generic names.
+
+**Cascade**:
+- CLI validation becomes simpler (mode is explicit input, not inferred)
+- Status display doesn't need to compute mode
+- Database queries can filter by mode directly
+- TypeScript/Swift models become cleaner (no nullable-means-something pattern)
+
+---
+
+## Opportunity 2: Flows are lists, not DAGs
+
+**Misalignment**: The product describes flows as "chains of steps"—sequential execution with commits between. The architecture has a full DAG system with `fork`, `join`, `Choose`, and parallel execution.
+
+**Symptom**: Looking at actual flow definitions in the repo:
+
+```python
+# submit.py - simple list
+def flow():
+    return {"steps": ["polish", "draft_commit"]}
+
+# ux.py - simple list
+def flow():
+    return {"steps": ["ux-research", "ux-gaps", "ux-fix"]}
+
+# ship.py - uses Choose/fork/join
+SHIP = Flow(
+    Choose(
+        options={
+            "add_to_roadmap": Flow(fork/join machinery...),
+            "scope_from_roadmap": Flow("design_from_roadmap", "implement", "polish"),
+        }
+    ),
+)
+```
+
+Two of three flows are simple lists. The complex one (`ship.py`) looks experimental. Meanwhile, `flows.py` has 308 lines of DAG resolution code: `FlowStep`, `FlowDef`, `ResolvedStep`, `resolve_flow()`, `Choose`, `Join`, `JoinConfig`, parallel group tracking.
+
+**Realignment**: A flow is a list of step names. Period.
+
+```python
+class FlowDef(BaseModel):
+    name: str
+    steps: list[str]
+
+def load_flow(name: str, repo: Path) -> FlowDef | None:
+    """Load flow from flows/{name}.py."""
+    # ... load module, call flow(), expect list[str]
+```
+
+If parallel execution is ever needed, it's a different primitive (`lf fork`) not flow machinery. The Choose pattern is better handled by a conditional step prompt than flow-level branching.
+
+**Cascade**:
+- `flows.py` shrinks from 308 lines to ~50
+- No `ResolvedStep`, no parallel group tracking
+- Flow execution is a simple for-loop
+- CLI can show flow as `step → step → step` directly
+- TypeScript/Swift models drop `fork`, `join`, `choose` types
+
+---
+
+## Opportunity 3: `lfd run` creates unnecessary agents
+
+**Misalignment**: The product distinguishes between one-shot execution (`lf`) and daemon-managed agents (`lfd`). But `lfd run` creates a "temporary agent" then runs it once:
+
+```python
+# lfd/cli.py:365-374
+def run(...):
+    # Create a temporary agent and run it once
+    agent = create_agent(repo=repo, flow=flow_name, voice=voice_list, area=[area])
+    result = start_agent(agent.id, foreground=True)
+```
+
+This conflates the concepts. An agent is a persistent entity that runs on triggers. A one-shot flow execution doesn't need an agent at all.
+
+**Symptom**: After `lfd run ship .`, there's a zombie agent in the database with status=IDLE and iteration=1. It served its purpose and will never run again, but it's stored as if it might.
+
+**Realignment**:
+- `lfd run` → remove command entirely
+- Use `lf flow ship` (or just `lf ship`) for one-shot flow execution
+- `lfd` manages only persistent agents: `lfd loop`, `lfd subscribe`, `lfd schedule`
+
+Or rename `lfd run` to something that doesn't imply creating an agent—maybe `lfd exec` or just have `lf flow` support the `--area` flag.
+
+**Cascade**:
+- Clear mental model: `lf` = run prompts, `lfd` = manage agents
+- No orphan agents from one-shot runs
+- Agent table only contains actual agents
+- Status display is cleaner (only shows things that matter)
+
+---
+
+## Aligned areas (patterns to preserve)
+
+**Context assembly is well-designed.** The `PromptComponents` dataclass, `ContextConfig`, and `gather_prompt_components()` are clean. Token trimming works. The display of context breakdown is useful. This is the core value prop and it works.
+
+**Step resolution is clean.** The search order (repo → global → builtin) with clear precedence, frontmatter parsing, and `StepConfig` merging are solid. Steps as markdown files in `.claude/commands/` or `.lf/steps/` is the right abstraction.
+
+**StepRun tracking is appropriate.** Logging individual step executions to the database makes sense—it's the unit of work that matters for debugging and history. The rename from `sessions` → `step_runs` was correct terminology.
+
+**Voice as files, not config.** Voices are markdown files in `.lf/voices/`. This is the right abstraction—they're documents, not structured data. The validator-based parsing (`load_voice`) is appropriate.
+
+---
+
+## Summary
+
+| Opportunity | Effort | Impact |
+|-------------|--------|--------|
+| Agent mode as discriminated union | S | Cleaner data model, simpler CLI |
+| Flows are lists, not DAGs | M | Delete ~250 lines, simpler mental model |
+| Remove `lfd run` | S | Clear separation of concerns |
+
+The theme: the architecture has grown features that the product doesn't use. Fork/join flows, implicit agent modes, one-shot agents—all complexity that doesn't match how the tool is actually used. Realigning means deleting code, not adding it.

--- a/src/loopflow/lfd/agent.py
+++ b/src/loopflow/lfd/agent.py
@@ -16,7 +16,14 @@ from croniter import croniter
 from loopflow.lf.context import find_worktree_root
 from loopflow.lfd.db import _get_db
 from loopflow.lfd.logging import trigger_log
-from loopflow.lfd.models import Agent, AgentStatus, MergeMode, agent_from_row, area_to_slug
+from loopflow.lfd.models import (
+    Agent,
+    AgentMode,
+    AgentStatus,
+    MergeMode,
+    agent_from_row,
+    area_to_slug,
+)
 
 
 def get_wt_from_cwd() -> Path | None:
@@ -103,10 +110,10 @@ def save_agent(agent: Agent, db_path: Path | None = None) -> None:
     conn.execute(
         """
         INSERT OR REPLACE INTO agents
-        (id, repo, flow, voice, area, status, iteration, main_branch,
+        (id, repo, flow, voice, area, mode, status, iteration, main_branch,
          pr_limit, merge_mode, pid, created_at, watch_paths, cron, last_main_sha,
          consecutive_failures)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         """,
         (
             agent.id,
@@ -114,6 +121,7 @@ def save_agent(agent: Agent, db_path: Path | None = None) -> None:
             agent.flow,
             json.dumps(agent.voice),
             json.dumps(agent.area),
+            agent.mode.value,
             agent.status.value,
             agent.iteration,
             agent.main_branch,
@@ -339,6 +347,15 @@ def _create_main_branch(repo: Path, branch: str) -> None:
 # Operations
 
 
+def _determine_mode(watch_paths: str | None, cron: str | None) -> AgentMode:
+    """Determine agent mode from trigger config."""
+    if watch_paths:
+        return AgentMode.WATCH
+    if cron:
+        return AgentMode.CRON
+    return AgentMode.LOOP
+
+
 def create_agent(
     repo: Path,
     flow: str,
@@ -371,6 +388,11 @@ def create_agent(
         if existing.cron != cron:
             existing.cron = cron
             changed = True
+        # Update mode if trigger config changed
+        new_mode = _determine_mode(watch_paths, cron)
+        if existing.mode != new_mode:
+            existing.mode = new_mode
+            changed = True
         if changed:
             save_agent(existing)
         return existing
@@ -378,12 +400,15 @@ def create_agent(
     main_branch = _allocate_main_branch(repo, area)
     _create_main_branch(repo, main_branch)
 
+    mode = _determine_mode(watch_paths, cron)
+
     agent = Agent(
         id=str(uuid.uuid4()),
         repo=repo,
         flow=flow,
         voice=voice,
         area=area,
+        mode=mode,
         status=AgentStatus.IDLE,
         main_branch=main_branch,
         pr_limit=pr_limit,

--- a/src/loopflow/lfd/cli.py
+++ b/src/loopflow/lfd/cli.py
@@ -366,9 +366,13 @@ def run(
 
     # Start it in foreground (runs once)
     result = start_agent(agent.id, foreground=True)
+
+    # Clean up temporary agent
+    delete_agent(agent.id)
+
     if result:
         msg = f"{c['green']}Completed{c['reset']} run {c['bold']}{area}{c['reset']}"
-        typer.echo(f"{msg} ({agent.short_id()})")
+        typer.echo(msg)
     else:
         typer.echo(f"{c['red']}Error:{c['reset']} Failed to run", err=True)
         raise typer.Exit(1)

--- a/src/loopflow/lfd/migrations/m_2025_01_23_z_agent_mode.py
+++ b/src/loopflow/lfd/migrations/m_2025_01_23_z_agent_mode.py
@@ -1,0 +1,22 @@
+"""Add explicit mode column to agents table."""
+
+import sqlite3
+
+VERSION = "2025-01-23T04:00:00"
+DESCRIPTION = "Add explicit mode column to agents"
+
+
+def apply(conn: sqlite3.Connection) -> None:
+    # Check if mode column already exists
+    cursor = conn.execute("PRAGMA table_info(agents)")
+    columns = {row[1] for row in cursor.fetchall()}
+    if "mode" in columns:
+        return  # Already migrated
+
+    # Add mode column with default 'loop'
+    conn.execute("ALTER TABLE agents ADD COLUMN mode TEXT NOT NULL DEFAULT 'loop'")
+
+    # Set mode based on existing trigger config
+    conn.execute("UPDATE agents SET mode = 'watch' WHERE watch_paths IS NOT NULL")
+    conn.execute("UPDATE agents SET mode = 'cron' WHERE cron IS NOT NULL")
+    conn.commit()

--- a/src/loopflow/lfd/models.py
+++ b/src/loopflow/lfd/models.py
@@ -27,6 +27,14 @@ class LfdModel(BaseModel):
     )
 
 
+class AgentMode(str, Enum):
+    """Activation mode of an agent."""
+
+    LOOP = "loop"
+    WATCH = "watch"
+    CRON = "cron"
+
+
 class AgentStatus(str, Enum):
     """Runtime status of an agent."""
 
@@ -46,10 +54,10 @@ class MergeMode(str, Enum):
 class Agent(LfdModel):
     """An AI coding agent.
 
-    Activation modes (derived from config):
-    - Continuous (default): runs when started until stopped or PR limit
+    Activation modes:
+    - Loop (default): runs when started until stopped or PR limit
     - Watch: runs when watch_paths change on main
-    - Scheduled: runs on cron schedule
+    - Cron: runs on cron schedule
     """
 
     id: str
@@ -58,6 +66,7 @@ class Agent(LfdModel):
     voice: list[str] = Field(min_length=1)
     area: list[str] = Field(min_length=1)
 
+    mode: AgentMode = AgentMode.LOOP
     status: AgentStatus = AgentStatus.IDLE
     iteration: int = 0
 
@@ -68,7 +77,7 @@ class Agent(LfdModel):
     pid: int | None = None
     created_at: datetime = Field(default_factory=datetime.now)
 
-    # Activation config (determines mode)
+    # Trigger config (for watch/cron modes)
     watch_paths: str | None = None
     cron: str | None = None
     last_main_sha: str | None = None
@@ -98,15 +107,6 @@ class Agent(LfdModel):
         return area_to_slug(self.area[0])
 
     @property
-    def mode(self) -> str:
-        """Return the activation mode: 'watch', 'cron', or 'loop'."""
-        if self.watch_paths:
-            return "watch"
-        if self.cron:
-            return "cron"
-        return "loop"
-
-    @property
     def voice_display(self) -> str:
         return ", ".join(self.voice)
 
@@ -127,12 +127,24 @@ def agent_from_row(row: dict) -> Agent:
     if merge_mode_str == "auto":
         merge_mode_str = "pr"
 
+    # Read mode from DB, with fallback for pre-migration rows
+    mode_str = row.get("mode")
+    if mode_str:
+        mode = AgentMode(mode_str)
+    elif row.get("watch_paths"):
+        mode = AgentMode.WATCH
+    elif row.get("cron"):
+        mode = AgentMode.CRON
+    else:
+        mode = AgentMode.LOOP
+
     return Agent(
         id=row["id"],
         repo=Path(row["repo"]),
         flow=row["flow"],
         voice=voice,
         area=area,
+        mode=mode,
         status=AgentStatus(row["status"]),
         iteration=row.get("iteration", 0),
         main_branch=row.get("main_branch", ""),

--- a/swift/LoopflowCore/Models/Agent.swift
+++ b/swift/LoopflowCore/Models/Agent.swift
@@ -4,6 +4,12 @@
 import Foundation
 import SwiftUI
 
+public enum AgentMode: String, Sendable, Codable {
+    case loop
+    case watch
+    case cron
+}
+
 public enum AgentStatus: String, Sendable, Codable {
     case idle
     case running
@@ -32,6 +38,7 @@ public struct Agent: Sendable, Identifiable, Hashable {
     public let area: [String]
     public let repo: String
 
+    public var mode: AgentMode
     public var status: AgentStatus
     public var iteration: Int
 
@@ -42,7 +49,7 @@ public struct Agent: Sendable, Identifiable, Hashable {
     public var pid: Int?
     public var createdAt: Date
 
-    // Activation config (determines mode)
+    // Trigger config (for watch/cron modes)
     public var watchPaths: String?
     public var cron: String?
     public var lastMainSha: String?
@@ -53,6 +60,7 @@ public struct Agent: Sendable, Identifiable, Hashable {
         voice: [String] = [],
         area: [String] = ["."],
         repo: String,
+        mode: AgentMode = .loop,
         status: AgentStatus = .idle,
         iteration: Int = 0,
         mainBranch: String,
@@ -69,6 +77,7 @@ public struct Agent: Sendable, Identifiable, Hashable {
         self.voice = voice
         self.area = area
         self.repo = repo
+        self.mode = mode
         self.status = status
         self.iteration = iteration
         self.mainBranch = mainBranch
@@ -82,13 +91,6 @@ public struct Agent: Sendable, Identifiable, Hashable {
     }
 
     public var shortId: String { String(id.prefix(7)) }
-
-    /// Activation mode: 'watch', 'cron', or 'loop'
-    public var mode: String {
-        if watchPaths != nil { return "watch" }
-        if cron != nil { return "cron" }
-        return "loop"
-    }
 
     public var areaDisplay: String {
         area.first == "." ? "root" : area.joined(separator: ", ")

--- a/tests/test_git_hooks.py
+++ b/tests/test_git_hooks.py
@@ -21,12 +21,8 @@ from loopflow.lfd.git_hooks import (
 def _init_git_repo(path: Path) -> Path:
     """Initialize a git repo at path and return it."""
     subprocess.run(["git", "init"], cwd=path, capture_output=True)
-    subprocess.run(
-        ["git", "config", "user.email", "test@test.com"], cwd=path, capture_output=True
-    )
-    subprocess.run(
-        ["git", "config", "user.name", "Test"], cwd=path, capture_output=True
-    )
+    subprocess.run(["git", "config", "user.email", "test@test.com"], cwd=path, capture_output=True)
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=path, capture_output=True)
     return path
 
 

--- a/tests/test_lfd.py
+++ b/tests/test_lfd.py
@@ -27,6 +27,7 @@ from loopflow.lfd.flow_run import (
 from loopflow.lfd.migrations.registry import MIGRATIONS
 from loopflow.lfd.models import (
     Agent,
+    AgentMode,
     AgentStatus,
     FlowRun,
     FlowRunStatus,
@@ -634,6 +635,14 @@ def test_server_handle_output_line_allows_empty_text():
 
 def _make_agent(**kwargs) -> Agent:
     """Helper to create an Agent with test defaults."""
+    # Determine mode from trigger config if not explicitly set
+    if "mode" not in kwargs:
+        if kwargs.get("watch_paths"):
+            kwargs["mode"] = AgentMode.WATCH
+        elif kwargs.get("cron"):
+            kwargs["mode"] = AgentMode.CRON
+        else:
+            kwargs["mode"] = AgentMode.LOOP
     defaults = {
         "id": "test-id",
         "flow": "ship",
@@ -673,13 +682,13 @@ def test_agent_model_short_id():
 def test_agent_mode_property():
     """Agent.mode returns correct activation mode."""
     loop_agent = _make_agent()
-    assert loop_agent.mode == "loop"
+    assert loop_agent.mode == AgentMode.LOOP
 
     watch_agent = _make_agent(watch_paths="src/**/*.py")
-    assert watch_agent.mode == "watch"
+    assert watch_agent.mode == AgentMode.WATCH
 
     cron_agent = _make_agent(cron="0 9 * * *")
-    assert cron_agent.mode == "cron"
+    assert cron_agent.mode == AgentMode.CRON
 
 
 def test_run_model():

--- a/web/src/models/agent.ts
+++ b/web/src/models/agent.ts
@@ -1,6 +1,8 @@
 // Agent - an autonomous AI coding agent.
 // Activation modes: loop (continuous), watch (on file change), cron (scheduled).
 
+export type AgentMode = 'loop' | 'watch' | 'cron'
+
 export type AgentStatus = 'idle' | 'running' | 'waiting' | 'error'
 
 export type MergeMode = 'pr' | 'land'
@@ -12,6 +14,7 @@ export interface Agent {
   area: string[]
   repo: string
 
+  mode: AgentMode
   status: AgentStatus
   iteration: number
 
@@ -22,7 +25,7 @@ export interface Agent {
   pid?: number
   createdAt: Date
 
-  // Activation config (determines mode)
+  // Trigger config (for watch/cron modes)
   watchPaths?: string
   cron?: string
   lastMainSha?: string
@@ -30,12 +33,6 @@ export interface Agent {
 
 export function agentShortId(agent: Agent): string {
   return agent.id.slice(0, 7)
-}
-
-export function agentMode(agent: Agent): 'watch' | 'cron' | 'loop' {
-  if (agent.watchPaths) return 'watch'
-  if (agent.cron) return 'cron'
-  return 'loop'
 }
 
 export function agentAreaDisplay(agent: Agent): string {


### PR DESCRIPTION
## Try it

```bash
lfd loop ship src/       # creates agent with mode='loop'
lfd watch ship docs/     # creates agent with mode='watch'
lfd status               # mode is now a stored field, not computed
```

## Summary

Agent mode (loop, watch, cron) is now an explicit field in the data model rather than being computed from nullable `watch_paths` and `cron` columns. This aligns the architecture with the product's description of three distinct agent modes as equals.

Previously, the `mode` property computed what should be explicit data. Now mode is stored directly, making the CLI simpler (mode is explicit input, not inferred), status display clearer, and database queries filterable by mode.

## Changes

- Add `AgentMode` enum to Python, Swift, and TypeScript models
- Add explicit `mode` column to agents table via migration
- Update `create_agent()` to determine and store mode from trigger config
- Clean up temporary agents after `lfd run` completes (no more zombie agents)
- Align Swift `Agent.swift` and TypeScript `agent.ts` with Python schema
- Remove computed `mode` property in favor of stored field