### PR TITLE
release: v0.9.3

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,43 +1,47 @@
-# v0.9.2
+# v0.9.3
 
-Chords let you compose waves together — join independent waves into ensembles and add cross-wave stimuli so one wave can listen to another's progress. Directions are now composable quality groups (`-d ux`, `-d craft`) instead of fixed role personas, and wave-scoped agents gain persistent memory and injectable `/slash` skills.
+Concerto ships on iOS, agents learn to remember across sessions, and Chords let you group waves into coordinated workstreams. This release also adds a provider auth broker, hardens token validation, and gates irreversible publishes behind GitHub Release success.
 
 ## New capabilities
 
-- **Chords** — join waves into ensembles with `loopflow.join("designer", "infra")` and add cross-wave awareness with `loopflow.add_stimulus("designer", kind="listen", source_wave_id="infra")`
-- **Composable direction groups** — stack quality lenses like `-d ux,clarity` or `-d infra`; groups expand recursively into member directions
-- **Skill injection** — built-in steps and directions appear as `/slash` commands in Claude Code when `inject_skills: true` is set in `.lf/config.yaml`; always on for `lfd` sessions and wave-spawned agents
-- **Wave memory** — agents read persistent context from `wave/<wave>/MEMORY.md`, carried across runs
-- **Interactive flow steps** — when a flow hits an interactive step, lfd creates a session and Concerto joins it inline; on completion the flow auto-commits and advances
-- **Portfolio dashboard** — Concerto opens a live dashboard of your repos instead of a welcome screen; click a wave row to jump in, click `+` to add repos from `~/src`
-- **Bundled daemon** — Concerto ships `lfd` inside the app bundle; no separate install needed, optional CLI symlink to `~/.local/bin`
-- **iOS support** — Concerto builds and runs on iOS Simulator (`uv run python scripts/concerto-dev.py run-ios`)
-- **Remote editor launch** — open Terminal, Cursor, VSCode, or Zed connected to a remote worktree directly from Concerto
-- **OpenCode harness** — third session adapter validates the API is provider-agnostic; OpenCode sessions communicate via HTTP+SSE
-- **`lf release`** — generate release notes from merged PRs and auto-tag on merge (`lf release`, `lf release minor`, `lf release 0.9.2`)
-- **`lf ops release`** — single command for the full release workflow: sync main, worktree, generate notes, commit, create and land PR
+- **Concerto on iOS.** Multiplatform build with shared state in LoopflowCore. Run on iPhone and iPad simulators with `uv run python scripts/concerto-dev.py run-ios`. macOS unchanged.
+- **Portfolio dashboard.** Concerto opens to a live portfolio view — repo cards with wave status, blocked counts, and diff totals. Click a wave to open it; `+` to add repos from `~/src`.
+- **Bundled daemon.** Concerto embeds `lfd` — no external install required. Open a repo and a local daemon starts automatically. Optional CLI symlink install for `lf` + `lfd`.
+- **Chords.** Group related waves into chords via the API. CRUD endpoints, membership management, and a Python client (`lfq`).
+- **Quote-replies.** Select text in an assistant bubble to open a reply composer. Queue text replies and emoji reacts, then send as one structured message.
+- **Action buttons.** Agents surface suggested next actions as tappable buttons — macOS and iOS. Tap one to send it as your next message.
+- **Wave memory.** Agents read persistent memory from `wave/<wave>/MEMORY.md`. Memory appears in the prompt automatically for wave-scoped steps.
+- **Skill injection.** Built-in steps and directions appear as `/slash` commands in Claude Code. Enable with `inject_skills: true` in `.lf/config.yaml`; always on for `lfd` sessions.
+- **Surface-adaptive prompts.** Prompts now adapt to where they run — CLI, headless daemon, Concerto desktop, or Concerto iPhone. Replaces the old `run_mode` string.
+- **Composable direction groups.** `lf review -d infra` expands to security + performance + reliability + observability. Stack groups freely: `lf implement -d ux,clarity`.
+- **Auth broker.** `lfq auth github`, `lfq auth claude`, `lfq auth codex` — connect providers in your browser. `lfq auth status` shows what's connected.
+- **OpenCode harness.** Third adapter validates provider-agnostic sessions. OpenCode communicates via HTTP+SSE, a different transport from Codex and Claude.
+- **Remote deployment.** EC2 dogfood lane with smoke test and Caddy TLS config. Deploy with Docker Compose and validate from your laptop.
+- **Remote connection seeding.** Drop a `~/.lf/concerto.yaml` with host and port — Concerto boots straight into remote mode. No manual setup on managed machines.
 
 ## Improvements
 
-- **Flow renames** — `ship` (headless) is now `build`; `design-ship-review` (interactive) is now `ship`; names match intent
-- **Filesystem wave config** — wave configuration lives in `wave/<name>/<name>.yaml` on disk; no schema resolution layer
-- **Docker fork parity** — fork flows now work in the Docker executor, matching native mode behavior
-- **Unified fork executor** — CLI, daemon, and Docker all follow one shared contract for worktree paths, branch identity, and workspace lifecycle
-- **Worktrees from remote branches** — `lf ops wt create jack-heart.mobile.20260225` checks out an existing remote branch instead of creating a new one
-- **Hardened message generation** — PR and commit messages now require structured JSON from the agent; the unsafe plaintext fallback parser is gone
-- **`provider` → `harness`** — session creation uses `"harness": "claude"` instead of `"provider": "claude"`; shared prompt assembly across harnesses
-- **DMG builds moved to CI** — local install simplified to `python3 scripts/install.py local`
+- **`lf ops release`** runs the full release workflow in one command: sync main, worktree, generate notes, commit, tag, and push.
+- **Flow naming clarity.** `ship` (headless) is now `build`. `design-ship-review` is now `ship`. `lf flow build` = implement → compress → gate → update-wave.
+- **Interactive flow steps** route through session orchestration — Concerto joins inline, and on completion the flow auto-commits and advances.
+- **Wave names route into PR titles** instead of commit messages, so commits stay descriptive and PRs stay traceable.
+- **Worktrees check out existing remote branches** by name — `lf ops wt create jack-heart.mobile` finds and tracks the remote branch.
+- **Orphaned OpenCode servers** are reaped on `lfd` restart. A runtime registry tracks which servers belong to which daemon process.
+- **`lfq` is available in the lfd Docker image** alongside `lf` and `lfd`.
+- **Codex flags updated** to the new sandbox and approval API (`--dangerously-bypass-approvals-and-sandbox`, `--ask-for-approval never`).
+- **PR and commit message generation** now validates LLM output as structured JSON — no more silent garbage from the plaintext fallback parser.
 
 ## Security
 
-- **API surface gating** — configurable limits on JSON body size, WebSocket frame/message size, and queue depth via `lfd.yaml` or environment variables
-- **Credential hygiene** — secrets carried in `SecretString` (zeroized on drop, redacted in logs); query-param credentials rejected; `lfd token rotate` for static token rotation
-- **Bearer token pre-validation** — malformed authorization headers (wrong scheme, embedded whitespace, overlength) rejected before reaching auth providers
+- **Bearer token pre-validation.** Malformed authorization headers (wrong scheme, whitespace, control chars, overlength) are rejected before reaching any provider.
+- **Live auth contract testing.** `test_auth_live_contract.py` validates all three providers end-to-end with CLI transcripts and credential tree snapshots.
+- **Irreversible publishes gated on GitHub Release.** Crates.io and PyPI uploads only run after the GitHub Release job succeeds.
 
 ## Infrastructure / reliability
 
-- **Session hardening** — event delivery uses unbounded `mpsc` instead of `broadcast` (no dropped events); crash recovery backfills lagged subscribers; conformance test suite added
-- **Orphan reaping** — lfd startup detects and terminates orphaned `opencode serve` processes from previous instances
-- **Contract hardening** — prompt pipeline enforces gather → budget → format ordering at the type level via newtypes; Docker metadata conventions enforced by invariant tests
-- **E2E test harness** — hermetic smoke tests build lfd from source against an isolated environment and exercise the full wave CRUD lifecycle
-- **Legacy cleanup** — removed standalone Rust agent/chat modules and `portable-pty` dependency; functionality superseded by the session API
+- **Session event delivery hardened.** Events flow through unbounded `mpsc` instead of `broadcast` — no dropped events under load. Crash recovery backfills lagged consumers.
+- **Contract newtypes.** Prompt pipeline enforces gather → budget → format ordering at the type level (`GatheredContext` → `BudgetedContext` → `RenderedPrompt`).
+- **OpenCode schema pinned** to canonical field names with recorded conformance traces. Defensive multi-key fallbacks removed.
+- **Legacy Rust agent/chat modules removed.** `agent::anthropic`, `agent::tools`, `chat::contract`, and the `lf-agent` binary are gone — functionality was superseded.
+- **Docker executor decomposed.** `docker.rs`, `store/mod.rs`, and `engine/agent.rs` split into focused modules for lower blast radius on future changes.
+- **DMG building moved to CI.** Local install simplified to `python3 scripts/install.py local`. Screenshots prefer the installed app over DerivedData builds.

--- a/swift/ConcertoTests/SessionStateTests.swift
+++ b/swift/ConcertoTests/SessionStateTests.swift
@@ -435,6 +435,7 @@ struct SessionStateTests {
         await state.send("hello")
         await waitUntil { service.sendInputCallCount == 1 }
         await state.endSession()
+        await waitUntil { service.streamCancellationCount >= 1 }
 
         #expect(service.stopSessionCallCount == 1)
         #expect(service.streamCancellationCount >= 1)


### PR DESCRIPTION
## Summary

Updates `RELEASE_NOTES.md` for v0.9.3.

Highlights: Concerto on iOS, portfolio dashboard, bundled daemon, chords API, quote-replies, action buttons, auth broker, surface-adaptive prompts, and gated irreversible publishes.

## Changes

- Rewrote release notes from v0.9.2 → v0.9.3 with new capabilities, improvements, security, and infrastructure sections
- Added: Concerto iOS multiplatform build, portfolio dashboard, bundled `lfd`, chords CRUD, quote-replies, action buttons, wave memory, skill injection, auth broker, remote deployment, remote connection seeding
- Added: `lf ops release` workflow, flow naming clarity, interactive flow steps, wave-name PR titles, orphaned server reaping, live auth contract testing, publish gating on GitHub Release
- Removed: v0.9.2 entries superseded by v0.9.3 content