### PR TITLE
release-v0-9-5: bump version and update release notes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.9.4"
+version = "0.9.5"
 edition = "2021"
 license = "MIT"
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,8 +1,6 @@
-# v0.9.4
+# v0.9.5
 
-Release notes written to `RELEASE_NOTES.md`. 39 PRs distilled into four sections:
+Release notes written to `RELEASE_NOTES.md`. 5 PRs across two sections:
 
-- **11 new capabilities** — voice input, tmux plugin, cross-repo DAG, mobile discovery, inline glance, live git state, usage aggregation, provider catalog, repo onboarding, containerized daemon, provider auth in Concerto
-- **9 improvements** — per-wave agent overrides, parallel chords, multi-step forks, target-scoped releases, context audit split, dynamic voice, "ride a wave", wave name normalization, session metering
-- **3 security** — DB-backed tokens, proactive refresh, git sync hardening
-- **6 infra/reliability** — two-stage releases, iOS multi-client, e2e concurrent tests, stream parser, Codex flag fix, skill injection removal
+- **2 new capabilities** — sandbox executor with adaptive container routing, fast-path step runner with worktree rotation
+- **3 improvements** — config-driven directions with `--no-direction` override, descendant doc gathering for area context, dirty/remote-gone awareness in worktree pruning

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "loopflow"
-version = "0.9.4"
+version = "0.9.5"
 description = "Run LLM coding agents from reusable prompt files"
 readme = "README.md"
 requires-python = ">=3.8"


### PR DESCRIPTION
## Summary

Cuts the v0.9.5 release — bumps version numbers in `pyproject.toml` and `Cargo.toml`, and writes release notes covering the 5 PRs that landed since v0.9.4.

## What's in v0.9.5

- **2 new capabilities** — sandbox executor with adaptive container routing, fast-path step runner with worktree rotation
- **3 improvements** — config-driven directions with `--no-direction` override, descendant doc gathering for area context, dirty/remote-gone awareness in worktree pruning

## Changes

- Version bump `0.9.4` → `0.9.5` in `pyproject.toml` and `Cargo.toml`
- `RELEASE_NOTES.md` rewritten for v0.9.5