### PR TITLE
cp: remove automatic context trimming

### DIFF
--- a/src/loopflow/lfops/cp.py
+++ b/src/loopflow/lfops/cp.py
@@ -14,11 +14,7 @@ from loopflow.lf.context import (
     format_prompt,
     gather_prompt_components,
 )
-from loopflow.lf.output import (
-    copy_to_clipboard,
-    trim_components_if_needed,
-    warn_if_context_too_large,
-)
+from loopflow.lf.output import copy_to_clipboard, warn_if_context_too_large
 from loopflow.lf.tokens import analyze_components
 
 
@@ -91,8 +87,6 @@ def register_commands(app: typer.Typer) -> None:
         # Apply docs flag
         if not include_docs:
             components.docs = []
-
-        components = trim_components_if_needed(components)
 
         prompt = format_prompt(components)
         copy_to_clipboard(prompt)


### PR DESCRIPTION
## Usage

```bash
lf cp my-step
```

The `cp` command no longer automatically trims context to fit within token limits. Users now get the full prompt assembled, with a warning if it exceeds the safe limit.

## Summary

Automatic trimming was silently dropping context (files, docs) which could lead to incomplete prompts without the user realizing what was removed. The warning mechanism remains in place to alert users when context is too large, but the decision of what to include is now left to the user via explicit flags like `--no-diff-files` or `-x`.