### PR TITLE
implement step: use codex model

### DIFF
--- a/rust/loopflow/src/engine/builtins/steps/code/implement.md
+++ b/rust/loopflow/src/engine/builtins/steps/code/implement.md
@@ -1,6 +1,7 @@
 ---
 requires: scratch/<branch>.md
 produces: code, tests
+model: codex
 ---
 Turn the design doc into working code.
 


### PR DESCRIPTION
## Summary

Sets the `model` frontmatter on the `code/implement` builtin step to `codex`, routing implementation work to the Codex model.

## Changes

- Added `model: codex` to the frontmatter of `rust/loopflow/src/engine/builtins/steps/code/implement.md`