### PR TITLE
lfd: simplify stimulus model to one-per-wave

### DIFF
--- a/scratch/jack-heart.bugs.20260127_2204-review.md
+++ b/scratch/jack-heart.bugs.20260127_2204-review.md
@@ -1,0 +1,58 @@
+# Design Review: Unified Wave Context Determination
+
+## What was implemented
+
+This branch adds unified wave context determination for prompts, enabling waves to be identified from multiple sources:
+
+1. **lfd database lookup** - Query the daemon database to find wave by worktree path
+2. **Worktree naming pattern** - Recognize `<repo>.<wave>.main` naming convention
+3. **CLI flag reordering** - Support `lf -m codex ship` syntax (flags before step/flow name)
+4. **Engine display header** - Show the coding agent and model in flow output
+5. **Documentation update** - Improved `ingest.md` step with clear wave discovery priority
+
+## Key choices
+
+**Priority order for wave determination:**
+1. Explicit `--wave` flag (highest)
+2. lfd database by worktree path
+3. Worktree naming pattern (`<repo>.<wave>.main`)
+4. Roadmap folder inference (lowest)
+
+This order ensures explicit configuration wins, daemon-managed waves are recognized, and naming conventions work as fallback. The database lookup fails silently if lfd isn't running.
+
+**CLI flag reordering approach:**
+Rather than forcing users to put flags after the step name, the CLI now scans for a valid step/flow name among the arguments and reorders internally. This makes `lf -m codex ship` work the same as `lf ship -m codex`.
+
+**Engine header display:**
+Added a simple dim gray line showing `engine: claude` or `engine: codex:o3` to give visibility into which coding agent is running without being intrusive.
+
+## How it fits together
+
+```
+User invokes lf/lfd
+       │
+       ▼
+determine_wave() in lf/wave.py
+       │
+       ├─► explicit_wave parameter? → use it
+       │
+       ├─► lfd database lookup via get_wave_by_worktree() → use wave.name
+       │
+       ├─► worktree name matches <repo>.<wave>.main? → extract wave name
+       │
+       └─► roadmap/<candidate>/ exists? → use candidate
+```
+
+The `get_wave_by_worktree()` function in `lfd/wave.py` mirrors the existing `get_wave_by_name()` pattern, querying SQLite with optional repo filtering.
+
+## Risks and bottlenecks
+
+**Database import overhead:** `_lookup_wave_from_lfd()` imports from `lfd.wave` which pulls in the database module. This is wrapped in try/except to fail silently, but adds import time when lfd is available. Mitigated by lazy import inside the function.
+
+**Worktree pattern matching:** The `<repo>.<wave>.main` pattern could false-positive on worktrees that happen to have 3+ dot-separated parts ending in "main". The check excludes digits and "master" but could still match unintended names.
+
+## What's not included
+
+- No changes to how waves are created or configured
+- No new CLI commands for wave management
+- No tests for the new wave determination logic (existing tests pass, but the new code paths aren't directly tested)

--- a/scratch/polish-priorities.md
+++ b/scratch/polish-priorities.md
@@ -1,0 +1,93 @@
+# Polish Priorities
+
+## Priority 1: Documentation mentions `reports/` inconsistently
+
+**Evidence**:
+- `--lfdocs` help text says "Include reports/, roadmap/, scratch/, and .md files"
+- Code includes `reports/` in `_DEFAULT_FILE_PATHS` at `context.py:148`
+- docs/index.md "Where Files Live" section doesn't mention `reports/`
+- docs/config.md doesn't mention `reports/`
+- `reports/` folder exists and contains 9 reference docs (landscape.md, target-customer.md, etc.)
+
+**Impact**: Users don't know about `reports/` as a first-class concept. The docs mention `scratch/` vs `roadmap/` but not `reports/` for reference material. Users may not understand where to put research and analysis that should persist.
+
+**Effort**: Low (documentation update)
+
+**Recommendation**: Add `reports/` to the file structure docs. Update "scratch/ vs roadmap/" section to explain all three: scratch/ (ephemeral), roadmap/ (actionable items), reports/ (reference material).
+
+---
+
+## Priority 2: Help text word-wrap artifacts in `lfd` commands
+
+**Evidence**:
+- `lfd loop --help` shows:
+  ```
+  Examples:     lfd loop swift-falcon                                   # run
+  existing wave     lfd loop swift-falcon --area src/                       #
+  create + set area + run
+  ```
+- Same issue in `lfd run --help`, `lfd watch --help`, `lfd cron --help`
+- Caused by inline examples in docstrings without proper line breaks
+
+**Impact**: Help text is hard to read. Users have to mentally parse the wrapped output to understand the examples.
+
+**Effort**: Low (add `\n` to docstrings in `cli.py`)
+
+**Recommendation**: Reformat examples in docstrings to use explicit newlines so Typer renders them correctly.
+
+---
+
+## Priority 3: `--direction` flag lacks context
+
+**Evidence**:
+- `lf run --help` shows: `--direction -d,-D TEXT Direction to apply (repeatable, or comma-separated)`
+- No mention of where directions come from (`.lf/directions/`) or built-in options
+
+**Impact**: New users don't understand what a "direction" is or how to use one. They'd need to read documentation to learn about `product-engineer`, `designer`, etc.
+
+**Effort**: Low (update help text)
+
+**Recommendation**: Change to: "Direction from .lf/directions/ or built-in (e.g., product-engineer)"
+
+---
+
+## Priority 4: Doctor output uses cryptic message
+
+**Evidence**:
+- `lfops doctor` shows: `- no task files (run: lf init)`
+- Doesn't explain what "task files" means or where they should be
+
+**Impact**: Users seeing this message don't know what's missing or where to look.
+
+**Effort**: Low (string change in `init.py:39`)
+
+**Recommendation**: Change to: `.lf/steps/ or .claude/commands/ not found (run: lf init)`
+
+---
+
+## Priority 5: Uppercase flag aliases add visual noise
+
+**Evidence**:
+- `--auto -a,-A`, `--interactive -i,-I`, `--clipboard -c,-C` etc.
+- Appears in help text for `lf run`, `lf inline`, and other commands
+- The uppercase variants exist for historical compatibility but clutter help output
+
+**Impact**: Minor visual noise. Help output is longer and harder to scan.
+
+**Effort**: Low (remove uppercase aliases)
+
+**Recommendation**: Defer. The uppercase aliases may have users depending on them. Consider removing in a future cleanup pass.
+
+---
+
+## Lower priority
+
+### Step descriptions in `lf --list`
+
+The `explore` step description says "Investigate current diff" but the step actually explores the codebase generally, not just the diff. Consider: "Investigate the codebase".
+
+### Error message for missing wave
+
+`lfd show nonexistent` shows: `Error: Wave 'nonexistent' not found`
+
+Could add: `Run 'lfd list' to see available waves.`


### PR DESCRIPTION
## Summary

Simplifies the wave-stimulus relationship from many-to-one back to one-to-one. Waves now own their stimulus directly rather than having a separate `Stimulus` entity table. This removes the `lfd stimuli` subcommands and associated complexity.

The Rust daemon scheduling code (loops, sessions, watch/cron/loop ticker) is removed pending a clean reimplementation tracked in `roadmap/rust/03-daemon-service.md`.

## Changes

- `Stimulus` is now a simple dataclass on `Wave` instead of a separate DB entity
- Remove `lfd stimuli list/add/enable/disable/rm` commands
- Remove `stimulus.py` module and stimuli migration
- Remove Rust `loops/` module (cron, watch, loop_ticker, recovery)
- Remove Rust `sessions.rs` 
- Simplify `store/sqlite.rs` to remove stimuli and pending_activations tables
- Update docs to remove multi-stimuli documentation
- Add `roadmap/rust/03-daemon-service.md` for future daemon implementation