### PR TITLE
publish: prefer /usr/local/bin on macOS when writable

### DIFF
--- a/scripts/publish.py
+++ b/scripts/publish.py
@@ -118,7 +118,16 @@ def _install_wheel() -> tuple[bool, str]:
 
 
 def _install_binaries() -> tuple[bool, str]:
-    install_dir = os.environ.get("LF_INSTALL_DIR", str(Path.home() / ".local" / "bin"))
+    env_dir = os.environ.get("LF_INSTALL_DIR")
+    if env_dir:
+        install_dir = env_dir
+    else:
+        default_dir = Path.home() / ".local" / "bin"
+        if sys.platform == "darwin":
+            mac_dir = Path("/usr/local/bin")
+            if mac_dir.exists() and os.access(mac_dir, os.W_OK):
+                default_dir = mac_dir
+        install_dir = str(default_dir)
     install_path = Path(install_dir)
     install_path.mkdir(parents=True, exist_ok=True)
 


### PR DESCRIPTION
## Usage

```bash
# macOS: installs to /usr/local/bin if writable, otherwise ~/.local/bin
./scripts/publish.py

# Override with env var (any platform)
LF_INSTALL_DIR=~/bin ./scripts/publish.py
```

## Summary

On macOS, `/usr/local/bin` is on `$PATH` by default while `~/.local/bin` often isn't. This changes the default install directory to `/usr/local/bin` when it exists and is writable, so `lf` and `lfd` work immediately after install without PATH modifications.

The `LF_INSTALL_DIR` env var still takes priority, and Linux keeps `~/.local/bin` as the default.