### PR TITLE
bug: replace removed --ask-for-approval flag with --full-auto

### DIFF
--- a/rust/loopflow/src/engine/agent.rs
+++ b/rust/loopflow/src/engine/agent.rs
@@ -318,15 +318,12 @@ pub fn build_codex_command(
 
     if launch.skip_permissions {
         cmd.push("--dangerously-bypass-approvals-and-sandbox".to_string());
+    } else if process.auto {
+        // --full-auto = sandboxed workspace-write + auto-approve safe operations.
+        cmd.push("--full-auto".to_string());
     } else {
         cmd.push("--sandbox".to_string());
         cmd.push("workspace-write".to_string());
-
-        // Non-interactive runs should never block on approval prompts.
-        if process.auto {
-            cmd.push("--ask-for-approval".to_string());
-            cmd.push("never".to_string());
-        }
     }
 
     cmd
@@ -841,12 +838,10 @@ mod tests {
         };
         let cmd = build_codex_command(&launch, &process, None);
         assert!(cmd.contains(&"exec".to_string()));
-        assert!(cmd.contains(&"--sandbox".to_string()));
-        assert!(cmd.contains(&"workspace-write".to_string()));
-        assert!(cmd.contains(&"--ask-for-approval".to_string()));
-        assert!(cmd.contains(&"never".to_string()));
+        assert!(cmd.contains(&"--full-auto".to_string()));
+        assert!(!cmd.contains(&"--sandbox".to_string()));
+        assert!(!cmd.contains(&"--ask-for-approval".to_string()));
         assert!(!cmd.contains(&"--dangerously-bypass-approvals-and-sandbox".to_string()));
-        assert!(!cmd.contains(&"--full-auto".to_string()));
     }
 
     #[test]
@@ -887,6 +882,7 @@ mod tests {
         assert!(cmd.contains(&"--dangerously-bypass-approvals-and-sandbox".to_string()));
         assert!(!cmd.contains(&"--sandbox".to_string()));
         assert!(!cmd.contains(&"--ask-for-approval".to_string()));
+        assert!(!cmd.contains(&"--full-auto".to_string()));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Codex removed the `--ask-for-approval` flag. This PR updates `build_codex_command` to use `--full-auto` for non-interactive auto runs instead.

## Changes

- When `process.auto` is true (and permissions aren't skipped), pass `--full-auto` instead of `--sandbox workspace-write --ask-for-approval never`
- `--full-auto` provides sandboxed workspace-write with auto-approval of safe operations — equivalent behavior with fewer flags
- Manual (non-auto) runs still get `--sandbox workspace-write` as before
- `skip_permissions` still uses `--dangerously-bypass-approvals-and-sandbox`
- Updated tests to match the new flag logic