### PR TITLE
lf commit: engine: inline prompt as task prompt, sync_main ignores untracked files

### DIFF
--- a/rust/loopflow/src/engine/git.rs
+++ b/rust/loopflow/src/engine/git.rs
@@ -180,12 +180,25 @@ pub fn get_default_branch(repo: &Path) -> Result<String, GitError> {
     Ok(raw)
 }
 
-/// Return true if working tree is clean.
+/// Return true if working tree is clean (including untracked files).
 pub fn is_clean(repo: &Path) -> Result<bool, GitError> {
     let output = run_git(repo, &["status", "--porcelain"])?;
     if !output.status.success() {
         return Err(GitError::CommandFailed {
             command: "git status --porcelain".to_string(),
+            stderr: String::from_utf8_lossy(&output.stderr).to_string(),
+        });
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).trim().is_empty())
+}
+
+/// Return true if tracked files have no staged or unstaged changes.
+/// Ignores untracked files — safe for operations like `reset --hard` that preserve them.
+pub fn is_index_clean(repo: &Path) -> Result<bool, GitError> {
+    let output = run_git(repo, &["status", "--porcelain", "--untracked-files=no"])?;
+    if !output.status.success() {
+        return Err(GitError::CommandFailed {
+            command: "git status --porcelain --untracked-files=no".to_string(),
             stderr: String::from_utf8_lossy(&output.stderr).to_string(),
         });
     }
@@ -237,7 +250,7 @@ pub fn sync_main(repo: &Path, main_branch: &str) -> Result<bool, GitError> {
         return Ok(true);
     }
 
-    if !is_clean(repo)? {
+    if !is_index_clean(repo)? {
         return Ok(false);
     }
 

--- a/rust/loopflow/src/engine/prompt.rs
+++ b/rust/loopflow/src/engine/prompt.rs
@@ -115,6 +115,8 @@ pub struct PromptComponents {
     pub loopflow_doc: Option<String>,
     /// User message (positional args after step/flow name)
     pub message: Option<String>,
+    /// Inline prompt text (from `lf : "text"`)
+    pub inline: Option<String>,
     /// How diff context was tiered
     pub diff_tier: DiffTier,
     /// Number of files changed on branch (for display)
@@ -509,6 +511,7 @@ pub fn gather_context(opts: &GatherContextOpts) -> Result<PromptComponents, Core
         wave: opts.wave.clone(),
         loopflow_doc,
         message: opts.message.clone(),
+        inline: opts.inline.clone(),
         diff_tier,
         diff_file_count,
         area_docs,
@@ -1403,18 +1406,22 @@ pub fn format_context_prompt(components: &PromptComponents) -> String {
 ///
 /// This is passed as the CLI argument when using `--append-system-prompt-file`.
 pub fn format_task_prompt(components: &PromptComponents) -> String {
-    let Some(ref step) = components.step else {
-        return String::new();
-    };
-
-    if let Some(ref content) = step.content {
-        format!(
-            "<lf:step:{}>\n{}\n</lf:step:{}>",
-            step.name, content, step.name
-        )
-    } else {
-        format!("<lf:step:{}>\n</lf:step:{}>", step.name, step.name)
+    if let Some(ref step) = components.step {
+        if let Some(ref content) = step.content {
+            return format!(
+                "<lf:step:{}>\n{}\n</lf:step:{}>",
+                step.name, content, step.name
+            );
+        } else {
+            return format!("<lf:step:{}>\n</lf:step:{}>", step.name, step.name);
+        }
     }
+
+    if let Some(ref inline) = components.inline {
+        return inline.clone();
+    }
+
+    String::new()
 }
 
 /// Write prompt to log file and return the path.
@@ -2440,10 +2447,40 @@ directions:
     }
 
     #[test]
-    fn format_task_prompt_empty_when_no_step() {
+    fn format_task_prompt_empty_when_no_step_or_inline() {
         let components = PromptComponents::default();
         let task = format_task_prompt(&components);
         assert!(task.is_empty());
+    }
+
+    #[test]
+    fn format_task_prompt_uses_inline_when_no_step() {
+        let components = PromptComponents {
+            inline: Some("Fix the bug in main.rs".to_string()),
+            ..Default::default()
+        };
+
+        let task = format_task_prompt(&components);
+        assert_eq!(task, "Fix the bug in main.rs");
+    }
+
+    #[test]
+    fn format_task_prompt_step_takes_priority_over_inline() {
+        let components = PromptComponents {
+            step: Some(Step {
+                name: "implement".to_string(),
+                content: Some("Build it.".to_string()),
+                model: None,
+                directions: vec![],
+                interactive: None,
+            }),
+            inline: Some("ignored inline text".to_string()),
+            ..Default::default()
+        };
+
+        let task = format_task_prompt(&components);
+        assert!(task.contains("Build it."));
+        assert!(!task.contains("ignored inline text"));
     }
 
     #[test]

--- a/rust/loopflow/tests/context_tests.rs
+++ b/rust/loopflow/tests/context_tests.rs
@@ -1,7 +1,7 @@
 use std::fs;
 use std::path::Path;
 
-use loopflow::engine::{format_prompt, gather_context, GatherContextOpts};
+use loopflow::engine::{format_prompt, format_task_prompt, gather_context, GatherContextOpts};
 use tempfile::TempDir;
 
 fn init_repo(dir: &Path) {
@@ -109,6 +109,11 @@ fn gather_context_with_inline_prompt() {
 
     // No step when using inline
     assert!(components.step.is_none());
+    // Inline text is preserved in components
+    assert_eq!(components.inline.as_deref(), Some("Fix the bug in main.rs"));
+    // format_task_prompt uses the inline text as the initial prompt
+    let task = format_task_prompt(&components);
+    assert_eq!(task, "Fix the bug in main.rs");
 }
 
 #[test]

--- a/rust/loopflow/tests/git_tests.rs
+++ b/rust/loopflow/tests/git_tests.rs
@@ -1,7 +1,8 @@
 use std::process::Command;
 
 use loopflow::engine::git::{
-    commit, create_branch, current_branch, get_default_branch, is_ancestor, is_clean, rebase,
+    commit, create_branch, current_branch, get_default_branch, is_ancestor, is_clean,
+    is_index_clean, rebase,
 };
 use loopflow_test_support::TestRepo;
 
@@ -161,11 +162,25 @@ fn rebase_feature_onto_main() {
 
 // Note: sync_main requires a remote, so we test the is_clean prerequisite instead
 #[test]
-fn sync_would_fail_on_dirty_tree() {
+fn sync_would_fail_on_staged_changes() {
     let repo = TestRepo::new();
 
     repo.create_file("dirty.txt", "uncommitted");
+    repo.stage_all();
 
-    // sync_main checks is_clean first - verify the check would fail
+    // Staged changes should block sync
     assert!(!is_clean(repo.path()).unwrap());
+    assert!(!is_index_clean(repo.path()).unwrap());
+}
+
+#[test]
+fn untracked_files_dont_block_sync() {
+    let repo = TestRepo::new();
+
+    repo.create_file("scratch/notes.md", "untracked content");
+
+    // is_clean sees untracked files
+    assert!(!is_clean(repo.path()).unwrap());
+    // is_index_clean ignores them — sync_main should proceed
+    assert!(is_index_clean(repo.path()).unwrap());
 }


### PR DESCRIPTION
format_task_prompt now returns the inline text when no step is present,
so `lf : "text"` passes through as the initial prompt.

sync_main uses new is_index_clean() instead of is_clean(), so untracked
files (e.g. scratch/) no longer block rebasing onto main.
