### PR TITLE
ci: fix sed -i portability for macos, switch to uv build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set version from tag
-        run: sed -i 's/^version = "0.0.0"/version = "'"${GITHUB_REF_NAME#v}"'"/' Cargo.toml
+        run: sed -i.bak 's/^version = "0.0.0"/version = "'"${GITHUB_REF_NAME#v}"'"/' Cargo.toml && rm Cargo.toml.bak
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
@@ -74,7 +74,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set version from tag
-        run: sed -i 's/^version = "0.0.0"/version = "'"${GITHUB_REF_NAME#v}"'"/' Cargo.toml
+        run: sed -i.bak 's/^version = "0.0.0"/version = "'"${GITHUB_REF_NAME#v}"'"/' Cargo.toml && rm Cargo.toml.bak
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
@@ -95,7 +95,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set version from tag
-        run: sed -i 's/^version = "0.0.0"/version = "'"${GITHUB_REF_NAME#v}"'"/' Cargo.toml
+        run: sed -i.bak 's/^version = "0.0.0"/version = "'"${GITHUB_REF_NAME#v}"'"/' Cargo.toml && rm Cargo.toml.bak
       - uses: dtolnay/rust-toolchain@stable
       - name: Publish to crates.io
         run: cargo publish -p loopflow

--- a/scripts/publish.py
+++ b/scripts/publish.py
@@ -97,7 +97,7 @@ def _check_on_main() -> None:
 
 def _build_wheel() -> tuple[bool, str]:
     result = subprocess.run(
-        ["uv", "run", "hatchling", "build"],
+        ["uv", "build"],
         cwd=ROOT,
         capture_output=True,
         text=True,


### PR DESCRIPTION
## Summary

Two small fixes to the build and release tooling:

- **Fix `sed -i` on macOS**: BSD `sed` (used on macOS runners) requires a backup extension argument with `-i`. Changed `sed -i` to `sed -i.bak` with cleanup in the release workflow so version stamping works on both Linux and macOS.
- **Use `uv build` directly**: Replace `uv run hatchling build` with `uv build` in the publish script — simpler invocation, same result.

## Changes

- `.github/workflows/release.yml`: Fix all three `sed -i` calls for BSD/macOS portability
- `scripts/publish.py`: Simplify wheel build command to `uv build`