### PR TITLE
scratch: note missing viz wave roadmap

### DIFF
--- a/scratch/questions.md
+++ b/scratch/questions.md
@@ -1,0 +1,12 @@
+# Open Questions
+
+## viz wave: no roadmap found
+
+The `viz` wave has no `roadmap/viz/` directory. No viz-related roadmap items exist anywhere in `roadmap/`.
+
+**Possible interpretations:**
+1. The viz wave roadmap hasn't been created yet — needs a `roadmap/viz/` directory with items before ingest can pick work
+2. The viz wave is defined elsewhere (external system, different repo)
+3. The wave name in the branch/prompt is incorrect
+
+**To unblock:** Create `roadmap/viz/README.md` with strategic context and add stage files (e.g., `01-foundation.md`) with pickable items.


### PR DESCRIPTION
## Summary

Documents an open question discovered during the viz wave: there is no `roadmap/viz/` directory or any viz-related roadmap items.

## Changes

- Adds `scratch/questions.md` noting the missing viz wave roadmap and possible interpretations
- Suggests creating `roadmap/viz/README.md` with strategic context and stage files to unblock work