### PR TITLE
cp: remove automatic context trimming

### DIFF
--- a/src/loopflow/lfops/cp.py
+++ b/src/loopflow/lfops/cp.py
@@ -14,11 +14,7 @@ from loopflow.lf.context import (
     format_prompt,
     gather_prompt_components,
 )
-from loopflow.lf.output import (
-    copy_to_clipboard,
-    trim_components_if_needed,
-    warn_if_context_too_large,
-)
+from loopflow.lf.output import copy_to_clipboard, warn_if_context_too_large
 from loopflow.lf.tokens import analyze_components
 
 
@@ -91,8 +87,6 @@ def register_commands(app: typer.Typer) -> None:
         # Apply docs flag
         if not include_docs:
             components.docs = []
-
-        components = trim_components_if_needed(components)
 
         prompt = format_prompt(components)
         copy_to_clipboard(prompt)


### PR DESCRIPTION
## Try it

```bash
lf cp
```

The `cp` command no longer automatically trims context to fit token limits. Users now get the full assembled context in their clipboard, with a warning if it exceeds the safe limit.

## Why

Automatic trimming was silently dropping files, which made it hard to know what context the agent actually received. Better to let users see the full prompt and make their own decisions about what to include.