### PR TITLE
release: v0.9.2 release notes

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,33 +1,43 @@
-# v0.9.1
+# v0.9.2
 
-Loopflow 0.9.1 ships Chords (compose multiple waves into ensembles), a bundled daemon inside Concerto, and a portfolio dashboard that replaces the old welcome screen. Security hardening continues with credential hygiene and API surface gating.
+Chords let you compose waves together — join independent waves into ensembles and add cross-wave stimuli so one wave can listen to another's progress. Directions are now composable quality groups (`-d ux`, `-d craft`) instead of fixed role personas, and wave-scoped agents gain persistent memory and injectable `/slash` skills.
 
 ## New capabilities
 
-- **Chords** — compose waves into multi-voice ensembles with `loopflow.join()`, and add cross-wave awareness with `loopflow.add_stimulus("designer", kind="listen", source_wave_id="infra")` (#384, #391)
-- **Portfolio dashboard** — Concerto now opens a live dashboard showing every repo's wave status, blocked count, and diff totals instead of the old welcome panel (#401)
-- **Bundled daemon** — Concerto ships its own `lfd`; open a repo and the daemon starts automatically on an ephemeral port with a generated token. No external install required (#404)
-- **Claude sessions** — `agentapi` supports Claude as a session provider with automatic `--resume` on subsequent turns (#382)
-- **Step-aware sessions** — sessions now accept a `step` field (e.g. `"design"`, `"ci-fix"`) instead of raw system prompts, and new built-in steps `lf ci-fix` and `lf release` are available out of the box (#400)
-- **Remote editor launch** — in Concerto connected to a remote `lfd`, open a terminal (SSH), Cursor/VSCode (`--remote ssh-remote+host`), or Zed (`ssh://host/path`) directly into the remote worktree (#388)
-- **`lf release`** — generates release notes from merged PRs since the last tag and auto-creates a git tag on merge to main (#397)
+- **Chords** — join waves into ensembles with `loopflow.join("designer", "infra")` and add cross-wave awareness with `loopflow.add_stimulus("designer", kind="listen", source_wave_id="infra")`
+- **Composable direction groups** — stack quality lenses like `-d ux,clarity` or `-d infra`; groups expand recursively into member directions
+- **Skill injection** — built-in steps and directions appear as `/slash` commands in Claude Code when `inject_skills: true` is set in `.lf/config.yaml`; always on for `lfd` sessions and wave-spawned agents
+- **Wave memory** — agents read persistent context from `wave/<wave>/MEMORY.md`, carried across runs
+- **Interactive flow steps** — when a flow hits an interactive step, lfd creates a session and Concerto joins it inline; on completion the flow auto-commits and advances
+- **Portfolio dashboard** — Concerto opens a live dashboard of your repos instead of a welcome screen; click a wave row to jump in, click `+` to add repos from `~/src`
+- **Bundled daemon** — Concerto ships `lfd` inside the app bundle; no separate install needed, optional CLI symlink to `~/.local/bin`
+- **iOS support** — Concerto builds and runs on iOS Simulator (`uv run python scripts/concerto-dev.py run-ios`)
+- **Remote editor launch** — open Terminal, Cursor, VSCode, or Zed connected to a remote worktree directly from Concerto
+- **OpenCode harness** — third session adapter validates the API is provider-agnostic; OpenCode sessions communicate via HTTP+SSE
+- **`lf release`** — generate release notes from merged PRs and auto-tag on merge (`lf release`, `lf release minor`, `lf release 0.9.2`)
+- **`lf ops release`** — single command for the full release workflow: sync main, worktree, generate notes, commit, create and land PR
 
 ## Improvements
 
-- **Docker executor supports fork flows** — `lf wave run` with fork-based flows (e.g. `wave-reduce`) now works identically in Docker and native mode (#380)
-- **Wave config is just a YAML file** — wave configuration lives at `wave/<name>/<name>.yaml` on disk; the schema discovery abstraction is gone (#387)
-- **Python session API client** — `from loopflow.api import create_session, send_session_input` for scripting session lifecycles (#389)
-- **`lfq` available in the Docker image** — the queue client is bundled alongside `lf` and `lfd` in the container (#399)
-- **Simpler local install** — `python3 scripts/install.py local` replaces the old publish script; DMG building moves to CI (#405)
-- **Cleaner Codex integration** — uses the native `--yolo` flag instead of verbose sandbox overrides (#395)
+- **Flow renames** — `ship` (headless) is now `build`; `design-ship-review` (interactive) is now `ship`; names match intent
+- **Filesystem wave config** — wave configuration lives in `wave/<name>/<name>.yaml` on disk; no schema resolution layer
+- **Docker fork parity** — fork flows now work in the Docker executor, matching native mode behavior
+- **Unified fork executor** — CLI, daemon, and Docker all follow one shared contract for worktree paths, branch identity, and workspace lifecycle
+- **Worktrees from remote branches** — `lf ops wt create jack-heart.mobile.20260225` checks out an existing remote branch instead of creating a new one
+- **Hardened message generation** — PR and commit messages now require structured JSON from the agent; the unsafe plaintext fallback parser is gone
+- **`provider` → `harness`** — session creation uses `"harness": "claude"` instead of `"provider": "claude"`; shared prompt assembly across harnesses
+- **DMG builds moved to CI** — local install simplified to `python3 scripts/install.py local`
 
 ## Security
 
-- **API surface gating** — configurable request-size limits for JSON bodies, WebSocket frames, and hook payloads via `lfd.yaml` or environment variables (#385)
-- **Credential hygiene** — secrets are zeroized on drop and redacted from logs; `lfd token rotate` rotates static auth tokens; query-parameter credentials are now rejected with 400 (#392)
+- **API surface gating** — configurable limits on JSON body size, WebSocket frame/message size, and queue depth via `lfd.yaml` or environment variables
+- **Credential hygiene** — secrets carried in `SecretString` (zeroized on drop, redacted in logs); query-param credentials rejected; `lfd token rotate` for static token rotation
+- **Bearer token pre-validation** — malformed authorization headers (wrong scheme, embedded whitespace, overlength) rejected before reaching auth providers
 
 ## Infrastructure / reliability
 
-- **E2E test harness** — hermetic smoke tests build `lfd` from source against an isolated HOME and temp repo, covering the full wave CRUD lifecycle (#390)
-- **PR/commit message validation** — the ops message pipeline now requires structured JSON from the agent and rejects malformed output instead of silently accepting garbage (#403)
-- **Legacy Rust agent removed** — the standalone Rust agent loop, tool dispatch, and `lf-agent` binary are gone; `portable-pty` dependency dropped (#406)
+- **Session hardening** — event delivery uses unbounded `mpsc` instead of `broadcast` (no dropped events); crash recovery backfills lagged subscribers; conformance test suite added
+- **Orphan reaping** — lfd startup detects and terminates orphaned `opencode serve` processes from previous instances
+- **Contract hardening** — prompt pipeline enforces gather → budget → format ordering at the type level via newtypes; Docker metadata conventions enforced by invariant tests
+- **E2E test harness** — hermetic smoke tests build lfd from source against an isolated environment and exercise the full wave CRUD lifecycle
+- **Legacy cleanup** — removed standalone Rust agent/chat modules and `portable-pty` dependency; functionality superseded by the session API


### PR DESCRIPTION
## Summary

Updates RELEASE_NOTES.md for v0.9.2. The notes cover the full release: composable direction groups, skill injection, wave memory, interactive flow steps, iOS support, the OpenCode harness, `lf ops release`, and infrastructure hardening (session event delivery, orphan reaping, contract newtypes).

## Changes

- Rewrote release notes from v0.9.1 → v0.9.2
- Added new capability sections: composable directions, skill injection, wave memory, interactive flows, iOS, OpenCode harness, `lf ops release`
- Updated improvements to reflect flow renames (`ship`/`build`), unified fork executor, worktree remote branch checkout, hardened message generation, and `provider` → `harness` rename
- Expanded security and infrastructure sections with bearer pre-validation, session hardening, orphan reaping, and contract newtypes