### PR TITLE
release: two-stage workflow and partial-failure handling

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,8 @@ on:
       - "v*"
 
 jobs:
-  # Build native binaries (GitHub Releases, shell installer)
+  # --- Stage 1: Build (failable work) ---
+
   build-native:
     strategy:
       matrix:
@@ -36,39 +37,8 @@ jobs:
           name: native-${{ matrix.target }}
           path: lf-*.tar.gz
 
-  # Publish to crates.io (irreversible — gates on GitHub Release)
-  publish-crates:
-    needs: [release]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - name: Publish to crates.io
-        run: cargo publish -p loopflow --allow-dirty
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-
-  # Publish pure Python package to PyPI (irreversible — gates on GitHub Release)
-  publish-pypi:
-    needs: [release]
-    runs-on: ubuntu-latest
-    environment: pypi
-    permissions:
-      id-token: write
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - uses: astral-sh/setup-uv@v4
-      - name: Build package
-        run: uv build
-      - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          packages-dir: dist/
-
-  # Build Concerto DMG and upload to R2
   build-dmg:
+    needs: [build-native]
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
@@ -110,9 +80,10 @@ jobs:
           name: dmg
           path: swift/dist/LoopflowConcerto.dmg
 
-  # Create GitHub Release with native binaries
+  # --- Stage 2: Publish (all gated on builds) ---
+
   release:
-    needs: [build-native, build-dmg]
+    needs: [build-dmg]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -225,3 +196,32 @@ jobs:
             dist/native/*.tar.gz
             dist/dmg/*.dmg
             dist/install.sh
+
+  publish-crates:
+    needs: [build-dmg]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Publish to crates.io
+        run: cargo publish -p loopflow --allow-dirty
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+  publish-pypi:
+    needs: [build-dmg]
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: astral-sh/setup-uv@v4
+      - name: Build package
+        run: uv build
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist/

--- a/rust/loopflow/src/ops/release.rs
+++ b/rust/loopflow/src/ops/release.rs
@@ -1152,8 +1152,10 @@ fn monitor_release_workflow_inner(
         ));
 
         if view.status == "completed" {
+            let release_exists = github_release_exists(repo, tag)?;
+
             if view.conclusion.as_deref() == Some("success") {
-                if github_release_exists(repo, tag)? {
+                if release_exists {
                     progress.status("GitHub Release is published.");
                 } else {
                     progress.error("Workflow succeeded but GitHub Release not found yet.");
@@ -1161,12 +1163,24 @@ fn monitor_release_workflow_inner(
                 return Ok(());
             }
 
+            // Workflow failed, but the release job may have succeeded
+            // (e.g. publish-crates failed after GitHub Release was created).
+            // Don't offer retag if the release already exists.
+            let conclusion = view.conclusion.unwrap_or_else(|| "unknown".to_string());
+            if release_exists {
+                progress.error(&format!(
+                    "Release workflow failed ({conclusion}), but GitHub Release is published. \
+                     Check failed jobs: gh run view {}",
+                    run.id
+                ));
+                return Err(OpsError::Message(
+                    "release workflow partially failed; GitHub Release exists".to_string(),
+                ));
+            }
+
             let logs = workflow_logs(repo, run.id)
                 .unwrap_or_else(|err| format!("failed to fetch workflow logs: {err}"));
-            progress.error(&format!(
-                "Release workflow failed: {}",
-                view.conclusion.unwrap_or_else(|| "unknown".to_string())
-            ));
+            progress.error(&format!("Release workflow failed: {conclusion}"));
             if !logs.trim().is_empty() {
                 progress.error(&logs);
             }


### PR DESCRIPTION
## Summary

Restructures the release workflow into two explicit stages and teaches the release monitor to handle partial failures gracefully.

Previously, `publish-crates` and `publish-pypi` ran *after* the GitHub Release job, meaning a crates.io or PyPI failure left a published release with missing packages—and the monitor would offer to retag, which is wrong if the release already exists.

## Changes

**Workflow (`release.yml`)**
- **Stage 1 — Build**: `build-native` → `build-dmg` (sequential, all failable work)
- **Stage 2 — Publish**: `release`, `publish-crates`, and `publish-pypi` all gate on `build-dmg` and run in parallel
- This ensures no irreversible publish happens until all builds succeed

**Monitor (`ops/release.rs`)**
- On workflow failure, checks whether the GitHub Release was already created
- If the release exists despite a failed workflow (e.g. `publish-crates` failed), reports the partial failure with a `gh run view` command instead of offering to retag
- Prevents accidentally re-tagging a release that already shipped