### PR TITLE
studio auth: document auth server and update roadmap for built state

### DIFF
--- a/roadmap/remote/05-concerto-remote.md
+++ b/roadmap/remote/05-concerto-remote.md
@@ -152,10 +152,14 @@ let repos = try await service.listRepos()
 
 Concerto shows a repo picker when connecting to a new server. No manual path entry.
 
+### Daemon discovery (Phase 07)
+
+With studio auth, manual host/port entry is replaced by auto-discovery. After sign-in, Concerto queries `GET /api/v1/daemons/discover` which returns a list of the user's registered daemons (machine_id, machine_name, url, last_heartbeat_at). Concerto shows a daemon picker when multiple machines are available, then connects to the selected one.
+
 ## Constraints
 
 - **TLS required**: Remote connections use HTTPS/WSS. Self-signed certs (Phase 04 Caddy) trusted via cert pinning on first connect.
-- **Single server**: Concerto connects to one lfd at a time. Multi-server is future work.
+- **Single server**: Concerto connects to one lfd at a time. Multi-server is future work (daemon picker from Phase 07 discovery is the first step).
 - **No offline mode**: If the connection drops, show disconnected state. Don't cache stale data.
 
 ## Done when

--- a/roadmap/remote/07-studio-auth.md
+++ b/roadmap/remote/07-studio-auth.md
@@ -1,18 +1,18 @@
 # 07: Studio Auth
 
-Real JWT auth via loopflow.studio. Replaces static tokens with proper identity.
+Real JWT auth via auth.loopflow.studio. Replaces static tokens with proper identity.
 
 ## What exists after this
 
-Users sign in with GitHub/Google/Apple via loopflow.studio. lfd validates JWTs locally (no per-request roundtrip). Concerto stores the token in Keychain with automatic refresh.
+Users sign in via WorkOS (GitHub/Google/Apple) through auth.loopflow.studio. lfd validates JWTs locally (no per-request roundtrip). Concerto stores the token in Keychain with automatic refresh. CLI authenticates via device code flow.
 
 ## What already exists
 
-Most of the client-side auth machinery is built:
+### Client-side (Concerto + lfd)
 
 | Component | File | Status |
 |-----------|------|--------|
-| OAuth flow | `AuthService.swift` | Done — `ASWebAuthenticationSession` to `loopflow.studio/auth/login`, callback via `loopflow://auth/callback` |
+| OAuth flow | `AuthService.swift` | Done — `ASWebAuthenticationSession` to `auth.loopflow.studio/auth/login`, callback via `loopflow://auth/callback` |
 | Keychain storage | `AuthService.swift` | Done — service `studio.loopflow.auth`, `kSecAttrAccessibleAfterFirstUnlock` |
 | Token refresh | `AuthService.swift` | Done — `POST /auth/refresh`, returns new JWT |
 | Auth state | `AuthState.swift` | Done — observable, tracks `isAuthenticated`/`isExpired`/`needsRefresh`, auto-refresh monitor (hourly, 24h before expiry) |
@@ -20,29 +20,121 @@ Most of the client-side auth machinery is built:
 | lfd registration | `registration.rs` | Done — registers with studio on startup, heartbeats every 60s |
 | lfd auth middleware | `auth.rs` | Done — distinguishes loopback vs non-loopback, validates bearer tokens |
 
+### Server-side (auth.loopflow.studio)
+
+The auth server is built. It's a FastAPI service backed by SQLModel + SQLAlchemy (SQLite dev, Postgres production), using WorkOS for OAuth and RS256 JWTs.
+
+#### Auth endpoints
+
+```
+POST /auth/device              → Start device code flow (for CLI)
+POST /auth/device/token        → Poll for token (device flow)
+GET  /cli/login?code={code}    → Web UI for device login
+GET  /auth/login               → Redirect to WorkOS OAuth
+GET  /auth/callback            → Exchange code, issue JWT, redirect
+POST /auth/refresh             → Refresh JWT (Bearer required)
+GET  /.well-known/jwks.json    → RSA public key for token verification
+```
+
+#### Daemon management endpoints (all require Bearer JWT)
+
+```
+POST /api/v1/daemons/register    → Register daemon instance
+POST /api/v1/daemons/heartbeat   → Keep-alive
+POST /api/v1/daemons/deregister  → Remove daemon
+GET  /api/v1/daemons/discover    → List user's daemons
+```
+
+#### Device code flow
+
+For CLI/daemon authentication where a browser isn't directly available:
+
+```
+POST /auth/device
+→ {
+    "device_code": "...",
+    "user_code": "XXXX-XXXX",
+    "verification_uri": "https://auth.loopflow.studio/cli/login?code=XXXX-XXXX",
+    "expires_in": 900
+  }
+```
+
+Client displays user_code and verification_uri. User authenticates in browser. Client polls:
+
+```
+POST /auth/device/token
+{ "device_code": "..." }
+
+→ { "error": "authorization_pending" }   // still waiting
+→ { "token": "eyJ..." }                  // done
+→ { "error": "expired_token" }           // TTL exceeded (15 min default)
+```
+
+#### Daemon registration
+
+```
+POST /api/v1/daemons/register
+Authorization: Bearer <JWT>
+{
+    "machine_id": "unique-machine-id",
+    "machine_name": "Studio Mac",          // optional
+    "capabilities": ["discover", "relay"],  // optional, default []
+    "url": "https://ec2-host:2486"         // optional
+}
+→ { "status": "registered" }
+```
+
+`machine_id` is unique globally — returns 403 if already claimed by a different user.
+
+#### Daemon discovery
+
+```
+GET /api/v1/daemons/discover
+Authorization: Bearer <JWT>
+
+→ {
+    "daemons": [
+      {
+        "machine_id": "...",
+        "machine_name": "Studio Mac",
+        "url": "https://ec2-host:2486",
+        "last_heartbeat_at": "2026-02-13T..."
+      }
+    ]
+  }
+```
+
+Returns all daemons owned by the authenticated user. Concerto uses this to offer a picker when the user has multiple machines.
+
+#### JWT structure
+
+RS256-signed, 7-day lifetime, 24h refresh window:
+
+```json
+{
+  "sub": "user_123",
+  "email": "user@example.com",
+  "name": "User Name",
+  "iss": "auth.loopflow.studio",
+  "aud": "loopflow-lfd",
+  "iat": 1739000000,
+  "exp": 1739604800
+}
+```
+
+Public key served at `/.well-known/jwks.json` for local validation.
+
 ## What's left to build
-
-### loopflow.studio endpoints (studio repo)
-
-The auth endpoints don't exist yet. This is the bulk of the work.
-
-```
-GET  /auth/login              → Redirect to OAuth provider (GitHub/Google/Apple)
-GET  /auth/callback           → Exchange code, issue JWT, redirect to client
-GET  /.well-known/jwks.json   → Public keys for JWT verification
-POST /auth/refresh             → Refresh expired JWT
-POST /api/v1/daemons/discover → Return user's registered lfd URL
-```
 
 ### lfd: JWKS validation
 
-Add JWT signature validation to the auth middleware. Short-lived JWTs (5 min) validated locally:
+Add JWT signature validation to the auth middleware. 7-day JWTs validated locally:
 
-1. lfd fetches JWKS from `loopflow.studio/.well-known/jwks.json` on startup (cached, refreshed hourly)
+1. lfd fetches JWKS from `auth.loopflow.studio/.well-known/jwks.json` on startup (cached, refreshed hourly)
 2. On each request: verify JWT signature against cached JWKS
-3. Check claims: `exp`, `aud` (loopflow-lfd), `iss` (loopflow.studio)
+3. Check claims: `exp`, `aud` (`loopflow-lfd`), `iss` (`auth.loopflow.studio`)
 4. Check `sub` or `email` against `allowed_users` in config
-5. No per-request roundtrip to loopflow.studio
+5. No per-request roundtrip to auth.loopflow.studio
 
 ```yaml
 # ~/.lf/lfd.yaml
@@ -50,8 +142,30 @@ auth:
   provider: loopflow.studio
   allowed_users:
     - user@example.com
-  jwks_url: https://loopflow.studio/.well-known/jwks.json
+  jwks_url: https://auth.loopflow.studio/.well-known/jwks.json
   audience: loopflow-lfd
+```
+
+### lfd: update registration payload
+
+Registration currently sends `url` and `version`. Update to match auth server's contract:
+
+```rust
+// registration.rs — update payload
+DaemonRegisterRequest {
+    machine_id: String,      // stable machine identifier
+    machine_name: Option<String>,
+    capabilities: Vec<String>,
+    url: Option<String>,
+}
+```
+
+Heartbeat and deregister use `machine_id` only:
+
+```rust
+DaemonMachineRequest {
+    machine_id: String,
+}
 ```
 
 ### Concerto: wire TokenProvider into requests
@@ -83,18 +197,30 @@ No auth UI exists. Add a sign-in view:
 - On success, auto-discover lfd via studio (replaces manual host/port entry)
 - Show loading/error states
 
-### Concerto: auto-discovery
+### Concerto: auto-discovery with daemon picker
 
-After sign-in, query studio for the user's lfd:
+After sign-in, query studio for the user's daemons:
 
 ```
 GET /api/v1/daemons/discover
 Authorization: Bearer <JWT>
 
-→ { "lfd_url": "https://ec2-host:2486", "last_heartbeat": "..." }
+→ { "daemons": [ { "machine_id": "...", "machine_name": "...", "url": "...", "last_heartbeat_at": "..." } ] }
 ```
 
-This eliminates manual host/port entry from Phase 05. Sign in → auto-discover lfd → connect.
+Discovery returns a list — the user may have multiple machines. Concerto shows a picker when more than one daemon is available. Single daemon auto-connects.
+
+This eliminates manual host/port entry from Phase 05. Sign in → discover daemons → pick machine → connect.
+
+### CLI: device code auth
+
+Wire the device code flow into `lf` for CLI-based authentication:
+
+1. `lf auth login` calls `POST /auth/device`
+2. Display user_code and open verification_uri in browser
+3. Poll `POST /auth/device/token` with backoff
+4. Store JWT in `~/.lf/credentials` or OS keychain
+5. Use JWT for lfd registration and API calls
 
 ## Deployment scenarios
 
@@ -104,21 +230,13 @@ This eliminates manual host/port entry from Phase 05. Sign in → auto-discover 
 | Remote + static token | Bearer token | lfd checks against config |
 | Remote + studio auth | JWT | lfd validates signature locally via JWKS |
 
-## Registration (lfd → studio)
-
-lfd registers on startup and sends heartbeats (already implemented in `registration.rs`):
-
-```
-POST /api/v1/daemons/register   → { "url": "https://...:2486", "version": "0.7.2" }
-POST /api/v1/daemons/heartbeat  → every 60s
-```
-
 ## Done when
 
-- loopflow.studio serves auth endpoints (login, callback, JWKS, refresh, discover)
-- lfd validates JWTs locally via cached JWKS
+- lfd validates JWTs locally via cached JWKS from `auth.loopflow.studio`
+- lfd registration sends `machine_id`, `machine_name`, `capabilities`, `url`
 - `TokenProvider` wired into `LocalWaveService` and `LocalEventService`
 - Sign-in UI exists in Concerto
-- Concerto auto-discovers lfd URL after sign-in
+- Concerto auto-discovers daemons after sign-in (with picker for multiple)
+- CLI authenticates via device code flow (`lf auth login`)
 - `allowed_users` config restricts access
 - Static token auth (Phase 03) still works as fallback

--- a/roadmap/remote/README.md
+++ b/roadmap/remote/README.md
@@ -16,7 +16,7 @@ lfd runs on a remote Linux machine (containerized). Concerto connects from your 
 | 04 | EC2 Infrastructure | A box to deploy on (Docker + compose) | 02 |
 | 05 | Concerto Remote Connection | Wave CRUD, events, logs over WAN | 03, 04 |
 | 06 | Remote File Access | One-click "Open in Cursor" per wave | 05 |
-| 07 | Studio Auth | Real JWT auth via loopflow.studio | 05 |
+| 07 | Studio Auth | Real JWT auth via auth.loopflow.studio (server built, client wiring remaining) | 05 |
 | 08 | API Expansion | File browsing, step/flow/direction typeahead | 05 |
 | 09 | Hosted SaaS | loopflow.studio runs lfd for you | 07, 08 |
 


### PR DESCRIPTION
## Summary

Updates the Phase 07 (Studio Auth) roadmap to reflect that the auth server (`auth.loopflow.studio`) is now built. The doc shifts from "everything needs building" to "server done, client wiring remaining."

## Changes

- **Auth server documented**: Added full API reference for the FastAPI auth server — auth endpoints, daemon management, device code flow, daemon registration/discovery, and JWT structure
- **Domain updated**: `loopflow.studio` → `auth.loopflow.studio` throughout
- **"What already exists" expanded**: Split into client-side (Concerto + lfd) and server-side sections, with the server-side section documenting all built endpoints and their request/response contracts
- **"What's left to build" narrowed**: Removed the server-side endpoint work (it's done). Remaining work is lfd JWKS validation, lfd registration payload update, Concerto token/UI/discovery wiring, and CLI device code auth
- **New work items**: Added lfd registration payload update (machine_id, capabilities), CLI device code flow (`lf auth login`), and daemon picker for multi-machine discovery
- **Phase 05 cross-reference**: Added daemon discovery section to `05-concerto-remote.md` explaining how Phase 07 replaces manual host/port entry
- **Roadmap README**: Updated Phase 07 summary to note server is built