### PR TITLE
waves: eager worktree creation and rename support

### DIFF
--- a/rust/loopflow/src/engine/git.rs
+++ b/rust/loopflow/src/engine/git.rs
@@ -141,6 +141,17 @@ pub fn delete_local_branch(repo: &Path, branch: &str) -> Result<(), GitError> {
     Ok(())
 }
 
+pub fn branch_rename(repo: &Path, old_name: &str, new_name: &str) -> Result<(), GitError> {
+    let output = run_git(repo, &["branch", "-m", old_name, new_name])?;
+    if !output.status.success() {
+        return Err(GitError::CommandFailed {
+            command: format!("git branch -m {} {}", old_name, new_name),
+            stderr: String::from_utf8_lossy(&output.stderr).to_string(),
+        });
+    }
+    Ok(())
+}
+
 /// Get current branch name. Returns None if in detached HEAD state.
 pub fn current_branch(repo: &Path) -> Result<Option<String>, GitError> {
     let output = run_git(repo, &["symbolic-ref", "--short", "HEAD"])?;
@@ -647,6 +658,18 @@ mod tests {
         checkout(repo.path(), "main").expect("checkout main");
 
         delete_local_branch(repo.path(), "feature").expect("delete branch");
+    }
+
+    #[test]
+    fn git_branch_rename() {
+        let repo = init_repo();
+        commit_file(repo.path(), "README.md", "hello");
+        checkout_new_branch(repo.path(), "old-name").expect("create branch");
+        branch_rename(repo.path(), "old-name", "new-name").expect("rename branch");
+        assert_eq!(
+            current_branch(repo.path()).unwrap(),
+            Some("new-name".to_string())
+        );
     }
 
     #[test]

--- a/rust/loopflow/src/engine/naming.rs
+++ b/rust/loopflow/src/engine/naming.rs
@@ -19,7 +19,7 @@ const MUSICAL: &[&str] = &[
     "sonata", "tempo", "trill", "tune", "verse", "waltz",
 ];
 
-fn sanitize_for_branch(value: &str) -> String {
+pub fn sanitize_for_branch(value: &str) -> String {
     let mut out = String::new();
     let mut last_was_dash = false;
     for ch in value.chars() {

--- a/rust/loopflow/src/engine/worktrees.rs
+++ b/rust/loopflow/src/engine/worktrees.rs
@@ -82,7 +82,7 @@ pub fn worktree_short_name(repo: &Path) -> Option<String> {
     }
 }
 
-fn branch_exists(repo: &Path, branch: &str) -> Result<bool, GitError> {
+pub fn branch_exists(repo: &Path, branch: &str) -> Result<bool, GitError> {
     let output = Command::new("git")
         .arg("-C")
         .arg(repo)

--- a/rust/loopflow/src/lfd/http/routes/waves.rs
+++ b/rust/loopflow/src/lfd/http/routes/waves.rs
@@ -5,9 +5,11 @@ use serde::Deserialize;
 use std::str::FromStr;
 use time::OffsetDateTime;
 
+use crate::engine::git::{branch_rename, current_branch, delete_remote_branch, push_with_upstream};
+use crate::engine::naming::sanitize_for_branch;
 use crate::engine::worktree::remove_worktree;
-use crate::engine::worktrees::worktree_path;
-use crate::lfd::executor::{create_wave_run_with_id, kill_process};
+use crate::engine::worktrees::{branch_exists, worktree_path};
+use crate::lfd::executor::{create_wave_run_with_id, ensure_wave_worktree, kill_process};
 use crate::lfd::http::dto::{
     ContinueWaveResponse, DeletedResourceResponse, LandWaveResponse, ListResponse, RunWaveResponse,
     StopWaveResponse, WaveDto,
@@ -170,6 +172,25 @@ pub async fn create_wave_handler(
         .await
         .map_err(map_store_error)?;
 
+    // Create worktree eagerly so it exists immediately.
+    let repo_for_wt = wave.repo.clone();
+    let name_for_wt = wave.name.clone();
+    let wt_result = tokio::task::spawn_blocking(move || {
+        ensure_wave_worktree(std::path::Path::new(&repo_for_wt), &name_for_wt)
+    })
+    .await
+    .map_err(|err| err.to_string())
+    .and_then(|r| r.map_err(|err| err.to_string()));
+
+    if let Err(err) = wt_result {
+        let wave_id = wave.id.clone();
+        let _ = run_store(&state.store, move |store| store.delete_wave(&wave_id)).await;
+        return Err(api_error(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("failed to create worktree: {err}"),
+        ));
+    }
+
     state
         .event_hub
         .send(Event::wave_created(wave.id.clone(), wave.name.clone()));
@@ -211,11 +232,58 @@ pub async fn update_wave_handler(
     .map_err(map_store_error)?
     .ok_or_else(|| api_error(StatusCode::NOT_FOUND, "wave not found"))?;
 
-    if let Some(name) = payload.name {
-        if !name.is_empty() {
-            wave.name = name;
+    // Handle rename: move worktree + rename branch before updating DB.
+    if let Some(ref name) = payload.name {
+        if !name.is_empty() && *name != wave.name {
+            let new_name = name.clone();
+
+            // Check for duplicate name in same repo.
+            let repo_for_check = wave.repo.clone();
+            let name_for_check = new_name.clone();
+            let existing = run_store(&state.store, move |store| {
+                let waves = store.list_waves(Some(&repo_for_check))?;
+                Ok(waves.into_iter().any(|w| w.name == name_for_check))
+            })
+            .await
+            .map_err(map_store_error)?;
+            if existing {
+                return Err(api_error(
+                    StatusCode::CONFLICT,
+                    format!("wave '{}' already exists in this repo", new_name),
+                ));
+            }
+
+            // Reject rename while wave is running or waiting.
+            let active_run = run_store(&state.store, {
+                let wave_id = wave.id.clone();
+                move |store| store.get_active_wave_run(&wave_id)
+            })
+            .await
+            .map_err(map_store_error)?;
+            if let Some(run) = active_run {
+                if matches!(run.status, WaveRunStatus::Running | WaveRunStatus::Waiting) {
+                    return Err(api_error(
+                        StatusCode::PRECONDITION_FAILED,
+                        "cannot rename wave while running",
+                    ));
+                }
+            }
+
+            // Move worktree + rename branch on disk.
+            let old_name = wave.name.clone();
+            let repo = wave.repo.clone();
+            let new_name_for_wt = new_name.clone();
+            tokio::task::spawn_blocking(move || {
+                rename_wave_worktree(std::path::Path::new(&repo), &old_name, &new_name_for_wt)
+            })
+            .await
+            .map_err(|err| api_error(StatusCode::INTERNAL_SERVER_ERROR, err.to_string()))?
+            .map_err(|err| api_error(StatusCode::CONFLICT, err))?;
+
+            wave.name = new_name;
         }
     }
+
     if let Some(flow) = payload.flow {
         wave.flow = flow;
     }
@@ -634,6 +702,57 @@ fn resolve_current_step_name(run: &WaveRun, _wave: &Wave, step_index: u32) -> St
             _ => None,
         });
     name.unwrap_or_else(|| format!("step-{step_index}"))
+}
+
+/// Move a wave's worktree and rename its branch to match the new name.
+/// Returns Ok(()) if no worktree exists (legacy wave). Returns Err with a
+/// user-facing message if the rename is not possible.
+fn rename_wave_worktree(
+    repo: &std::path::Path,
+    old_name: &str,
+    new_name: &str,
+) -> Result<(), String> {
+    use crate::engine::git::worktree_move;
+
+    let old_wt = worktree_path(repo, old_name);
+    if !old_wt.exists() {
+        return Ok(());
+    }
+
+    let new_wt = worktree_path(repo, new_name);
+    if new_wt.exists() {
+        return Err(format!(
+            "destination worktree already exists: {}",
+            new_wt.display()
+        ));
+    }
+
+    // Compute new branch name by substituting the sanitized wave name.
+    let old_branch = current_branch(&old_wt)
+        .map_err(|e| e.to_string())?
+        .ok_or_else(|| "worktree is in detached HEAD state".to_string())?;
+
+    let old_sanitized = sanitize_for_branch(old_name);
+    let new_sanitized = sanitize_for_branch(new_name);
+    let new_branch = old_branch.replacen(&old_sanitized, &new_sanitized, 1);
+
+    if new_branch != old_branch && branch_exists(repo, &new_branch).map_err(|e| e.to_string())? {
+        return Err(format!("branch already exists: {new_branch}"));
+    }
+
+    // Move worktree directory.
+    worktree_move(repo, &old_wt, &new_wt).map_err(|e| e.to_string())?;
+
+    // Rename branch.
+    if new_branch != old_branch {
+        branch_rename(repo, &old_branch, &new_branch).map_err(|e| e.to_string())?;
+
+        // Update remote (best-effort).
+        let _ = push_with_upstream(repo, "origin", &new_branch);
+        let _ = delete_remote_branch(repo, "origin", &old_branch);
+    }
+
+    Ok(())
 }
 
 fn auto_commit_if_dirty(worktree: &std::path::Path, step_name: &str) -> Result<(), String> {

--- a/rust/loopflow/tests/wave_worktree_tests.rs
+++ b/rust/loopflow/tests/wave_worktree_tests.rs
@@ -1,7 +1,9 @@
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use loopflow::engine::worktrees::worktree_path;
+use loopflow::engine::git::{branch_rename, current_branch, worktree_move};
+use loopflow::engine::naming::sanitize_for_branch;
+use loopflow::engine::worktrees::{branch_exists, worktree_path};
 use loopflow::lfd::executor::{create_wave_run_with_id, ensure_wave_worktree};
 use loopflow::lfd::id::LfdId;
 use loopflow::lfd::store::sqlite::SqliteStore;
@@ -122,4 +124,72 @@ fn ensure_wave_worktree_reuses_existing() {
     let (path2, branch2) = ensure_wave_worktree(repo.path(), "reduce").unwrap();
     assert_eq!(path1, path2);
     assert_eq!(branch1, branch2);
+}
+
+#[test]
+fn wave_rename_moves_worktree() {
+    let repo = TestRepo::new();
+    let (_wt_path, _branch) = ensure_wave_worktree(repo.path(), "old-wave").unwrap();
+
+    let old_wt = worktree_path(repo.path(), "old-wave");
+    let new_wt = worktree_path(repo.path(), "new-wave");
+    assert!(old_wt.exists());
+
+    worktree_move(repo.path(), &old_wt, &new_wt).unwrap();
+
+    assert!(!old_wt.exists(), "old worktree should be gone");
+    assert!(new_wt.exists(), "new worktree should exist");
+}
+
+#[test]
+fn wave_rename_renames_branch() {
+    let repo = TestRepo::new();
+    let (_wt_path, old_branch) = ensure_wave_worktree(repo.path(), "old-wave").unwrap();
+
+    let old_sanitized = sanitize_for_branch("old-wave");
+    let new_sanitized = sanitize_for_branch("new-wave");
+    let new_branch = old_branch.replacen(&old_sanitized, &new_sanitized, 1);
+
+    // Move worktree first (branch rename operates on repo, not worktree path).
+    let old_wt = worktree_path(repo.path(), "old-wave");
+    let new_wt = worktree_path(repo.path(), "new-wave");
+    worktree_move(repo.path(), &old_wt, &new_wt).unwrap();
+
+    branch_rename(repo.path(), &old_branch, &new_branch).unwrap();
+
+    let current = current_branch(&new_wt).unwrap().unwrap();
+    assert_eq!(current, new_branch);
+    assert!(
+        current.contains("new-wave"),
+        "branch should contain the new wave name"
+    );
+}
+
+#[test]
+fn wave_rename_detects_destination_conflict() {
+    let repo = TestRepo::new();
+    ensure_wave_worktree(repo.path(), "wave-a").unwrap();
+    ensure_wave_worktree(repo.path(), "wave-b").unwrap();
+
+    // Our rename logic checks new_wt.exists() before attempting git worktree move.
+    let new_wt = worktree_path(repo.path(), "wave-b");
+    assert!(
+        new_wt.exists(),
+        "destination worktree should exist, blocking rename"
+    );
+}
+
+#[test]
+fn wave_rename_branch_exists_check() {
+    let repo = TestRepo::new();
+    let (_wt_path, old_branch) = ensure_wave_worktree(repo.path(), "alpha").unwrap();
+
+    assert!(
+        branch_exists(repo.path(), &old_branch).unwrap(),
+        "branch should exist after worktree creation"
+    );
+    assert!(
+        !branch_exists(repo.path(), "nonexistent-branch").unwrap(),
+        "nonexistent branch should not exist"
+    );
 }


### PR DESCRIPTION
## Try it

```bash
# Create a wave — worktree is ready immediately
curl -X POST localhost:4242/waves -d '{"repo": "/path/to/repo", "name": "my-feature"}'

# Rename a wave — worktree and branch follow
curl -X PATCH localhost:4242/waves/<id> -d '{"name": "better-name"}'
```

## Summary

Wave worktrees are now created eagerly at wave creation time instead of lazily on first run. This means the worktree directory and branch exist immediately after `POST /waves`, so editors and other tools can open them right away. If worktree creation fails, the wave is rolled back from the store.

Renaming a wave (`PATCH /waves/:id` with a new `name`) now moves the worktree directory and renames the associated branch to match. The remote is updated on a best-effort basis (push new branch, delete old). Renames are rejected if the wave is currently running or if the destination name/branch already exists.

## Changes

- `create_wave_handler` calls `ensure_wave_worktree` immediately; rolls back on failure
- `update_wave_handler` handles rename with worktree move + branch rename
- New `branch_rename` in `engine::git`, `sanitize_for_branch` and `branch_exists` made public
- Integration tests for worktree move, branch rename, and conflict detection