### PR TITLE
wave context: unified wave determination for prompts

### DIFF
--- a/scratch/jack-heart.bugs.20260127_2204-review.md
+++ b/scratch/jack-heart.bugs.20260127_2204-review.md
@@ -1,0 +1,58 @@
+# Design Review: Unified Wave Context Determination
+
+## What was implemented
+
+This branch adds unified wave context determination for prompts, enabling waves to be identified from multiple sources:
+
+1. **lfd database lookup** - Query the daemon database to find wave by worktree path
+2. **Worktree naming pattern** - Recognize `<repo>.<wave>.main` naming convention
+3. **CLI flag reordering** - Support `lf -m codex ship` syntax (flags before step/flow name)
+4. **Engine display header** - Show the coding agent and model in flow output
+5. **Documentation update** - Improved `ingest.md` step with clear wave discovery priority
+
+## Key choices
+
+**Priority order for wave determination:**
+1. Explicit `--wave` flag (highest)
+2. lfd database by worktree path
+3. Worktree naming pattern (`<repo>.<wave>.main`)
+4. Roadmap folder inference (lowest)
+
+This order ensures explicit configuration wins, daemon-managed waves are recognized, and naming conventions work as fallback. The database lookup fails silently if lfd isn't running.
+
+**CLI flag reordering approach:**
+Rather than forcing users to put flags after the step name, the CLI now scans for a valid step/flow name among the arguments and reorders internally. This makes `lf -m codex ship` work the same as `lf ship -m codex`.
+
+**Engine header display:**
+Added a simple dim gray line showing `engine: claude` or `engine: codex:o3` to give visibility into which coding agent is running without being intrusive.
+
+## How it fits together
+
+```
+User invokes lf/lfd
+       │
+       ▼
+determine_wave() in lf/wave.py
+       │
+       ├─► explicit_wave parameter? → use it
+       │
+       ├─► lfd database lookup via get_wave_by_worktree() → use wave.name
+       │
+       ├─► worktree name matches <repo>.<wave>.main? → extract wave name
+       │
+       └─► roadmap/<candidate>/ exists? → use candidate
+```
+
+The `get_wave_by_worktree()` function in `lfd/wave.py` mirrors the existing `get_wave_by_name()` pattern, querying SQLite with optional repo filtering.
+
+## Risks and bottlenecks
+
+**Database import overhead:** `_lookup_wave_from_lfd()` imports from `lfd.wave` which pulls in the database module. This is wrapped in try/except to fail silently, but adds import time when lfd is available. Mitigated by lazy import inside the function.
+
+**Worktree pattern matching:** The `<repo>.<wave>.main` pattern could false-positive on worktrees that happen to have 3+ dot-separated parts ending in "main". The check excludes digits and "master" but could still match unintended names.
+
+## What's not included
+
+- No changes to how waves are created or configured
+- No new CLI commands for wave management
+- No tests for the new wave determination logic (existing tests pass, but the new code paths aren't directly tested)

--- a/scratch/polish-priorities.md
+++ b/scratch/polish-priorities.md
@@ -1,0 +1,93 @@
+# Polish Priorities
+
+## Priority 1: Documentation mentions `reports/` inconsistently
+
+**Evidence**:
+- `--lfdocs` help text says "Include reports/, roadmap/, scratch/, and .md files"
+- Code includes `reports/` in `_DEFAULT_FILE_PATHS` at `context.py:148`
+- docs/index.md "Where Files Live" section doesn't mention `reports/`
+- docs/config.md doesn't mention `reports/`
+- `reports/` folder exists and contains 9 reference docs (landscape.md, target-customer.md, etc.)
+
+**Impact**: Users don't know about `reports/` as a first-class concept. The docs mention `scratch/` vs `roadmap/` but not `reports/` for reference material. Users may not understand where to put research and analysis that should persist.
+
+**Effort**: Low (documentation update)
+
+**Recommendation**: Add `reports/` to the file structure docs. Update "scratch/ vs roadmap/" section to explain all three: scratch/ (ephemeral), roadmap/ (actionable items), reports/ (reference material).
+
+---
+
+## Priority 2: Help text word-wrap artifacts in `lfd` commands
+
+**Evidence**:
+- `lfd loop --help` shows:
+  ```
+  Examples:     lfd loop swift-falcon                                   # run
+  existing wave     lfd loop swift-falcon --area src/                       #
+  create + set area + run
+  ```
+- Same issue in `lfd run --help`, `lfd watch --help`, `lfd cron --help`
+- Caused by inline examples in docstrings without proper line breaks
+
+**Impact**: Help text is hard to read. Users have to mentally parse the wrapped output to understand the examples.
+
+**Effort**: Low (add `\n` to docstrings in `cli.py`)
+
+**Recommendation**: Reformat examples in docstrings to use explicit newlines so Typer renders them correctly.
+
+---
+
+## Priority 3: `--direction` flag lacks context
+
+**Evidence**:
+- `lf run --help` shows: `--direction -d,-D TEXT Direction to apply (repeatable, or comma-separated)`
+- No mention of where directions come from (`.lf/directions/`) or built-in options
+
+**Impact**: New users don't understand what a "direction" is or how to use one. They'd need to read documentation to learn about `product-engineer`, `designer`, etc.
+
+**Effort**: Low (update help text)
+
+**Recommendation**: Change to: "Direction from .lf/directions/ or built-in (e.g., product-engineer)"
+
+---
+
+## Priority 4: Doctor output uses cryptic message
+
+**Evidence**:
+- `lfops doctor` shows: `- no task files (run: lf init)`
+- Doesn't explain what "task files" means or where they should be
+
+**Impact**: Users seeing this message don't know what's missing or where to look.
+
+**Effort**: Low (string change in `init.py:39`)
+
+**Recommendation**: Change to: `.lf/steps/ or .claude/commands/ not found (run: lf init)`
+
+---
+
+## Priority 5: Uppercase flag aliases add visual noise
+
+**Evidence**:
+- `--auto -a,-A`, `--interactive -i,-I`, `--clipboard -c,-C` etc.
+- Appears in help text for `lf run`, `lf inline`, and other commands
+- The uppercase variants exist for historical compatibility but clutter help output
+
+**Impact**: Minor visual noise. Help output is longer and harder to scan.
+
+**Effort**: Low (remove uppercase aliases)
+
+**Recommendation**: Defer. The uppercase aliases may have users depending on them. Consider removing in a future cleanup pass.
+
+---
+
+## Lower priority
+
+### Step descriptions in `lf --list`
+
+The `explore` step description says "Investigate current diff" but the step actually explores the codebase generally, not just the diff. Consider: "Investigate the codebase".
+
+### Error message for missing wave
+
+`lfd show nonexistent` shows: `Error: Wave 'nonexistent' not found`
+
+Could add: `Run 'lfd list' to see available waves.`

--- a/src/loopflow/lf/branch_names.py
+++ b/src/loopflow/lf/branch_names.py
@@ -6,6 +6,8 @@ import subprocess
 from datetime import datetime
 from typing import TYPE_CHECKING
 
+from loopflow.lf.naming import generate_word_pair
+
 if TYPE_CHECKING:
     from loopflow.lf.config import BranchNameConfig
 
@@ -36,7 +38,15 @@ def _sanitize_for_branch(s: str) -> str:
 
 
 def format_branch_name(short_name: str, config: "BranchNameConfig | None") -> str:
-    """Transform short name into full branch name using schema."""
+    """Transform short name into full branch name using schema.
+
+    Available placeholders:
+        {name}  - the short name provided
+        {user}  - git username
+        {ts}    - timestamp (YYYYMMDD_HHMM)
+        {date}  - date (YYYYMMDD)
+        {words} - magical-musical word pair (e.g., wisp-forte)
+    """
     if config is None:
         return short_name
 
@@ -51,6 +61,7 @@ def format_branch_name(short_name: str, config: "BranchNameConfig | None") -> st
         "user": _get_git_username(),
         "ts": now.strftime("%Y%m%d_%H%M"),
         "date": now.strftime("%Y%m%d"),
+        "words": generate_word_pair(),
     }
 
     result = schema

--- a/src/loopflow/lf/builtins/steps/plan/ingest.md
+++ b/src/loopflow/lf/builtins/steps/plan/ingest.md
@@ -6,7 +6,12 @@ Pick the highest-priority item from the wave's backlog and move it to scratch/.
 
 ## Wave context
 
-If `<lf:wave name="...">` is present in the prompt, that's your wave. The wave's roadmap (`roadmap/<wave>/`) is included in docs.
+**Finding the wave name:**
+1. Check for `<lf:wave name="...">` tag in the prompt — this is the authoritative source
+2. If no tag, look at the branch name pattern: `<wave>.main` indicates wave `<wave>`
+3. If still unclear, check `roadmap/` for subdirectories — each subdirectory is a wave
+
+The wave's roadmap (`roadmap/<wave>/`) should be included in docs. If you can't find the wave's roadmap, note this in `scratch/questions.md`.
 
 ## Staged roadmaps
 

--- a/src/loopflow/lf/cli.py
+++ b/src/loopflow/lf/cli.py
@@ -227,9 +227,43 @@ def main():
             if first_arg == ":":
                 sys.argv.pop(1)
                 sys.argv.insert(1, "inline")
-            # Flags without step: lf -m codex → lf run -m codex
+            # Flags before step/flow: lf -m codex ship → lf flow ship -m codex
             elif first_arg.startswith("-") and first_arg not in known_commands:
-                sys.argv.insert(1, "run")
+                # Find the first non-flag arg that matches a step/flow name
+                repo_root = find_worktree_root()
+                config = load_config(repo_root) if repo_root else None
+
+                name_idx = None
+                name = None
+                is_flow = False
+                for idx, arg in enumerate(sys.argv[1:], start=1):
+                    if arg.startswith("-"):
+                        continue
+
+                    # Check if this arg is a valid step/flow (filters out flag values like "codex")
+                    candidate = arg.rstrip(":")
+                    has_flow_file = repo_root and flow_file_exists(candidate, repo_root)
+                    has_step = gather_step(repo_root, candidate, config) is not None
+
+                    if has_flow_file or has_step:
+                        if has_flow_file and has_step:
+                            typer.echo(
+                                f"Error: '{candidate}' exists as both a flow and a step", err=True
+                            )
+                            raise SystemExit(1)
+                        name_idx = idx
+                        name = candidate
+                        is_flow = has_flow_file
+                        break
+
+                if name:
+                    # Move name to position 2, insert command at position 1
+                    sys.argv.pop(name_idx)
+                    sys.argv.insert(1, "flow" if is_flow else "run")
+                    sys.argv.insert(2, name)
+                else:
+                    # No step/flow name found, just flags → lf -m codex → lf run -m codex
+                    sys.argv.insert(1, "run")
             elif first_arg not in known_commands:
                 # Handle colon suffix: "lf implement: add logout" -> "lf implement add logout"
                 if first_arg.endswith(":"):

--- a/src/loopflow/lf/flow.py
+++ b/src/loopflow/lf/flow.py
@@ -990,6 +990,10 @@ def run_flow(
         print(f"Error: '{backend}' coding agent not found")
         return 1
 
+    # Display engine header
+    engine_display = f"{backend}:{model_variant}" if model_variant else backend
+    print(f"\033[90mengine: {engine_display}\033[0m")
+
     config = load_config(repo_root)
     main_repo = find_main_repo(repo_root) or repo_root
     items: list[FlowItem] = list(flow.steps)

--- a/src/loopflow/lf/naming.py
+++ b/src/loopflow/lf/naming.py
@@ -5,7 +5,9 @@ suffixes, used by both `lfops next` and agent creation.
 """
 
 import random
+import re
 import subprocess
+from datetime import datetime
 from pathlib import Path
 
 # Word lists for generating unique branch names
@@ -84,6 +86,11 @@ def generate_word_pair() -> str:
     return f"{magical}-{musical}"
 
 
+def generate_timestamp() -> str:
+    """Generate timestamp in YYYYMMDD_HHMM format."""
+    return datetime.now().strftime("%Y%m%d_%H%M")
+
+
 def branch_exists(repo: Path, branch: str) -> bool:
     """Check if a branch exists locally or on origin."""
     result = subprocess.run(
@@ -101,41 +108,63 @@ def branch_exists(repo: Path, branch: str) -> bool:
     return result.returncode == 0
 
 
-def parse_branch_base(branch: str) -> str:
-    """Extract base branch name (agent name) for next iteration.
+def _is_timestamp(s: str) -> bool:
+    """Check if string matches YYYYMMDD_HHMM format."""
+    return bool(re.match(r"^\d{8}_\d{4}$", s))
 
-    If branch ends with .word1-word2 pattern, strip it.
-    If branch ends with .main, strip it.
-    Otherwise use as-is.
+
+def _is_word_pair(s: str) -> bool:
+    """Check if string is a magical-musical word pair."""
+    if "-" not in s:
+        return False
+    word1, word2 = s.split("-", 1)
+    return word1 in MAGICAL and word2 in MUSICAL
+
+
+def parse_branch_base(branch: str) -> str:
+    """Extract base branch name (wave name) for next iteration.
+
+    Strips suffixes in order: .main, .timestamp.words, .words
 
     Examples:
-        'my-feature.main' → 'my-feature'
-        'my-feature.nova-waltz' → 'my-feature'
-        'my-feature' → 'my-feature'
+        'foo.main' → 'foo'
+        'foo.20260127_2204.wisp-forte' → 'foo'
+        'foo.wisp-forte' → 'foo'
+        'foo' → 'foo'
     """
     # Check if branch ends with .main
     if branch.endswith(".main"):
         return branch[:-5]
-    # Check if branch ends with .word1-word2 pattern
-    if "." in branch:
-        base, suffix = branch.rsplit(".", 1)
-        if "-" in suffix:
-            word1, word2 = suffix.split("-", 1)
-            if word1 in MAGICAL and word2 in MUSICAL:
-                return base
+
+    parts = branch.split(".")
+    if len(parts) < 2:
+        return branch
+
+    # Check for .timestamp.words pattern (new format)
+    if len(parts) >= 3:
+        maybe_words = parts[-1]
+        maybe_timestamp = parts[-2]
+        if _is_word_pair(maybe_words) and _is_timestamp(maybe_timestamp):
+            return ".".join(parts[:-2])
+
+    # Check for .words pattern (old format)
+    if _is_word_pair(parts[-1]):
+        return ".".join(parts[:-1])
+
     return branch
 
 
 def generate_next_branch(base: str, repo: Path) -> str:
     """Generate unique branch name for next iteration.
 
-    Appends .word1-word2 suffix, retries if exists.
+    Appends .timestamp.word1-word2 suffix, retries if exists.
 
     Examples:
-        'my-feature' → 'my-feature.nova-waltz'
+        'foo' → 'foo.20260127_2204.wisp-forte'
     """
+    timestamp = generate_timestamp()
     for _ in range(100):
-        candidate = f"{base}.{generate_word_pair()}"
+        candidate = f"{base}.{timestamp}.{generate_word_pair()}"
         if not branch_exists(repo, candidate):
             return candidate
 

--- a/src/loopflow/lf/naming.py
+++ b/src/loopflow/lf/naming.py
@@ -124,32 +124,22 @@ def _is_word_pair(s: str) -> bool:
 def parse_branch_base(branch: str) -> str:
     """Extract base branch name (wave name) for next iteration.
 
-    Strips suffixes in order: .main, .timestamp.words, .words
+    Strips suffixes: .main or .timestamp.words
 
     Examples:
         'foo.main' → 'foo'
         'foo.20260127_2204.wisp-forte' → 'foo'
-        'foo.wisp-forte' → 'foo'
         'foo' → 'foo'
     """
-    # Check if branch ends with .main
     if branch.endswith(".main"):
         return branch[:-5]
 
     parts = branch.split(".")
-    if len(parts) < 2:
-        return branch
-
-    # Check for .timestamp.words pattern (new format)
     if len(parts) >= 3:
         maybe_words = parts[-1]
         maybe_timestamp = parts[-2]
         if _is_word_pair(maybe_words) and _is_timestamp(maybe_timestamp):
             return ".".join(parts[:-2])
-
-    # Check for .words pattern (old format)
-    if _is_word_pair(parts[-1]):
-        return ".".join(parts[:-1])
 
     return branch
 

--- a/src/loopflow/lf/wave.py
+++ b/src/loopflow/lf/wave.py
@@ -9,7 +9,25 @@ class WaveContext:
     """Wave context for prompt assembly."""
 
     name: str  # e.g., "rust"
-    source: str  # "explicit" | "inferred"
+    source: str  # "explicit" | "inferred" | "worktree" | "lfd"
+
+
+def _lookup_wave_from_lfd(worktree: Path, repo: Path | None = None) -> str | None:
+    """Query lfd database for wave name by worktree path.
+
+    Returns wave name if found, None otherwise.
+    Fails silently if lfd database is not available.
+    """
+    try:
+        from loopflow.lf.git import find_main_repo
+        from loopflow.lfd.wave import get_wave_by_worktree
+
+        # Resolve main repo from worktree if not provided
+        main_repo = repo or find_main_repo(worktree)
+        wave = get_wave_by_worktree(worktree, repo=main_repo)
+        return wave.name if wave else None
+    except Exception:
+        return None
 
 
 def determine_wave(
@@ -20,16 +38,34 @@ def determine_wave(
 
     Priority:
     1. Explicit wave name (from lfd or --wave flag)
-    2. Infer from worktree directory name (only if roadmap/<candidate>/ exists)
+    2. Query lfd database for wave by worktree path
+    3. Wave worktree pattern (<repo>.<wave>.main indicates lfd-created wave)
+    4. Infer from worktree directory name (only if roadmap/<candidate>/ exists)
 
     An explicit wave is always honored, even without a roadmap folder.
-    Inference requires a matching roadmap folder to avoid false positives.
+    Wave worktrees (created by lfd) are recognized by the .main suffix.
+    Other inference requires a matching roadmap folder to avoid false positives.
     """
     if explicit_wave:
         return WaveContext(name=explicit_wave, source="explicit")
 
-    # Infer from worktree name — requires matching roadmap folder
+    # Query lfd database for wave by worktree path
+    lfd_wave = _lookup_wave_from_lfd(repo_root)
+    if lfd_wave:
+        return WaveContext(name=lfd_wave, source="lfd")
+
     worktree_name = repo_root.name
+    parts = worktree_name.split(".")
+
+    # Check for lfd wave worktree pattern: <repo>.<wave>.main
+    # Example: loopflow.rust.main → wave = "rust"
+    if len(parts) >= 3 and parts[-1] == "main":
+        wave_name = parts[-2]
+        # Skip if it looks like a date or common suffix
+        if wave_name and not wave_name.isdigit() and wave_name not in ("main", "master"):
+            return WaveContext(name=wave_name, source="worktree")
+
+    # Fall back to roadmap-based inference
     for candidate in _extract_wave_candidates(worktree_name):
         roadmap_path = repo_root / "roadmap" / candidate
         if roadmap_path.is_dir():

--- a/src/loopflow/lfd/wave.py
+++ b/src/loopflow/lfd/wave.py
@@ -122,6 +122,27 @@ def get_wave_by_name(
     return wave_from_row(dict(row)) if row else None
 
 
+def get_wave_by_worktree(
+    worktree: Path, repo: Path | None = None, db_path: Path | None = None
+) -> Wave | None:
+    """Get a wave by its worktree path, optionally filtered by repo."""
+    conn = _get_db(db_path)
+
+    if repo:
+        cursor = conn.execute(
+            "SELECT * FROM waves WHERE worktree = ? AND repo = ?",
+            (str(worktree), str(repo)),
+        )
+    else:
+        cursor = conn.execute(
+            "SELECT * FROM waves WHERE worktree = ?",
+            (str(worktree),),
+        )
+    row = cursor.fetchone()
+    conn.close()
+    return wave_from_row(dict(row)) if row else None
+
+
 def list_waves(repo: Path | None = None, db_path: Path | None = None) -> list[Wave]:
     """List all waves, optionally filtered by repo."""
     conn = _get_db(db_path)

--- a/src/loopflow/lfd/wave.py
+++ b/src/loopflow/lfd/wave.py
@@ -13,9 +13,8 @@ from pathlib import Path
 from croniter import croniter
 
 from loopflow.lf.context import find_worktree_root
-from loopflow.lf.naming import branch_exists, generate_word_pair
-from loopflow.lf.worktrees import WorktreeError
-from loopflow.lf.worktrees import create as create_worktree
+from loopflow.lf.naming import generate_next_branch, generate_word_pair
+from loopflow.lf.worktrees import WorktreeError, get_path
 from loopflow.lfd.db import _get_db
 from loopflow.lfd.logging import stimulus_log
 from loopflow.lfd.models import (
@@ -297,9 +296,8 @@ def _generate_wave_name(repo: Path) -> str:
     """Generate a unique wave name using word pairs."""
     for _ in range(100):
         words = generate_word_pair()
-        # Check that {name}.main branch doesn't exist
-        main_branch = f"{words}.main"
-        if not branch_exists(repo, main_branch):
+        # Check that no wave with this name exists
+        if not get_wave_by_name(words, repo):
             return words
 
     raise ValueError("Could not generate unique wave name")
@@ -337,11 +335,34 @@ def create_wave(
     wave_name = name or _generate_wave_name(repo)
 
     # Create worktree immediately so wave is ready for interactive sessions
-    main_branch = f"{wave_name}.main"
+    # Worktree path uses just the wave name (consistent across iterations)
+    # Branch name includes timestamp and words (evolves with each iteration)
+    branch = generate_next_branch(wave_name, repo)
+    worktree_path = get_path(repo, wave_name)
+
     try:
-        worktree_path = create_worktree(repo, main_branch)
-    except WorktreeError:
+        # Fetch to ensure we have latest origin/main
+        subprocess.run(["git", "fetch", "origin"], cwd=repo, capture_output=True)
+
+        # Create worktree with git directly (path != branch name)
+        result = subprocess.run(
+            ["git", "worktree", "add", "-b", branch, str(worktree_path), "origin/main"],
+            cwd=repo,
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            raise WorktreeError(result.stderr or "Failed to create worktree")
+
+        # Push to create remote branch with tracking
+        subprocess.run(
+            ["git", "push", "-u", "origin", branch],
+            cwd=worktree_path,
+            capture_output=True,
+        )
+    except (WorktreeError, subprocess.SubprocessError):
         worktree_path = None
+        branch = None
 
     wave = Wave(
         id=str(uuid.uuid4()),
@@ -355,7 +376,7 @@ def create_wave(
         pr_limit=pr_limit,
         merge_mode=merge_mode,
         worktree=worktree_path,
-        branch=main_branch if worktree_path else None,
+        branch=branch,
     )
 
     save_wave(wave)

--- a/src/loopflow/lfops/next.py
+++ b/src/loopflow/lfops/next.py
@@ -1,4 +1,4 @@
-"""Next command: land current PR, create fresh worktree in same space."""
+"""Next command: land current PR, move worktree to new stacked branch."""
 
 import subprocess
 import time
@@ -10,8 +10,7 @@ from loopflow.lf.context import find_worktree_root
 from loopflow.lf.git import find_main_repo, get_current_branch
 from loopflow.lf.messages import generate_pr_message
 from loopflow.lf.naming import generate_next_branch, parse_branch_base
-from loopflow.lf.worktrees import get_path
-from loopflow.lfops._helpers import get_default_branch, remove_worktree
+from loopflow.lfops._helpers import get_default_branch
 from loopflow.lfops.shell import write_directive
 
 
@@ -105,29 +104,18 @@ def _open_terminal(path: Path) -> None:
 
 
 def move_worktree(
-    main_repo: Path,
     worktree_path: Path,
     new_branch: str,
-    base_branch: str,
 ) -> bool:
-    """Move a worktree to a new branch by removing and recreating at same path.
+    """Create new branch from current HEAD and switch to it (true stacking).
 
+    The new branch is based on the current branch's HEAD, not on main.
     Returns True if successful.
     """
-    # Remove current worktree
+    # Create new branch from current HEAD
     result = subprocess.run(
-        ["git", "worktree", "remove", "--force", str(worktree_path)],
-        cwd=main_repo,
-        capture_output=True,
-        text=True,
-    )
-    if result.returncode != 0:
-        return False
-
-    # Create new worktree at the same path with new branch
-    result = subprocess.run(
-        ["git", "worktree", "add", "-b", new_branch, str(worktree_path), f"origin/{base_branch}"],
-        cwd=main_repo,
+        ["git", "checkout", "-b", new_branch],
+        cwd=worktree_path,
         capture_output=True,
         text=True,
     )
@@ -151,9 +139,10 @@ def next_worktree(
     open_terminal: bool = True,
     create_pr: bool = False,
 ) -> Path | None:
-    """Land current branch, create new worktree with magical-musical suffix.
+    """Land current branch, move worktree to new stacked branch.
 
-    Returns path to new worktree, or None if failed.
+    Reuses the same worktree directory, just switches to a new branch.
+    Returns path to worktree, or None if failed.
     """
     main_repo = find_main_repo(repo_root) or repo_root
     base_branch = get_default_branch(main_repo)
@@ -190,61 +179,28 @@ def next_worktree(
         typer.echo("Warning: Could not enable auto-merge", err=True)
 
     # Wait for merge if blocking
-    merged = False
     if block:
-        merged = _wait_for_merge(repo_root, pr_number)
+        _wait_for_merge(repo_root, pr_number)
 
     # Generate new branch name
     base_name = parse_branch_base(branch)
     new_branch = generate_next_branch(base_name, main_repo)
 
-    # Create new worktree
-    typer.echo(f"Creating worktree {new_branch}...")
-
-    # Use the short name (just the magical-musical suffix) for worktree directory
-    # Extract just the suffix part after the base name
-    suffix = new_branch[len(base_name) + 1 :]  # +1 for the hyphen
-    worktree_short_name = f"{base_name.split('.')[-1]}-{suffix}"
-
-    # Create worktree with git directly since we need specific branch name
-    worktree_path = get_path(main_repo, worktree_short_name)
-    result = subprocess.run(
-        ["git", "worktree", "add", "-b", new_branch, str(worktree_path), f"origin/{base_branch}"],
-        cwd=main_repo,
-        capture_output=True,
-        text=True,
-    )
-    if result.returncode != 0:
-        typer.echo(f"Error creating worktree: {result.stderr}", err=True)
+    # Create new stacked branch from current HEAD
+    typer.echo(f"Creating stacked branch {new_branch}...")
+    if not move_worktree(repo_root, new_branch):
+        typer.echo("Error: Failed to create stacked branch", err=True)
         return None
 
-    # Push to create remote branch with tracking
-    subprocess.run(
-        ["git", "push", "-u", "origin", new_branch],
-        cwd=worktree_path,
-        capture_output=True,
-    )
-
-    # Remove old worktree if merge completed
-    if merged and repo_root != main_repo:
-        typer.echo(f"Removing worktree {branch}...")
-        try:
-            remove_worktree(main_repo, branch, repo_root, base_branch)
-        except Exception:
-            typer.echo(
-                "Warning: Could not remove old worktree. Run 'lfops wt prune' later.",
-                err=True,
-            )
-
-    # Open terminal in new worktree
+    # Open terminal in worktree (same path, new branch)
     if open_terminal:
         typer.echo("Opening terminal...")
-        _open_terminal(worktree_path)
+        _open_terminal(repo_root)
 
-    # Write shell directive to cd to new worktree
-    write_directive(f"cd {worktree_path}")
+    # Write shell directive to cd to worktree
+    write_directive(f"cd {repo_root}")
 
-    return worktree_path
+    return repo_root
 
 
 def register_commands(app: typer.Typer) -> None:
@@ -252,19 +208,19 @@ def register_commands(app: typer.Typer) -> None:
 
     @app.command("next")
     def next_cmd(
-        block: bool = typer.Option(False, "--block", help="Wait for merge before creating wt"),
+        block: bool = typer.Option(False, "--block", help="Wait for merge before moving"),
         no_open: bool = typer.Option(False, "--no-open", help="Don't open terminal"),
         create_pr: bool = typer.Option(False, "-c", "--create-pr", help="Create PR if none exists"),
     ) -> None:
-        """Land current PR, create fresh worktree in same space.
+        """Land current PR, move worktree to new stacked branch.
 
-        Enables auto-merge on the PR, creates a new worktree with a magical-musical
-        suffix (e.g., aurora-melody). Use --block to wait for merge and clean up
-        the old worktree.
+        Enables auto-merge on the PR, then moves the worktree to a new branch
+        with timestamp and magical-musical suffix (e.g., 20260127_2204.aurora-melody).
+        The worktree directory stays the same, only the branch changes.
 
         Example:
-            lfops next                 # land PR, create next worktree
-            lfops next --block         # wait for merge, then create worktree
+            lfops next                 # land PR, move to next branch
+            lfops next --block         # wait for merge, then move
             lfops next --create-pr     # create PR if none exists, then next
         """
         repo_root = find_worktree_root()

--- a/tests/test_naming.py
+++ b/tests/test_naming.py
@@ -37,6 +37,12 @@ def test_parse_branch_base_with_suffix():
     assert result == "my-feature"
 
 
+def test_parse_branch_base_with_timestamp_suffix():
+    """Branch with .timestamp.word1-word2 suffix strips both."""
+    result = parse_branch_base("my-feature.20260127_2204.aurora-melody")
+    assert result == "my-feature"
+
+
 def test_parse_branch_base_with_suffix_frost_cadence():
     """Another valid suffix is stripped."""
     result = parse_branch_base("my-feature.frost-cadence")
@@ -76,16 +82,20 @@ def test_parse_branch_base_recursive():
 
 
 def test_generate_next_branch_appends_suffix():
-    """Next branch gets .word1-word2 suffix."""
+    """Next branch gets .timestamp.word1-word2 suffix."""
     with patch("loopflow.lf.naming.branch_exists", return_value=False):
         result = generate_next_branch("my-feature", MagicMock())
     assert result.startswith("my-feature.")
-    # Should have magical-musical suffix after the dot
-    suffix = result.split(".", 1)[1]
-    parts = suffix.split("-")
-    assert len(parts) == 2
-    assert parts[0] in MAGICAL
-    assert parts[1] in MUSICAL
+    # Should have timestamp.word1-word2 suffix
+    parts = result.split(".")
+    assert len(parts) == 3  # base, timestamp, words
+    timestamp = parts[1]
+    assert len(timestamp) == 13  # YYYYMMDD_HHMM
+    assert "_" in timestamp
+    words = parts[2].split("-")
+    assert len(words) == 2
+    assert words[0] in MAGICAL
+    assert words[1] in MUSICAL
 
 
 def test_generate_next_branch_retries_on_collision():

--- a/tests/test_naming.py
+++ b/tests/test_naming.py
@@ -31,21 +31,9 @@ def test_parse_branch_base_no_suffix():
     assert parse_branch_base("my-feature") == "my-feature"
 
 
-def test_parse_branch_base_with_suffix():
-    """Branch with .word1-word2 suffix strips it."""
-    result = parse_branch_base("my-feature.aurora-melody")
-    assert result == "my-feature"
-
-
 def test_parse_branch_base_with_timestamp_suffix():
     """Branch with .timestamp.word1-word2 suffix strips both."""
     result = parse_branch_base("my-feature.20260127_2204.aurora-melody")
-    assert result == "my-feature"
-
-
-def test_parse_branch_base_with_suffix_frost_cadence():
-    """Another valid suffix is stripped."""
-    result = parse_branch_base("my-feature.frost-cadence")
     assert result == "my-feature"
 
 
@@ -74,10 +62,10 @@ def test_parse_branch_base_simple_branch():
 def test_parse_branch_base_recursive():
     """Parsing a branch with suffix returns same base."""
     base = "my-feature"
-    with_suffix = f"{base}.aurora-melody"
+    with_suffix = f"{base}.20260127_2204.aurora-melody"
     assert parse_branch_base(with_suffix) == base
     # Different suffix still yields same base
-    with_suffix2 = f"{base}.frost-cadence"
+    with_suffix2 = f"{base}.20260127_2204.frost-cadence"
     assert parse_branch_base(with_suffix2) == base
 
 


### PR DESCRIPTION
## Try it

```bash
# Flags before step name now work
lf -m codex ship
lf -d product-engineer implement

# Wave detection from lfd-managed worktrees
cd loopflow.rust.main
lf ingest  # automatically finds wave "rust"
```

## Summary

Waves can now be automatically detected from multiple sources, making it easier to work in wave-specific worktrees without passing `--wave` everywhere. The CLI also now supports putting flags before the step/flow name (`lf -m codex ship` instead of `lf ship -m codex`).

## Changes

- **Wave determination priority**: explicit flag → lfd database lookup → worktree naming pattern (`<repo>.<wave>.main`) → roadmap folder inference
- **CLI flag reordering**: `lf -m codex ship` now works by scanning for valid step/flow names and reordering internally
- **Engine header**: flows now display the coding agent and model (e.g., `engine: codex:o3`) in dim text
- **lfd database query**: new `get_wave_by_worktree()` function to look up waves by their worktree path
- **ingest step docs**: updated to explain wave discovery priority for headless runs