### PR TITLE
release-fix: resume partially-completed releases; reorder directions before step in prompt

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -23,5 +23,14 @@ jobs:
             echo "Tag $version already exists"
             exit 0
           fi
+
+          # Verify Cargo.toml version matches before tagging
+          cargo_version=$(sed -n 's/^version = "\(.*\)"/\1/p' Cargo.toml | head -1)
+          expected="${version#v}"
+          if [ "$cargo_version" != "$expected" ]; then
+            echo "::error::Version mismatch: RELEASE_NOTES.md says $version but Cargo.toml has $cargo_version"
+            exit 1
+          fi
+
           git tag "$version"
           git push origin "$version"

--- a/rust/loopflow/src/engine/prompt.rs
+++ b/rust/loopflow/src/engine/prompt.rs
@@ -1615,11 +1615,7 @@ pub fn format_prompt(mode: PromptFormatMode, components: &BudgetedContext) -> Re
         PromptFormatMode::Full => {
             let mut parts = format_reference_sections(components);
 
-            // Task sections: step, directions, clipboard, message
-            if let Some(ref step) = components.step {
-                parts.push(format!("The step.\n\n{}", format_step_tag(step)));
-            }
-
+            // Context sections: directions, clipboard
             if !components.directions.is_empty() {
                 let label = if components.directions.len() == 1 {
                     "Direction"
@@ -1640,6 +1636,11 @@ pub fn format_prompt(mode: PromptFormatMode, components: &BudgetedContext) -> Re
                 ));
             }
 
+            // Task sections: step, message
+            if let Some(ref step) = components.step {
+                parts.push(format!("The step.\n\n{}", format_step_tag(step)));
+            }
+
             if let Some(ref message) = components.message {
                 parts.push(format!(
                     "Additional instructions from user.\n\n\
@@ -1653,6 +1654,10 @@ pub fn format_prompt(mode: PromptFormatMode, components: &BudgetedContext) -> Re
         PromptFormatMode::Context => {
             let mut parts = format_reference_sections(components);
 
+            if !components.directions.is_empty() {
+                parts.push(format_direction_tags(&components.directions));
+            }
+
             if let Some(ref clipboard) = components.clipboard {
                 parts.push(format!(
                     "Content from clipboard.\n\n\
@@ -1665,10 +1670,6 @@ pub fn format_prompt(mode: PromptFormatMode, components: &BudgetedContext) -> Re
         }
         PromptFormatMode::Task => {
             let mut parts = Vec::new();
-
-            if !components.directions.is_empty() {
-                parts.push(format_direction_tags(&components.directions));
-            }
 
             if let Some(ref step) = components.step {
                 parts.push(format_step_tag(step));
@@ -1689,7 +1690,7 @@ pub fn format_context_prompt(components: &BudgetedContext) -> String {
     format_prompt(PromptFormatMode::Context, components).into_string()
 }
 
-/// Format task prompt for user message (directions + step + free text).
+/// Format task prompt for user message (step + free text).
 pub fn format_task_prompt(components: &BudgetedContext) -> String {
     format_prompt(PromptFormatMode::Task, components).into_string()
 }
@@ -2351,23 +2352,23 @@ mod tests {
 
         let prompt = render_full_prompt(components);
 
-        // Verify order: loopflow -> surface block -> wave -> docs -> diff -> step -> direction -> clipboard
+        // Verify order: loopflow -> surface block -> wave -> docs -> diff -> direction -> clipboard -> step
         let loopflow_pos = prompt.find("<lf:loopflow>").unwrap();
         let auto_pos = prompt.find("Run mode is auto").unwrap();
         let wave_pos = prompt.find("<lf:wave").unwrap();
         let docs_pos = prompt.find("<lf:docs>").unwrap();
         let diff_pos = prompt.find("<lf:diff>").unwrap();
-        let step_pos = prompt.find("<lf:step:implement>").unwrap();
         let direction_pos = prompt.find("<lf:direction:concise>").unwrap();
         let clipboard_pos = prompt.find("<lf:clipboard>").unwrap();
+        let step_pos = prompt.find("<lf:step:implement>").unwrap();
 
         assert!(loopflow_pos < auto_pos);
         assert!(auto_pos < wave_pos);
         assert!(wave_pos < docs_pos);
         assert!(docs_pos < diff_pos);
-        assert!(diff_pos < step_pos);
-        assert!(step_pos < direction_pos);
+        assert!(diff_pos < direction_pos);
         assert!(direction_pos < clipboard_pos);
+        assert!(clipboard_pos < step_pos);
     }
 
     #[test]
@@ -2916,10 +2917,12 @@ directions:
         assert!(context.contains("<lf:docs>"));
         assert!(context.contains("# Project"));
         assert!(context.contains("<lf:clipboard>"));
-        // Should NOT include step or directions (both go in task prompt)
+        // Should include directions (context, not task)
+        assert!(context.contains("<lf:direction:concise>"));
+        assert!(context.contains("Be concise."));
+        // Should NOT include step (goes in task prompt)
         assert!(!context.contains("<lf:step:debug>"));
         assert!(!context.contains("Fix the error."));
-        assert!(!context.contains("<lf:direction:concise>"));
     }
 
     #[test]

--- a/rust/loopflow/src/ops/release.rs
+++ b/rust/loopflow/src/ops/release.rs
@@ -210,6 +210,15 @@ pub fn publish_release(
 
     let prev_tag = latest_tag(&main_repo, &target)?;
     let version = resolve_version(&prev_tag, &options.version_input, &target)?;
+
+    // Check for a release that's prepared (notes + manifests) but not yet tagged,
+    // or already tagged but with a failed workflow. Resume instead of starting fresh.
+    if let Some(result) =
+        try_resume_release(&main_repo, &version, &target, options.dry_run, progress)?
+    {
+        return Ok(result);
+    }
+
     let wt_name = if target.name == "default" {
         format!("release-v{version}")
     } else {
@@ -264,6 +273,101 @@ pub fn publish_release(
         target: target.name,
         bootstrapped: false,
     })
+}
+
+/// Check if a release for `version` is already prepared or tagged, and resume it.
+///
+/// Returns `Some(result)` if the release was resumed (or already complete).
+/// Returns `None` to fall through to the fresh workflow.
+fn try_resume_release(
+    repo: &Path,
+    version: &str,
+    target: &ReleaseTarget,
+    dry_run: bool,
+    progress: &impl Progress,
+) -> OpsResult<Option<PublishResult>> {
+    let notes_version = read_release_notes_version(repo);
+    if notes_version.as_deref() != Some(version) {
+        return Ok(None);
+    }
+
+    if !manifests_at_version(repo, target, version) {
+        return Ok(None);
+    }
+
+    let tag = target_tag(target, version);
+    let remote_tag = tag_exists_remote(repo, &tag)?;
+
+    if remote_tag {
+        // Tag exists on remote — check workflow/release status.
+        let release_exists = github_release_exists(repo, &tag)?;
+        let workflow = find_workflow_run(repo, &tag, target)?;
+
+        let workflow_ok = workflow
+            .as_ref()
+            .is_some_and(|r| r.conclusion.as_deref() == Some("success"));
+
+        if release_exists && workflow_ok {
+            progress.status(&format!("{tag} already released."));
+            return Ok(Some(PublishResult {
+                version: Some(version.to_string()),
+                target: target.name.clone(),
+                bootstrapped: false,
+            }));
+        }
+
+        if dry_run {
+            progress.status(&format!(
+                "Would resume {tag} (tag exists, monitoring workflow)"
+            ));
+            return Ok(Some(PublishResult {
+                version: Some(version.to_string()),
+                target: target.name.clone(),
+                bootstrapped: false,
+            }));
+        }
+
+        // Tag pushed but workflow incomplete or failed — monitor/diagnose.
+        progress.status(&format!(
+            "Resuming {tag} (tag exists, checking workflow)..."
+        ));
+        monitor_release_workflow(repo, &tag, target, progress)?;
+
+        progress.status(&format!("{tag} published."));
+        return Ok(Some(PublishResult {
+            version: Some(version.to_string()),
+            target: target.name.clone(),
+            bootstrapped: false,
+        }));
+    }
+
+    // Notes + manifests ready but no remote tag — sync, tag, and push.
+    if dry_run {
+        progress.status(&format!(
+            "Would resume {tag} (notes and manifests ready, tagging)"
+        ));
+        return Ok(Some(PublishResult {
+            version: Some(version.to_string()),
+            target: target.name.clone(),
+            bootstrapped: false,
+        }));
+    }
+
+    progress.status(&format!(
+        "Resuming {tag} (notes and manifests ready, tagging)..."
+    ));
+    let main_branch = get_default_branch(repo)?;
+    sync_main(repo, &main_branch)?;
+
+    let pushed_tag = tag_and_push(repo, version, target)?;
+    monitor_release_workflow(repo, &pushed_tag, target, progress)?;
+
+    progress.status(&format!("{tag} published."));
+    Ok(Some(PublishResult {
+        version: Some(version.to_string()),
+        target: target.name.clone(),
+        bootstrapped: false,
+    }))
 }
 
 pub fn release_status(repo: &Path, target_name: Option<&str>) -> OpsResult<ReleaseStatusResult> {
@@ -577,6 +681,57 @@ fn tag_glob(target: &ReleaseTarget) -> String {
     format!("{}v*", target.tag_prefix)
 }
 
+/// Read the version from the first line of RELEASE_NOTES.md (`# v{X.Y.Z}`).
+fn read_release_notes_version(repo: &Path) -> Option<String> {
+    let path = repo.join("RELEASE_NOTES.md");
+    let content = fs::read_to_string(path).ok()?;
+    let first_line = content.lines().next()?.trim();
+    let version = first_line.strip_prefix("# v")?;
+    if version.split('.').count() == 3 {
+        Some(version.to_string())
+    } else {
+        None
+    }
+}
+
+/// Check whether all manifests in the target already have the given version.
+fn manifests_at_version(repo: &Path, target: &ReleaseTarget, version: &str) -> bool {
+    if target.manifests.is_empty() {
+        return false;
+    }
+
+    target.manifests.iter().all(|manifest| {
+        let path = repo.join(manifest);
+        let Ok(content) = fs::read_to_string(&path) else {
+            return false;
+        };
+        match manifest.file_name().and_then(|n| n.to_str()) {
+            Some("Cargo.toml") => toml_has_version(&content, version),
+            Some("package.json") => json_has_version(&content, version),
+            Some("pyproject.toml") => toml_has_version(&content, version),
+            _ => false,
+        }
+    })
+}
+
+fn toml_has_version(content: &str, version: &str) -> bool {
+    let target = format!("version = \"{version}\"");
+    content.lines().any(|line| line.trim() == target)
+}
+
+fn json_has_version(content: &str, version: &str) -> bool {
+    let target = format!("\"version\": \"{version}\"");
+    content
+        .lines()
+        .any(|line| line.replace(' ', "").contains(&target.replace(' ', "")))
+}
+
+/// Check if a tag exists on the remote.
+fn tag_exists_remote(repo: &Path, tag: &str) -> OpsResult<bool> {
+    let output = run_stdout(repo, "git", &["ls-remote", "--tags", "origin", tag])?;
+    Ok(!output.trim().is_empty())
+}
+
 fn merged_prs_since(repo: &Path, tag: &str, target: &ReleaseTarget) -> OpsResult<Vec<MergedPr>> {
     let tagged_at = run_stdout(repo, "git", &["log", "-1", "--format=%aI", tag])?;
     if tagged_at.is_empty() {
@@ -840,6 +995,9 @@ fn bump_manifest_versions(
         return Ok(());
     }
 
+    let mut bumped_cargo = false;
+    let mut bumped_pyproject = false;
+
     for manifest in &target.manifests {
         let manifest_path = repo.join(manifest);
         if !manifest_path.exists() {
@@ -850,7 +1008,8 @@ fn bump_manifest_versions(
         }
 
         let original = fs::read_to_string(&manifest_path)?;
-        let updated = match manifest_path.file_name().and_then(|name| name.to_str()) {
+        let name = manifest_path.file_name().and_then(|name| name.to_str());
+        let updated = match name {
             Some("Cargo.toml") => bump_cargo_toml(&original, version)?,
             Some("package.json") => bump_package_json(&original, version)?,
             Some("pyproject.toml") => bump_pyproject_toml(&original, version)?,
@@ -860,7 +1019,23 @@ fn bump_manifest_versions(
         if updated != original {
             fs::write(&manifest_path, updated)?;
             progress.status(&format!("Bumped version in {}", manifest_path.display()));
+            match name {
+                Some("Cargo.toml") => bumped_cargo = true,
+                Some("pyproject.toml") => bumped_pyproject = true,
+                _ => {}
+            }
         }
+    }
+
+    // Update lock files so they stay in sync with manifest versions.
+    if bumped_cargo && repo.join("Cargo.lock").exists() {
+        let _ = Command::new("cargo")
+            .args(["update", "--workspace"])
+            .current_dir(repo)
+            .output();
+    }
+    if bumped_pyproject && repo.join("uv.lock").exists() {
+        let _ = Command::new("uv").arg("lock").current_dir(repo).output();
     }
 
     Ok(())
@@ -1737,5 +1912,142 @@ version = "2.0.0"
             workflow: None,
         };
         assert_eq!(target_tag(&target, "2.0.0"), "cli/v2.0.0");
+    }
+
+    // ======================================================================
+    // read_release_notes_version
+    // ======================================================================
+
+    #[test]
+    fn release_notes_version_valid() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join("RELEASE_NOTES.md"), "# v0.9.5\n\nNotes.").unwrap();
+        assert_eq!(
+            read_release_notes_version(dir.path()),
+            Some("0.9.5".to_string())
+        );
+    }
+
+    #[test]
+    fn release_notes_version_missing_file() {
+        let dir = tempfile::tempdir().unwrap();
+        assert_eq!(read_release_notes_version(dir.path()), None);
+    }
+
+    #[test]
+    fn release_notes_version_no_header() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join("RELEASE_NOTES.md"), "Just some text.").unwrap();
+        assert_eq!(read_release_notes_version(dir.path()), None);
+    }
+
+    #[test]
+    fn release_notes_version_invalid_format() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(
+            dir.path().join("RELEASE_NOTES.md"),
+            "# v1.0\n\nOnly two parts.",
+        )
+        .unwrap();
+        assert_eq!(read_release_notes_version(dir.path()), None);
+    }
+
+    // ======================================================================
+    // manifests_at_version
+    // ======================================================================
+
+    #[test]
+    fn manifests_match_cargo_toml() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(
+            dir.path().join("Cargo.toml"),
+            "[workspace.package]\nversion = \"1.2.3\"\n",
+        )
+        .unwrap();
+        let target = ReleaseTarget {
+            name: "default".to_string(),
+            area: vec![],
+            tag_prefix: String::new(),
+            manifests: vec![PathBuf::from("Cargo.toml")],
+            workflow: None,
+        };
+        assert!(manifests_at_version(dir.path(), &target, "1.2.3"));
+        assert!(!manifests_at_version(dir.path(), &target, "1.2.4"));
+    }
+
+    #[test]
+    fn manifests_match_pyproject_toml() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(
+            dir.path().join("pyproject.toml"),
+            "[project]\nversion = \"0.5.0\"\n",
+        )
+        .unwrap();
+        let target = ReleaseTarget {
+            name: "default".to_string(),
+            area: vec![],
+            tag_prefix: String::new(),
+            manifests: vec![PathBuf::from("pyproject.toml")],
+            workflow: None,
+        };
+        assert!(manifests_at_version(dir.path(), &target, "0.5.0"));
+        assert!(!manifests_at_version(dir.path(), &target, "0.6.0"));
+    }
+
+    #[test]
+    fn manifests_empty_returns_false() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = ReleaseTarget {
+            name: "default".to_string(),
+            area: vec![],
+            tag_prefix: String::new(),
+            manifests: vec![],
+            workflow: None,
+        };
+        assert!(!manifests_at_version(dir.path(), &target, "1.0.0"));
+    }
+
+    #[test]
+    fn manifests_partial_mismatch() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(
+            dir.path().join("Cargo.toml"),
+            "[package]\nversion = \"1.0.0\"\n",
+        )
+        .unwrap();
+        fs::write(
+            dir.path().join("pyproject.toml"),
+            "[project]\nversion = \"0.9.0\"\n",
+        )
+        .unwrap();
+        let target = ReleaseTarget {
+            name: "default".to_string(),
+            area: vec![],
+            tag_prefix: String::new(),
+            manifests: vec![PathBuf::from("Cargo.toml"), PathBuf::from("pyproject.toml")],
+            workflow: None,
+        };
+        // Both must match for true
+        assert!(!manifests_at_version(dir.path(), &target, "1.0.0"));
+    }
+
+    // ======================================================================
+    // toml_has_version / json_has_version
+    // ======================================================================
+
+    #[test]
+    fn toml_version_check() {
+        assert!(toml_has_version("version = \"1.0.0\"\n", "1.0.0"));
+        assert!(!toml_has_version("version = \"1.0.0\"\n", "2.0.0"));
+        assert!(toml_has_version(
+            "[package]\nversion = \"1.0.0\"\nedition = \"2021\"\n",
+            "1.0.0"
+        ));
+    }
+
+    #[test]
+    fn json_version_check() {
+        assert!(json_has_version("{\n  \"version\": \"1.0.0\"\n}", "1.0.0"));
+        assert!(!json_has_version("{\n  \"version\": \"1.0.0\"\n}", "2.0.0"));
     }
 }

--- a/tests/goldens/with_direction.md
+++ b/tests/goldens/with_direction.md
@@ -198,16 +198,16 @@ Run mode is auto (headless). Proceed without pausing for questions. If you need 
 
 No rendering environment. Output is logged, not displayed. Optimize for structured, parseable output over human readability.
 
-The step.
-
-<lf:step:test>
-Test step content with direction.
-
-</lf:step:test>
-
 Direction for this work.
 
 <lf:direction:thorough>
 Be thorough.
 
 </lf:direction:thorough>
+
+The step.
+
+<lf:step:test>
+Test step content with direction.
+
+</lf:step:test>

--- a/tests/goldens/with_direction_group.md
+++ b/tests/goldens/with_direction_group.md
@@ -198,13 +198,6 @@ Run mode is auto (headless). Proceed without pausing for questions. If you need 
 
 No rendering environment. Output is logged, not displayed. Optimize for structured, parseable output over human readability.
 
-The step.
-
-<lf:step:test>
-Test step content with builtin direction group.
-
-</lf:step:test>
-
 Directions for this work.
 
 <lf:directions>
@@ -243,3 +236,10 @@ Start with minimal data structures and APIs. If the core is right, trimming exce
 
 </lf:direction:simplicity>
 </lf:directions>
+
+The step.
+
+<lf:step:test>
+Test step content with builtin direction group.
+
+</lf:step:test>


### PR DESCRIPTION
## Try it

```bash
# Release resumes automatically if notes + manifests are already bumped
cargo run -- ops release publish

# If the tag exists but the workflow failed, it monitors/retries
cargo run -- ops release publish
```

## Summary

Two independent improvements shipped together.

**Release resumption**: `publish_release` now detects when a release is partially complete — notes written, manifests bumped, maybe even tagged — and resumes from where it left off instead of failing or starting over. This handles the common case where a release workflow fails after tagging, or where the process was interrupted after preparing notes but before pushing the tag.

**Prompt reordering**: Directions now appear before the step in the full prompt, and move from the task prompt to the context prompt. This puts context (directions, clipboard) together and task instructions (step, message) together, so the LLM sees guidance before the specific task.

## Changes

- Add `try_resume_release()` that checks release notes version, manifest versions, and remote tag state to determine where to resume
- Add helpers: `read_release_notes_version`, `manifests_at_version`, `tag_exists_remote`, `toml_has_version`, `json_has_version`
- Update lock files (`Cargo.lock`, `uv.lock`) after bumping manifest versions
- Validate `Cargo.toml` version matches before auto-tagging in CI
- Move directions from `Task` prompt to `Context` prompt; reorder directions before step in `Full` prompt
- Update golden tests to match new prompt ordering