### PR TITLE
waves: default to empty direction when creating from UI

### DIFF
--- a/swift/Concerto/State/RepoState.swift
+++ b/swift/Concerto/State/RepoState.swift
@@ -452,7 +452,7 @@ final class RepoState {
                 name: waveName,
                 repo: repo.path,
                 flow: "design",
-                direction: ["default"],
+                direction: [],
                 area: [],
                 stimulus: Stimulus(kind: .once),
                 status: .idle,


### PR DESCRIPTION
## Summary

When creating a new wave from the Concerto UI, the optimistic local model now defaults to an empty `direction` array instead of `["default"]`. This matches the server-side behavior and avoids pre-populating a direction the user didn't choose.

## Changes

- Changed the `direction` field in the pending `Wave` from `["default"]` to `[]` in `RepoState.createWave`