### PR TITLE
publish: clean dist, improve release notes, refresh PR before landing

### DIFF
--- a/src/loopflow/lf/builtins/release_notes.txt
+++ b/src/loopflow/lf/builtins/release_notes.txt
@@ -1,25 +1,41 @@
 Generate release notes for a version bump.
 
-You're writing for someone scanning PyPI or GitHub releases to decide if they should upgrade. Outcome over process. What's new, not how it was built.
+You're writing for someone scanning PyPI or GitHub releases to decide if they should upgrade.
 
 Do not ask questions. If anything is unclear, make the best assumption and proceed.
+
+## Philosophy
+
+Translate implementation into experience. A series of small commits might add up to "the daemon is now reliable" or "Concerto feels snappier." Find that thread.
+
+Ask: What can users do now that they couldn't before? What's easier? What's fixed? What feels different?
+
+## For minor/major releases
+
+When summarizing many commits, the commit messages alone won't tell the full story. Use `git diff` and read key files to understand actual impact. Look for:
+- New commands or CLI flags users can run
+- Changed behavior or defaults they'll notice
+- Removed friction or fixed pain points
+- New workflows that are now possible
 
 ## Output format
 
 Return a structured response with:
-- **summary**: 2-3 sentences explaining what this release adds or fixes
-- **changes**: bullet list of notable changes (3-8 items)
+- **summary**: 2-3 sentences capturing the feeling of this release. What's the headline? For minor releases, paint the bigger picture of how the tool has evolved.
+- **changes**: bullet list of notable changes (5-10 items for minor releases, 3-8 for patches)
 
 ## Style
 
-Lead with what users get, not what changed internally.
+Lead with outcomes, not mechanisms.
 
 Good:
-- "Add `lfops publish` command for automated PyPI releases"
-- "Fix session tracking when daemon isn't running"
+- "Agents now persist their worktrees across iterations—no more lost context between runs"
+- "New `lfops cycle` command: land a PR and immediately continue in a fresh worktree"
+- "The daemon auto-recovers from database schema changes instead of failing silently"
 
 Bad:
+- "Add worktree persistence to agent runner"
 - "Refactored publish.py to use new pattern"
-- "Updated llm_http.py with release notes generation"
+- "Updated schema migration logic"
 
-Skip internal refactors unless they affect behavior. Focus on user-visible changes.
+Skip internal refactors unless they affect what users experience.

--- a/src/loopflow/lf/messages.py
+++ b/src/loopflow/lf/messages.py
@@ -219,10 +219,15 @@ def generate_pr_message_from_diff(repo_root: Path, diff: str | None) -> CommitMe
     return _generate_message(repo_root, prompt, "pr message")
 
 
-def _get_commits_since_tag(repo_root: Path, tag: str) -> str | None:
-    """Get commit log since a tag."""
+def _get_commits_since_tag(repo_root: Path, tag: str, full: bool = False) -> str | None:
+    """Get commit log since a tag. If full=True, include commit bodies."""
+    if full:
+        # Full messages: subject + body, separated by blank lines
+        fmt = "%s%n%b"
+    else:
+        fmt = "%s"
     result = subprocess.run(
-        ["git", "log", f"{tag}..HEAD", "--oneline"],
+        ["git", "log", f"{tag}..HEAD", f"--format={fmt}"],
         cwd=repo_root,
         capture_output=True,
         text=True,
@@ -236,8 +241,8 @@ def _get_base_tag_for_release(old_version: str, new_version: str) -> str:
     """Determine the base tag for release notes based on bump type.
 
     For patch bumps: use old_version (e.g., 0.6.5 → 0.6.6 uses v0.6.5)
-    For minor bumps: use first patch of old minor (e.g., 0.6.5 → 0.7.0 uses v0.6.1)
-    For major bumps: use first patch of old major (e.g., 0.6.5 → 1.0.0 uses v0.1.0)
+    For minor bumps: use first release of old minor (e.g., 0.6.11 → 0.7.0 uses v0.6.0)
+    For major bumps: use first release of old major (e.g., 0.6.5 → 1.0.0 uses v0.0.0)
     """
     old_parts = [int(x) for x in old_version.split(".")]
     new_parts = [int(x) for x in new_version.split(".")]
@@ -250,11 +255,11 @@ def _get_base_tag_for_release(old_version: str, new_version: str) -> str:
 
     # Major bump: summarize all changes since start of old major version
     if new_major > old_major:
-        return f"v{old_major}.1.0"
+        return f"v{old_major}.0.0"
 
     # Minor bump: summarize all changes since start of old minor version
     if new_minor > old_minor:
-        return f"v{old_major}.{old_minor}.1"
+        return f"v{old_major}.{old_minor}.0"
 
     # Patch bump: just changes since old version
     return f"v{old_version}"
@@ -278,13 +283,17 @@ def _parse_release_notes(output: str) -> ReleaseNotes:
 def generate_release_notes(repo_root: Path, old_version: str, new_version: str) -> ReleaseNotes:
     """Generate release notes from commits since last tag via CLI."""
     base_tag = _get_base_tag_for_release(old_version, new_version)
-    commits = _get_commits_since_tag(repo_root, base_tag)
+
+    # For minor/major releases, include full commit messages
+    is_minor_or_major = base_tag != f"v{old_version}"
+    commits = _get_commits_since_tag(repo_root, base_tag, full=is_minor_or_major)
     task_prompt = get_builtin_prompt("release_notes")
 
     parts = [f"Version bump: {old_version} → {new_version}"]
-    if base_tag != f"v{old_version}":
+    if is_minor_or_major:
         release_type = "major" if new_version.split(".")[0] > old_version.split(".")[0] else "minor"
         parts.append(f"This is a {release_type} release summarizing all changes since {base_tag}.")
+        parts.append("Use git diff and read files to understand the full impact of these changes.")
     if commits:
         parts.append(f"<commits>\n{commits}\n</commits>")
     parts.append(f"<task>\n{task_prompt}\n</task>")

--- a/src/loopflow/lfops/land.py
+++ b/src/loopflow/lfops/land.py
@@ -349,20 +349,16 @@ def _land_pr(strict: bool, worktree: str | None, create_pr: bool = False) -> Non
     else:
         pr_number = pr_data.get("number")
         base_branch = pr_data.get("baseRefName", "main").strip()
-        if create_pr:
-            # Regenerate and update PR title/body
-            typer.echo("Updating PR...")
-            message = generate_pr_message(repo_root)
-            title = message.title
-            body = message.body
-            subprocess.run(
-                ["gh", "pr", "edit", str(pr_number), "--title", title, "--body", body],
-                cwd=repo_root,
-                check=True,
-            )
-        else:
-            title = pr_data.get("title", "").strip()
-            body = pr_data.get("body", "").strip()
+        # Always regenerate PR title/body to reflect latest changes
+        typer.echo("Refreshing PR...")
+        message = generate_pr_message(repo_root)
+        title = message.title
+        body = message.body
+        subprocess.run(
+            ["gh", "pr", "edit", str(pr_number), "--title", title, "--body", body],
+            cwd=repo_root,
+            check=True,
+        )
 
     if not title:
         typer.echo("Error: PR has no title", err=True)

--- a/src/loopflow/lfops/next.py
+++ b/src/loopflow/lfops/next.py
@@ -9,6 +9,7 @@ import typer
 
 from loopflow.lf.context import find_worktree_root
 from loopflow.lf.git import find_main_repo, get_current_branch
+from loopflow.lf.messages import generate_pr_message
 from loopflow.lf.naming import generate_next_branch, parse_branch_base
 from loopflow.lf.worktrees import get_path
 from loopflow.lfops._helpers import get_default_branch, remove_worktree
@@ -42,20 +43,22 @@ def _get_pr_state(repo_root: Path, pr_number: int) -> str | None:
 
 
 def _enable_auto_merge(repo_root: Path, pr_number: int) -> bool:
-    """Enable auto-merge on a PR. Returns True if successful."""
-    # Get PR title for squash commit message
-    result = subprocess.run(
-        ["gh", "pr", "view", str(pr_number), "--json", "title,body"],
+    """Enable auto-merge on a PR. Returns True if successful.
+
+    Regenerates the PR title/body to reflect latest changes before merging.
+    """
+    # Regenerate PR message to reflect latest changes
+    typer.echo("Refreshing PR...")
+    message = generate_pr_message(repo_root)
+    title = message.title
+    body = message.body
+
+    # Update the PR
+    subprocess.run(
+        ["gh", "pr", "edit", str(pr_number), "--title", title, "--body", body],
         cwd=repo_root,
         capture_output=True,
-        text=True,
     )
-    if result.returncode != 0:
-        return False
-
-    pr_data = json.loads(result.stdout)
-    title = pr_data.get("title", "")
-    body = pr_data.get("body", "")
 
     merge_cmd = [
         "gh",

--- a/src/loopflow/publish.py
+++ b/src/loopflow/publish.py
@@ -203,6 +203,14 @@ def run_tests(repo_root: Path | None = None) -> tuple[bool, str]:
 def build_package(repo_root: Path | None = None) -> tuple[bool, str]:
     """Build package with uv. Returns (success, output)."""
     cwd = repo_root or Path.cwd()
+    dist_dir = cwd / "dist"
+
+    # Clean old artifacts (keep .gitignore)
+    if dist_dir.exists():
+        for f in dist_dir.iterdir():
+            if f.name != ".gitignore":
+                f.unlink()
+
     result = _run(["uv", "build"], cwd)
     success = result.returncode == 0
     output = result.stdout + result.stderr

--- a/tests/test_next.py
+++ b/tests/test_next.py
@@ -53,21 +53,28 @@ def test_get_pr_state_open():
 
 def test_enable_auto_merge_success():
     """Returns True on successful auto-merge enable."""
-    with patch("subprocess.run") as mock_run:
-        # First call gets PR info, second enables auto-merge
-        mock_run.side_effect = [
-            MagicMock(returncode=0, stdout='{"title": "My PR", "body": "Description"}'),
-            MagicMock(returncode=0),
-        ]
-        result = _enable_auto_merge(Path("/repo"), 42)
+    mock_message = MagicMock(title="My PR", body="Description")
+    with patch("loopflow.lfops.next.generate_pr_message", return_value=mock_message):
+        with patch("subprocess.run") as mock_run:
+            # First call edits PR, second enables auto-merge
+            mock_run.side_effect = [
+                MagicMock(returncode=0),  # gh pr edit
+                MagicMock(returncode=0),  # gh pr merge --auto
+            ]
+            result = _enable_auto_merge(Path("/repo"), 42)
     assert result is True
 
 
 def test_enable_auto_merge_failure():
     """Returns False when auto-merge fails."""
-    with patch("subprocess.run") as mock_run:
-        mock_run.return_value = MagicMock(returncode=1)
-        result = _enable_auto_merge(Path("/repo"), 42)
+    mock_message = MagicMock(title="My PR", body="Description")
+    with patch("loopflow.lfops.next.generate_pr_message", return_value=mock_message):
+        with patch("subprocess.run") as mock_run:
+            mock_run.side_effect = [
+                MagicMock(returncode=0),  # gh pr edit
+                MagicMock(returncode=1),  # gh pr merge --auto fails
+            ]
+            result = _enable_auto_merge(Path("/repo"), 42)
     assert result is False
 
 


### PR DESCRIPTION
## Try it

```bash
# Publish cleans old artifacts before build
lfops publish --dry-run

# Land always refreshes PR title/body
lfops land
lfops next
```

## Summary

Publishing now cleans the `dist/` directory before building to prevent stale artifacts. Release notes for minor/major versions include full commit bodies and instruct the LLM to use `git diff` for deeper understanding. Both `land` and `next` commands regenerate PR title/body before merging, ensuring the PR always reflects the latest changes.

## Changes

- Clean `dist/` before `uv build` to prevent publishing stale wheel/sdist files
- Include full commit messages (subject + body) for minor/major release notes
- Fix base tag calculation: minor bumps now use `.0` (e.g., v0.6.0) instead of `.1`
- Prompt LLM to read files and diffs for better release note quality
- Always refresh PR title/body before landing (not just when creating)
- `_enable_auto_merge` now regenerates PR message before merge