### PR TITLE
lf ops: use batch mode for lint, skip stale releases in publish

### DIFF
--- a/scripts/publish.py
+++ b/scripts/publish.py
@@ -107,6 +107,9 @@ def _find_pending_release() -> str | None:
         # Match "release: v0.7.1" or "release: v0.7.1 [skip ci]"
         if line.startswith("release: v"):
             version = line.replace("release: v", "").split()[0]
+            if _tag_exists(version) and _is_on_pypi(version):
+                # Found a complete release - older incomplete releases are stale
+                return None
             if not _tag_exists(version) or not _is_on_pypi(version):
                 return version
     return None

--- a/src/loopflow/lf/ops/_helpers.py
+++ b/src/loopflow/lf/ops/_helpers.py
@@ -68,7 +68,7 @@ def run_lint(repo_root: Path) -> bool:
     else:
         typer.echo("Running lint...")
 
-    agent_result = subprocess.run(["lf", "lint", "-a"], cwd=repo_root)
+    agent_result = subprocess.run(["lf", "lint", "-b"], cwd=repo_root)
     return agent_result.returncode == 0
 
 


### PR DESCRIPTION
## Summary

Two small fixes to ops tooling:

1. **Lint uses batch mode (-b)** instead of agent mode (-a). Batch mode runs lint fixes without an interactive agent session, which is appropriate for automated workflows like `lf ops pr land`.

2. **Publish skips stale releases** when scanning for pending releases. If a complete release (tagged + on PyPI) is found before an incomplete one, the older incomplete release is treated as stale and ignored. This prevents the publish script from trying to finalize abandoned release commits.

## Changes

- `_helpers.py`: Switch `lf lint -a` → `lf lint -b` for batch mode
- `publish.py`: Return `None` early when a complete release is found, treating older incomplete releases as stale