### PR TITLE
download: use uv run --with instead of uv pip install --system

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,8 +48,7 @@ jobs:
         working-directory: ${{ github.workspace }}
       - name: Upload DMG to R2
         run: |
-          uv pip install --system boto3
-          python3 - <<'SCRIPT'
+          uv run --with boto3 python3 - <<'SCRIPT'
           import boto3, os
           version = os.environ["GITHUB_REF_NAME"].lstrip("v")
           client = boto3.client(


### PR DESCRIPTION
## Summary

Switch the R2 upload step in the release workflow from `uv pip install --system` to `uv run --with boto3`. This avoids polluting the system Python environment and is the idiomatic way to run a script with an ad-hoc dependency in uv.

## Changes

- Replace two-line `uv pip install --system boto3` + `python3 -` with single `uv run --with boto3 python3 -` in the DMG upload step