### PR TITLE
remove worktrunk dependency, fix worktree add on Apple Git

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,9 +154,6 @@ Install the Rust binaries directly with cargo.
 - [Codex CLI](https://github.com/openai/codex) — OpenAI's coding agent
 - [Gemini CLI](https://github.com/google-gemini/gemini-cli) — Google's coding agent
 
-**Tools**
-- [worktrunk](https://github.com/loopflowstudio/worktrunk) — git worktree management (`wt` commands)
-
 **Skill Libraries**
 - [superpowers](https://github.com/obra/superpowers) — prompt library (`lf sp:<skill>`)
 - [SkillRegistry](https://skillregistry.io/) — remote skill directory (`lf sr:<skill>`)

--- a/rust/lf/src/commands/ops/mod.rs
+++ b/rust/lf/src/commands/ops/mod.rs
@@ -636,14 +636,11 @@ fn doctor() -> Result<()> {
         println!("- not in a git repo");
     }
 
-    let mut all_ok = true;
-
-    // Required: worktrunk (wt)
+    // Optional: worktrunk (wt)
     if which("wt") {
         println!("✓ wt");
     } else {
-        println!("✗ wt - Run: lf init");
-        all_ok = false;
+        println!("- wt: brew install max-sixty/worktrunk/wt");
     }
 
     let is_macos = cfg!(target_os = "macos");
@@ -710,11 +707,7 @@ fn doctor() -> Result<()> {
         println!("- gh: https://cli.github.com/");
     }
 
-    if all_ok {
-        Ok(())
-    } else {
-        Err(anyhow!("some required dependencies are missing"))
-    }
+    Ok(())
 }
 
 fn which(cmd: &str) -> bool {

--- a/rust/lf/src/commands/ops/mod.rs
+++ b/rust/lf/src/commands/ops/mod.rs
@@ -636,13 +636,6 @@ fn doctor() -> Result<()> {
         println!("- not in a git repo");
     }
 
-    // Optional: worktrunk (wt)
-    if which("wt") {
-        println!("✓ wt");
-    } else {
-        println!("- wt: brew install max-sixty/worktrunk/wt");
-    }
-
     let is_macos = cfg!(target_os = "macos");
 
     // Optional: npm

--- a/rust/loopflow-engine/src/builtins/steps/ops/init.md
+++ b/rust/loopflow-engine/src/builtins/steps/ops/init.md
@@ -6,7 +6,7 @@ Guide the user through setting up loopflow in this repository.
 
 ## Prerequisites
 
-This prompt assumes loopflow is already installed globally via `uv tool install loopflow`. It handles everything after that: installing Claude Code, worktrunk, configuring the repo, and optional extras.
+This prompt assumes loopflow is already installed globally via `uv tool install loopflow`. It handles everything after that: installing Claude Code, configuring the repo, and optional extras.
 
 ## Phase 1: Check environment
 
@@ -24,7 +24,6 @@ which npm     # Node.js (needed for coding agents)
 which claude  # Claude Code
 which codex   # Codex CLI
 which gemini  # Gemini CLI
-which wt      # worktrunk (optional)
 test -f .lf/config.yaml && echo "config exists"
 test -d ~/.superpowers && echo "superpowers exists"
 ```
@@ -35,7 +34,6 @@ Checking environment...
 ✓ Homebrew
 ✓ Node.js
 ✓ Claude Code (coding agent)
-- worktrunk (optional)
 - superpowers (optional)
 
 Config: not initialized
@@ -61,12 +59,6 @@ If no coding agent is installed (none of claude, codex, or gemini found):
   - Codex CLI: `npm install -g @openai/codex`
   - Gemini CLI: `npm install -g @google/gemini-cli`
   - Skip: explain they need to install one manually before using loopflow
-
-If worktrunk is missing:
-- Mention: "worktrunk is optional. Loopflow has built-in worktree management via `lf ops wt`."
-- Ask: "Install worktrunk anyway? It provides `wt list` for quick worktree overview."
-- Yes: `brew install max-sixty/worktrunk/wt`
-- No: skip
 
 ## Phase 3: Configure repository
 
@@ -202,7 +194,6 @@ Setup complete!
 
 ✓ Node.js (already installed)
 ✓ Claude Code (coding agent)
-✓ worktrunk installed
 ✓ .lf/config.yaml created
 ✓ superpowers installed
 

--- a/rust/loopflow-engine/src/builtins/steps/ops/init.md
+++ b/rust/loopflow-engine/src/builtins/steps/ops/init.md
@@ -24,7 +24,7 @@ which npm     # Node.js (needed for coding agents)
 which claude  # Claude Code
 which codex   # Codex CLI
 which gemini  # Gemini CLI
-which wt      # worktrunk
+which wt      # worktrunk (optional)
 test -f .lf/config.yaml && echo "config exists"
 test -d ~/.superpowers && echo "superpowers exists"
 ```
@@ -35,7 +35,7 @@ Checking environment...
 ✓ Homebrew
 ✓ Node.js
 ✓ Claude Code (coding agent)
-✗ worktrunk (required)
+- worktrunk (optional)
 - superpowers (optional)
 
 Config: not initialized
@@ -63,9 +63,10 @@ If no coding agent is installed (none of claude, codex, or gemini found):
   - Skip: explain they need to install one manually before using loopflow
 
 If worktrunk is missing:
-- Ask: "worktrunk is required for worktree management. Install it?"
+- Mention: "worktrunk is optional. Loopflow has built-in worktree management via `lf ops wt`."
+- Ask: "Install worktrunk anyway? It provides `wt list` for quick worktree overview."
 - Yes: `brew install max-sixty/worktrunk/wt`
-- No: explain they can install it manually later with that command
+- No: skip
 
 ## Phase 3: Configure repository
 

--- a/rust/loopflow-engine/src/git.rs
+++ b/rust/loopflow-engine/src/git.rs
@@ -297,6 +297,11 @@ pub fn worktree_add(
         ],
     )?;
     if !output.status.success() {
+        // Apple Git 2.50.1 returns exit code 1 even on successful creation.
+        // Verify the worktree was actually created before reporting failure.
+        if path.join(".git").exists() {
+            return Ok(());
+        }
         return Err(GitError::CommandFailed {
             command: format!(
                 "git worktree add -b {} {} {}",

--- a/rust/loopflow-engine/src/git.rs
+++ b/rust/loopflow-engine/src/git.rs
@@ -297,8 +297,8 @@ pub fn worktree_add(
         ],
     )?;
     if !output.status.success() {
-        // Apple Git 2.50.1 returns exit code 1 even on successful creation.
-        // Verify the worktree was actually created before reporting failure.
+        // A failing post-checkout hook causes git to exit non-zero even when
+        // the worktree was created successfully. Verify before reporting failure.
         if path.join(".git").exists() {
             return Ok(());
         }


### PR DESCRIPTION
## Try it

```bash
lf ops doctor        # no longer requires wt
lf ops init          # skips worktrunk install step
git worktree add … # succeeds even when post-checkout hook exits non-zero
```

## Summary

Drops `worktrunk` (`wt`) as a required dependency. Loopflow no longer checks for it in `lf ops doctor`, no longer prompts to install it in `lf ops init`, and removes it from the README's related tools section.

Also fixes a bug where `git worktree add` would report failure on Apple Git when a post-checkout hook exits non-zero, even though the worktree was created successfully. The fix verifies the worktree actually exists before propagating the error.

## Changes

- **doctor**: remove `wt` from required dependency checks; `doctor` now always returns `Ok(())`
- **init prompt**: remove worktrunk install phase and all references
- **git.rs**: after a non-zero exit from `git worktree add`, check if `.git` exists in the target path before reporting failure
- **README**: remove worktrunk from related tools