### PR TITLE
lfd runner: persist agent worktree across iterations, move branch on completion

### DIFF
--- a/src/loopflow/lfd/agent.py
+++ b/src/loopflow/lfd/agent.py
@@ -43,8 +43,8 @@ def save_agent(agent: Agent, db_path: Path | None = None) -> None:
         INSERT OR REPLACE INTO agents
         (id, repo, flow, voice, area, mode, status, iteration, main_branch,
          worktree, branch, pr_limit, merge_mode, pid, created_at, watch_paths,
-         cron, last_main_sha, consecutive_failures)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+         cron, last_main_sha, consecutive_failures, pending_activations, buffer_mode)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         """,
         (
             agent.id,
@@ -66,6 +66,8 @@ def save_agent(agent: Agent, db_path: Path | None = None) -> None:
             agent.cron,
             agent.last_main_sha,
             agent.consecutive_failures,
+            agent.pending_activations,
+            agent.buffer_mode,
         ),
     )
     conn.commit()
@@ -185,6 +187,22 @@ def update_agent_consecutive_failures(
     cursor = conn.execute(
         "UPDATE agents SET consecutive_failures = ? WHERE id = ? OR id LIKE ?",
         (failures, agent_id, f"{agent_id}%"),
+    )
+    conn.commit()
+    updated = cursor.rowcount > 0
+    conn.close()
+    return updated
+
+
+def update_agent_pending_activations(
+    agent_id: str, pending: int, db_path: Path | None = None
+) -> bool:
+    """Update an agent's pending activations count."""
+    conn = _get_db(db_path)
+
+    cursor = conn.execute(
+        "UPDATE agents SET pending_activations = ? WHERE id = ? OR id LIKE ?",
+        (pending, agent_id, f"{agent_id}%"),
     )
     conn.commit()
     updated = cursor.rowcount > 0
@@ -555,6 +573,7 @@ def check_watch(agent: Agent) -> bool:
 # Cron mode checking
 
 SCHEDULE_GRACE_PERIOD = timedelta(hours=24)
+MAX_PENDING_ACTIVATIONS = 10
 
 
 def should_trigger_cron(
@@ -603,24 +622,53 @@ def check_cron(agent: Agent) -> bool:
 # Daemon check functions
 
 
+def _queue_activation(agent: Agent) -> bool:
+    """Queue an activation for a busy agent. Returns True if queued."""
+    if agent.pending_activations >= MAX_PENDING_ACTIVATIONS:
+        trigger_log.warning(
+            f"[{agent.short_id()}] pending activations at max ({MAX_PENDING_ACTIVATIONS}), dropping"
+        )
+        return False
+
+    if agent.buffer_mode == "combine":
+        # Combine mode: only queue if nothing pending (idempotent)
+        if agent.pending_activations == 0:
+            update_agent_pending_activations(agent.id, 1)
+            trigger_log.info(f"[{agent.short_id()}] queued activation (combine mode)")
+            return True
+        trigger_log.debug(f"[{agent.short_id()}] already has pending activation (combine mode)")
+        return False
+    else:
+        # Queue mode: always increment
+        new_pending = agent.pending_activations + 1
+        update_agent_pending_activations(agent.id, new_pending)
+        trigger_log.info(f"[{agent.short_id()}] queued activation (queue, now {new_pending})")
+        return True
+
+
 def run_watch_check() -> list[str]:
-    """Check all watch-mode agents and trigger as needed."""
+    """Check all watch-mode agents and trigger or queue as needed."""
     agents = list_agents()
-    watch_agents = [a for a in agents if a.watch_paths and a.status != AgentStatus.RUNNING]
+    watch_agents = [a for a in agents if a.watch_paths]
     trigger_log.debug(f"watch check: {len(watch_agents)} agents to check")
 
     triggered = []
     for agent in watch_agents:
         try:
             if check_watch(agent):
-                result = start_agent(agent.id)
-                if result:
-                    trigger_log.info(f"[{agent.short_id()}] started from watch trigger")
-                    triggered.append(agent.id)
+                if agent.status in (AgentStatus.RUNNING, AgentStatus.WAITING):
+                    # Agent is busy, queue the activation
+                    _queue_activation(agent)
                 else:
-                    trigger_log.warning(
-                        f"[{agent.short_id()}] watch triggered but start failed: {result.reason}"
-                    )
+                    # Agent is idle, start it
+                    result = start_agent(agent.id)
+                    if result:
+                        trigger_log.info(f"[{agent.short_id()}] started from watch activation")
+                        triggered.append(agent.id)
+                    else:
+                        trigger_log.warning(
+                            f"[{agent.short_id()}] watch activated but failed: {result.reason}"
+                        )
         except Exception as e:
             trigger_log.error(f"[{agent.short_id()}] watch check error: {e}")
 
@@ -628,23 +676,28 @@ def run_watch_check() -> list[str]:
 
 
 def run_cron_check() -> list[str]:
-    """Check all cron-mode agents and trigger as needed."""
+    """Check all cron-mode agents and trigger or queue as needed."""
     agents = list_agents()
-    cron_agents = [a for a in agents if a.cron and a.status != AgentStatus.RUNNING]
+    cron_agents = [a for a in agents if a.cron]
     trigger_log.debug(f"cron check: {len(cron_agents)} agents to check")
 
     triggered = []
     for agent in cron_agents:
         try:
             if check_cron(agent):
-                result = start_agent(agent.id)
-                if result:
-                    trigger_log.info(f"[{agent.short_id()}] started from cron trigger")
-                    triggered.append(agent.id)
+                if agent.status in (AgentStatus.RUNNING, AgentStatus.WAITING):
+                    # Agent is busy, queue the activation
+                    _queue_activation(agent)
                 else:
-                    trigger_log.warning(
-                        f"[{agent.short_id()}] cron triggered but start failed: {result.reason}"
-                    )
+                    # Agent is idle, start it
+                    result = start_agent(agent.id)
+                    if result:
+                        trigger_log.info(f"[{agent.short_id()}] started from cron activation")
+                        triggered.append(agent.id)
+                    else:
+                        trigger_log.warning(
+                            f"[{agent.short_id()}] cron activated but start failed: {result.reason}"
+                        )
         except Exception as e:
             trigger_log.error(f"[{agent.short_id()}] cron check error: {e}")
 

--- a/src/loopflow/lfd/agent.py
+++ b/src/loopflow/lfd/agent.py
@@ -42,9 +42,9 @@ def save_agent(agent: Agent, db_path: Path | None = None) -> None:
         """
         INSERT OR REPLACE INTO agents
         (id, repo, flow, voice, area, mode, status, iteration, main_branch,
-         pr_limit, merge_mode, pid, created_at, watch_paths, cron, last_main_sha,
-         consecutive_failures)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+         worktree, branch, pr_limit, merge_mode, pid, created_at, watch_paths,
+         cron, last_main_sha, consecutive_failures)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         """,
         (
             agent.id,
@@ -56,6 +56,8 @@ def save_agent(agent: Agent, db_path: Path | None = None) -> None:
             agent.status.value,
             agent.iteration,
             agent.main_branch,
+            str(agent.worktree) if agent.worktree else None,
+            agent.branch,
             agent.pr_limit,
             agent.merge_mode.value,
             agent.pid,
@@ -183,6 +185,25 @@ def update_agent_consecutive_failures(
     cursor = conn.execute(
         "UPDATE agents SET consecutive_failures = ? WHERE id = ? OR id LIKE ?",
         (failures, agent_id, f"{agent_id}%"),
+    )
+    conn.commit()
+    updated = cursor.rowcount > 0
+    conn.close()
+    return updated
+
+
+def update_agent_worktree_branch(
+    agent_id: str,
+    worktree: Path | None,
+    branch: str | None,
+    db_path: Path | None = None,
+) -> bool:
+    """Update an agent's worktree path and current branch."""
+    conn = _get_db(db_path)
+
+    cursor = conn.execute(
+        "UPDATE agents SET worktree = ?, branch = ? WHERE id = ? OR id LIKE ?",
+        (str(worktree) if worktree else None, branch, agent_id, f"{agent_id}%"),
     )
     conn.commit()
     updated = cursor.rowcount > 0

--- a/src/loopflow/lfd/execution/runner.py
+++ b/src/loopflow/lfd/execution/runner.py
@@ -3,7 +3,6 @@
 Executes a single iteration of an Agent.
 """
 
-import json
 import subprocess
 import sys
 import uuid
@@ -36,8 +35,6 @@ from loopflow.lf.worktrees import WorktreeError, get_path
 from loopflow.lf.worktrees import create as create_worktree
 from loopflow.lf.worktrees import remove as remove_worktree
 from loopflow.lfd.daemon.client import notify_event
-from loopflow.lfops._helpers import get_default_branch
-from loopflow.lfops.next import move_worktree
 from loopflow.lfd.flow_run import (
     save_run,
     update_run_pr,
@@ -45,6 +42,8 @@ from loopflow.lfd.flow_run import (
     update_run_step,
 )
 from loopflow.lfd.models import Agent, FlowRun, FlowRunStatus
+from loopflow.lfops._helpers import get_default_branch
+from loopflow.lfops.next import move_worktree
 
 
 def _iteration_branch_prefix(main_branch: str) -> str:
@@ -400,12 +399,16 @@ def run_iteration(
         branch = generate_next_branch(area_slug, agent.repo)
         worktree_path = get_path(agent.repo, area_slug)
         try:
-            subprocess.run(
-                ["git", "worktree", "add", "-b", branch, str(worktree_path), f"origin/{base_branch}"],
-                cwd=agent.repo,
-                capture_output=True,
-                check=True,
-            )
+            git_cmd = [
+                "git",
+                "worktree",
+                "add",
+                "-b",
+                branch,
+                str(worktree_path),
+                f"origin/{base_branch}",
+            ]
+            subprocess.run(git_cmd, cwd=agent.repo, capture_output=True, check=True)
             subprocess.run(
                 ["git", "push", "-u", "origin", branch],
                 cwd=worktree_path,
@@ -710,5 +713,3 @@ def _enable_auto_merge(worktree_path: Path) -> bool:
         text=True,
     )
     return result.returncode == 0
-
-

--- a/src/loopflow/lfd/execution/runner.py
+++ b/src/loopflow/lfd/execution/runner.py
@@ -46,13 +46,6 @@ from loopflow.lfops._helpers import get_default_branch
 from loopflow.lfops.next import move_worktree
 
 
-def _iteration_branch_prefix(main_branch: str) -> str:
-    """Derive iteration branch prefix from main branch."""
-    if main_branch.endswith("-main"):
-        return main_branch[:-5]
-    return main_branch
-
-
 def _build_loop_prompt(
     agent: Agent,
     effective_voices: list,
@@ -417,7 +410,7 @@ def run_iteration(
         except (subprocess.CalledProcessError, WorktreeError) as e:
             error_msg = f"Failed to create worktree: {e}"
             notify_event("agent.error", {"agent_id": agent.id, "error": error_msg})
-            return False, None, None, None
+            return False, None, None
 
     run = FlowRun(
         id=run_id or str(uuid.uuid4()),

--- a/src/loopflow/lfd/execution/runner.py
+++ b/src/loopflow/lfd/execution/runner.py
@@ -30,11 +30,14 @@ from loopflow.lf.flows import (
 from loopflow.lf.launcher import build_model_command, get_runner
 from loopflow.lf.logging import write_prompt_file
 from loopflow.lf.messages import generate_pr_message
+from loopflow.lf.naming import generate_next_branch, parse_branch_base
 from loopflow.lf.voices import render_voices, resolve_voices
-from loopflow.lf.worktrees import WorktreeError
+from loopflow.lf.worktrees import WorktreeError, get_path
 from loopflow.lf.worktrees import create as create_worktree
 from loopflow.lf.worktrees import remove as remove_worktree
 from loopflow.lfd.daemon.client import notify_event
+from loopflow.lfops._helpers import get_default_branch
+from loopflow.lfops.next import move_worktree
 from loopflow.lfd.flow_run import (
     save_run,
     update_run_pr,
@@ -377,21 +380,41 @@ def run_iteration(
     agent: Agent,
     iteration: int,
     run_id: str | None = None,
-) -> bool:
+) -> tuple[bool, Path | None, str | None]:
     """Run a single iteration of an agent.
 
-    Returns True if successful, False on error.
+    Returns (success, worktree_path, new_branch).
+    - worktree_path: the agent's worktree (same path, persists across iterations)
+    - new_branch: the branch after moving (for next iteration)
     """
     config = load_config(agent.repo)
+    base_branch = get_default_branch(agent.repo)
 
-    prefix = _iteration_branch_prefix(agent.main_branch)
-    branch = f"{prefix}/{iteration:03d}"
-    try:
-        worktree_path = create_worktree(agent.repo, branch, base=agent.main_branch)
-    except WorktreeError as e:
-        error_msg = f"Failed to create worktree: {e}"
-        notify_event("agent.error", {"agent_id": agent.id, "error": error_msg})
-        return False
+    # Use agent's persistent worktree, or create on first iteration
+    if agent.worktree and agent.worktree.exists():
+        worktree_path = agent.worktree
+        branch = agent.branch
+    else:
+        # First iteration: generate initial branch and create worktree
+        area_slug = agent.area_slug
+        branch = generate_next_branch(area_slug, agent.repo)
+        worktree_path = get_path(agent.repo, area_slug)
+        try:
+            subprocess.run(
+                ["git", "worktree", "add", "-b", branch, str(worktree_path), f"origin/{base_branch}"],
+                cwd=agent.repo,
+                capture_output=True,
+                check=True,
+            )
+            subprocess.run(
+                ["git", "push", "-u", "origin", branch],
+                cwd=worktree_path,
+                capture_output=True,
+            )
+        except (subprocess.CalledProcessError, WorktreeError) as e:
+            error_msg = f"Failed to create worktree: {e}"
+            notify_event("agent.error", {"agent_id": agent.id, "error": error_msg})
+            return False, None, None, None
 
     run = FlowRun(
         id=run_id or str(uuid.uuid4()),
@@ -425,26 +448,22 @@ def run_iteration(
     flow = agent.flow
     if not flow:
         update_run_status(run.id, FlowRunStatus.FAILED, error="Flow is required")
-        _cleanup_worktree(agent.repo, worktree_path, branch)
-        return False
+        return False, None, None
 
     try:
         flow_def = load_flow(flow, agent.repo)
     except ValueError as exc:
         update_run_status(run.id, FlowRunStatus.FAILED, error=str(exc))
-        _cleanup_worktree(agent.repo, worktree_path, branch)
-        return False
+        return False, None, None
 
     if not flow_def:
         update_run_status(run.id, FlowRunStatus.FAILED, error=f"Unknown flow '{flow}'")
-        _cleanup_worktree(agent.repo, worktree_path, branch)
-        return False
+        return False, None, None
 
     resolved = resolve_flow(flow_def, agent.repo)
     if not resolved:
         update_run_status(run.id, FlowRunStatus.FAILED, error=f"Empty flow '{flow}'")
-        _cleanup_worktree(agent.repo, worktree_path, branch)
-        return False
+        return False, None, None
 
     agent_model = config.agent_model if config else "claude:opus"
     backend, model_variant = parse_model(agent_model)
@@ -452,7 +471,7 @@ def run_iteration(
     runner = get_runner(backend)
     if not runner.is_available():
         update_run_status(run.id, FlowRunStatus.FAILED, error=f"'{backend}' CLI not found")
-        return False
+        return False, None, None
 
     skip_permissions = config.yolo if config else False
 
@@ -473,8 +492,7 @@ def run_iteration(
                 update_run_status(
                     run.id, FlowRunStatus.FAILED, error="Fork must be immediately followed by join"
                 )
-                _cleanup_worktree(agent.repo, worktree_path, branch)
-                return False
+                return False, None, None
 
             try:
                 result_code = _run_fork_join_group(
@@ -492,12 +510,10 @@ def run_iteration(
                 )
             except StepTimeoutError as e:
                 update_run_status(run.id, FlowRunStatus.FAILED, error=str(e))
-                _cleanup_worktree(agent.repo, worktree_path, branch)
-                return False
+                return False, None, None
             if result_code != 0:
                 update_run_status(run.id, FlowRunStatus.FAILED, error="join failed")
-                _cleanup_worktree(agent.repo, worktree_path, branch)
-                return False
+                return False, None, None
 
             i += 1
             continue
@@ -514,8 +530,7 @@ def run_iteration(
                 )
             except RuntimeError as exc:
                 update_run_status(run.id, FlowRunStatus.FAILED, error=str(exc))
-                _cleanup_worktree(agent.repo, worktree_path, branch)
-                return False
+                return False, None, None
 
             branch_steps = step.choose.options[choice]
             branch_flow = FlowDef.from_dict(f"{flow_def.name}:{choice}", {"steps": branch_steps})
@@ -525,8 +540,7 @@ def run_iteration(
 
         if step.join is not None:
             update_run_status(run.id, FlowRunStatus.FAILED, error="Join must follow fork")
-            _cleanup_worktree(agent.repo, worktree_path, branch)
-            return False
+            return False, None, None
 
         if not step.step:
             i += 1
@@ -568,8 +582,7 @@ def run_iteration(
             update_run_status(
                 run.id, FlowRunStatus.FAILED, error=f"Step file not found: {step_name}"
             )
-            _cleanup_worktree(agent.repo, worktree_path, branch)
-            return False
+            return False, None, None
 
         prompt, _step_file = prompt_result
         try:
@@ -592,8 +605,7 @@ def run_iteration(
                 },
             )
             update_run_status(run.id, FlowRunStatus.FAILED, error=str(e))
-            _cleanup_worktree(agent.repo, worktree_path, branch)
-            return False
+            return False, None, None
 
         notify_event(
             "agent.step.completed",
@@ -606,20 +618,17 @@ def run_iteration(
 
         if result_code != 0:
             update_run_status(run.id, FlowRunStatus.FAILED, error=f"{step_name} failed")
-            _cleanup_worktree(agent.repo, worktree_path, branch)
-            return False
+            return False, None, None
 
         i += 1
 
     update_run_step(run.id, None)
 
-    pr_url = _create_pr_to_main_branch(agent, worktree_path, branch, iteration)
+    # Create PR targeting main
+    pr_url = _create_pr_to_main(agent, worktree_path, branch, iteration, base_branch)
     if pr_url:
         update_run_pr(run.id, pr_url)
-        _auto_merge_pr(worktree_path)
-
-        if agent.merge_mode.value == "land":
-            _land_to_main(agent)
+        _enable_auto_merge(worktree_path)
 
     update_run_status(run.id, FlowRunStatus.COMPLETED)
 
@@ -635,15 +644,20 @@ def run_iteration(
         },
     )
 
-    _cleanup_worktree(agent.repo, worktree_path, branch)
+    # Move worktree to new branch for next iteration
+    base_name = parse_branch_base(branch)
+    new_branch = generate_next_branch(base_name, agent.repo)
+    if not move_worktree(agent.repo, worktree_path, new_branch, base_branch):
+        notify_event("agent.error", {"agent_id": agent.id, "error": "Failed to move worktree"})
+        return True, worktree_path, None  # Iteration succeeded, but couldn't prep for next
 
-    return True
+    return True, worktree_path, new_branch
 
 
-def _create_pr_to_main_branch(
-    agent: Agent, worktree_path: Path, branch: str, iteration: int
+def _create_pr_to_main(
+    agent: Agent, worktree_path: Path, branch: str, iteration: int, base_branch: str
 ) -> str | None:
-    """Push branch and create PR targeting main_branch."""
+    """Push branch and create PR targeting base branch (usually main)."""
     result = subprocess.run(
         ["git", "push", "-u", "origin", branch],
         cwd=worktree_path,
@@ -678,7 +692,7 @@ def _create_pr_to_main_branch(
         "--body",
         body,
         "--base",
-        agent.main_branch,
+        base_branch,
     ]
     result = subprocess.run(cmd, cwd=worktree_path, capture_output=True, text=True)
 
@@ -687,10 +701,10 @@ def _create_pr_to_main_branch(
     return None
 
 
-def _auto_merge_pr(worktree_path: Path) -> bool:
-    """Auto-merge the current PR."""
+def _enable_auto_merge(worktree_path: Path) -> bool:
+    """Enable auto-merge on the current PR (squash when CI passes)."""
     result = subprocess.run(
-        ["gh", "pr", "merge", "--squash", "--delete-branch"],
+        ["gh", "pr", "merge", "--squash", "--auto"],
         cwd=worktree_path,
         capture_output=True,
         text=True,
@@ -698,79 +712,3 @@ def _auto_merge_pr(worktree_path: Path) -> bool:
     return result.returncode == 0
 
 
-def _land_to_main(agent: Agent) -> str | None:
-    """Create or update PR from main_branch to main, enable auto-merge."""
-    repo = agent.repo
-
-    subprocess.run(["git", "push", "origin", agent.main_branch], cwd=repo, capture_output=True)
-
-    result = subprocess.run(
-        [
-            "gh",
-            "pr",
-            "list",
-            "--head",
-            agent.main_branch,
-            "--base",
-            "main",
-            "--json",
-            "number,url",
-            "--state",
-            "open",
-        ],
-        cwd=repo,
-        capture_output=True,
-        text=True,
-    )
-    existing = json.loads(result.stdout) if result.returncode == 0 and result.stdout.strip() else []
-
-    if existing:
-        pr_number = existing[0]["number"]
-        subprocess.run(
-            ["gh", "pr", "merge", str(pr_number), "--squash", "--auto"],
-            cwd=repo,
-            capture_output=True,
-        )
-        return existing[0]["url"]
-
-    result = subprocess.run(
-        [
-            "gh",
-            "pr",
-            "create",
-            "--base",
-            "main",
-            "--head",
-            agent.main_branch,
-            "--title",
-            f"[{agent.area_slug}] Land accumulated work",
-            "--body",
-            f"Auto-land from agent: {agent.area_display} [{agent.voice_display}] "
-            f"(flow: {agent.flow})",
-        ],
-        cwd=repo,
-        capture_output=True,
-        text=True,
-    )
-    if result.returncode != 0:
-        return None
-
-    pr_url = result.stdout.strip()
-
-    subprocess.run(["gh", "pr", "merge", "--squash", "--auto"], cwd=repo, capture_output=True)
-
-    return pr_url
-
-
-def _cleanup_worktree(repo: Path, worktree_path: Path, branch: str) -> None:
-    """Remove worktree and delete branch."""
-    try:
-        remove_worktree(repo, branch)
-    except Exception:
-        pass
-
-    subprocess.run(
-        ["git", "push", "origin", "--delete", branch],
-        cwd=repo,
-        capture_output=True,
-    )

--- a/src/loopflow/lfd/execution/worker.py
+++ b/src/loopflow/lfd/execution/worker.py
@@ -18,6 +18,7 @@ from loopflow.lfd.agent import (
     update_agent_iteration,
     update_agent_pid,
     update_agent_status,
+    update_agent_worktree_branch,
 )
 from loopflow.lfd.daemon.client import notify_event
 from loopflow.lfd.execution.runner import run_iteration
@@ -156,7 +157,7 @@ def run_agent_iterations(agent: Agent) -> None:
             time.sleep(MANAGER_POLL_INTERVAL)
 
         try:
-            success = _run_with_retry(agent, iteration, run_id)
+            success, worktree_path, new_branch = _run_with_retry(agent, iteration, run_id)
             if success:
                 worker_log.info(f"[{short_id}] iteration {iteration} completed successfully")
                 # Reset failures on success
@@ -167,6 +168,14 @@ def run_agent_iterations(agent: Agent) -> None:
 
                 update_agent_iteration(agent.id, iteration)
                 agent.iteration = iteration
+
+                # Update worktree and branch
+                if worktree_path:
+                    update_agent_worktree_branch(agent.id, worktree_path, new_branch)
+                    agent.worktree = worktree_path
+                    agent.branch = new_branch
+                    if new_branch:
+                        worker_log.info(f"[{short_id}] moved to branch {new_branch}")
             else:
                 # Increment failures
                 consecutive_failures += 1
@@ -212,17 +221,22 @@ def run_agent_iterations(agent: Agent) -> None:
     update_agent_pid(agent.id, None)
 
 
-def _run_with_retry(agent: Agent, iteration: int, run_id: str) -> bool:
-    """Run iteration with retry and backoff."""
+def _run_with_retry(
+    agent: Agent, iteration: int, run_id: str
+) -> tuple[bool, Path | None, str | None]:
+    """Run iteration with retry and backoff.
+
+    Returns (success, worktree_path, new_branch).
+    """
     short_id = agent.short_id()
     last_error = None
 
     for attempt in range(MAX_RETRIES):
         try:
             worker_log.debug(f"[{short_id}] attempt {attempt + 1}/{MAX_RETRIES}")
-            success = run_iteration(agent, iteration, run_id)
+            success, worktree_path, new_branch = run_iteration(agent, iteration, run_id)
             if success:
-                return True
+                return True, worktree_path, new_branch
 
             # run_iteration returned False (failure without exception)
             if attempt < MAX_RETRIES - 1:
@@ -243,7 +257,7 @@ def _run_with_retry(agent: Agent, iteration: int, run_id: str) -> bool:
                 time.sleep(RETRY_BACKOFF_SECONDS)
             else:
                 worker_log.error(f"[{short_id}] all {MAX_RETRIES} attempts failed")
-                return False
+                return False, None, None
 
         except Exception as e:
             last_error = e
@@ -272,7 +286,7 @@ def _run_with_retry(agent: Agent, iteration: int, run_id: str) -> bool:
     # All retries exhausted
     if last_error:
         raise last_error
-    return False
+    return False, None, None
 
 
 def main() -> None:

--- a/src/loopflow/lfd/execution/worker.py
+++ b/src/loopflow/lfd/execution/worker.py
@@ -16,6 +16,7 @@ from loopflow.lfd.agent import (
     get_agent,
     update_agent_consecutive_failures,
     update_agent_iteration,
+    update_agent_pending_activations,
     update_agent_pid,
     update_agent_status,
     update_agent_worktree_branch,
@@ -23,7 +24,7 @@ from loopflow.lfd.agent import (
 from loopflow.lfd.daemon.client import notify_event
 from loopflow.lfd.execution.runner import run_iteration
 from loopflow.lfd.logging import worker_log
-from loopflow.lfd.models import Agent, AgentStatus
+from loopflow.lfd.models import Agent, AgentMode, AgentStatus
 
 SOCKET_PATH = Path.home() / ".lf" / "lfd.sock"
 MANAGER_POLL_INTERVAL = 30  # seconds between slot checks
@@ -176,6 +177,25 @@ def run_agent_iterations(agent: Agent) -> None:
                     agent.branch = new_branch
                     if new_branch:
                         worker_log.info(f"[{short_id}] moved to branch {new_branch}")
+
+                # Mode-specific continuation logic
+                if agent.mode == AgentMode.LOOP:
+                    # Loop mode: always continue
+                    pass
+                else:
+                    # Watch/Cron: check pending activations
+                    agent = get_agent(agent.id)
+                    if agent and agent.pending_activations > 0:
+                        update_agent_pending_activations(agent.id, agent.pending_activations - 1)
+                        worker_log.info(
+                            f"[{short_id}] processing queued activation "
+                            f"({agent.pending_activations - 1} remaining)"
+                        )
+                    else:
+                        # No pending activations, go IDLE
+                        worker_log.info(f"[{short_id}] no pending activations, going idle")
+                        update_agent_status(agent.id, AgentStatus.IDLE)
+                        break
             else:
                 # Increment failures
                 consecutive_failures += 1

--- a/src/loopflow/lfd/migrations/README.md
+++ b/src/loopflow/lfd/migrations/README.md
@@ -5,18 +5,32 @@ All schema changes go through migrations. The baseline contains the current sche
 ## Adding a Migration
 
 1. Create `m_YYYY_MM_DD_description.py`
-2. Define `VERSION` (ISO timestamp), `DESCRIPTION`, and `apply(conn)`
+2. Define `VERSION` (ISO timestamp after baseline), `DESCRIPTION`, and `apply(conn)`
 3. Make it idempotent—check before modifying
+4. **Register in `registry.py`**—migrations won't run unless registered
 
 ```python
-VERSION = "2025-01-23T00:00:00"
+# m_2026_01_23_add_foo.py
+VERSION = "2026-01-23T12:00:00Z"
 DESCRIPTION = "add foo column to bars"
 
 def apply(conn):
-    cols = {r["name"] for r in conn.execute("PRAGMA table_info(bars)")}
+    cols = {r[1] for r in conn.execute("PRAGMA table_info(bars)")}
     if "foo" not in cols:
         conn.execute("ALTER TABLE bars ADD COLUMN foo TEXT")
 ```
+
+```python
+# registry.py
+from loopflow.lfd.migrations import baseline, m_2026_01_23_add_foo
+
+MIGRATIONS = [
+    Migration(baseline.SCHEMA_VERSION, baseline.DESCRIPTION, baseline.apply),
+    Migration(m_2026_01_23_add_foo.VERSION, m_2026_01_23_add_foo.DESCRIPTION, m_2026_01_23_add_foo.apply),
+]
+```
+
+**Important:** Migration `VERSION` must sort after `baseline.SCHEMA_VERSION` (use ISO timestamps with Z suffix).
 
 ## Consolidating Migrations
 
@@ -40,6 +54,8 @@ The version uses **git commit timestamp + SHA** (`2026-01-23T16:39:43Z_abc1234`)
 ## Rules
 
 - **All schema changes go through migrations.** Never ALTER tables in runtime code.
+- **Never modify baseline.py directly.** New columns = new migration. Baseline only changes during consolidation.
 - **Make migrations idempotent.** Check if the change is needed before applying.
 - **One migration per change.** Don't modify existing migration files.
+- **Register all migrations.** Unregistered migrations won't run.
 - **Migrations are one-way.** No rollback support—branch switching may require `rm ~/.lf/lfd.db`.

--- a/src/loopflow/lfd/migrations/m_2025_01_23_zz_agent_worktree.py
+++ b/src/loopflow/lfd/migrations/m_2025_01_23_zz_agent_worktree.py
@@ -6,7 +6,7 @@ Agents maintain a single persistent worktree, cycling through branches via `next
 
 import sqlite3
 
-VERSION = "2025-01-23T05:00:00"
+VERSION = "2026-01-23T17:00:00Z"
 DESCRIPTION = "Add worktree and branch to agents"
 
 

--- a/src/loopflow/lfd/migrations/m_2025_01_23_zz_agent_worktree.py
+++ b/src/loopflow/lfd/migrations/m_2025_01_23_zz_agent_worktree.py
@@ -1,0 +1,21 @@
+"""
+Add worktree and branch columns to agents table.
+
+Agents maintain a single persistent worktree, cycling through branches via `next`.
+"""
+
+import sqlite3
+
+VERSION = "2025-01-23T05:00:00"
+DESCRIPTION = "Add worktree and branch to agents"
+
+
+def apply(conn: sqlite3.Connection) -> None:
+    cursor = conn.execute("PRAGMA table_info(agents)")
+    columns = {row[1] for row in cursor.fetchall()}
+
+    if "worktree" not in columns:
+        conn.execute("ALTER TABLE agents ADD COLUMN worktree TEXT")
+
+    if "branch" not in columns:
+        conn.execute("ALTER TABLE agents ADD COLUMN branch TEXT")

--- a/src/loopflow/lfd/migrations/m_2026_01_23_activation_queue.py
+++ b/src/loopflow/lfd/migrations/m_2026_01_23_activation_queue.py
@@ -1,0 +1,26 @@
+"""Add activation queue columns to agents table.
+
+Agents can queue activations when busy (RUNNING/WAITING).
+- pending_activations: count of queued activations
+- buffer_mode: "combine" (default) or "queue"
+"""
+
+import sqlite3
+
+VERSION = "2026-01-23T20:45:00Z"
+DESCRIPTION = "Add activation queue to agents"
+
+
+def apply(conn: sqlite3.Connection) -> None:
+    cursor = conn.execute("PRAGMA table_info(agents)")
+    columns = {row[1] for row in cursor.fetchall()}
+
+    if "pending_activations" not in columns:
+        conn.execute(
+            "ALTER TABLE agents ADD COLUMN pending_activations INTEGER NOT NULL DEFAULT 0"
+        )
+
+    if "buffer_mode" not in columns:
+        conn.execute(
+            "ALTER TABLE agents ADD COLUMN buffer_mode TEXT NOT NULL DEFAULT 'combine'"
+        )

--- a/src/loopflow/lfd/migrations/m_2026_01_23_activation_queue.py
+++ b/src/loopflow/lfd/migrations/m_2026_01_23_activation_queue.py
@@ -16,11 +16,7 @@ def apply(conn: sqlite3.Connection) -> None:
     columns = {row[1] for row in cursor.fetchall()}
 
     if "pending_activations" not in columns:
-        conn.execute(
-            "ALTER TABLE agents ADD COLUMN pending_activations INTEGER NOT NULL DEFAULT 0"
-        )
+        conn.execute("ALTER TABLE agents ADD COLUMN pending_activations INTEGER NOT NULL DEFAULT 0")
 
     if "buffer_mode" not in columns:
-        conn.execute(
-            "ALTER TABLE agents ADD COLUMN buffer_mode TEXT NOT NULL DEFAULT 'combine'"
-        )
+        conn.execute("ALTER TABLE agents ADD COLUMN buffer_mode TEXT NOT NULL DEFAULT 'combine'")

--- a/src/loopflow/lfd/migrations/registry.py
+++ b/src/loopflow/lfd/migrations/registry.py
@@ -4,7 +4,11 @@ import sqlite3
 from dataclasses import dataclass
 from typing import Callable
 
-from loopflow.lfd.migrations import baseline
+from loopflow.lfd.migrations import (
+    baseline,
+    m_2025_01_23_zz_agent_worktree,
+    m_2026_01_23_activation_queue,
+)
 
 
 @dataclass
@@ -16,4 +20,14 @@ class Migration:
 
 MIGRATIONS = [
     Migration(baseline.SCHEMA_VERSION, baseline.DESCRIPTION, baseline.apply),
+    Migration(
+        m_2025_01_23_zz_agent_worktree.VERSION,
+        m_2025_01_23_zz_agent_worktree.DESCRIPTION,
+        m_2025_01_23_zz_agent_worktree.apply,
+    ),
+    Migration(
+        m_2026_01_23_activation_queue.VERSION,
+        m_2026_01_23_activation_queue.DESCRIPTION,
+        m_2026_01_23_activation_queue.apply,
+    ),
 ]

--- a/src/loopflow/lfd/models.py
+++ b/src/loopflow/lfd/models.py
@@ -87,6 +87,10 @@ class Agent(LfdModel):
     # Circuit breaker
     consecutive_failures: int = 0
 
+    # Activation queue
+    pending_activations: int = 0
+    buffer_mode: str = "combine"  # "combine" (default) or "queue"
+
     @field_validator("voice", mode="before")
     @classmethod
     def normalize_voice(cls, v):
@@ -163,6 +167,8 @@ def agent_from_row(row: dict) -> Agent:
         cron=row.get("cron"),
         last_main_sha=row.get("last_main_sha"),
         consecutive_failures=row.get("consecutive_failures", 0),
+        pending_activations=row.get("pending_activations", 0),
+        buffer_mode=row.get("buffer_mode", "combine"),
     )
 
 

--- a/src/loopflow/lfd/models.py
+++ b/src/loopflow/lfd/models.py
@@ -70,7 +70,9 @@ class Agent(LfdModel):
     status: AgentStatus = AgentStatus.IDLE
     iteration: int = 0
 
-    main_branch: str = ""
+    main_branch: str = ""  # deprecated, use branch
+    worktree: Path | None = None  # persistent worktree location
+    branch: str | None = None  # current branch name
     pr_limit: int = Field(default=5, ge=1)
     merge_mode: MergeMode = MergeMode.PR
 
@@ -138,6 +140,9 @@ def agent_from_row(row: dict) -> Agent:
     else:
         mode = AgentMode.LOOP
 
+    worktree_str = row.get("worktree")
+    worktree = Path(worktree_str) if worktree_str else None
+
     return Agent(
         id=row["id"],
         repo=Path(row["repo"]),
@@ -148,6 +153,8 @@ def agent_from_row(row: dict) -> Agent:
         status=AgentStatus(row["status"]),
         iteration=row.get("iteration", 0),
         main_branch=row.get("main_branch", ""),
+        worktree=worktree,
+        branch=row.get("branch"),
         pr_limit=row.get("pr_limit", 5),
         merge_mode=MergeMode(merge_mode_str),
         pid=row.get("pid"),

--- a/src/loopflow/lfops/next.py
+++ b/src/loopflow/lfops/next.py
@@ -1,4 +1,4 @@
-"""Next command: land current PR, create fresh worktree in same space."""
+"""Next command: land current PR, move worktree to new branch."""
 
 import json
 import subprocess
@@ -10,8 +10,7 @@ import typer
 from loopflow.lf.context import find_worktree_root
 from loopflow.lf.git import find_main_repo, get_current_branch
 from loopflow.lf.naming import generate_next_branch, parse_branch_base
-from loopflow.lf.worktrees import get_path
-from loopflow.lfops._helpers import get_default_branch, remove_worktree
+from loopflow.lfops._helpers import get_default_branch
 from loopflow.lfops.shell import write_directive
 
 
@@ -102,6 +101,46 @@ def _open_terminal(path: Path) -> None:
     subprocess.run(["open", f"warp://action/new_window?path={path}"])
 
 
+def move_worktree(
+    main_repo: Path,
+    worktree_path: Path,
+    new_branch: str,
+    base_branch: str,
+) -> bool:
+    """Move a worktree to a new branch by removing and recreating at same path.
+
+    Returns True if successful.
+    """
+    # Remove current worktree
+    result = subprocess.run(
+        ["git", "worktree", "remove", "--force", str(worktree_path)],
+        cwd=main_repo,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        return False
+
+    # Create new worktree at the same path with new branch
+    result = subprocess.run(
+        ["git", "worktree", "add", "-b", new_branch, str(worktree_path), f"origin/{base_branch}"],
+        cwd=main_repo,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        return False
+
+    # Push to create remote branch with tracking
+    subprocess.run(
+        ["git", "push", "-u", "origin", new_branch],
+        cwd=worktree_path,
+        capture_output=True,
+    )
+
+    return True
+
+
 def next_worktree(
     repo_root: Path,
     branch: str,
@@ -109,9 +148,10 @@ def next_worktree(
     open_terminal: bool = True,
     create_pr: bool = False,
 ) -> Path | None:
-    """Land current branch, create new worktree with magical-musical suffix.
+    """Land current branch, move worktree to new branch with magical-musical suffix.
 
-    Returns path to new worktree, or None if failed.
+    Removes the current worktree and recreates it at the same path with a new branch.
+    Returns the worktree path (unchanged), or None if failed.
     """
     main_repo = find_main_repo(repo_root) or repo_root
     base_branch = get_default_branch(main_repo)
@@ -148,61 +188,29 @@ def next_worktree(
         typer.echo("Warning: Could not enable auto-merge", err=True)
 
     # Wait for merge if blocking
-    merged = False
     if block:
-        merged = _wait_for_merge(repo_root, pr_number)
+        _wait_for_merge(repo_root, pr_number)
 
     # Generate new branch name
     base_name = parse_branch_base(branch)
     new_branch = generate_next_branch(base_name, main_repo)
 
-    # Create new worktree
-    typer.echo(f"Creating worktree {new_branch}...")
+    # Move worktree to new branch (remove + create at same path)
+    typer.echo(f"Moving worktree to {new_branch}...")
 
-    # Use the short name (just the magical-musical suffix) for worktree directory
-    # Extract just the suffix part after the base name
-    suffix = new_branch[len(base_name) + 1 :]  # +1 for the hyphen
-    worktree_short_name = f"{base_name.split('.')[-1]}-{suffix}"
-
-    # Create worktree with git directly since we need specific branch name
-    worktree_path = get_path(main_repo, worktree_short_name)
-    result = subprocess.run(
-        ["git", "worktree", "add", "-b", new_branch, str(worktree_path), f"origin/{base_branch}"],
-        cwd=main_repo,
-        capture_output=True,
-        text=True,
-    )
-    if result.returncode != 0:
-        typer.echo(f"Error creating worktree: {result.stderr}", err=True)
+    if not move_worktree(main_repo, repo_root, new_branch, base_branch):
+        typer.echo("Error: Failed to move worktree", err=True)
         return None
 
-    # Push to create remote branch with tracking
-    subprocess.run(
-        ["git", "push", "-u", "origin", new_branch],
-        cwd=worktree_path,
-        capture_output=True,
-    )
-
-    # Remove old worktree if merge completed
-    if merged and repo_root != main_repo:
-        typer.echo(f"Removing worktree {branch}...")
-        try:
-            remove_worktree(main_repo, branch, repo_root, base_branch)
-        except Exception:
-            typer.echo(
-                "Warning: Could not remove old worktree. Run 'lfops wt prune' later.",
-                err=True,
-            )
-
-    # Open terminal in new worktree
+    # Open terminal in worktree
     if open_terminal:
         typer.echo("Opening terminal...")
-        _open_terminal(worktree_path)
+        _open_terminal(repo_root)
 
-    # Write shell directive to cd to new worktree
-    write_directive(f"cd {worktree_path}")
+    # Write shell directive to cd to worktree (in case shell lost track)
+    write_directive(f"cd {repo_root}")
 
-    return worktree_path
+    return repo_root
 
 
 def register_commands(app: typer.Typer) -> None:
@@ -210,19 +218,19 @@ def register_commands(app: typer.Typer) -> None:
 
     @app.command("next")
     def next_cmd(
-        block: bool = typer.Option(False, "--block", help="Wait for merge before creating wt"),
+        block: bool = typer.Option(False, "--block", help="Wait for merge before moving"),
         no_open: bool = typer.Option(False, "--no-open", help="Don't open terminal"),
         create_pr: bool = typer.Option(False, "-c", "--create-pr", help="Create PR if none exists"),
     ) -> None:
-        """Land current PR, create fresh worktree in same space.
+        """Land current PR, move worktree to new branch.
 
-        Enables auto-merge on the PR, creates a new worktree with a magical-musical
-        suffix (e.g., aurora-melody). Use --block to wait for merge and clean up
-        the old worktree.
+        Enables auto-merge on the PR, then moves the worktree to a new branch
+        with a magical-musical suffix (e.g., aurora-melody). The worktree stays
+        at the same path but points to the new branch.
 
         Example:
-            lfops next                 # land PR, create next worktree
-            lfops next --block         # wait for merge, then create worktree
+            lfops next                 # land PR, move to next branch
+            lfops next --block         # wait for merge, then move
             lfops next --create-pr     # create PR if none exists, then next
         """
         repo_root = find_worktree_root()

--- a/tests/test_lfd.py
+++ b/tests/test_lfd.py
@@ -5,12 +5,14 @@ from datetime import datetime, timedelta
 from pathlib import Path
 
 from loopflow.lfd.agent import (
+    MAX_PENDING_ACTIVATIONS,
     delete_agent,
     get_agent,
     get_agent_by_area_repo,
     list_agents,
     save_agent,
     update_agent_iteration,
+    update_agent_pending_activations,
     update_agent_pid,
     update_agent_status,
 )
@@ -1275,30 +1277,6 @@ def test_schedule_first_run_beyond_grace():
     assert result is False
 
 
-# Iteration branch prefix tests
-
-
-def test_iteration_branch_prefix_strips_main_suffix():
-    """_iteration_branch_prefix strips -main suffix."""
-    from loopflow.lfd.execution.runner import _iteration_branch_prefix
-
-    assert _iteration_branch_prefix("product-engineer-main") == "product-engineer"
-    assert _iteration_branch_prefix("product-engineer-1-main") == "product-engineer-1"
-    assert _iteration_branch_prefix("test-main") == "test"
-    # New format with random words
-    branch = "product-engineer-swift-river-main"
-    assert _iteration_branch_prefix(branch) == "product-engineer-swift-river"
-    assert _iteration_branch_prefix("test-api-calm-brook-main") == "test-api-calm-brook"
-
-
-def test_iteration_branch_prefix_without_suffix():
-    """_iteration_branch_prefix handles edge case without -main suffix."""
-    from loopflow.lfd.execution.runner import _iteration_branch_prefix
-
-    # Shouldn't happen in practice, but function handles it gracefully
-    assert _iteration_branch_prefix("product-engineer") == "product-engineer"
-
-
 # Random word generation tests
 
 
@@ -2077,3 +2055,82 @@ def test_agent_model_with_consecutive_failures():
     """Agent model accepts consecutive_failures parameter."""
     agent = _make_agent(consecutive_failures=10)
     assert agent.consecutive_failures == 10
+
+
+# Activation queue tests
+
+
+def test_agent_model_activation_queue_defaults():
+    """Agent model has activation queue defaults."""
+    agent = _make_agent()
+    assert agent.pending_activations == 0
+    assert agent.buffer_mode == "combine"
+
+
+def test_agent_model_with_activation_queue():
+    """Agent model accepts activation queue parameters."""
+    agent = _make_agent(pending_activations=3, buffer_mode="queue")
+    assert agent.pending_activations == 3
+    assert agent.buffer_mode == "queue"
+
+
+def test_update_agent_pending_activations():
+    """Can update agent's pending activations."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = Path(tmpdir) / "test.db"
+
+        agent = _make_agent(id="agent-pa", pending_activations=0)
+        save_agent(agent, db_path)
+
+        # Increment pending
+        updated = update_agent_pending_activations("agent-pa", 3, db_path)
+        assert updated is True
+
+        loaded = get_agent("agent-pa", db_path)
+        assert loaded.pending_activations == 3
+
+        # Decrement pending
+        updated = update_agent_pending_activations("agent-pa", 2, db_path)
+        assert updated is True
+
+        loaded = get_agent("agent-pa", db_path)
+        assert loaded.pending_activations == 2
+
+
+def test_agent_buffer_mode_save_load():
+    """Buffer mode persists through save/load cycle."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = Path(tmpdir) / "test.db"
+
+        agent = _make_agent(id="agent-bm", buffer_mode="queue")
+        save_agent(agent, db_path)
+
+        loaded = get_agent("agent-bm", db_path)
+        assert loaded.buffer_mode == "queue"
+
+
+def test_max_pending_activations_constant():
+    """MAX_PENDING_ACTIVATIONS is defined."""
+    assert MAX_PENDING_ACTIVATIONS == 10
+
+
+def test_migrations_cover_activation_queue():
+    """Migrations include activation queue columns."""
+    from loopflow.lfd.migrations.registry import MIGRATIONS
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        import sqlite3
+
+        db_path = Path(tmpdir) / "test.db"
+        conn = sqlite3.connect(db_path)
+
+        # Apply all migrations
+        for migration in MIGRATIONS:
+            migration.apply(conn)
+
+        cursor = conn.execute("PRAGMA table_info(agents)")
+        columns = {row[1] for row in cursor.fetchall()}
+        conn.close()
+
+        assert "pending_activations" in columns
+        assert "buffer_mode" in columns

--- a/tests/test_next.py
+++ b/tests/test_next.py
@@ -3,20 +3,13 @@
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-import pytest
-
 from loopflow.lfops.next import (
     _enable_auto_merge,
     _get_pr_number,
     _get_pr_state,
+    move_worktree,
     next_worktree,
 )
-
-
-@pytest.fixture
-def mock_repo(tmp_path):
-    """Create a mock repo directory."""
-    return tmp_path / "repo"
 
 
 def test_get_pr_number_returns_number():
@@ -94,8 +87,36 @@ def test_next_fails_without_pr():
     assert result is None
 
 
-def test_next_creates_worktree_with_suffix(tmp_path):
-    """Creates new worktree with magical-musical suffix."""
+def test_move_worktree_success():
+    """move_worktree removes and recreates at same path."""
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(returncode=0)
+        result = move_worktree(
+            Path("/main"),
+            Path("/main/worktree"),
+            "new-branch",
+            "main",
+        )
+    assert result is True
+    # Should call: remove, add, push
+    assert mock_run.call_count == 3
+
+
+def test_move_worktree_fails_on_remove():
+    """move_worktree returns False if remove fails."""
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(returncode=1)
+        result = move_worktree(
+            Path("/main"),
+            Path("/main/worktree"),
+            "new-branch",
+            "main",
+        )
+    assert result is False
+
+
+def test_next_moves_worktree_in_place(tmp_path):
+    """next_worktree returns same path (moves in place)."""
     repo = tmp_path / "repo"
     repo.mkdir()
 
@@ -103,26 +124,25 @@ def test_next_creates_worktree_with_suffix(tmp_path):
         with patch("loopflow.lfops.next.get_default_branch", return_value="main"):
             with patch("loopflow.lfops.next._get_pr_number", return_value=42):
                 with patch("loopflow.lfops.next._enable_auto_merge", return_value=True):
-                    with patch("loopflow.lfops.next._wait_for_merge", return_value=False):
+                    with patch(
+                        "loopflow.lfops.next.generate_next_branch",
+                        return_value="jack.auth.20260123_1112-aurora-melody",
+                    ):
                         with patch(
-                            "loopflow.lfops.next.generate_next_branch",
-                            return_value="jack.auth.20260123_1112-aurora-melody",
+                            "loopflow.lfops.next.parse_branch_base",
+                            return_value="jack.auth.20260123_1112",
                         ):
                             with patch(
-                                "loopflow.lfops.next.parse_branch_base",
-                                return_value="jack.auth.20260123_1112",
+                                "loopflow.lfops.next.move_worktree", return_value=True
                             ):
-                                with patch("subprocess.run") as mock_run:
-                                    # git worktree add succeeds
-                                    mock_run.return_value = MagicMock(returncode=0)
-                                    with patch("loopflow.lfops.next.write_directive"):
-                                        result = next_worktree(
-                                            repo,
-                                            "jack.auth.20260123_1112",
-                                            block=False,
-                                            open_terminal=False,
-                                        )
+                                with patch("loopflow.lfops.next.write_directive"):
+                                    result = next_worktree(
+                                        repo,
+                                        "jack.auth.20260123_1112",
+                                        block=False,
+                                        open_terminal=False,
+                                    )
 
     assert result is not None
-    # Worktree path should be sibling to repo
-    assert result.parent == repo.parent
+    # Returns same path - worktree moved in place
+    assert result == repo

--- a/tests/test_next.py
+++ b/tests/test_next.py
@@ -132,9 +132,7 @@ def test_next_moves_worktree_in_place(tmp_path):
                             "loopflow.lfops.next.parse_branch_base",
                             return_value="jack.auth.20260123_1112",
                         ):
-                            with patch(
-                                "loopflow.lfops.next.move_worktree", return_value=True
-                            ):
+                            with patch("loopflow.lfops.next.move_worktree", return_value=True):
                                 with patch("loopflow.lfops.next.write_directive"):
                                     result = next_worktree(
                                         repo,


### PR DESCRIPTION
## Usage

```bash
lfd loop ship src/        # agent reuses same worktree path
lfd status                 # shows worktree + branch columns
lfops next                 # moves worktree in place to new branch
```

## Summary

Agents now maintain a single persistent worktree rather than creating and destroying one per iteration. When an iteration completes, the worktree is "moved" to a new branch by removing and recreating it at the same path. This reduces churn and keeps the working directory stable.

The `lfops next` command now also moves in place rather than creating a sibling worktree, matching the agent behavior.

## Changes

- Add `worktree` and `branch` columns to agents table
- Extract `move_worktree()` function for reuse between runner and `lfops next`
- PRs target base branch directly with `--auto` merge instead of intermediate land step
- Remove `_land_to_main` and `_cleanup_worktree` functions (no longer needed)
- Update `run_iteration` to return worktree path and new branch for persistence