### PR TITLE
ci: use native arm runner for aarch64-linux builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,7 +98,7 @@ jobs:
             target: x86_64-apple-darwin
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
-          - os: ubuntu-latest
+          - os: ubuntu-24.04-arm
             target: aarch64-unknown-linux-gnu
     runs-on: ${{ matrix.os }}
     steps:
@@ -106,12 +106,6 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
-      - name: Install cross-compilation tools
-        if: matrix.target == 'aarch64-unknown-linux-gnu'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y gcc-aarch64-linux-gnu
-          echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc" >> "$GITHUB_ENV"
       - name: Build
         run: cargo build --release --target ${{ matrix.target }} -p lf -p lfd
       - name: Package


### PR DESCRIPTION
## Summary

Switch the aarch64-linux release build from cross-compiling on an x86_64 runner to building natively on an `ubuntu-24.04-arm` runner.

## Changes

- Use `ubuntu-24.04-arm` runner for the `aarch64-unknown-linux-gnu` target instead of `ubuntu-latest`
- Remove the cross-compilation toolchain setup step (`gcc-aarch64-linux-gnu` install and `CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER` env var)

Native builds are simpler and avoid potential cross-compilation issues.