### PR TITLE
roadmap: add rust port and enterprise infrastructure plans

### DIFF
--- a/roadmap/enterprise/00-overview.md
+++ b/roadmap/enterprise/00-overview.md
@@ -1,0 +1,30 @@
+# Enterprise Roadmap: Overview
+
+Identify infra and architectural changes needed for managed clusters that are **outside** the Rust port. Split work into pre‑Rust and post‑Rust phases.
+
+## Principles
+- Rust port covers **core engine and daemon** changes.
+- Enterprise roadmap covers **infra, deployment, security, and ops** that are independent of language.
+- If it benefits Python and Rust equally, it belongs here.
+
+## Phases
+### Pre‑Rust (can start now)
+- Containerization and runtime isolation
+- Authn/z and access control
+- Observability and audit logging
+- Configuration and secrets management
+
+### Post‑Rust (can be done later)
+- Cluster scheduling and multi-tenant quotas
+- Managed control plane features
+- Enterprise onboarding and compliance tooling
+
+## What stays in the Rust roadmap
+- Protocol + engine + daemon implementation
+- Core scheduling logic
+- Internal state model
+
+## Success criteria
+- Clear separation of responsibilities between Rust and enterprise tracks.
+- Every enterprise requirement mapped to a phase and owner.
+- Hosted `lfd` trial path defined for remote clients (desktop + mobile).

--- a/roadmap/enterprise/01-pre-rust-foundations.md
+++ b/roadmap/enterprise/01-pre-rust-foundations.md
@@ -1,0 +1,39 @@
+# Enterprise Roadmap: Pre‑Rust Foundations
+
+Work that should happen before the Rust port because it clarifies requirements and is language‑independent.
+
+## 1) OS portability policy
+**Goal:** Support Linux and macOS with identical behavior.
+- Define supported OS versions and filesystem assumptions.
+- Remove macOS-only assumptions in paths, process management, and file watchers.
+- Standardize environment variables and config discovery across OSes.
+
+## 2) Container runtime model
+**Goal:** Decide how runs are executed in managed clusters.
+- Define a container/job runner model (sidecar, job queue, or worker pool).
+- Document isolation boundaries (per-run, per-tenant, per-agent).
+- Establish resource limit defaults (CPU, memory, disk).
+
+## 3) Access control model
+**Goal:** Define authentication and authorization before protocol changes.
+- Identify user, team, and service identities.
+- Define project scoping rules and tenancy boundaries.
+- Decide on API key vs OIDC for early managed clusters.
+
+## 4) Observability requirements
+**Goal:** Make runs auditable and debuggable in production.
+- Structured logs with trace IDs across processes.
+- Metrics: run latency, error rate, queue depth, resource usage.
+- Retention and redaction policies.
+
+## 5) Secrets and config management
+**Goal:** Make secrets deployable and safe.
+- Define secret storage (env, file, secret manager).
+- Establish config layering (global, project, user, runtime overrides).
+
+## Deliverables
+- A written portability and runtime policy.
+- A containerized execution PoC.
+- A minimal access control spec.
+- An observability schema (log fields + metrics list).
+

--- a/roadmap/enterprise/02-containers-and-runtime.md
+++ b/roadmap/enterprise/02-containers-and-runtime.md
@@ -1,0 +1,22 @@
+# Enterprise Roadmap: Containers + Runtime Isolation
+
+Define how Loopflow runs agents in a managed environment.
+
+## Goal
+Establish a container-first execution model that works for Python or Rust engines.
+
+## Scope
+- Container image strategy for agents
+- Execution isolation (per run, per tenant)
+- Resource limits and scheduling
+
+## Decisions to make
+- Worker model: long-lived pool vs per-run job.
+- Storage: ephemeral vs persistent workspaces.
+- Image build: prebuilt vs user-provided.
+
+## Success criteria
+- A working containerized run path.
+- Resource caps enforced in practice.
+- Clear docs for user-provided images.
+

--- a/roadmap/enterprise/03-access-control.md
+++ b/roadmap/enterprise/03-access-control.md
@@ -1,0 +1,23 @@
+# Enterprise Roadmap: Access Control
+
+Define authentication, authorization, and tenancy boundaries.
+
+## Goal
+Establish a security model that works for managed clusters and enterprise deployments.
+
+## Scope
+- Identity types (user, service, agent)
+- Tenant and project scoping
+- Authn mechanisms (API keys, OIDC)
+- Authorization rules
+
+## Key decisions
+- Default authn for early adopters: API keys.
+- Enterprise authn: OIDC with SSO.
+- Authorization: role-based at tenant + project scopes.
+
+## Success criteria
+- All API calls scoped to a tenant + project.
+- Clear role definitions and least-privilege defaults.
+- Auditable access logs.
+

--- a/roadmap/enterprise/04-observability.md
+++ b/roadmap/enterprise/04-observability.md
@@ -1,0 +1,18 @@
+# Enterprise Roadmap: Observability + Audit
+
+Make the system diagnosable and compliant in production.
+
+## Goal
+Provide traceable, structured insight into all runs and system behavior.
+
+## Scope
+- Structured logging schema
+- Metrics and dashboards
+- Audit trail requirements
+- Data retention and redaction
+
+## Success criteria
+- Every run has a trace ID across components.
+- Logs and metrics make it possible to diagnose failures quickly.
+- Audit trails are queryable and exportable.
+

--- a/roadmap/enterprise/05-portability.md
+++ b/roadmap/enterprise/05-portability.md
@@ -1,0 +1,18 @@
+# Enterprise Roadmap: Full OS Portability
+
+Make Loopflow behavior consistent across macOS and Linux.
+
+## Goal
+Ensure identical behavior on supported OSes to enable managed clusters.
+
+## Scope
+- File watching semantics
+- Process and signal handling
+- Path and filesystem assumptions
+- Dependency footprints
+
+## Success criteria
+- A documented OS support matrix.
+- CI runs on both macOS and Linux.
+- No macOS-only assumptions in core flows.
+

--- a/roadmap/enterprise/06-post-rust-managed-clusters.md
+++ b/roadmap/enterprise/06-post-rust-managed-clusters.md
@@ -1,0 +1,18 @@
+# Enterprise Roadmap: Managed Clusters (Post‑Rust)
+
+Work that depends on the Rust protocol-first engine but is separate from the port itself.
+
+## Goal
+Enable multi-tenant managed clusters with quotas, scheduling policies, and enterprise operations.
+
+## Scope
+- Multi-tenant scheduling
+- Quotas and rate limiting
+- Resource pools per tenant
+- Cluster ops tooling
+
+## Success criteria
+- Tenants are isolated with clear quotas.
+- Ops can scale clusters horizontally with predictable behavior.
+- SLA metrics are measurable and enforceable.
+

--- a/roadmap/enterprise/07-deployment.md
+++ b/roadmap/enterprise/07-deployment.md
@@ -1,0 +1,18 @@
+# Enterprise Roadmap: Deployment + Ops
+
+Define production-grade deployment paths for managed environments.
+
+## Goal
+Enable reliable installs, upgrades, and rollback in enterprise settings.
+
+## Scope
+- Helm charts and manifests
+- Secrets integration
+- Upgrade/rollback playbooks
+- On-call runbooks
+
+## Success criteria
+- One-command dev cluster setup.
+- Documented upgrade + rollback procedures.
+- Clear operational ownership.
+

--- a/roadmap/enterprise/08-gates.md
+++ b/roadmap/enterprise/08-gates.md
@@ -1,0 +1,17 @@
+# Enterprise Roadmap: Gates + Readiness
+
+Define go/no‑go checks for managed cluster readiness.
+
+## Goal
+Create explicit gates that must be met before running enterprise clusters.
+
+## Gates
+1. **Portability gate**: Linux + macOS parity.
+2. **Isolation gate**: containerized execution with resource limits.
+3. **Access gate**: tenant‑scoped authn/z.
+4. **Observability gate**: trace IDs + audit logs.
+5. **Reliability gate**: restart behavior under fault injection.
+
+## Success criteria
+- Each gate has automated tests or operational checklists.
+

--- a/roadmap/rust/01-protocol.md
+++ b/roadmap/rust/01-protocol.md
@@ -1,0 +1,291 @@
+# Rust Roadmap: Protocol-First Engine (Stage 1)
+
+Define the stable API that all clients and services use to control Loopflow.
+
+## Goal
+Create a versioned, transport-agnostic protocol that supports local and remote control of Loopflow. This is the foundation for managed clusters, Concerto integration, and CLI clients.
+
+## Scope
+- Request/response schema and event stream
+- Versioning and compatibility rules
+- Authn/z and multi-tenant routing hooks
+- Error model and retry semantics
+
+## Non-goals
+- Implementing the server runtime
+- Migrating existing Python internals
+
+## Key decisions
+- **Transport:** gRPC over HTTP/2 for structured APIs; JSON over HTTP for simple tooling.
+- **Streaming:** server-side event stream for run progress.
+- **Versioning:** semantic protocol version with strict compatibility checks.
+- **Error model:** typed errors with retry hints and idempotency keys.
+
+## API surface (v1)
+### Runs
+- `CreateRun(flow_id, area, direction, params)`
+- `CancelRun(run_id)`
+- `GetRun(run_id)`
+- `ListRuns(filters)`
+
+### Flows
+- `StartFlow(flow_id, area, direction, params)`
+- `GetFlow(flow_id)`
+- `ValidateFlow(flow_spec)`
+
+### Events
+- `ReportEvent(run_id, event)`
+- `WatchEvents(filters)` (stream)
+
+## Errors
+- Typed error codes with retry hints (retryable, terminal, auth, not found).
+- Include `trace_id` for observability.
+- Idempotency keys for run creation and cancellation.
+
+## Authn/z
+- API keys for early phase.
+- JWT/OIDC for enterprise integration.
+- Tenant and project scoping in every request.
+
+## Compatibility
+- Protocol version in handshake and every response.
+- Client must refuse incompatible versions.
+- Server advertises supported version ranges.
+
+## Typed RPC options: gRPC vs other schema‑first protocols
+### gRPC + Protobuf (recommended default)
+- **Pros:** strong schema, excellent codegen for mobile/desktop, efficient streaming, ecosystem maturity.
+- **Cons:** requires HTTP/2, harder to debug with curl, protobuf schema language constraints.
+
+### Connect (gRPC‑compatible over HTTP/1.1)
+- **Pros:** Protobuf‑based with better browser compatibility; can speak gRPC or JSON.
+- **Cons:** smaller ecosystem; still needs protobuf schemas and tooling.
+
+### Twirp (RPC over HTTP/1.1 + Protobuf)
+- **Pros:** simple deployment, protobuf schema, easy debugging.
+- **Cons:** no native streaming; less standard for multi‑language clients.
+
+### Thrift
+- **Pros:** mature IDL, multiple transports.
+- **Cons:** weaker modern tooling; less common on mobile; streaming story weaker.
+
+### Cap’n Proto / FlatBuffers
+- **Pros:** very fast, zero‑copy; great for high‑throughput.
+- **Cons:** limited tooling and cross‑platform adoption; not ideal for public APIs.
+
+### JSON Schema + REST
+- **Pros:** maximum compatibility; easy tooling.
+- **Cons:** weaker typing guarantees; harder to evolve safely; streaming is ad‑hoc.
+
+### Practical stance
+- **gRPC + Protobuf** for core control plane APIs and streaming events.
+- Optionally **Connect** as a compatibility layer for browser/mobile clients.
+- Avoid non‑protobuf IDLs unless a specific client forces it.
+
+## Internal protocol (lf/lfd ↔ lfd‑core)
+- Must be **well‑typed** and schema‑first.
+- Treat as the primary design artifact; public surfaces derive from it.
+
+## Remote lf behavior
+- Remote `lf` talks to **`lfd`** (control plane), never directly to `lfd‑core`.
+- Local `lf` must still work **without** a daemon running.
+- Local mode uses direct `lf` ↔ `lfd-core` calls.
+- `lfd` must expose the **subset of `lfd-core` APIs** that `lf` calls in local mode.
+- This subset is the **engine contract**; remote mode is an engine swap.
+
+### Engine contract (subset parity)
+The engine contract is the minimal API surface that `lf` depends on in local mode. `lfd` must expose an equivalent remote API so `lf` can switch engines without changing UX.
+
+**Core execution**
+- `ExecuteFlow(flow_id, area, direction, params)` → run result + events
+- `ExecuteStep(step_id, context, direction)` → step result + events
+- `CancelExecution(run_id)`
+
+**Context + prompt**
+- `GatherContext(area, rules, diff_mode)` → context bundle
+- `FormatPrompt(components)` → prompt text
+
+**Flows + steps**
+- `LoadFlow(flow_id)` → flow graph
+- `ValidateFlow(flow_spec)` → errors
+- `LoadStep(step_id)` → step definition
+
+**Tokens + limits**
+- `CountTokens(text, model)` → token count
+- `EnforceLimits(context)` → trimmed/validated bundle
+
+**Artifacts**
+- `WriteArtifact(path, contents)`
+- `ReadArtifact(path)` (if needed for resume)
+
+**Events**
+- `WatchEvents(filters)` (stream)
+
+### gRPC proto sketch (engine contract)
+```proto
+syntax = "proto3";
+
+package loopflow.engine.v1;
+
+service Engine {
+  // Core execution
+  rpc ExecuteFlow(ExecuteFlowRequest) returns (ExecuteFlowResponse);
+  rpc ExecuteStep(ExecuteStepRequest) returns (ExecuteStepResponse);
+  rpc CancelExecution(CancelExecutionRequest) returns (CancelExecutionResponse);
+
+  // Context + prompt
+  rpc GatherContext(GatherContextRequest) returns (GatherContextResponse);
+  rpc FormatPrompt(FormatPromptRequest) returns (FormatPromptResponse);
+
+  // Flows + steps
+  rpc LoadFlow(LoadFlowRequest) returns (LoadFlowResponse);
+  rpc ValidateFlow(ValidateFlowRequest) returns (ValidateFlowResponse);
+  rpc LoadStep(LoadStepRequest) returns (LoadStepResponse);
+
+  // Tokens + limits
+  rpc CountTokens(CountTokensRequest) returns (CountTokensResponse);
+  rpc EnforceLimits(EnforceLimitsRequest) returns (EnforceLimitsResponse);
+
+  // Artifacts
+  rpc WriteArtifact(WriteArtifactRequest) returns (WriteArtifactResponse);
+  rpc ReadArtifact(ReadArtifactRequest) returns (ReadArtifactResponse);
+
+  // Events
+  rpc WatchEvents(WatchEventsRequest) returns (stream Event);
+}
+
+message ExecuteFlowRequest {
+  string flow_id = 1;
+  string area = 2;
+  repeated string direction = 3;
+  map<string, string> params = 4;
+}
+
+message ExecuteFlowResponse {
+  string run_id = 1;
+  RunResult result = 2;
+}
+
+message ExecuteStepRequest {
+  string step_id = 1;
+  ContextBundle context = 2;
+  repeated string direction = 3;
+}
+
+message ExecuteStepResponse {
+  string run_id = 1;
+  RunResult result = 2;
+}
+
+message CancelExecutionRequest {
+  string run_id = 1;
+}
+
+message CancelExecutionResponse {
+  bool cancelled = 1;
+}
+
+message GatherContextRequest {
+  string area = 1;
+  repeated string rules = 2;
+  string diff_mode = 3;
+}
+
+message GatherContextResponse {
+  ContextBundle context = 1;
+}
+
+message FormatPromptRequest {
+  PromptComponents components = 1;
+}
+
+message FormatPromptResponse {
+  string prompt = 1;
+}
+
+message LoadFlowRequest {
+  string flow_id = 1;
+}
+
+message LoadFlowResponse {
+  Flow flow = 1;
+}
+
+message ValidateFlowRequest {
+  string flow_spec = 1;
+}
+
+message ValidateFlowResponse {
+  repeated ValidationError errors = 1;
+}
+
+message LoadStepRequest {
+  string step_id = 1;
+}
+
+message LoadStepResponse {
+  Step step = 1;
+}
+
+message CountTokensRequest {
+  string text = 1;
+  string model = 2;
+}
+
+message CountTokensResponse {
+  uint64 tokens = 1;
+}
+
+message EnforceLimitsRequest {
+  ContextBundle context = 1;
+}
+
+message EnforceLimitsResponse {
+  ContextBundle context = 1;
+  repeated ValidationError warnings = 2;
+}
+
+message WriteArtifactRequest {
+  string path = 1;
+  bytes contents = 2;
+}
+
+message WriteArtifactResponse {
+  bool ok = 1;
+}
+
+message ReadArtifactRequest {
+  string path = 1;
+}
+
+message ReadArtifactResponse {
+  bytes contents = 1;
+}
+
+message WatchEventsRequest {
+  string run_id = 1;
+}
+
+message Event {
+  string run_id = 1;
+  string kind = 2;
+  string message = 3;
+  map<string, string> data = 4;
+}
+```
+
+## UX compatibility requirements
+- **Must not change:** prompt/flow semantics, artifact paths, CLI affordances.
+- **Should not change:** direction composition, flow execution order, local defaults.
+- **Ambiguous:** token counting heuristics, scheduling jitter, minor error strings.
+
+## Success criteria
+- `lf` can target local or remote `lfd` with no behavior differences.
+- Concerto can drive runs over the same API.
+- Backward-compatible changes are routine; breaking changes are rare and explicit.
+- Protocol supports remote clients beyond desktop (mobile app readiness).
+- Artifact and prompt paths remain unchanged.
+
+## Open questions
+- Do we want strict protobuf-only for v1 to avoid dual protocols?
+- Do we need bi-directional streaming for interactive steps?

--- a/roadmap/rust/02-core-engine.md
+++ b/roadmap/rust/02-core-engine.md
@@ -1,0 +1,44 @@
+# Rust Roadmap: Core Engine (Stage 2)
+
+Build the Rust engine that implements flow execution and core behavior.
+
+## Goal
+Implement the single source of truth for flow evaluation, prompt assembly, and run state transitions in Rust.
+
+## Scope
+- Flow parsing and validation
+- Run state machine (steps, retries, failures)
+- Prompt assembly pipeline
+- Worktree and git operations
+- Event model and internal logging
+- Token counting policy and limits
+
+## Non-goals
+- Full daemon scheduling and triggers
+- Cluster deployment
+
+## Core modules
+- `flow`: parse/load steps and DAGs
+- `runtime`: run state machine
+- `prompt`: context assembly, file selection, formatting
+- `worktree`: create/find/remove worktrees
+- `git`: status, diff, commit utilities
+- `event`: structured events for runs and steps
+
+## Interfaces
+- Rust crate API for daemon use
+- Protocol adapter layer for external clients
+
+## Risks
+- Parity gaps vs Python flow behavior
+- Worktree edge cases on macOS vs Linux
+
+## Success criteria
+- Engine can execute a flow end-to-end with the same output as Python.
+- Run state machine emits correct events for every step.
+- Behavior differences are documented and intentional.
+
+## Open questions
+- Which Python behaviors should be left behind vs matched exactly?
+- How much of prompt rendering should be configurable vs hard-coded?
+- Which tokenizer is acceptable, and when do we fall back to byte limits?

--- a/roadmap/rust/03-daemon-service.md
+++ b/roadmap/rust/03-daemon-service.md
@@ -1,0 +1,39 @@
+# Rust Roadmap: Daemon Service (Stage 3)
+
+Implement the Rust daemon that owns scheduling, triggers, and run orchestration.
+
+## Goal
+Deliver a production-grade service that runs 24/7, with stable scheduling, safe concurrency, and clear observability.
+
+## Scope
+- Socket/HTTP server with protocol handlers
+- Scheduling loops for watch/cron/loop
+- Concurrency limits and queueing
+- Run lifecycle management
+- Metrics, logs, and tracing
+
+## Non-goals
+- Cluster multi-node scheduling
+- Enterprise authn/z (beyond API keys)
+
+## Key components
+- `server`: gRPC/HTTP handlers
+- `scheduler`: trigger evaluation
+- `queue`: concurrency and backpressure
+- `runs`: persistence and state transitions
+- `obs`: logs + metrics + tracing
+
+## Reliability requirements
+- Explicit timeouts on all external operations
+- Graceful shutdown with run reconciliation
+- Circuit breaker for repeated failures
+
+## Success criteria
+- Stable long-running operation under synthetic load.
+- Trigger evaluation jitter below agreed threshold.
+- Clear, structured logs for every run.
+
+## Open questions
+- Do we keep SQLite for v1 or jump to Postgres now?
+- How do we handle per-tenant isolation in early phases?
+

--- a/roadmap/rust/04-lf-client.md
+++ b/roadmap/rust/04-lf-client.md
@@ -1,0 +1,39 @@
+# Rust Roadmap: lf Client Refactor (Stage 4)
+
+Make `lf` a protocol client that can target local or remote engines.
+
+## Goal
+Keep the CLI UX but move execution to the protocol-first engine, enabling remote control and managed clusters.
+
+## Scope
+- Client config for target engine (local/remote)
+- Authn for API keys and tokens
+- Mapping existing commands to protocol calls
+- Event streaming to terminal
+- Local standalone mode without requiring `lfd`
+- Local mode uses direct `lf` ↔ `lfd-core` integration
+ - Remote mode switches `lf` engine to `lfd` that exposes the same subset of `lfd-core` APIs used by `lf`
+
+## Non-goals
+- Removing Python immediately
+- Rewriting all UX flows
+
+## UX principles
+- `lf` behaves the same whether local or remote.
+- Clear, actionable errors on auth or protocol mismatch.
+- Local mode remains the default for dev.
+- Users can run `lf` without installing or running `lfd`.
+- Local mode should not require a daemon process.
+ - Remote mode should be a pure engine switch, not a UX switch.
+
+## Success criteria
+- `lf run` works identically against local and remote.
+- Concerto and `lf` can connect to the same daemon.
+- Users can opt into remote with a single config change.
+- Hosted `lfd` can be targeted from a local `lf` without special flags.
+- Local `lf` works out of the box with no daemon running.
+ - Remote `lf` uses the same engine API surface as local `lf` (subset parity).
+
+## Open questions
+- How should credentials be stored (keychain vs file)?
+- Do we need offline mode with cached flows?

--- a/roadmap/rust/05-data-backend.md
+++ b/roadmap/rust/05-data-backend.md
@@ -1,0 +1,34 @@
+# Rust Roadmap: Data Backend (Stage 5)
+
+Migrate persistence from local SQLite to a service DB for multi-node clusters.
+
+## Goal
+Support multi-tenant managed clusters with durable state, concurrency safety, and auditability.
+
+## Scope
+- Postgres schema design
+- Migrations and versioning
+- Data access layer in Rust
+- Operational backups and retention
+
+## Non-goals
+- Full data warehouse or analytics pipeline
+
+## Schema needs
+- Sessions, runs, triggers, agents
+- Event streams or append-only logs
+- Tenant and project scoping
+
+## Migration strategy
+- Dual-write or export/import tooling
+- Compatibility layer for local mode (SQLite still supported)
+
+## Success criteria
+- Multi-node daemon workers share a consistent view.
+- No run state corruption under concurrent access.
+- Backups/restores are tested and documented.
+
+## Open questions
+- Do we keep SQLite for local dev long-term?
+- Should we adopt an event-sourcing model?
+

--- a/roadmap/rust/06-deployment.md
+++ b/roadmap/rust/06-deployment.md
@@ -1,0 +1,30 @@
+# Rust Roadmap: Deployment + Operations (Stage 6)
+
+Harden deployment for managed clusters and enterprise environments.
+
+## Goal
+Make Loopflow easy to deploy, observe, and operate in production.
+
+## Scope
+- Container images and Helm charts
+- Service discovery and config management
+- Secrets handling
+- Monitoring and alerting
+
+## Non-goals
+- Full SaaS control plane
+
+## Operational requirements
+- Zero-downtime upgrades
+- Clear health checks and readiness probes
+- Structured logs and trace IDs
+
+## Success criteria
+- One-command install for a dev cluster.
+- Upgrade path with documented rollback.
+- Sane defaults for resource limits.
+
+## Open questions
+- Do we ship a single binary + config, or a full container stack?
+- How much ops code lives in repo vs separate infra repo?
+

--- a/roadmap/rust/07-validation.md
+++ b/roadmap/rust/07-validation.md
@@ -1,0 +1,37 @@
+# Rust Roadmap: Validation + Experiments (Stage 7)
+
+Prove the Rust engine meets reliability, performance, and parity goals.
+
+## Goal
+Run experiments that justify the rewrite and define go/no-go gates.
+
+## Scope
+- Shadow-mode parity testing
+- Synthetic load tests
+- Failure injection
+- Cluster portability trials
+
+## Experiments
+1. **Rust daemon prototype**: minimal socket server + read‑only DB.
+2. **Parity suite**: compare Rust engine output vs Python for representative flows.
+3. **Load test**: simulate 1000+ loops with fake agents.
+4. **Failure injection**: crash runs, DB locks, network drops.
+5. **Remote control**: `lf` on laptop controlling a remote daemon.
+6. **Cross‑platform build**: macOS + Linux binaries, size + startup time.
+7. **Token counting check**: compare Rust token counts vs Python.
+8. **Full step run**: Rust context assembly + agent launch parity.
+
+## Metrics
+- Scheduling jitter
+- CPU/RAM per loop
+- Error rate per 100 runs
+- Recovery time after failures
+
+## Success criteria
+- Parity ≥ 95% on golden flow set.
+- Jitter reduction ≥ 30% vs Python.
+- No data loss under crash tests.
+
+## Open questions
+- What is the canonical "golden flow" set?
+- What level of parity is acceptable if behavior changes are improvements?

--- a/roadmap/rust/README.md
+++ b/roadmap/rust/README.md
@@ -1,0 +1,126 @@
+# Rust Roadmap
+
+This folder tracks the Rust program of work. It is the source of truth for the staged plan, migration rules, and enterprise posture it enables.
+
+## Why now
+Loopflow is evolving beyond single‑developer macOS use to managed, multi‑tenant clusters. The daemon is the long‑lived, critical path service; it needs a stable protocol boundary, predictable runtime, and portable deployment.
+
+## Goals
+- Improve daemon reliability (24/7 operation, fewer runtime failures).
+- Improve portability for managed clusters (Linux‑friendly, container‑ready, easy distribution).
+- Preserve Loopflow UX: prompts, flows, directions, and artifact paths remain unchanged.
+- Establish a protocol‑first architecture for remote clients (desktop + mobile).
+
+## Non‑goals
+- Full redesign of flows/steps/prompts.
+- UX changes beyond remote connectivity and observability.
+
+## North star
+A protocol‑first, Rust‑based control plane that can be driven locally or remotely (desktop + mobile), with strict isolation between control and execution.
+
+## Principles
+- **Protocol first:** every project starts by validating the protocol surface.
+- **UX invariants:** prompts, flows, directions, and artifact paths must not change.
+- **Control/execution isolation:** failures in execution must not destabilize control plane.
+- **Postgres in managed mode:** Postgres is the system of record for hosted `lfd`.
+
+## Control vs execution isolation
+- **Control plane:** long‑lived daemon for scheduling, run state, policy enforcement.
+- **Execution plane:** isolated workers (process/container/job) that run agents.
+- Failures in execution must not destabilize control plane.
+
+## Recommendation
+Commit to **protocol‑first** Rust `lfd` with remote client support. The protocol is the primary design artifact; every project starts by validating that the protocol surface fits the intended behavior.
+
+## Ideal end state (ignoring transition costs)
+- Rust control plane + Rust execution engine
+- Postgres as system of record
+- Protocol‑first APIs (gRPC/JSON)
+- Per‑run sandboxing with strict resource limits
+- Remote clients (desktop + mobile) as first‑class
+
+## Decision criteria
+- Idle overhead reduced by >50% vs Python daemon.
+- Scheduling jitter reduced by >30% under synthetic load.
+- Protocol supports local + remote clients without UX drift.
+- Parity ≥ 95% on golden flow set.
+
+## Stages
+- Stage 1: `roadmap/rust/01-protocol.md`
+- Stage 2: `roadmap/rust/02-core-engine.md`
+- Stage 3: `roadmap/rust/03-daemon-service.md`
+- Stage 4: `roadmap/rust/04-lf-client.md`
+- Stage 5: `roadmap/rust/05-data-backend.md`
+- Stage 6: `roadmap/rust/06-deployment.md`
+- Stage 7: `roadmap/rust/07-validation.md`
+
+## Parity + test story (stage by stage)
+### Stage 1 — Protocol
+- **Keep:** Python `lf` + Python `lfd` as default.
+- **Parity focus:** protocol schemas mirror current behavior.
+- **Tests:** schema compatibility tests + golden event payloads.
+
+### Stage 2 — Core engine
+- **Keep:** Python stack remains default; Rust core is opt‑in behind a flag.
+- **Parity focus:** prompt assembly + flow parsing output equivalence.
+- **Tests:** golden prompt fixtures; diff‑based tests on context assembly.
+
+### Stage 3 — Rust daemon
+- **Keep:** Python `lfd` stays default; Rust `lfd` runs in shadow mode.
+- **Parity focus:** scheduling decisions and run state transitions.
+- **Tests:** shadow‑mode trace comparison; fault‑injection tests.
+
+### Stage 4 — lf client
+- **Keep:** local `lf` uses in‑process `lfd‑core` by default.
+- **Parity focus:** local vs remote `lf` behavior is identical.
+- **Tests:** end‑to‑end CLI parity suite; remote integration tests.
+
+### Stage 5 — Data backend
+- **Keep:** local stays on SQLite; managed mode uses Postgres.
+- **Parity focus:** run state persistence and event ordering.
+- **Tests:** dual‑backend tests; migration tests; consistency checks.
+
+### Stage 6 — Deployment
+- **Keep:** single‑machine dev workflow intact.
+- **Parity focus:** behavior unchanged when containerized.
+- **Tests:** container smoke tests; upgrade/rollback tests.
+
+### Stage 7 — Validation
+- **Keep:** Python stack available as fallback until gates are met.
+- **Parity focus:** golden flow set ≥ 95% parity.
+- **Tests:** full validation suite; performance + reliability benchmarks.
+
+## Library transitions (when and how)
+### Token counting
+- **Stage 2:** evaluate Rust tokenizer options.
+- **Rule:** if no accurate/maintained tokenizer exists, fall back to byte‑based limits with explicit guardrails.
+
+### Cron parsing
+- **Stage 2/3:** validate Rust cron parsing against existing croniter behavior.
+- **Rule:** parity for supported expressions; document any intentional reductions.
+
+### SQLite → Postgres
+- **Stage 5:** move managed/cluster mode to Postgres.
+- **Rule:** local mode may stay on SQLite, but hosted `lfd` uses Postgres by default.
+
+### Pydantic → Serde
+- **Stage 2:** replace validation with serde‑based types in Rust core.
+- **Rule:** keep protocol schema as the source of truth; validation errors map to protocol error codes.
+
+### YAML parsing
+- **Stage 2:** serde_yaml replaces pyyaml for flow/step parsing in Rust core.
+- **Rule:** preserve parsing semantics; document any differences.
+
+### HTTP/Socket server
+- **Stage 3:** Rust server replaces Python asyncio/FastAPI.
+- **Rule:** protocol compatibility is required; no UX changes.
+
+## CI + release expectations
+- Rust builds on macOS + Linux.
+- Protocol compatibility tests run in CI.
+- If Python bindings exist, wheels are built for supported platforms.
+
+## UX compatibility matrix
+- **Must not change:** prompt/flow semantics, artifact paths, CLI affordances.
+- **Should not change:** direction composition, flow execution order, local defaults.
+- **Ambiguous:** token counting heuristics, scheduling jitter, minor error strings.


### PR DESCRIPTION
## Overview

Adds comprehensive roadmaps for two major initiatives: porting the Loopflow daemon to Rust, and preparing enterprise infrastructure for managed clusters.

## Rust Roadmap (`roadmap/rust/`)

Defines a 7-stage plan for a protocol-first Rust rewrite:

1. **Protocol** — gRPC/Protobuf API surface with engine contract spec
2. **Core Engine** — flow execution, prompt assembly, run state machine
3. **Daemon Service** — scheduling, triggers, concurrency, observability
4. **lf Client** — CLI refactor to target local or remote engines
5. **Data Backend** — Postgres for managed clusters
6. **Deployment** — containers, Helm, ops tooling
7. **Validation** — parity testing, load tests, failure injection

Key principles: protocol-first design, control/execution isolation, UX invariants (prompts, flows, artifact paths unchanged).

## Enterprise Roadmap (`roadmap/enterprise/`)

Identifies infra work independent of the Rust port:

- **Pre-Rust:** OS portability, container runtime model, access control, observability, secrets management
- **Post-Rust:** multi-tenant scheduling, quotas, managed control plane

Includes readiness gates for managed cluster launch.

## Why now

Loopflow is evolving beyond single-developer macOS use toward managed, multi-tenant clusters. The daemon needs a stable protocol boundary, predictable runtime, and portable deployment. These roadmaps separate concerns: Rust handles core engine/daemon, enterprise handles infra/ops.