### PR TITLE
wave: restructure READMEs to vision/goals/risks/metrics format

### DIFF
--- a/wave/agentapi/README.md
+++ b/wave/agentapi/README.md
@@ -4,29 +4,42 @@ Unified session API for interactive coding agents. lfd spawns and manages provid
 
 `lf` is unchanged. This is purely a new lfd API surface.
 
-## North Star
+## Vision
 
 lfd exposes a provider-agnostic session API. Clients create sessions, send input, subscribe to events, and end sessions. lfd owns the agent lifecycle — spawning processes, translating events, persisting state. Clients connect and disconnect freely; sessions survive reconnect.
 
-## Design Decisions
+### Not here
 
-**Harness-first, not protocol-first.** Build a working harness end-to-end before abstracting. The protocol emerged from real provider behavior — Codex first, then Claude validated the abstraction. Harness mapping modules (`codex_mapping.rs`, `claude_mapping.rs`) now live alongside harness logic.
+- Approval routing / permission management (container safety instead)
+- Advanced Concerto UI (tool visualization, diff views, multi-panel layouts)
+- Multi-agent per step (parallel agents within one interactive step)
+- Cross-wave session sharing
 
-**lfd owns the session lifecycle.** Concerto is a thin client. Agent processes survive Concerto close/reopen. Session state lives in lfd's store.
+## Goals
 
-**Turn+item event model.** Provider harnesses translate native events (Codex JSON-RPC, Claude NDJSON, OpenCode SSE) into a canonical event model. Turns are first-class (every turn-scoped event carries `turn_id`). Items are typed (`Command`, `File`, `Message`, `Thought`, `Tool`) with lifecycles (`ItemStarted → ItemUpdated → ItemCompleted`). High-frequency deltas (`TextDelta`, `ReasoningDelta`) stay top-level for streaming efficiency.
-
-**Container-first safety.** All harnesses run in yolo/bypass mode. Safety comes from the container, not tool-level permissions. No approval routing in v1.
-
-**Provider-owned auth.** Codex and Claude handle their own OAuth/login. lfd never collects raw credentials.
-
-## Invariants
-
+- Provider-agnostic: same client code works regardless of which agent runs the session
+- Harness-first: build working harnesses end-to-end before abstracting (protocol emerged from real provider behavior)
+- lfd owns the session lifecycle — Concerto is a thin client, agent processes survive close/reopen
+- Turn+item event model with typed items (`Command`, `File`, `Message`, `Thought`, `Tool`) and explicit lifecycles
+- Container-first safety — harnesses run in yolo/bypass mode, safety comes from the container
+- Provider-owned auth — Codex and Claude handle their own OAuth/login, lfd never collects raw credentials
 - At most one active session per wave run at a time
-- Session end is idempotent (multiple calls safe)
-- UI disconnect does not affect session state
+- Session end is idempotent; UI disconnect does not affect session state
 - Reconnect replays persisted events then follows live stream
-- Session end triggers wave continue only when wave run still waits on that session
+
+## Risks
+
+- **Provider layer drift.** `lf` CLI and `/v0/sessions` HTTP use separate execution paths through the same harnesses. Until Phase 07 unifies them, changes to one path can miss the other. Mitigate: shared conformance tests once the third harness validates the abstraction.
+- **Claude `--resume` fragility.** Each turn spawns a new process with `--resume`. If the resume format changes or session state corrupts, the entire session breaks with no partial recovery. Mitigate: session events are persisted, so replay from a new session is possible even if resume fails.
+- **Container-only safety model.** No tool-level permission routing means local (non-container) sessions run with full agent permissions. Acceptable for v1 but becomes a gap if local interactive sessions grow in usage.
+- **SSE replay scalability.** Long sessions accumulate events; full replay on reconnect grows linearly. Not a problem at current scale but could become one with multi-hour sessions.
+
+## Metrics
+
+- All three provider harnesses (Codex, Claude, OpenCode) pass shared conformance tests
+- Session reconnect replays full event history and resumes live streaming without data loss
+- Concerto renders typed transcript with item cards for all event types
+- Session lifecycle (create → interact → end) works identically for local and remote lfd
 
 ## Phases
 
@@ -39,14 +52,6 @@ lfd exposes a provider-agnostic session API. Clients create sessions, send input
 | 05 | Claude `--sdk-url` | Reference only — not pursuing unless landscape changes | |
 | 06 | OpenCode Harness | Third provider harness validates the abstraction | |
 | 07 | Provider Layer Unification | Make provider harnesses the shared core used by both `lf` CLI runs and `/v0/sessions` HTTP sessions | planned |
-
-## Future direction
-
-After Phase 06, unify the provider layer so `lf` and Session HTTP are explicitly two API surfaces over the same harness core:
-
-- one provider execution/mapping core
-- two entry points (`lf` CLI and `lfd` Session HTTP)
-- shared conformance tests across both surfaces
 
 ## Architecture
 
@@ -81,9 +86,10 @@ DELETE /v0/sessions/{id}         # end session
 | Claude | subprocess stdio | NDJSON (stream-json) | New process per turn (`--resume`) | OAuth (provider-owned) |
 | OpenCode | HTTP client | SSE events | REST calls | Provider-owned |
 
-## What's not here
+## Future direction
 
-- Approval routing / permission management (container safety instead)
-- Advanced Concerto UI (tool visualization, diff views, multi-panel layouts)
-- Multi-agent per step (parallel agents within one interactive step)
-- Cross-wave session sharing
+After Phase 06, unify the provider layer so `lf` and Session HTTP are explicitly two API surfaces over the same harness core:
+
+- one provider execution/mapping core
+- two entry points (`lf` CLI and `lfd` Session HTTP)
+- shared conformance tests across both surfaces

--- a/wave/chords/README.md
+++ b/wave/chords/README.md
@@ -2,21 +2,56 @@
 
 Named groups of waves with inter-wave listening. Chords organize related waves and let them react to each other via the `listen` stimulus.
 
-**Model:** Waves are flat. Chords group them. Listening connects them.
-
-## North Star
+## Vision
 
 A user creates waves, groups them into a chord, and wires `listen` stimuli so waves react to each other's work. No nested execution engine, no inherited triggers — just grouping and stimulus-based coordination.
 
-## Design Decisions
+Waves are flat. Chords group them. Listening connects them.
 
-**Waves are flat.** No enum, no tree. A `Wave` is a single struct. Chords are a separate concept stored in their own tables (`chords` + `chord_members`). A wave can belong to multiple chords or none.
+### Not here
 
-**Chords are groups, not executors.** A chord doesn't own a trigger or manage child lifecycle. It's a named collection. Execution is still per-wave, driven by each wave's own stimuli.
+- Nested chord orchestration (inherited triggers, child scheduling, beat-grid execution) — lives in Symphonia/studio
+- Multi-user chord coordination — lives in lfd-hub
+- Approval routing for cross-wave side effects
 
-**Listening is a stimulus.** `StimulusKind::Listen` with a `source_wave_id` fires a wave when its source completes. No special iteration-aware scheduling — it's just another stimulus type alongside loop/cron/watch/once.
+## Goals
 
-**Flat over nested.** The recursive model (chord-as-wave, nested chords, inherited triggers) moved to Symphonia/studio. OSS keeps the simpler model where composition happens through stimulus wiring, not tree structure.
+- Waves are flat: a `Wave` is a single struct, no enum/tree/parent. A wave can belong to multiple chords or none.
+- Chords are groups, not executors: no trigger ownership or child lifecycle management. Execution is per-wave via each wave's own stimuli.
+- Listening is a stimulus: `StimulusKind::Listen` with `source_wave_id` fires when the source completes. Just another stimulus type alongside loop/cron/watch/once.
+- Stimulus-based composition over tree structure: a wave can listen to any other wave regardless of chord membership. Chords provide organization; stimuli provide coordination. These are orthogonal.
+- Chords exist as named groups with membership CRUD
+- HTTP API and Python client support chord operations
+- Concerto shows chord grouping and listen relationships
+
+## Risks
+
+- **Schema migration if chord model evolves.** The `chords`/`chord_members` tables are simple join tables now. If chords gain execution semantics later, the schema may need non-trivial migration. Mitigate: keep the Symphonia execution model separate; don't add execution fields to the chord tables.
+- **Listen stimulus fan-out.** If many waves listen to the same source, a single completion triggers N wave runs simultaneously. No concurrency limiting exists today. Mitigate: acceptable at current scale (single user, handful of waves); revisit if fan-out exceeds scheduler slot capacity.
+- **Default chord enrollment ambiguity.** Open question whether new waves should auto-enroll in a default chord. If yes, the concept of "ungrouped waves" disappears, which may confuse users who don't use chords. If no, chords are opt-in and may go unused.
+- **Listen authoring before chord CRUD.** Accepting `listen` stimuli in wave schema files before chord CRUD lands means users can wire listening without seeing the grouping context. May lead to confusion about which waves are related.
+
+## Metrics
+
+- Chord CRUD works end-to-end: create chord, add/remove waves, list members, delete chord
+- Listen stimulus fires reliably when source wave completes (including edge cases: source fails, source is stopped)
+- Concerto UI shows chord grouping and listen wiring visually
+- A wave listening to another wave in a different chord works identically to same-chord listening
+
+## Phases
+
+| # | Phase | Focus | Status |
+|---|-------|-------|--------|
+| 01 | Flatten + Listen | Drop tree model, add listen stimulus, migration 012 | shipped |
+| 02 | Chord CRUD | Domain type, store ops, HTTP API, Python client | |
+| 03 | Listen Authoring | Listen stimulus in wave schema files, deeper inter-wave communication | |
+| 04 | Concerto UI | Chord groups and listen wiring in the macOS app | |
+
+### Phase 01 retrospective
+
+The original plan called for a recursive `Wave` enum (Voice | Chord) with join/leave composition, nested execution, and inherited triggers. Building it revealed that the recursive model was over-engineered for the OSS use case — users want named groups and inter-wave reactivity, not a tree-structured wave scheduler.
+
+The pivot: flatten `Wave` to a single struct, drop `wave_type`/`parent_id`/`position`/`join`/`leave`, add `chords`/`chord_members` tables for grouping, and add `StimulusKind::Listen` with `source_wave_id` for inter-wave coordination. Migration 012 handles the schema transition. Python client updated to match (removed `join()`/`leave()`, added `source_wave_id` to stimulus API).
 
 ## Data Model
 
@@ -50,28 +85,7 @@ CREATE TABLE chord_members (
 );
 ```
 
-## Phases
-
-| # | Phase | Focus | Status |
-|---|-------|-------|--------|
-| 01 | Flatten + Listen | Drop tree model, add listen stimulus, migration 012 | shipped |
-| 02 | Chord CRUD | Domain type, store ops, HTTP API, Python client | |
-| 03 | Listen Authoring | Listen stimulus in wave schema files, deeper inter-wave communication | |
-| 04 | Concerto UI | Chord groups and listen wiring in the macOS app | |
-
-### Phase 01 retrospective
-
-The original plan called for a recursive `Wave` enum (Voice | Chord) with join/leave composition, nested execution, and inherited triggers. Building it revealed that the recursive model was over-engineered for the OSS use case — users want named groups and inter-wave reactivity, not a tree-structured wave scheduler.
-
-The pivot: flatten `Wave` to a single struct, drop `wave_type`/`parent_id`/`position`/`join`/`leave`, add `chords`/`chord_members` tables for grouping, and add `StimulusKind::Listen` with `source_wave_id` for inter-wave coordination. Migration 012 handles the schema transition. Python client updated to match (removed `join()`/`leave()`, added `source_wave_id` to stimulus API).
-
-Key insight: stimulus-based listening (`source_wave_id`) is simpler and more composable than the nested iteration model. A wave can listen to any other wave regardless of chord membership. Chords provide organization; stimuli provide coordination. These are orthogonal.
-
 ## Future Directions
-
-### Nested Chord Orchestration (Symphonia)
-
-The recursive model — inherited triggers, child scheduling, beat-grid execution — lives in Symphonia/studio. If OSS needs it later, the `chords`/`chord_members` schema is a clean foundation to build on, but the execution engine stays simple here.
 
 ### Listen Step (post-chord CRUD)
 
@@ -82,15 +96,3 @@ Once chord CRUD is in place, a dedicated `listen` step could inject sibling PR c
 - lfd stays simple: one user, one machine, local chords
 - lfd-hub (private codebase) orchestrates across lfd instances
 - The listen stimulus protocol is the clean seam — lfd-hub can inject remote activations the same way lfd handles local ones
-
-## Open Questions
-
-- Should new waves auto-enroll in a default chord?
-- Should `listen` stimuli be accepted in wave schema files now, or remain API-only until chord CRUD lands?
-
-## Done When (wave complete)
-
-- Chords exist as named groups with membership CRUD
-- HTTP API and Python client support chord operations
-- Listen stimulus wires waves to react to each other
-- Concerto shows chord grouping and listen relationships

--- a/wave/remote/README.md
+++ b/wave/remote/README.md
@@ -39,6 +39,14 @@ Smoke tests for SSE/WSS through Caddy TLS proxy happen during deployment (steps 
 - Keep orchestration ownership in loopflow while editors handle their native remote transport
 - Ship remote connectivity incrementally: secure auth first, then UX and API breadth
 
+## Risks
+
+- **TLS proxy latency for SSE/WSS.** Real-time event streaming through Caddy TLS proxy adds latency that hasn't been validated at scale. Mitigate: smoke test SSE/WSS through Caddy during deployment steps 1-2, not as a separate phase.
+- **Host-side git worktrees for prompt assembly.** Docker fork branches rely on host-side worktrees before container launch. Moving prompt assembly into containers would require container→host sync or a prompt build path that doesn't need host materialization. Acceptable for now.
+- **Stale PR state without GitHub token.** Queue UX must degrade gracefully when no token is configured — treat as degraded mode, not hard failure.
+- **Remote file access depends on editor SSH support.** Cursor/VSCode/Zed each have different Remote SSH implementations. If any breaks or changes behavior, the one-click workflow breaks for that editor. Mitigate: "Copy SSH Command" as universal fallback.
+- **Agent timeout configuration surface.** `executor.agent_timeout` is daemon-config only. If users need per-wave or per-session timeouts, the config model needs rethinking. Defer until dogfooding reveals whether this is a real need.
+
 ## Update after Phase 01E (Docker fork parity)
 
 Phases 01A–01E are fully shipped. What we now treat as non-negotiable for remote work:

--- a/wave/wavemodel/04-interactive-sessions.md
+++ b/wave/wavemodel/04-interactive-sessions.md
@@ -1,0 +1,38 @@
+# Interactive Sessions in Flow Execution
+
+When a wave flow hits an interactive step (design, review, explore, refine), lfd should surface an agent session in Concerto automatically.
+
+## Current state
+
+Start Wave → interactive design step works: user enters a wave name, Concerto creates the wave and launches `lf design` in the wave's worktree via embedded terminal. On exit, `lf ops commit --push` auto-commits and pushes.
+
+This is a single interactive step, not a flow. The user runs follow-up steps manually from the StepRunner.
+
+## Progression
+
+1. **Now:** Start wave → interactive `design` → commit+push. Single step, manual follow-up.
+2. **This phase:** Default NUX flow becomes `design → ship → review`. lfd runs the flow; when it hits an interactive step, Concerto surfaces the session inline. Auto steps run headless as today.
+3. **Steady state:** Waves run the `ship-roadmap` loop (`ingest → kickoff → review-design → ship → review`). Interactive steps surface in Concerto; auto steps run in the background.
+
+## What needs to happen
+
+Route wave executor interactive steps through the session orchestration path:
+
+1. lfd recognizes a step as interactive (from step frontmatter or config)
+2. lfd creates a session and signals Concerto via WebSocket that an interactive session is waiting
+3. Concerto surfaces the session inline on the wave detail panel (InteractiveSessionView takes over)
+4. User interacts with the session until the step completes
+5. lfd auto-commits, then continues the flow to the next step
+
+## Dependencies
+
+- agentapi phases 01-03 (shipped): session API, harness, Concerto UI
+- wavemodel phase 03 (shipped): design-first onboarding, wave content display
+- Runtime convergence: wave executor and session paths share the same orchestration
+
+## What's not here
+
+- Multi-session per step (parallel agents within one interactive step)
+- Session handoff between users
+- Background sessions that don't require user interaction (those just run as auto steps)
+- Switching InteractiveSessionView from embedded terminal to session API (separate agentapi work)


### PR DESCRIPTION
## Summary

- Standardize agentapi, chords, and remote wave READMEs to consistent section structure: Vision → Goals → Risks → Metrics → Phases
- Move "Design Decisions" content into Goals, "Open Questions" and "Done When" into Goals/Risks
- Add interactive sessions wavemodel doc (phase 04)

## Test plan

- [ ] Docs-only change, no code affected