### PR TITLE
ci: update macos runner labels in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,9 +42,9 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: macos-14
+          - os: macos-latest
             target: aarch64-apple-darwin
-          - os: macos-15-large
+          - os: macos-15-intel
             target: x86_64-apple-darwin
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
@@ -92,9 +92,9 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: macos-14
+          - os: macos-latest
             target: aarch64-apple-darwin
-          - os: macos-15-large
+          - os: macos-15-intel
             target: x86_64-apple-darwin
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu


### PR DESCRIPTION
## Summary

Updates the macOS GitHub Actions runner labels used in the release workflow's build matrix.

## Changes

- `macos-14` → `macos-latest` for aarch64 (Apple Silicon) builds
- `macos-15-large` → `macos-15-intel` for x86_64 (Intel) builds

Both the build and test matrix entries are updated to use the current runner labels.