### PR TITLE
lf lint: context: remove reports/ from defaults, simplify cli flags

### DIFF
--- a/.lf/config.yaml
+++ b/.lf/config.yaml
@@ -6,9 +6,6 @@ skill_sources:
   - name: superpowers
     prefix: sp
     path: ~/.superpowers
-context:
-  - docs
-  - .design
 exclude:
   - uv.lock
 push: true

--- a/src/loopflow/lf/context.py
+++ b/src/loopflow/lf/context.py
@@ -16,7 +16,6 @@ from loopflow.lf.design import (
     gather_ancestral_docs,
     gather_area,
     gather_design_docs,
-    gather_internal_docs,
 )
 from loopflow.lf.directions import Direction
 from loopflow.lf.files import (
@@ -145,14 +144,16 @@ class DiffMode(str, Enum):
 
 
 # Default paths always included unless explicitly excluded
-_DEFAULT_FILE_PATHS = ["scratch/", "reports/", "roadmap/", "*.md"]
+# Note: reports/ is NOT included by default - use area to scope to relevant reports
+_DEFAULT_FILE_PATHS = ["scratch/", "*.md"]
 
 
 class FilesetConfig(BaseModel):
     """Configuration for file context.
 
-    Default paths (scratch/, reports/, roadmap/, *.md) are always included unless excluded.
-    The paths field is additive to defaults.
+    Default paths: scratch/ (design docs) and root *.md files.
+    reports/ is NOT included by default - use area to include relevant reports.
+    roadmap/ is included only for the active wave (inferred from branch/worktree name).
     """
 
     paths: list[str] = Field(default_factory=list)  # Additive to defaults
@@ -167,7 +168,7 @@ class ContextConfig(BaseModel):
     # Branch work
     diff_mode: DiffMode = DiffMode.FILES
 
-    # User files (defaults: scratch/, reports/, roadmap/, *.md)
+    # User files (defaults: scratch/, *.md; wave-specific roadmap/)
     files: FilesetConfig = Field(default_factory=FilesetConfig)
 
     # Area path (e.g., "lf/cli" or "concerto/ui")
@@ -855,16 +856,14 @@ def gather_prompt_components(
     if not area_summary_used and context_config.budget_area > 0 and area_docs:
         area_docs, _ = _limit_to_budget(area_docs, context_config.budget_area)
 
-    # Gather reference docs: scratch/ (ephemeral), roadmap context, and repo root .md
+    # Gather reference docs: scratch/ (ephemeral) and repo root .md
+    # reports/ is NOT included by default - use area to scope to relevant reports
     design_docs = gather_design_docs(repo_root)
-    roadmap_docs = []
+    ancestral_docs = []
     if context_config.area:
-        # Area-scoped: ancestral docs from parent paths
-        roadmap_docs = gather_ancestral_docs(repo_root, context_config.area)
-    else:
-        # No area: include all of reports/ as reference
-        roadmap_docs = gather_internal_docs(repo_root)
-    ref_docs = design_docs + roadmap_docs + docs
+        # Area-scoped: ancestral docs (parent READMEs + reports/<area>/)
+        ancestral_docs = gather_ancestral_docs(repo_root, context_config.area)
+    ref_docs = design_docs + ancestral_docs + docs
 
     # Apply docs budget to reference docs
     if context_config.budget_docs > 0 and ref_docs:

--- a/src/loopflow/lf/step.py
+++ b/src/loopflow/lf/step.py
@@ -29,7 +29,6 @@ from loopflow.lf.output import (
     warn_if_context_too_large,
 )
 from loopflow.lf.tokens import analyze_components
-from loopflow.lf.worktrees import WorktreeError, create
 
 ModelType = Optional[str]
 
@@ -141,25 +140,22 @@ def _launch_interactive_default(
 def run(
     ctx: typer.Context,
     step: Optional[str] = typer.Argument(None, help="Step name (e.g., 'review', 'implement')"),
-    auto: bool = typer.Option(False, "-a", "-A", "--auto", help="Override to run in auto mode"),
+    batch: bool = typer.Option(False, "-b", "-B", "--batch", help="Run in batch/headless mode"),
     interactive: bool = typer.Option(
         False, "-i", "-I", "--interactive", help="Override to run in interactive mode"
     ),
-    area: list[str] = typer.Option(None, "--area", help="Area scope (paths to include in context)"),
+    area: list[str] = typer.Option(
+        None, "-a", "-A", "--area", help="Area scope (paths to include in context)"
+    ),
     wave: Optional[str] = typer.Option(
-        None, "--wave", help="Wave name for roadmap scoping (e.g., 'rust', 'enterprise')"
+        None, "-w", "-W", "--wave", help="Wave name for roadmap scoping"
     ),
-    worktree: str = typer.Option(
-        None, "-w", "-W", "--worktree", help="Create worktree and run step there"
-    ),
-    web: bool = typer.Option(
-        False, "--web", help="Copy to clipboard and open web client (claude.ai, chatgpt.com, etc.)"
-    ),
+    web: bool = typer.Option(False, "--web", help="Copy to clipboard and open web client"),
     clipboard: Optional[bool] = typer.Option(
-        None, "-c", "-C", "--clipboard/--no-clipboard", help="Include clipboard content in prompt"
+        None, "-c", "-C", "--clipboard/--no-clipboard", help="Include clipboard content"
     ),
     docs: Optional[bool] = typer.Option(
-        None, "--lfdocs/--no-lfdocs", help="Include reports/, roadmap/, scratch/, and .md files"
+        None, "--lfdocs/--no-lfdocs", help="Include scratch/, root .md, and loopflow docs"
     ),
     diff_mode: Optional[str] = typer.Option(
         None, "--diff-mode", help="How to include branch changes: files, diff, or none"
@@ -168,7 +164,7 @@ def run(
         None, "-m", "-M", "--model", help="Model to use (backend or backend:variant)"
     ),
     direction: Optional[list[str]] = typer.Option(
-        None, "-d", "-D", "--direction", help="Direction to apply (repeatable, or comma-separated)"
+        None, "-d", "-D", "--direction", help="Direction to apply (repeatable)"
     ),
     chrome: Optional[bool] = typer.Option(
         None, "--chrome/--no-chrome", help="Enable Chrome browser automation"
@@ -177,24 +173,11 @@ def run(
     """Run a step with an LLM model."""
     repo_root = find_worktree_root()
 
-    # Some features require a git repo
+    # Use cwd as fallback for non-git usage
     if not repo_root:
-        if worktree:
-            typer.echo("Error: --worktree requires a git repository", err=True)
-            raise typer.Exit(1)
-        # Use cwd as fallback for non-git usage
         repo_root = Path.cwd()
 
     config = load_config(repo_root)
-
-    if worktree:
-        try:
-            worktree_path = create(repo_root, worktree)
-        except WorktreeError as e:
-            typer.echo(f"Error: {e}", err=True)
-            raise typer.Exit(1)
-        repo_root = worktree_path
-        config = load_config(repo_root)
 
     # Handle no step: launch interactive claude with docs context
     if step is None:
@@ -221,7 +204,7 @@ def run(
         global_config=config,
         frontmatter=frontmatter,
         cli_interactive=True if interactive else None,
-        cli_auto=True if auto else None,
+        cli_auto=True if batch else None,
         cli_model=model,
         cli_context=list(area) if area else None,
         cli_direction=cli_directions or None,
@@ -330,30 +313,27 @@ def run(
         chrome=chrome_enabled,
     )
 
-    if worktree:
-        typer.echo(f"\nWorktree: {repo_root}")
-
     raise typer.Exit(result_code)
 
 
 def inline(
     prompt: str = typer.Argument(help="Inline prompt to run"),
-    auto: bool = typer.Option(False, "-a", "-A", "--auto", help="Override to run in auto mode"),
+    batch: bool = typer.Option(False, "-b", "-B", "--batch", help="Run in batch/headless mode"),
     interactive: bool = typer.Option(
         False, "-i", "-I", "--interactive", help="Override to run in interactive mode"
     ),
-    area: list[str] = typer.Option(None, "--area", help="Area scope (paths to include in context)"),
+    area: list[str] = typer.Option(
+        None, "-a", "-A", "--area", help="Area scope (paths to include in context)"
+    ),
     wave: Optional[str] = typer.Option(
-        None, "--wave", help="Wave name for roadmap scoping (e.g., 'rust', 'enterprise')"
+        None, "-w", "-W", "--wave", help="Wave name for roadmap scoping"
     ),
-    web: bool = typer.Option(
-        False, "--web", help="Copy to clipboard and open web client (claude.ai, chatgpt.com, etc.)"
-    ),
+    web: bool = typer.Option(False, "--web", help="Copy to clipboard and open web client"),
     clipboard: Optional[bool] = typer.Option(
         None, "-c", "-C", "--clipboard/--no-clipboard", help="Include clipboard content in prompt"
     ),
     docs: Optional[bool] = typer.Option(
-        None, "--lfdocs/--no-lfdocs", help="Include reports/, roadmap/, scratch/, and .md files"
+        None, "--lfdocs/--no-lfdocs", help="Include scratch/, root .md, and loopflow docs"
     ),
     diff_mode: Optional[str] = typer.Option(
         None, "--diff-mode", help="How to include branch changes: files, diff, or none"
@@ -385,7 +365,7 @@ def inline(
         global_config=config,
         frontmatter=StepConfig(),
         cli_interactive=True if interactive else None,
-        cli_auto=True if auto else None,
+        cli_auto=True if batch else None,
         cli_model=model,
         cli_context=list(area) if area else None,
         cli_direction=cli_directions or None,
@@ -493,25 +473,17 @@ def inline(
 
 def flow(
     name: str = typer.Argument(help="Flow name from .lf/flows/"),
-    area: list[str] = typer.Option(None, "--area", help="Area scope (paths to include in context)"),
-    worktree: str = typer.Option(
-        None, "-w", "-W", "--worktree", help="Create worktree and run flow there"
+    area: list[str] = typer.Option(
+        None, "-a", "-A", "--area", help="Area scope (paths to include in context)"
     ),
     pr: bool = typer.Option(None, "--pr", help="Open PR when done"),
-    web: bool = typer.Option(
-        False, "--web", help="Copy to clipboard and open web client (claude.ai, chatgpt.com, etc.)"
-    ),
+    web: bool = typer.Option(False, "--web", help="Copy to clipboard and open web client"),
     model: ModelType = typer.Option(
         None, "-m", "-M", "--model", help="Model to use (backend or backend:variant)"
     ),
 ):
     """Run a named flow."""
     repo_root = find_worktree_root()
-
-    # Worktree creation still requires git
-    if not repo_root and worktree:
-        typer.echo("Error: --worktree requires a git repository", err=True)
-        raise typer.Exit(1)
 
     # Use cwd as fallback for non-git usage
     if not repo_root:
@@ -537,14 +509,6 @@ def flow(
     if not web and not runner.is_available():
         typer.echo(f"Error: '{backend}' CLI not found", err=True)
         raise typer.Exit(1)
-
-    if worktree:
-        try:
-            worktree_path = create(repo_root, worktree)
-        except WorktreeError as e:
-            typer.echo(f"Error: {e}", err=True)
-            raise typer.Exit(1)
-        repo_root = worktree_path
 
     all_context = list(config.context) if config and config.context else []
     if area:

--- a/src/loopflow/lf/wave.py
+++ b/src/loopflow/lf/wave.py
@@ -65,12 +65,38 @@ def determine_wave(
         if wave_name and not wave_name.isdigit() and wave_name not in ("main", "master"):
             return WaveContext(name=wave_name, source="worktree")
 
-    # Fall back to roadmap-based inference
+    # Fall back to roadmap-based inference from worktree name
     for candidate in _extract_wave_candidates(worktree_name):
         roadmap_path = repo_root / "roadmap" / candidate
         if roadmap_path.is_dir():
             return WaveContext(name=candidate, source="inferred")
 
+    # Try branch name as additional source
+    branch_name = _get_current_branch(repo_root)
+    if branch_name and branch_name != worktree_name:
+        for candidate in _extract_wave_candidates(branch_name):
+            roadmap_path = repo_root / "roadmap" / candidate
+            if roadmap_path.is_dir():
+                return WaveContext(name=candidate, source="branch")
+
+    return None
+
+
+def _get_current_branch(repo_root: Path) -> str | None:
+    """Get current git branch name."""
+    import subprocess
+
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+            cwd=repo_root,
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode == 0:
+            return result.stdout.strip()
+    except Exception:
+        pass
     return None
 
 

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -610,8 +610,8 @@ def _setup_task_template(tmp_path):
 # =============================================================================
 
 
-def test_internal_docs_auto_included(tmp_path):
-    """reports/ markdown files are auto-included in context."""
+def test_internal_docs_not_auto_included(tmp_path):
+    """reports/ is NOT auto-included by default - use area to include relevant reports."""
     (tmp_path / ".git").mkdir()
     (tmp_path / "README.md").write_text("# Test\n")
 
@@ -625,11 +625,11 @@ def test_internal_docs_auto_included(tmp_path):
     components = gather_prompt_components(tmp_path, "implement")
     prompt = format_prompt(components)
 
-    # reports/ files should be included
-    assert "# Architecture" in prompt
-    assert "How it works." in prompt
-    assert "# ADR 001" in prompt
-    assert "We chose X." in prompt
+    # reports/ files should NOT be included by default
+    assert "# Architecture" not in prompt
+    assert "How it works." not in prompt
+    assert "# ADR 001" not in prompt
+    assert "We chose X." not in prompt
 
 
 def test_internal_docs_empty_when_missing(tmp_path):
@@ -664,8 +664,8 @@ def test_public_docs_not_auto_included(tmp_path):
     assert "# API Reference" not in prompt
 
 
-def test_internal_docs_before_root_docs(tmp_path):
-    """reports/ appears before repo root .md files in context."""
+def test_scratch_before_root_docs(tmp_path):
+    """scratch/ appears before repo root .md files in context."""
     (tmp_path / ".git").mkdir()
     (tmp_path / "README.md").write_text("# Root README\n")
 
@@ -673,19 +673,14 @@ def test_internal_docs_before_root_docs(tmp_path):
     scratch_dir.mkdir()
     (scratch_dir / "plan.md").write_text("# Design Plan\n")
 
-    internal_docs = tmp_path / "reports"
-    internal_docs.mkdir()
-    (internal_docs / "context.md").write_text("# Internal Context\n")
-
     components = gather_prompt_components(tmp_path, step=None, inline="test")
 
-    # Check order: scratch/, then reports/, then root docs
+    # Check order: scratch/ before root docs
     doc_paths = [str(p) for p, _ in components.docs]
     scratch_idx = next(i for i, p in enumerate(doc_paths) if "scratch" in p)
-    internal_idx = next(i for i, p in enumerate(doc_paths) if "reports" in p)
     readme_idx = next(i for i, p in enumerate(doc_paths) if "README" in p)
 
-    assert scratch_idx < internal_idx < readme_idx
+    assert scratch_idx < readme_idx
 
 
 def test_trim_prompt_components_drops_oversize_diff_files(tmp_path):


### PR DESCRIPTION
## Usage

```bash
lf review -a src/loopflow/lf    # area scope with -a shorthand
lf implement -w rust            # wave scope with -w shorthand
lf debug -b                     # batch mode with -b (was -a/--auto)
```

## Summary

Simplifies context defaults and CLI flags. `reports/` is no longer auto-included in every prompt—use `-a/--area` to scope to relevant reports instead. This reduces noise when working outside a specific area.

CLI flags are reorganized for consistency:
- `-a/-A` now means `--area` (was `--auto`)
- `-b/-B` means `--batch` (renamed from `--auto`)
- `-w/-W` means `--wave` (was `--worktree`)
- Worktree creation removed from `lf step` (use `wt` separately)

## Changes

- Default context paths reduced from `[scratch/, reports/, roadmap/, *.md]` to `[scratch/, *.md]`
- Wave detection now also checks branch name, not just worktree name
- Removed `--worktree` flag from `run`, `inline`, and `flow` commands
- Removed `context:` section from `.lf/config.yaml` (paths are now explicit via area)