### PR TITLE
qawave: branch construct for conditional routing, qa-deploy pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ Steps are prompts that run coding agents. Add your own in `.lf/steps/`.
 | `implement` | Build from a design doc |
 | `compress` | Simplify touched code |
 | `gate` | Ship-ready code and reviewer-friendly docs |
+| `qa` | Thorough quality assessment of the current branch |
+| `triage` | Assess QA findings, separate blocking from polish |
 
 ### Interactive steps (`interactive/`)
 
@@ -110,6 +112,9 @@ Steps chain into flows. Flows feed into waves.
 | `start` | ingest → kickoff |
 | `ship-wave` | start → build |
 | `ship-roadmap` | ingest → kickoff → review-design → build → review |
+| `qa-deploy` | qa → triage → branch(fix: qa-fix, deploy: deploy) |
+| `qa-fix` | implement → compress → lint → gate |
+| `deploy` | gate → update-wave |
 
 ### Plan flows (`plan/`)
 
@@ -134,6 +139,26 @@ lf flow wave-reduce    # runs reduce 3x with different perspectives
 ```
 
 `wave-reduce` forks `reduce` across infra, ux, and ceo directions, then reconciles results with `update-wave`.
+
+### Branches
+
+Branches route a flow based on an agent's assessment of the current state.
+
+```yaml
+# flow: qa-deploy
+- qa
+- triage
+- branch:
+    paths:
+      fix:
+        flow: qa-fix
+        description: "Blocking issues found, fix before deploy"
+      deploy:
+        flow: deploy
+        description: "Clean enough to ship"
+```
+
+The branch construct runs a routing agent that reads scratch/ and chooses a path. The selected sub-flow runs inline. Combined with cron scheduling and loop iteration, this enables cycles like daily QA → fix → deploy.
 
 ## Playing in the Waves
 

--- a/python/loopflow/api.py
+++ b/python/loopflow/api.py
@@ -173,12 +173,14 @@ def add_stimulus(
     kind: str,
     cron: Optional[str] = None,
     source_wave_id: Optional[str] = None,
+    max_iterations: Optional[int] = None,
 ) -> dict[str, Any]:
     return _client().add_stimulus(
         name_or_id,
         kind,
         cron=cron,
         source_wave_id=source_wave_id,
+        max_iterations=max_iterations,
     )
 
 

--- a/python/loopflow/client.py
+++ b/python/loopflow/client.py
@@ -248,12 +248,15 @@ class Client:
         kind: str,
         cron: Optional[str] = None,
         source_wave_id: Optional[str] = None,
+        max_iterations: Optional[int] = None,
     ) -> dict[str, Any]:
         body: dict[str, Any] = {"kind": kind}
         if cron is not None:
             body["cron"] = cron
         if source_wave_id is not None:
             body["source_wave_id"] = source_wave_id
+        if max_iterations is not None:
+            body["max_iterations"] = max_iterations
         return self._request_json("POST", f"/v0/waves/{name_or_id}/stimulus", json=body)
 
     def remove_stimulus(self, name_or_id: str, stimulus_id: str) -> dict[str, Any]:

--- a/python/loopflow/models.py
+++ b/python/loopflow/models.py
@@ -11,6 +11,7 @@ class Stimulus(BaseModel):
     kind: str
     source_wave_id: Optional[str] = None
     cron: Optional[str] = None
+    max_iterations: Optional[int] = None
 
 
 class PullRequest(BaseModel):

--- a/rust/loopflow/src/engine/builtins/flows/code/deploy.yaml
+++ b/rust/loopflow/src/engine/builtins/flows/code/deploy.yaml
@@ -1,0 +1,2 @@
+- gate
+- update-wave

--- a/rust/loopflow/src/engine/builtins/flows/code/qa-deploy.yaml
+++ b/rust/loopflow/src/engine/builtins/flows/code/qa-deploy.yaml
@@ -1,0 +1,10 @@
+- qa
+- triage
+- branch:
+    paths:
+      fix:
+        flow: qa-fix
+        description: "Blocking issues found, fix before deploy"
+      deploy:
+        flow: deploy
+        description: "Clean enough to ship"

--- a/rust/loopflow/src/engine/builtins/flows/code/qa-fix.yaml
+++ b/rust/loopflow/src/engine/builtins/flows/code/qa-fix.yaml
@@ -1,0 +1,4 @@
+- implement
+- compress
+- lint
+- gate

--- a/rust/loopflow/src/engine/builtins/steps/code/qa.md
+++ b/rust/loopflow/src/engine/builtins/steps/code/qa.md
@@ -1,0 +1,47 @@
+---
+requires: code on branch
+produces: scratch/qa-findings.md
+default_agent: codex
+action_style: procedural
+---
+Thorough quality assessment of the current branch state.
+
+## Goal
+
+Find every issue that would block deploy or embarrass the team. One deep pass beats five shallow checks.
+
+## Workflow
+
+1. Read the diff against main. Understand what changed and why.
+2. Run the full test suite. Note failures, flaky tests, and missing coverage.
+3. Read scratch/ for design intent. Check whether the implementation matches.
+4. Walk through the code changes looking for:
+   - Bugs: logic errors, off-by-ones, race conditions, null handling
+   - Regressions: existing behavior broken by the changes
+   - Security: injection, auth bypass, data exposure
+   - Edge cases: empty inputs, large inputs, concurrent access
+5. If the codebase has a UI, verify the user-facing changes work correctly.
+
+## Output
+
+Write findings to `scratch/qa-findings.md`:
+
+```markdown
+## Blocking Issues
+
+Issues that must be fixed before deploy.
+
+- [description of issue, file:line, severity]
+
+## Polish Items
+
+Non-blocking improvements to track for later.
+
+- [description, file:line]
+
+## Test Results
+
+[summary of test run: passed/failed/skipped counts, notable failures]
+```
+
+Be specific. File paths, line numbers, reproduction steps. Vague findings waste the fix cycle.

--- a/rust/loopflow/src/engine/builtins/steps/code/triage.md
+++ b/rust/loopflow/src/engine/builtins/steps/code/triage.md
@@ -1,0 +1,41 @@
+---
+requires: scratch/qa-findings.md
+produces: scratch/triage.md
+action_style: procedural
+---
+Assess QA findings. Separate blocking issues from polish items.
+
+## Workflow
+
+1. Read `scratch/qa-findings.md` from the QA step.
+2. For each finding, assess:
+   - Is this a real issue or a false positive?
+   - Does it block deploy (regression, security, data loss) or is it polish?
+   - How severe? How hard to fix?
+3. Write the triage assessment.
+
+## Output
+
+Write to `scratch/triage.md`:
+
+```markdown
+## Summary
+
+[1-2 sentences: overall state of the branch. Deployable or not?]
+
+## Blocking
+
+Issues that must be fixed before deploy, ordered by severity.
+
+1. [issue] — [why it blocks, estimated fix complexity]
+
+## Polish
+
+Non-blocking items to track. Write each to `wave/polish/` if a polish wave exists.
+
+- [item] — [impact if left unfixed]
+
+## Verdict
+
+[DEPLOY or FIX] — [reasoning in one sentence]
+```

--- a/rust/loopflow/src/engine/flow.rs
+++ b/rust/loopflow/src/engine/flow.rs
@@ -687,6 +687,36 @@ fn parse_branch_value(value: &Value) -> Result<FlowItem, LoadError> {
     Ok(FlowItem::Branch(BranchDef { paths }))
 }
 
+/// Validate that flows referenced by branch paths contain only steps.
+/// Forks and nested branches inside branch sub-flows are not supported.
+fn validate_branch_paths(branch_def: &BranchDef, repo: &Path) -> Result<(), LoadError> {
+    for (key, path) in &branch_def.paths {
+        let Some(ref flow_name) = path.flow else {
+            continue;
+        };
+        let flow = load_flow(flow_name, repo)?;
+        let items = expand_flow(&flow, repo)?;
+        for item in &items {
+            match item {
+                ConcreteItem::Step(_) => {}
+                ConcreteItem::Fork(_) => {
+                    return Err(LoadError::InvalidFlow(format!(
+                        "branch path '{key}' references flow '{flow_name}' which contains a fork; \
+                         branch sub-flows must contain only steps"
+                    )));
+                }
+                ConcreteItem::Branch(_) => {
+                    return Err(LoadError::InvalidFlow(format!(
+                        "branch path '{key}' references flow '{flow_name}' which contains a nested branch; \
+                         branch sub-flows must contain only steps"
+                    )));
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
 fn parse_flow_ref_value(value: &Value) -> Result<FlowItem, LoadError> {
     let name = value
         .as_str()
@@ -796,6 +826,7 @@ fn expand_with_chain(
                 items.push(ConcreteItem::Fork(fork));
             }
             FlowItem::Branch(branch_def) => {
+                validate_branch_paths(branch_def, repo)?;
                 items.push(ConcreteItem::Branch(ConcreteBranch {
                     paths: branch_def.paths.clone(),
                     flow_parents: chain.clone(),

--- a/rust/loopflow/src/engine/flow.rs
+++ b/rust/loopflow/src/engine/flow.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashSet, VecDeque};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -47,6 +47,21 @@ pub enum FlowItem {
     Step(Step),
     Fork { branches: Vec<FlowItem> },
     FlowRef(String),
+    Branch(BranchDef),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct BranchDef {
+    pub paths: HashMap<String, BranchPath>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct BranchPath {
+    pub flow: Option<String>,
+    pub step: Option<String>,
+    pub description: String,
+    #[serde(default)]
+    pub direction: Vec<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -54,6 +69,7 @@ pub enum FlowAction {
     RunStep { step: ConcreteStep },
     WaitInteractive { step: ConcreteStep },
     Fork { fork: ConcreteFork },
+    Branch { branch: ConcreteBranch },
     Complete,
 }
 
@@ -98,9 +114,16 @@ pub struct ConcreteFork {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ConcreteBranch {
+    pub paths: HashMap<String, BranchPath>,
+    pub flow_parents: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ConcreteItem {
     Step(ConcreteStep),
     Fork(ConcreteFork),
+    Branch(ConcreteBranch),
 }
 
 #[derive(Debug, Clone)]
@@ -124,6 +147,7 @@ pub fn next_action(items: &[ConcreteItem], step_index: usize) -> FlowAction {
             }
         }
         ConcreteItem::Fork(fork) => FlowAction::Fork { fork },
+        ConcreteItem::Branch(branch) => FlowAction::Branch { branch },
     }
 }
 
@@ -451,8 +475,11 @@ fn parse_flow_mapping(map: &serde_yaml_ng::Mapping) -> Result<FlowItem, LoadErro
     if let Some(fork_value) = map.get(key("fork")) {
         return parse_fork_value(fork_value);
     }
+    if let Some(branch_value) = map.get(key("branch")) {
+        return parse_branch_value(branch_value);
+    }
     Err(LoadError::InvalidFlow(
-        "flow item mapping must include step, flow, or fork".to_string(),
+        "flow item mapping must include step, flow, fork, or branch".to_string(),
     ))
 }
 
@@ -596,6 +623,70 @@ fn parse_fork_branch_item(value: &Value) -> Result<FlowItem, LoadError> {
     }
 }
 
+fn parse_branch_value(value: &Value) -> Result<FlowItem, LoadError> {
+    let map = value
+        .as_mapping()
+        .ok_or_else(|| LoadError::InvalidFlow("branch must be mapping".to_string()))?;
+
+    let paths_value = map
+        .get(key("paths"))
+        .ok_or_else(|| LoadError::InvalidFlow("branch must have paths".to_string()))?;
+    let paths_map = paths_value
+        .as_mapping()
+        .ok_or_else(|| LoadError::InvalidFlow("branch paths must be mapping".to_string()))?;
+
+    if paths_map.is_empty() {
+        return Err(LoadError::InvalidFlow(
+            "branch must have at least one path".to_string(),
+        ));
+    }
+
+    let mut paths = HashMap::new();
+    for (path_key, path_value) in paths_map {
+        let key_str = path_key
+            .as_str()
+            .ok_or_else(|| LoadError::InvalidFlow("branch path key must be string".to_string()))?;
+        let path_map = path_value.as_mapping().ok_or_else(|| {
+            LoadError::InvalidFlow(format!("branch path '{key_str}' must be mapping"))
+        })?;
+
+        let flow = parse_optional_string(path_map, "flow");
+        let step = parse_optional_string(path_map, "step");
+
+        match (&flow, &step) {
+            (None, None) => {
+                return Err(LoadError::InvalidFlow(format!(
+                    "branch path '{key_str}' must have flow or step"
+                )))
+            }
+            (Some(_), Some(_)) => {
+                return Err(LoadError::InvalidFlow(format!(
+                    "branch path '{key_str}' cannot have both flow and step"
+                )))
+            }
+            _ => {}
+        }
+
+        let description = parse_optional_string(path_map, "description").ok_or_else(|| {
+            LoadError::InvalidFlow(format!("branch path '{key_str}' must have description"))
+        })?;
+
+        let direction = parse_directions_field(path_map);
+
+        paths.insert(
+            key_str.to_string(),
+            BranchPath {
+                flow,
+                step,
+                description,
+                direction,
+            },
+        );
+    }
+
+    Ok(FlowItem::Branch(BranchDef { paths }))
+}
+
 fn parse_flow_ref_value(value: &Value) -> Result<FlowItem, LoadError> {
     let name = value
         .as_str()
@@ -704,6 +795,12 @@ fn expand_with_chain(
                 let fork = expand_fork(branches, repo, &chain, depth)?;
                 items.push(ConcreteItem::Fork(fork));
             }
+            FlowItem::Branch(branch_def) => {
+                items.push(ConcreteItem::Branch(ConcreteBranch {
+                    paths: branch_def.paths.clone(),
+                    flow_parents: chain.clone(),
+                }));
+            }
         }
     }
 
@@ -757,6 +854,9 @@ fn expand_fork_branch(
         FlowItem::FlowRef(name) => expand_flow_ref_branch(name, &[], repo, chain, depth),
         FlowItem::Fork { .. } => Err(LoadError::InvalidFlow(
             "fork branches cannot contain nested forks".to_string(),
+        )),
+        FlowItem::Branch(_) => Err(LoadError::InvalidFlow(
+            "fork branches cannot contain branch constructs".to_string(),
         )),
     }
 }
@@ -824,6 +924,11 @@ fn extract_fork_branch_steps(
             ConcreteItem::Fork(_) => {
                 return Err(LoadError::InvalidFlow(format!(
                     "fork branch flow ref '{flow_name}' contains a nested fork"
+                )))
+            }
+            ConcreteItem::Branch(_) => {
+                return Err(LoadError::InvalidFlow(format!(
+                    "fork branch flow ref '{flow_name}' contains a branch construct"
                 )))
             }
         }
@@ -1177,6 +1282,18 @@ Be careful.
                                     name,
                                     step.step.name,
                                     result.err()
+                                );
+                            }
+                        }
+                    }
+                    ConcreteItem::Branch(branch) => {
+                        for (path_key, path) in &branch.paths {
+                            if let Some(ref flow_name) = path.flow {
+                                let result = load_flow(flow_name, tmp.path());
+                                assert!(
+                                    result.is_ok(),
+                                    "builtin flow '{}' branch path '{}' references missing flow '{}': {:?}",
+                                    name, path_key, flow_name, result.err()
                                 );
                             }
                         }
@@ -1558,5 +1675,228 @@ Be careful.
             err.contains("nested fork"),
             "expected nested fork error, got: {err}"
         );
+    }
+
+    #[test]
+    fn parse_branch_with_flow_paths() {
+        let yaml = r#"
+- qa
+- triage
+- branch:
+    paths:
+      fix:
+        flow: qa-fix
+        description: "Blocking issues found, fix before deploy"
+      deploy:
+        flow: deploy
+        description: "Clean enough to ship"
+"#;
+        let value: Value = serde_yaml_ng::from_str(yaml).unwrap();
+        let items = parse_flow_items(&value).unwrap();
+        assert_eq!(items.len(), 3);
+
+        match &items[2] {
+            FlowItem::Branch(branch) => {
+                assert_eq!(branch.paths.len(), 2);
+                let fix = &branch.paths["fix"];
+                assert_eq!(fix.flow.as_deref(), Some("qa-fix"));
+                assert!(fix.step.is_none());
+                assert_eq!(fix.description, "Blocking issues found, fix before deploy");
+                let deploy = &branch.paths["deploy"];
+                assert_eq!(deploy.flow.as_deref(), Some("deploy"));
+                assert_eq!(deploy.description, "Clean enough to ship");
+            }
+            other => panic!("expected Branch, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_branch_with_step_path() {
+        let yaml = r#"
+- branch:
+    paths:
+      skip:
+        step: gate
+        description: "Just run gate"
+      full:
+        flow: build
+        description: "Full build"
+"#;
+        let value: Value = serde_yaml_ng::from_str(yaml).unwrap();
+        let items = parse_flow_items(&value).unwrap();
+        assert_eq!(items.len(), 1);
+
+        match &items[0] {
+            FlowItem::Branch(branch) => {
+                let skip = &branch.paths["skip"];
+                assert_eq!(skip.step.as_deref(), Some("gate"));
+                assert!(skip.flow.is_none());
+                let full = &branch.paths["full"];
+                assert_eq!(full.flow.as_deref(), Some("build"));
+                assert!(full.step.is_none());
+            }
+            other => panic!("expected Branch, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_branch_with_direction_override() {
+        let yaml = r#"
+- branch:
+    paths:
+      careful:
+        flow: build
+        description: "Build carefully"
+        direction: [care, clarity]
+"#;
+        let value: Value = serde_yaml_ng::from_str(yaml).unwrap();
+        let items = parse_flow_items(&value).unwrap();
+
+        match &items[0] {
+            FlowItem::Branch(branch) => {
+                let careful = &branch.paths["careful"];
+                assert_eq!(careful.direction, vec!["care", "clarity"]);
+            }
+            other => panic!("expected Branch, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_branch_rejects_both_flow_and_step() {
+        let yaml = r#"
+- branch:
+    paths:
+      bad:
+        flow: build
+        step: gate
+        description: "invalid"
+"#;
+        let value: Value = serde_yaml_ng::from_str(yaml).unwrap();
+        let result = parse_flow_items(&value);
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("flow") && err.contains("step"),
+            "expected error about both flow and step, got: {err}"
+        );
+    }
+
+    #[test]
+    fn parse_branch_rejects_missing_flow_and_step() {
+        let yaml = r#"
+- branch:
+    paths:
+      bad:
+        description: "no target"
+"#;
+        let value: Value = serde_yaml_ng::from_str(yaml).unwrap();
+        let result = parse_flow_items(&value);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn parse_branch_rejects_missing_description() {
+        let yaml = r#"
+- branch:
+    paths:
+      bad:
+        flow: build
+"#;
+        let value: Value = serde_yaml_ng::from_str(yaml).unwrap();
+        let result = parse_flow_items(&value);
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("description"),
+            "expected error about missing description, got: {err}"
+        );
+    }
+
+    #[test]
+    fn expand_branch_keeps_concrete_branch() {
+        let tmp = TempDir::new().unwrap();
+        let flow = Flow {
+            name: "test-branch".to_string(),
+            items: vec![
+                FlowItem::Step(Step::named("gate")),
+                FlowItem::Branch(BranchDef {
+                    paths: {
+                        let mut m = HashMap::new();
+                        m.insert(
+                            "fix".to_string(),
+                            BranchPath {
+                                flow: Some("build".to_string()),
+                                step: None,
+                                description: "Fix it".to_string(),
+                                direction: Vec::new(),
+                            },
+                        );
+                        m
+                    },
+                }),
+            ],
+        };
+
+        let items = expand_flow(&flow, tmp.path()).unwrap();
+        assert_eq!(items.len(), 2);
+        assert!(matches!(&items[0], ConcreteItem::Step(_)));
+        assert!(matches!(&items[1], ConcreteItem::Branch(_)));
+
+        if let ConcreteItem::Branch(branch) = &items[1] {
+            assert_eq!(branch.paths.len(), 1);
+            assert_eq!(branch.paths["fix"].description, "Fix it");
+        }
+    }
+
+    #[test]
+    fn next_action_returns_branch_action() {
+        let items = vec![ConcreteItem::Branch(ConcreteBranch {
+            paths: {
+                let mut m = HashMap::new();
+                m.insert(
+                    "a".to_string(),
+                    BranchPath {
+                        flow: Some("build".to_string()),
+                        step: None,
+                        description: "Path A".to_string(),
+                        direction: Vec::new(),
+                    },
+                );
+                m
+            },
+            flow_parents: Vec::new(),
+        })];
+
+        let action = next_action(&items, 0);
+        assert!(
+            matches!(action, FlowAction::Branch { .. }),
+            "expected Branch action, got {action:?}"
+        );
+    }
+
+    #[test]
+    fn qa_deploy_flow_parses_and_expands() {
+        let tmp = TempDir::new().unwrap();
+        let flow = load_flow("qa-deploy", tmp.path()).unwrap();
+        let items = expand_flow(&flow, tmp.path()).unwrap();
+        // qa, triage, branch
+        assert_eq!(items.len(), 3);
+        assert!(matches!(&items[2], ConcreteItem::Branch(_)));
+    }
+
+    #[test]
+    fn qa_fix_flow_parses_and_expands() {
+        let tmp = TempDir::new().unwrap();
+        let flow = load_flow("qa-fix", tmp.path()).unwrap();
+        let items = expand_flow(&flow, tmp.path()).unwrap();
+        assert_eq!(items.len(), 4); // implement, compress, lint, gate
+    }
+
+    #[test]
+    fn deploy_flow_parses_and_expands() {
+        let tmp = TempDir::new().unwrap();
+        let flow = load_flow("deploy", tmp.path()).unwrap();
+        let items = expand_flow(&flow, tmp.path()).unwrap();
+        assert_eq!(items.len(), 2); // gate, update-wave
     }
 }

--- a/rust/loopflow/src/engine/mod.rs
+++ b/rust/loopflow/src/engine/mod.rs
@@ -27,8 +27,9 @@ pub use command::{run_command, CommandError};
 pub use config::{load_config, load_config_or_default, parse_agent, Config};
 pub use error::{CoreError, GitError, LoadError, StoreError};
 pub use flow::{
-    expand_flow, load_direction, load_flow, load_step, next_action, ConcreteFork,
-    ConcreteForkBranch, ConcreteItem, ConcreteStep, Direction, Flow, FlowAction, FlowItem, Step,
+    expand_flow, load_direction, load_flow, load_step, next_action, BranchDef, BranchPath,
+    ConcreteBranch, ConcreteFork, ConcreteForkBranch, ConcreteItem, ConcreteStep, Direction, Flow,
+    FlowAction, FlowItem, Step,
 };
 pub use launch::{
     prepare_launch_prompt, ContextSourceOverrides, LaunchPromptInput, PreparedLaunchPrompt,

--- a/rust/loopflow/src/lf/commands/flow.rs
+++ b/rust/loopflow/src/lf/commands/flow.rs
@@ -31,6 +31,7 @@ fn print_pipeline_header(flow_name: &str, items: &[ConcreteItem]) {
         .map(|item| match item {
             ConcreteItem::Step(s) => s.step.name.as_str(),
             ConcreteItem::Fork(_) => "[fork]",
+            ConcreteItem::Branch(_) => "[branch]",
         })
         .collect();
 
@@ -74,6 +75,18 @@ fn run_steps(items: &[ConcreteItem], message: Option<&str>, cli: &Cli, repo: &Pa
             FlowAction::Fork { fork } => {
                 run_fork(&fork, message, cli, repo)?;
                 commit_step_work(repo, "fork")?;
+            }
+            FlowAction::Branch { .. } => {
+                // Branch routing requires the daemon executor; skip in CLI flow runner.
+                let colors = Colors::new();
+                eprintln!(
+                    "{dim}[{current}/{total}]{reset} {bold}[branch]{reset} (requires lfd)",
+                    dim = colors.dim,
+                    reset = colors.reset,
+                    bold = colors.bold,
+                    current = index + 1,
+                    total = total,
+                );
             }
             FlowAction::Complete => break,
         }

--- a/rust/loopflow/src/lfd/executor/docker/tests.rs
+++ b/rust/loopflow/src/lfd/executor/docker/tests.rs
@@ -344,6 +344,7 @@ async fn create_running_wave_and_run(
         area: vec![],
         status: WaveStatus::Running,
         iteration: 0,
+        cycle_start_iteration: 0,
         created_at: Some(OffsetDateTime::now_utc()),
         serialized: false,
     };
@@ -584,6 +585,7 @@ async fn docker_startup_lost_agent_does_not_flip_terminal_run_wave_status() {
         area: vec![],
         status: WaveStatus::Idle,
         iteration: 0,
+        cycle_start_iteration: 0,
         created_at: Some(OffsetDateTime::now_utc()),
         serialized: false,
     };

--- a/rust/loopflow/src/lfd/executor/helpers.rs
+++ b/rust/loopflow/src/lfd/executor/helpers.rs
@@ -308,6 +308,7 @@ pub(crate) fn flow_parents_for_index(items: &[ConcreteItem], step_index: u32) ->
     match items.get(step_index as usize) {
         Some(ConcreteItem::Step(step)) => step.flow_parents.clone(),
         Some(ConcreteItem::Fork(fork)) => fork.flow_parents.clone(),
+        Some(ConcreteItem::Branch(branch)) => branch.flow_parents.clone(),
         None => Vec::new(),
     }
 }

--- a/rust/loopflow/src/lfd/executor/helpers.rs
+++ b/rust/loopflow/src/lfd/executor/helpers.rs
@@ -94,6 +94,10 @@ pub async fn create_parallel_wave_run(
     };
     store.create_wave_run(&run).await?;
     if let Ok(Some(mut wave)) = store.get_wave(wave.id()).await {
+        // New cycle: record the starting iteration for max_iterations safety valve.
+        if wave.status == WaveStatus::Idle || wave.status == WaveStatus::Paused {
+            wave.cycle_start_iteration = iteration;
+        }
         wave.status = WaveStatus::Running;
         wave.iteration = iteration;
         if let Err(err) = store.update_wave(&wave).await {
@@ -174,6 +178,9 @@ pub async fn create_wave_run_with_id(
     };
     store.create_wave_run(&run).await?;
     if let Ok(Some(mut wave)) = store.get_wave(wave.id()).await {
+        if wave.status == WaveStatus::Idle || wave.status == WaveStatus::Paused {
+            wave.cycle_start_iteration = iteration;
+        }
         wave.status = WaveStatus::Running;
         wave.iteration = iteration;
         if let Err(err) = store.update_wave(&wave).await {

--- a/rust/loopflow/src/lfd/executor/wave/mod.rs
+++ b/rust/loopflow/src/lfd/executor/wave/mod.rs
@@ -16,7 +16,8 @@ use crate::engine::agent::build_agent_command;
 use crate::engine::config::{load_config_or_default, parse_agent};
 use crate::engine::fast_path::{try_fast_path, FailureContext, FastPathResult};
 use crate::engine::flow::{
-    expand_flow, load_flow, next_action, ConcreteItem, ConcreteStep, FlowAction,
+    expand_flow, load_flow, load_step, next_action, BranchPath, ConcreteBranch, ConcreteItem,
+    ConcreteStep, FlowAction, Step,
 };
 use crate::engine::worktree::remove_worktree;
 use crate::lfd::config::{ExecutorConfig, ExecutorType, GitHubConfig};
@@ -510,6 +511,140 @@ impl WaveExecutor {
                         return Ok(());
                     }
                 }
+                FlowAction::Branch { branch } => {
+                    // Pre-branch sync: pick up sibling pushes.
+                    if let Err(err) = pre_step_sync(
+                        Path::new(&run.snapshot.repo),
+                        Path::new(&run.worktree),
+                        &run.branch,
+                    ) {
+                        warn!(run_id = %run.id, error = %err, "pre-branch sync failed, continuing");
+                    }
+
+                    info!(
+                        run_id = %run.id,
+                        paths = branch.paths.len(),
+                        step_index = run.step_index,
+                        "running branch routing"
+                    );
+
+                    // Build routing prompt and run as a synthetic step.
+                    let routing_prompt = build_branch_routing_prompt(&branch);
+                    let routing_step = ConcreteStep {
+                        step: Step {
+                            name: "branch-route".to_string(),
+                            agent: Some("claude:sonnet".to_string()),
+                            default_agent: None,
+                            directions: Vec::new(),
+                            action_style: None,
+                            interactive: None,
+                            content: Some(routing_prompt),
+                            fast_path: None,
+                        },
+                        flow_parents: branch.flow_parents.clone(),
+                    };
+
+                    let exit_code = self.run_step(&wave, &mut run, &routing_step).await?;
+                    if exit_code != 0 {
+                        self.fail_run(&mut run, &wave, "branch routing step failed".to_string())
+                            .await?;
+                        return Ok(());
+                    }
+
+                    // Post-routing sync: commit the verdict.
+                    if let Err(err) =
+                        post_step_sync(Path::new(&run.worktree), &run.branch, "branch-route")
+                    {
+                        self.fail_run(
+                            &mut run,
+                            &wave,
+                            format!("post-branch-route sync failed: {err}"),
+                        )
+                        .await?;
+                        return Ok(());
+                    }
+
+                    // Read the verdict from scratch/route-branch.md.
+                    let verdict_path = Path::new(&run.worktree).join("scratch/route-branch.md");
+                    let selected_path = match read_branch_verdict(&verdict_path, &branch) {
+                        Ok(path) => path,
+                        Err(err) => {
+                            self.fail_run(&mut run, &wave, err).await?;
+                            return Ok(());
+                        }
+                    };
+
+                    info!(
+                        run_id = %run.id,
+                        selected = %selected_path,
+                        "branch routed"
+                    );
+
+                    // Load and execute the selected sub-flow inline.
+                    let branch_path = branch
+                        .paths
+                        .get(&selected_path)
+                        .expect("selected path validated by read_branch_verdict");
+
+                    let sub_items =
+                        load_branch_path_items(branch_path, Path::new(&run.snapshot.repo))?;
+
+                    for sub_item in &sub_items {
+                        let sub_step = match sub_item {
+                            ConcreteItem::Step(step) => step,
+                            _ => continue,
+                        };
+
+                        // Pre-step sync for each sub-step.
+                        if let Err(err) = pre_step_sync(
+                            Path::new(&run.snapshot.repo),
+                            Path::new(&run.worktree),
+                            &run.branch,
+                        ) {
+                            warn!(run_id = %run.id, error = %err, "pre-step sync failed in branch sub-step, continuing");
+                        }
+
+                        if let Err(err) = self.ensure_summary_fresh(&wave, &run).await {
+                            warn!(run_id = %run.id, error = %err, "summary refresh failed, continuing");
+                        }
+
+                        info!(
+                            run_id = %run.id,
+                            step = %sub_step.step.name,
+                            "running branch sub-step"
+                        );
+
+                        let exit_code = self.run_step(&wave, &mut run, sub_step).await?;
+                        if exit_code != 0 {
+                            self.fail_run(
+                                &mut run,
+                                &wave,
+                                format!("branch sub-step {} failed", sub_step.step.name),
+                            )
+                            .await?;
+                            return Ok(());
+                        }
+
+                        if let Err(err) = post_step_sync(
+                            Path::new(&run.worktree),
+                            &run.branch,
+                            &sub_step.step.name,
+                        ) {
+                            self.fail_run(
+                                &mut run,
+                                &wave,
+                                format!(
+                                    "post-step sync failed for branch sub-step {}: {err}",
+                                    sub_step.step.name
+                                ),
+                            )
+                            .await?;
+                            return Ok(());
+                        }
+                    }
+
+                    self.advance_run_step(&mut run, &plan, wave.id()).await?;
+                }
                 FlowAction::Complete => {
                     run.status = WaveRunStatus::Completed;
                     run.ended_at = Some(OffsetDateTime::now_utc());
@@ -1002,6 +1137,78 @@ fn interactive_session_config(
     }
 }
 
+// -----------------------------------------------------------------------------
+// Branch helpers
+// -----------------------------------------------------------------------------
+
+fn build_branch_routing_prompt(branch: &ConcreteBranch) -> String {
+    let mut prompt = String::from(
+        "Read the current state of this branch: scratch/ contents, recent commits, \
+         and PR status. Choose which path to take next.\n\n\
+         Available paths:\n\n",
+    );
+    let mut keys: Vec<&String> = branch.paths.keys().collect();
+    keys.sort();
+    for key in &keys {
+        let path = &branch.paths[*key];
+        prompt.push_str(&format!("- {key}: {}\n", path.description));
+    }
+    prompt.push_str(
+        "\nWrite your choice to scratch/route-branch.md.\n\
+         First line must be: path: <key>\n\
+         Then explain your reasoning.\n",
+    );
+    prompt
+}
+
+fn read_branch_verdict(verdict_path: &Path, branch: &ConcreteBranch) -> Result<String, String> {
+    let content = std::fs::read_to_string(verdict_path).map_err(|err| {
+        format!(
+            "branch verdict not found at {}: {err}",
+            verdict_path.display()
+        )
+    })?;
+
+    let first_line = content
+        .lines()
+        .next()
+        .ok_or_else(|| "branch verdict file is empty".to_string())?;
+
+    let selected = first_line
+        .strip_prefix("path:")
+        .map(|s| s.trim().to_string())
+        .ok_or_else(|| {
+            format!("branch verdict first line must start with 'path:', got: {first_line}")
+        })?;
+
+    if !branch.paths.contains_key(&selected) {
+        let valid_keys: Vec<&String> = branch.paths.keys().collect();
+        return Err(format!(
+            "unknown branch path: {selected}, expected one of: {valid_keys:?}"
+        ));
+    }
+
+    Ok(selected)
+}
+
+fn load_branch_path_items(branch_path: &BranchPath, repo: &Path) -> Result<Vec<ConcreteItem>> {
+    if let Some(ref flow_name) = branch_path.flow {
+        let flow = load_flow(flow_name, repo)?;
+        let items = expand_flow(&flow, repo)?;
+        return Ok(items);
+    }
+
+    if let Some(ref step_name) = branch_path.step {
+        let step = load_step(step_name, repo)?;
+        return Ok(vec![ConcreteItem::Step(ConcreteStep {
+            step,
+            flow_parents: Vec::new(),
+        })]);
+    }
+
+    Err(anyhow!("branch path has neither flow nor step"))
+}
+
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 struct OrphanedForkCleanup {
     cleaned_runs: u32,
@@ -1234,6 +1441,7 @@ mod tests {
             last_triggered_at: None,
             created_at: Some(OffsetDateTime::now_utc()),
             enabled: true,
+            max_iterations: None,
         }
     }
 

--- a/rust/loopflow/src/lfd/executor/wave/mod.rs
+++ b/rust/loopflow/src/lfd/executor/wave/mod.rs
@@ -533,8 +533,8 @@ impl WaveExecutor {
                     let routing_step = ConcreteStep {
                         step: Step {
                             name: "branch-route".to_string(),
-                            agent: Some("claude:sonnet".to_string()),
-                            default_agent: None,
+                            agent: None,
+                            default_agent: Some("claude:sonnet".to_string()),
                             directions: Vec::new(),
                             action_style: None,
                             interactive: None,
@@ -592,7 +592,14 @@ impl WaveExecutor {
                     for sub_item in &sub_items {
                         let sub_step = match sub_item {
                             ConcreteItem::Step(step) => step,
-                            _ => continue,
+                            other => {
+                                warn!(
+                                    run_id = %run.id,
+                                    item = ?other,
+                                    "branch sub-flow contains non-step item, skipping"
+                                );
+                                continue;
+                            }
                         };
 
                         // Pre-step sync for each sub-step.
@@ -1335,6 +1342,7 @@ mod tests {
             area: vec![],
             status: WaveStatus::Running,
             iteration: 0,
+            cycle_start_iteration: 0,
             created_at: Some(OffsetDateTime::now_utc()),
             serialized: false,
         };
@@ -1388,6 +1396,7 @@ mod tests {
             area: vec![],
             status,
             iteration: 0,
+            cycle_start_iteration: 0,
             created_at: Some(OffsetDateTime::now_utc()),
             serialized: false,
         }
@@ -1572,6 +1581,7 @@ mod tests {
             area: vec![],
             status: WaveStatus::Idle,
             iteration: 0,
+            cycle_start_iteration: 0,
             created_at: Some(OffsetDateTime::now_utc()),
             serialized: true,
         };

--- a/rust/loopflow/src/lfd/http/routes/chords.rs
+++ b/rust/loopflow/src/lfd/http/routes/chords.rs
@@ -178,6 +178,7 @@ mod tests {
             area: Vec::new(),
             status: WaveStatus::Idle,
             iteration: 0,
+            cycle_start_iteration: 0,
             created_at: Some(OffsetDateTime::now_utc()),
             serialized: false,
         }

--- a/rust/loopflow/src/lfd/http/routes/flows.rs
+++ b/rust/loopflow/src/lfd/http/routes/flows.rs
@@ -132,6 +132,9 @@ fn extract_step_names(items: &[crate::engine::flow::ConcreteItem]) -> Vec<String
                     }
                 }
             }
+            crate::engine::flow::ConcreteItem::Branch(_) => {
+                names.push("[branch]".to_string());
+            }
         }
     }
     names

--- a/rust/loopflow/src/lfd/http/routes/hooks.rs
+++ b/rust/loopflow/src/lfd/http/routes/hooks.rs
@@ -815,6 +815,7 @@ mod tests {
             last_triggered_at: None,
             created_at: Some(OffsetDateTime::now_utc()),
             enabled: true,
+            max_iterations: None,
         };
         state
             .store

--- a/rust/loopflow/src/lfd/http/routes/hooks.rs
+++ b/rust/loopflow/src/lfd/http/routes/hooks.rs
@@ -800,6 +800,7 @@ mod tests {
             area: vec![],
             status: WaveStatus::Idle,
             iteration: 0,
+            cycle_start_iteration: 0,
             created_at: Some(OffsetDateTime::now_utc()),
             serialized: false,
         };

--- a/rust/loopflow/src/lfd/http/routes/mod.rs
+++ b/rust/loopflow/src/lfd/http/routes/mod.rs
@@ -463,6 +463,7 @@ mod tests {
             area: vec![],
             status: WaveStatus::Idle,
             iteration: 0,
+            cycle_start_iteration: 0,
             created_at: Some(OffsetDateTime::now_utc()),
             serialized: false,
         }

--- a/rust/loopflow/src/lfd/http/routes/repos.rs
+++ b/rust/loopflow/src/lfd/http/routes/repos.rs
@@ -478,6 +478,7 @@ mod tests {
             area: Vec::new(),
             status: WaveStatus::Idle,
             iteration: 0,
+            cycle_start_iteration: 0,
             created_at: Some(OffsetDateTime::now_utc()),
             serialized: false,
         }

--- a/rust/loopflow/src/lfd/http/routes/usage.rs
+++ b/rust/loopflow/src/lfd/http/routes/usage.rs
@@ -583,6 +583,7 @@ mod tests {
             area: Vec::new(),
             status: WaveStatus::Idle,
             iteration: 1,
+            cycle_start_iteration: 0,
             created_at: Some(OffsetDateTime::now_utc()),
             serialized: false,
         };

--- a/rust/loopflow/src/lfd/http/routes/waves.rs
+++ b/rust/loopflow/src/lfd/http/routes/waves.rs
@@ -237,6 +237,7 @@ pub async fn create_wave_handler(
         area,
         status: WaveStatus::Idle,
         iteration: 0,
+        cycle_start_iteration: 0,
         created_at: Some(OffsetDateTime::now_utc()),
         serialized,
     };
@@ -1636,6 +1637,7 @@ mod tests {
             area: Vec::new(),
             status: WaveStatus::Idle,
             iteration: 0,
+            cycle_start_iteration: 0,
             created_at: Some(OffsetDateTime::now_utc()),
             serialized: false,
         };
@@ -1648,6 +1650,7 @@ mod tests {
             area: Vec::new(),
             status: WaveStatus::Idle,
             iteration: 0,
+            cycle_start_iteration: 0,
             created_at: Some(OffsetDateTime::now_utc()),
             serialized: false,
         };
@@ -1719,6 +1722,7 @@ mod tests {
             area: Vec::new(),
             status: WaveStatus::Idle,
             iteration: 0,
+            cycle_start_iteration: 0,
             created_at: Some(OffsetDateTime::now_utc()),
             serialized: false,
         };

--- a/rust/loopflow/src/lfd/http/routes/waves.rs
+++ b/rust/loopflow/src/lfd/http/routes/waves.rs
@@ -136,6 +136,7 @@ pub struct AddStimulusRequest {
     flow: Option<String>,
     cron: Option<String>,
     source_wave_id: Option<String>,
+    max_iterations: Option<u32>,
 }
 
 #[derive(Debug, Clone)]
@@ -806,6 +807,7 @@ async fn ensure_manual_stimulus(state: &HttpState, wave_id: &LfdId) -> Result<Lf
         last_triggered_at: None,
         created_at: Some(OffsetDateTime::now_utc()),
         enabled: true,
+        max_iterations: None,
     };
     state
         .store
@@ -904,6 +906,7 @@ pub async fn add_stimulus_handler(
         last_triggered_at: None,
         created_at: Some(OffsetDateTime::now_utc()),
         enabled: true,
+        max_iterations: payload.max_iterations,
     };
 
     state

--- a/rust/loopflow/src/lfd/queue.rs
+++ b/rust/loopflow/src/lfd/queue.rs
@@ -593,6 +593,7 @@ mod tests {
             area: Vec::new(),
             status: WaveStatus::Idle,
             iteration: 0,
+            cycle_start_iteration: 0,
             created_at: Some(OffsetDateTime::now_utc()),
             serialized: false,
         }

--- a/rust/loopflow/src/lfd/store/catalog.rs
+++ b/rust/loopflow/src/lfd/store/catalog.rs
@@ -250,32 +250,32 @@ const QUERY_DEFS: [QueryDef; QUERY_COUNT] = [
         postgres_override: None,
     },
     QueryDef {
-        template: "SELECT id, wave_id, signal, flow, cron, last_main_sha, last_triggered_at, created_at, enabled, source_wave_id\n             FROM stimuli ORDER BY created_at",
+        template: "SELECT id, wave_id, signal, flow, cron, last_main_sha, last_triggered_at, created_at, enabled, source_wave_id, max_iterations\n             FROM stimuli ORDER BY created_at",
         sqlite_override: None,
         postgres_override: None,
     },
     QueryDef {
-        template: "SELECT id, wave_id, signal, flow, cron, last_main_sha, last_triggered_at, created_at, enabled, source_wave_id\n             FROM stimuli WHERE wave_id = {p1} ORDER BY created_at",
+        template: "SELECT id, wave_id, signal, flow, cron, last_main_sha, last_triggered_at, created_at, enabled, source_wave_id, max_iterations\n             FROM stimuli WHERE wave_id = {p1} ORDER BY created_at",
         sqlite_override: None,
         postgres_override: None,
     },
     QueryDef {
-        template: "SELECT id, wave_id, signal, flow, cron, last_main_sha, last_triggered_at, created_at, enabled, source_wave_id\n             FROM stimuli WHERE signal = {p1} ORDER BY created_at",
+        template: "SELECT id, wave_id, signal, flow, cron, last_main_sha, last_triggered_at, created_at, enabled, source_wave_id, max_iterations\n             FROM stimuli WHERE signal = {p1} ORDER BY created_at",
         sqlite_override: None,
         postgres_override: None,
     },
     QueryDef {
-        template: "SELECT id, wave_id, signal, flow, cron, last_main_sha, last_triggered_at, created_at, enabled, source_wave_id\n             FROM stimuli WHERE id = {p1}",
+        template: "SELECT id, wave_id, signal, flow, cron, last_main_sha, last_triggered_at, created_at, enabled, source_wave_id, max_iterations\n             FROM stimuli WHERE id = {p1}",
         sqlite_override: None,
         postgres_override: None,
     },
     QueryDef {
-        template: "INSERT INTO stimuli (id, wave_id, signal, flow, cron, last_main_sha, last_triggered_at, created_at, enabled, source_wave_id)\n             VALUES ({p1}, {p2}, {p3}, {p4}, {p5}, {p6}, {p7}, {p8}, {p9}, {p10})",
+        template: "INSERT INTO stimuli (id, wave_id, signal, flow, cron, last_main_sha, last_triggered_at, created_at, enabled, source_wave_id, max_iterations)\n             VALUES ({p1}, {p2}, {p3}, {p4}, {p5}, {p6}, {p7}, {p8}, {p9}, {p10}, {p11})",
         sqlite_override: None,
         postgres_override: None,
     },
     QueryDef {
-        template: "UPDATE stimuli SET\n                signal = {p1}, flow = {p2}, cron = {p3}, last_main_sha = {p4},\n                last_triggered_at = {p5}, enabled = {p6}, source_wave_id = {p7}\n             WHERE id = {p8}",
+        template: "UPDATE stimuli SET\n                signal = {p1}, flow = {p2}, cron = {p3}, last_main_sha = {p4},\n                last_triggered_at = {p5}, enabled = {p6}, source_wave_id = {p7},\n                max_iterations = {p8}\n             WHERE id = {p9}",
         sqlite_override: None,
         postgres_override: None,
     },

--- a/rust/loopflow/src/lfd/store/catalog.rs
+++ b/rust/loopflow/src/lfd/store/catalog.rs
@@ -150,27 +150,27 @@ const QUERY_DEFS: [QueryDef; QUERY_COUNT] = [
         postgres_override: None,
     },
     QueryDef {
-        template: "SELECT id, name, repo, flow, direction, area, paused, status, iteration,\n                    created_at, serialized\n             FROM waves\n             ORDER BY created_at DESC",
+        template: "SELECT id, name, repo, flow, direction, area, paused, status, iteration,\n                    cycle_start_iteration, created_at, serialized\n             FROM waves\n             ORDER BY created_at DESC",
         sqlite_override: None,
         postgres_override: None,
     },
     QueryDef {
-        template: "SELECT id, name, repo, flow, direction, area, paused, status, iteration,\n                    created_at, serialized\n             FROM waves\n             WHERE repo = {p1}\n             ORDER BY created_at DESC",
+        template: "SELECT id, name, repo, flow, direction, area, paused, status, iteration,\n                    cycle_start_iteration, created_at, serialized\n             FROM waves\n             WHERE repo = {p1}\n             ORDER BY created_at DESC",
         sqlite_override: None,
         postgres_override: None,
     },
     QueryDef {
-        template: "INSERT INTO waves (\n                id, name, repo, flow, direction, area, paused, status, iteration, created_at, serialized\n            ) VALUES ({p1}, {p2}, {p3}, {p4}, {p5}, {p6}, {p7}, {p8}, {p9}, {p10}, {p11})\n            ON CONFLICT(id) DO UPDATE SET\n                name = excluded.name,\n                repo = excluded.repo,\n                flow = excluded.flow,\n                direction = excluded.direction,\n                area = excluded.area,\n                paused = excluded.paused,\n                status = excluded.status,\n                iteration = excluded.iteration,\n                created_at = excluded.created_at,\n                serialized = excluded.serialized",
+        template: "INSERT INTO waves (\n                id, name, repo, flow, direction, area, paused, status, iteration, cycle_start_iteration, created_at, serialized\n            ) VALUES ({p1}, {p2}, {p3}, {p4}, {p5}, {p6}, {p7}, {p8}, {p9}, {p10}, {p11}, {p12})\n            ON CONFLICT(id) DO UPDATE SET\n                name = excluded.name,\n                repo = excluded.repo,\n                flow = excluded.flow,\n                direction = excluded.direction,\n                area = excluded.area,\n                paused = excluded.paused,\n                status = excluded.status,\n                iteration = excluded.iteration,\n                cycle_start_iteration = excluded.cycle_start_iteration,\n                created_at = excluded.created_at,\n                serialized = excluded.serialized",
         sqlite_override: None,
         postgres_override: None,
     },
     QueryDef {
-        template: "SELECT id, name, repo, flow, direction, area, paused, status, iteration,\n                    created_at, serialized\n             FROM waves WHERE id = {p1}",
+        template: "SELECT id, name, repo, flow, direction, area, paused, status, iteration,\n                    cycle_start_iteration, created_at, serialized\n             FROM waves WHERE id = {p1}",
         sqlite_override: None,
         postgres_override: None,
     },
     QueryDef {
-        template: "SELECT id, name, repo, flow, direction, area, paused, status, iteration,\n                    created_at, serialized\n             FROM waves\n             WHERE name = {p1}",
+        template: "SELECT id, name, repo, flow, direction, area, paused, status, iteration,\n                    cycle_start_iteration, created_at, serialized\n             FROM waves\n             WHERE name = {p1}",
         sqlite_override: None,
         postgres_override: None,
     },

--- a/rust/loopflow/src/lfd/store/migrations.rs
+++ b/rust/loopflow/src/lfd/store/migrations.rs
@@ -107,6 +107,10 @@ const ALL_MIGRATIONS: &[Migration] = &[
         version: "022_stimulus_max_iterations",
         sql: include_str!("migrations/022_stimulus_max_iterations.sql"),
     },
+    Migration {
+        version: "023_wave_cycle_start_iteration",
+        sql: include_str!("migrations/023_wave_cycle_start_iteration.sql"),
+    },
 ];
 
 /// Migrations applicable to a backend. Currently returns all migrations

--- a/rust/loopflow/src/lfd/store/migrations.rs
+++ b/rust/loopflow/src/lfd/store/migrations.rs
@@ -103,6 +103,10 @@ const ALL_MIGRATIONS: &[Migration] = &[
         version: "021_repo_edges",
         sql: include_str!("migrations/021_repo_edges.sql"),
     },
+    Migration {
+        version: "022_stimulus_max_iterations",
+        sql: include_str!("migrations/022_stimulus_max_iterations.sql"),
+    },
 ];
 
 /// Migrations applicable to a backend. Currently returns all migrations

--- a/rust/loopflow/src/lfd/store/migrations/022_stimulus_max_iterations.sql
+++ b/rust/loopflow/src/lfd/store/migrations/022_stimulus_max_iterations.sql
@@ -1,0 +1,2 @@
+-- Add max_iterations column to stimuli for safety valve on looping waves.
+ALTER TABLE stimuli ADD COLUMN max_iterations INTEGER;

--- a/rust/loopflow/src/lfd/store/migrations/023_wave_cycle_start_iteration.sql
+++ b/rust/loopflow/src/lfd/store/migrations/023_wave_cycle_start_iteration.sql
@@ -1,0 +1,1 @@
+ALTER TABLE waves ADD COLUMN cycle_start_iteration INTEGER NOT NULL DEFAULT 0;

--- a/rust/loopflow/src/lfd/store/mod.rs
+++ b/rust/loopflow/src/lfd/store/mod.rs
@@ -2150,6 +2150,7 @@ mod tests {
             last_triggered_at: None,
             created_at: Some(OffsetDateTime::now_utc()),
             enabled: true,
+            max_iterations: None,
         };
         store
             .create_stimulus(&stimulus)

--- a/rust/loopflow/src/lfd/store/mod.rs
+++ b/rust/loopflow/src/lfd/store/mod.rs
@@ -1991,6 +1991,7 @@ mod tests {
             area: vec!["src".to_string()],
             status: WaveStatus::Idle,
             iteration: 0,
+            cycle_start_iteration: 0,
             created_at: Some(OffsetDateTime::now_utc()),
             serialized: false,
         }

--- a/rust/loopflow/src/lfd/store/postgres.rs
+++ b/rust/loopflow/src/lfd/store/postgres.rs
@@ -1340,6 +1340,7 @@ impl PostgresStore {
                         &created_at,
                         &enabled,
                         &stimulus.source_wave_id,
+                        &stimulus.max_iterations.map(|v| v as i32),
                     ],
                 )
                 .await?;
@@ -1362,6 +1363,7 @@ impl PostgresStore {
                         &stimulus.last_triggered_at,
                         &enabled,
                         &stimulus.source_wave_id,
+                        &stimulus.max_iterations.map(|v| v as i32),
                         &stimulus.id,
                     ],
                 )

--- a/rust/loopflow/src/lfd/store/postgres.rs
+++ b/rust/loopflow/src/lfd/store/postgres.rs
@@ -126,6 +126,7 @@ impl PostgresStore {
                         &paused,
                         &(wave.status().as_i32()),
                         &(wave.iteration() as i32),
+                        &(wave.cycle_start_iteration() as i32),
                         &created_at,
                         &serialized,
                     ],
@@ -927,7 +928,7 @@ impl PostgresStore {
         self.with_client(|client| async move {
             let rows = client
                 .query(
-                    "SELECT w.id, w.name, w.repo, w.flow, w.direction, w.area, w.paused, w.status, w.iteration, w.created_at, w.serialized
+                    "SELECT w.id, w.name, w.repo, w.flow, w.direction, w.area, w.paused, w.status, w.iteration, w.cycle_start_iteration, w.created_at, w.serialized
                      FROM waves w
                      INNER JOIN chord_members cm ON cm.wave_id = w.id
                      WHERE cm.chord_id = $1

--- a/rust/loopflow/src/lfd/store/rows.rs
+++ b/rust/loopflow/src/lfd/store/rows.rs
@@ -227,7 +227,7 @@ pub fn map_live_pr_state_row(row: &impl StoreRow) -> StoreResult<LivePullRequest
 }
 
 /// SELECT id, wave_id, signal, flow, cron, last_main_sha, last_triggered_at, created_at,
-///        enabled, source_wave_id
+///        enabled, source_wave_id, max_iterations
 pub fn map_stimulus_row(row: &impl StoreRow) -> StoreResult<Stimulus> {
     let created_at = unix_to_datetime(row.bigint(7)?);
 
@@ -242,6 +242,7 @@ pub fn map_stimulus_row(row: &impl StoreRow) -> StoreResult<Stimulus> {
         created_at: Some(created_at),
         enabled: row.int(8)? != 0,
         source_wave_id: row.opt_text(9)?.map(LfdId::from_raw),
+        max_iterations: row.opt_int(10)?.map(|v| v as u32),
     })
 }
 

--- a/rust/loopflow/src/lfd/store/rows.rs
+++ b/rust/loopflow/src/lfd/store/rows.rs
@@ -99,15 +99,16 @@ pub fn parse_pr(value: Option<String>) -> StoreResult<Option<PullRequest>> {
 // -- Shared row mappers ------------------------------------------------------
 
 /// SELECT id, name, repo, flow, direction, area, paused, status, iteration,
-///        created_at, serialized
+///        cycle_start_iteration, created_at, serialized
 pub fn map_wave_row(row: &impl StoreRow) -> StoreResult<Wave> {
     let direction = parse_json_vec(&row.text(4)?)?;
     let area = parse_json_vec(&row.text(5)?)?;
     let paused = row.int(6)? != 0;
     let status_value = row.int(7)?;
     let iteration = row.int(8)? as u32;
-    let created_at = unix_to_datetime(row.bigint(9)?);
-    let serialized = row.int(10)? != 0;
+    let cycle_start_iteration = row.int(9)? as u32;
+    let created_at = unix_to_datetime(row.bigint(10)?);
+    let serialized = row.int(11)? != 0;
     let mut status = WaveStatus::from_i32(status_value);
     if paused {
         status = WaveStatus::Paused;
@@ -122,6 +123,7 @@ pub fn map_wave_row(row: &impl StoreRow) -> StoreResult<Wave> {
         area,
         status,
         iteration,
+        cycle_start_iteration,
         created_at: Some(created_at),
         serialized,
     })

--- a/rust/loopflow/src/lfd/store/sqlite.rs
+++ b/rust/loopflow/src/lfd/store/sqlite.rs
@@ -1186,6 +1186,7 @@ impl SqliteStore {
                 created_at,
                 stimulus.enabled as i64,
                 stimulus.source_wave_id,
+                stimulus.max_iterations.map(|v| v as i64),
             ],
         )?;
         Ok(())
@@ -1203,6 +1204,7 @@ impl SqliteStore {
                 stimulus.last_triggered_at,
                 stimulus.enabled as i64,
                 stimulus.source_wave_id,
+                stimulus.max_iterations.map(|v| v as i64),
                 stimulus.id,
             ],
         )?;

--- a/rust/loopflow/src/lfd/store/sqlite.rs
+++ b/rust/loopflow/src/lfd/store/sqlite.rs
@@ -100,6 +100,7 @@ impl SqliteStore {
                 },
                 wave.status().as_i32() as i64,
                 wave.iteration() as i64,
+                wave.cycle_start_iteration() as i64,
                 created_at,
                 if wave.serialized { 1i64 } else { 0i64 },
             ],
@@ -792,7 +793,7 @@ impl SqliteStore {
 
         let conn = self.conn.lock().expect("store mutex poisoned");
         let mut stmt = conn.prepare(
-            "SELECT w.id, w.name, w.repo, w.flow, w.direction, w.area, w.paused, w.status, w.iteration, w.created_at, w.serialized
+            "SELECT w.id, w.name, w.repo, w.flow, w.direction, w.area, w.paused, w.status, w.iteration, w.cycle_start_iteration, w.created_at, w.serialized
              FROM waves w
              INNER JOIN chord_members cm ON cm.wave_id = w.id
              WHERE cm.chord_id = ?1

--- a/rust/loopflow/src/lfd/triggers/activation.rs
+++ b/rust/loopflow/src/lfd/triggers/activation.rs
@@ -494,6 +494,7 @@ mod tests {
             area: Vec::new(),
             status: WaveStatus::Idle,
             iteration: 0,
+            cycle_start_iteration: 0,
             created_at: Some(OffsetDateTime::now_utc()),
             serialized: false,
         };

--- a/rust/loopflow/src/lfd/triggers/activation.rs
+++ b/rust/loopflow/src/lfd/triggers/activation.rs
@@ -513,6 +513,7 @@ mod tests {
             last_triggered_at: None,
             created_at: Some(OffsetDateTime::now_utc()),
             enabled: true,
+            max_iterations: None,
         };
         store
             .create_stimulus(&stimulus)

--- a/rust/loopflow/src/lfd/triggers/ci_failure.rs
+++ b/rust/loopflow/src/lfd/triggers/ci_failure.rs
@@ -192,6 +192,7 @@ mod tests {
             area: Vec::new(),
             status: WaveStatus::Idle,
             iteration: 0,
+            cycle_start_iteration: 0,
             created_at: Some(OffsetDateTime::now_utc()),
             serialized: false,
         };
@@ -262,6 +263,7 @@ mod tests {
             area: Vec::new(),
             status: WaveStatus::Idle,
             iteration: 0,
+            cycle_start_iteration: 0,
             created_at: Some(OffsetDateTime::now_utc()),
             serialized: true,
         };

--- a/rust/loopflow/src/lfd/triggers/ci_failure.rs
+++ b/rust/loopflow/src/lfd/triggers/ci_failure.rs
@@ -157,6 +157,7 @@ async fn resolve_ci_failure_stimulus(
         last_triggered_at: Some(OffsetDateTime::now_utc().unix_timestamp()),
         created_at: Some(OffsetDateTime::now_utc()),
         enabled: true,
+        max_iterations: None,
     };
     store
         .create_stimulus(&stimulus)
@@ -210,6 +211,7 @@ mod tests {
             last_triggered_at: None,
             created_at: Some(OffsetDateTime::now_utc()),
             enabled: true,
+            max_iterations: None,
         };
         store
             .create_stimulus(&stimulus)

--- a/rust/loopflow/src/lfd/triggers/loop_ticker.rs
+++ b/rust/loopflow/src/lfd/triggers/loop_ticker.rs
@@ -162,5 +162,9 @@ fn should_pause_for_max_iterations(stimulus: &Stimulus, wave: &Wave) -> bool {
     let Some(max) = stimulus.max_iterations else {
         return false;
     };
-    max > 0 && wave.iteration() >= max
+    let cycle_iterations = wave
+        .iteration()
+        .saturating_sub(wave.cycle_start_iteration())
+        + 1;
+    max > 0 && cycle_iterations >= max
 }

--- a/rust/loopflow/src/lfd/triggers/loop_ticker.rs
+++ b/rust/loopflow/src/lfd/triggers/loop_ticker.rs
@@ -12,7 +12,7 @@ use crate::lfd::executor::WaveExecutor;
 use crate::lfd::scheduler::Scheduler;
 use crate::lfd::store::SharedStore;
 use crate::lfd::types::ActivationSource;
-use crate::lfd::types::{Signal, WaveStatus};
+use crate::lfd::types::{Signal, Stimulus, Wave, WaveStatus};
 
 pub fn spawn_loop_ticker(
     scheduler: Arc<Scheduler>,
@@ -43,13 +43,22 @@ async fn tick_loop_waves(
     store: &SharedStore,
     event_hub: &EventHub,
 ) {
-    let stimuli = match store.list_stimuli_by_signal(Signal::Loop.as_i32()).await {
+    // Collect stimuli that can trigger re-runs: Loop and Cron.
+    let mut stimuli = match store.list_stimuli_by_signal(Signal::Loop.as_i32()).await {
         Ok(stimuli) => stimuli,
         Err(err) => {
             tracing::error!(error = %err, "failed to list loop stimuli");
             return;
         }
     };
+
+    // Cron waves with active wave state should also loop within a cycle.
+    match store.list_stimuli_by_signal(Signal::Cron.as_i32()).await {
+        Ok(cron_stimuli) => stimuli.extend(cron_stimuli),
+        Err(err) => {
+            tracing::error!(error = %err, "failed to list cron stimuli");
+        }
+    }
 
     for stimulus in stimuli {
         if !stimulus.enabled {
@@ -88,8 +97,38 @@ async fn tick_loop_waves(
 
         let worktree = worktree_path(Path::new(wave.repo()), wave.name());
         let wave_dir = worktree.join("wave").join(wave.name());
-        if worktree.exists() && !wave_dir.exists() {
-            tracing::info!(wave = %wave.name(), "wave dir removed, skipping loop tick");
+
+        // For Loop stimuli: skip if wave dir was removed (cycle complete).
+        // For Cron stimuli: only re-trigger if wave dir still exists (mid-cycle).
+        if stimulus.signal == Signal::Loop {
+            if worktree.exists() && !wave_dir.exists() {
+                tracing::info!(wave = %wave.name(), "wave dir removed, skipping loop tick");
+                continue;
+            }
+        } else if stimulus.signal == Signal::Cron {
+            // Cron stimuli only loop within a cycle — wave state presence is the signal.
+            if !wave_dir.exists() {
+                continue;
+            }
+        }
+
+        // Safety valve: check max_iterations before re-triggering.
+        if should_pause_for_max_iterations(&stimulus, &wave) {
+            tracing::warn!(
+                wave = %wave.name(),
+                iteration = wave.iteration(),
+                max = stimulus.max_iterations.unwrap_or(0),
+                "max iterations exceeded, pausing wave"
+            );
+            let mut paused_wave = wave.clone();
+            paused_wave.status = WaveStatus::Paused;
+            if let Err(err) = store.update_wave(&paused_wave).await {
+                tracing::error!(
+                    wave_id = %paused_wave.id,
+                    error = %err,
+                    "failed to pause wave after max iterations"
+                );
+            }
             continue;
         }
 
@@ -117,4 +156,11 @@ async fn tick_loop_waves(
             .await;
         }
     }
+}
+
+fn should_pause_for_max_iterations(stimulus: &Stimulus, wave: &Wave) -> bool {
+    let Some(max) = stimulus.max_iterations else {
+        return false;
+    };
+    max > 0 && wave.iteration() >= max
 }

--- a/rust/loopflow/src/lfd/types/stimulus.rs
+++ b/rust/loopflow/src/lfd/types/stimulus.rs
@@ -120,6 +120,10 @@ pub struct Stimulus {
     pub created_at: Option<OffsetDateTime>,
     #[serde(default = "default_enabled")]
     pub enabled: bool,
+    /// Maximum iterations per cycle. When a wave's iteration count reaches this
+    /// value, the loop ticker pauses the wave instead of re-triggering.
+    #[serde(default)]
+    pub max_iterations: Option<u32>,
 }
 
 fn default_enabled() -> bool {
@@ -139,6 +143,7 @@ impl Stimulus {
             last_triggered_at: None,
             created_at: Some(OffsetDateTime::now_utc()),
             enabled: true,
+            max_iterations: None,
         }
     }
 }

--- a/rust/loopflow/src/lfd/types/wave.rs
+++ b/rust/loopflow/src/lfd/types/wave.rs
@@ -191,6 +191,11 @@ pub struct Wave {
     pub area: Vec<String>,
     pub status: WaveStatus,
     pub iteration: u32,
+    /// First iteration of the current cycle. Used with `max_iterations` to
+    /// bound re-triggers within a single cycle rather than across the wave's
+    /// lifetime.
+    #[serde(default)]
+    pub cycle_start_iteration: u32,
     #[serde(with = "time::serde::rfc3339::option")]
     pub created_at: Option<OffsetDateTime>,
     /// When true, only one run at a time — activations queue and dispatch
@@ -212,6 +217,7 @@ impl Wave {
             area: Vec::new(),
             status: WaveStatus::Idle,
             iteration: 0,
+            cycle_start_iteration: 0,
             created_at: Some(OffsetDateTime::now_utc()),
             serialized: false,
         }
@@ -247,6 +253,10 @@ impl Wave {
 
     pub fn iteration(&self) -> u32 {
         self.iteration
+    }
+
+    pub fn cycle_start_iteration(&self) -> u32 {
+        self.cycle_start_iteration
     }
 
     pub fn created_at(&self) -> Option<OffsetDateTime> {

--- a/rust/loopflow/tests/wave_worktree_tests.rs
+++ b/rust/loopflow/tests/wave_worktree_tests.rs
@@ -34,6 +34,7 @@ fn make_wave(repo: &str, name: &str) -> Wave {
         area: vec![],
         status: WaveStatus::Idle,
         iteration: 0,
+        cycle_start_iteration: 0,
         created_at: None,
         serialized: false,
     }

--- a/wave/chords/02-concerto-ui.md
+++ b/wave/chords/02-concerto-ui.md
@@ -20,3 +20,5 @@ Signal cleanup (01) should land first — it establishes WaveMode on the wave st
 - Listen stimulus indicator (which wave listens to which)
 - Chord CRUD from the UI: create chord, delete chord, add/remove wave from chord
 - Clean display for ungrouped waves alongside chord groups
+- Branch flow visualization — show which path was taken, routing verdict, cycle status for QA→fix→deploy loops
+- Human-in-the-loop branch selection — allow manual path override from the UI

--- a/wave/chords/03-iteration-reset.md
+++ b/wave/chords/03-iteration-reset.md
@@ -1,0 +1,15 @@
+# 03: Iteration Counter Reset
+
+**Finish line:** `max_iterations` counts per-cycle, not per-wave-lifetime. A cron wave that completes one QA cycle and starts another gets a fresh counter.
+
+## Context
+
+The branch construct uses `max_iterations` as a safety valve for QA→fix→deploy loops. Today `wave.iteration` increments monotonically — the counter never resets between cron cycles. This means the safety valve fires based on total lifetime iterations rather than iterations within the current cycle.
+
+Low urgency: `max_iterations` defaults to `None` and won't bite until someone configures it and runs multiple cycles. But it's a correctness issue that should be fixed before QA waves are used in production.
+
+## What to build
+
+- Reset `wave.iteration` when a cron cycle completes (wave state cleared by deploy flow's `update-wave`)
+- Or: reset on next cron tick when starting a new cycle
+- Either approach works. The key invariant: `max_iterations` bounds iterations within a single cycle, not across the wave's lifetime

--- a/wave/chords/03-iteration-reset.md
+++ b/wave/chords/03-iteration-reset.md
@@ -1,15 +1,9 @@
 # 03: Iteration Counter Reset
 
+**Status:** Done (this branch)
+
 **Finish line:** `max_iterations` counts per-cycle, not per-wave-lifetime. A cron wave that completes one QA cycle and starts another gets a fresh counter.
 
-## Context
+## Solution
 
-The branch construct uses `max_iterations` as a safety valve for QA→fix→deploy loops. Today `wave.iteration` increments monotonically — the counter never resets between cron cycles. This means the safety valve fires based on total lifetime iterations rather than iterations within the current cycle.
-
-Low urgency: `max_iterations` defaults to `None` and won't bite until someone configures it and runs multiple cycles. But it's a correctness issue that should be fixed before QA waves are used in production.
-
-## What to build
-
-- Reset `wave.iteration` when a cron cycle completes (wave state cleared by deploy flow's `update-wave`)
-- Or: reset on next cron tick when starting a new cycle
-- Either approach works. The key invariant: `max_iterations` bounds iterations within a single cycle, not across the wave's lifetime
+Added `cycle_start_iteration` to the Wave struct. When a wave transitions from idle/paused to running, `cycle_start_iteration` is set to the current iteration number. The safety valve (`should_pause_for_max_iterations`) compares cycle-relative iteration count against `max_iterations` instead of the lifetime counter.

--- a/wave/chords/README.md
+++ b/wave/chords/README.md
@@ -112,6 +112,8 @@ CREATE TABLE chord_members (
 - **Concurrent CI stimulus creation.** CI failure trigger resolves-then-creates `Signal::CiFailure` stimuli. Serialized today by one event loop; needs uniqueness guard if parallelized.
 - **Run worktree accumulation.** Parallel runs create per-run worktrees cleaned up on completion. Daemon crash mid-run leaves orphans until janitor sweep.
 - **Integrate-upstream false positives.** Watch triggers on any main advance, even when upstream changes are irrelevant to the wave. The integrate-upstream step should no-op quickly in that case, but it still costs an agent invocation.
+- **Iteration counter cumulative across cycles.** `wave.iteration` increments with every WaveRun and never resets between cron cycles. If `max_iterations` is 5, the safety valve fires on the 6th total WaveRun — not the 6th within a single daily cycle. Needs a reset mechanism on cycle completion or cron re-start. Low urgency since `max_iterations` defaults to `None`.
+- **Branch sub-flow items silently skipped.** The branch executor only handles Step items — forks or nested branches in a branch path's flow are silently ignored. Fork-in-branch is prevented at parse time, but a branch path pointing to a flow containing a fork would skip it.
 
 ## Metrics
 

--- a/wave/chords/chords.yaml
+++ b/wave/chords/chords.yaml
@@ -1,0 +1,4 @@
+flow: ship-wave
+direction:
+  - clarity
+  - care


### PR DESCRIPTION
## Try it

```bash
lf flow qa-deploy    # runs qa → triage → branch(fix or deploy)
lf flow qa-fix       # implement → compress → lint → gate
lf flow deploy       # gate → update-wave
```

Branch routing in action:

```yaml
# flow: qa-deploy
- qa
- triage
- branch:
    paths:
      fix:
        flow: qa-fix
        description: "Blocking issues found, fix before deploy"
      deploy:
        flow: deploy
        description: "Clean enough to ship"
```

## Summary

Adds a `branch` construct to the flow engine that routes execution based on an agent's assessment of the current state. A routing agent reads scratch/ and writes a verdict to `scratch/route-branch.md`, then the selected sub-flow runs inline. This enables automated QA cycles: run QA, triage findings, then either fix and re-run or deploy.

Also adds per-cycle `max_iterations` as a safety valve for looping waves. Previously `max_iterations` counted across the wave's entire lifetime — now `cycle_start_iteration` tracks where each cycle began, so a cron wave that completes one QA cycle and starts another gets a fresh counter.

## Changes

- **New flow construct: `branch`** — parsed, validated, expanded, and executed by the daemon. Branch paths can reference a flow or a single step, must have a description, and are validated to contain only steps (no nested forks or branches).
- **New steps:** `qa` (thorough quality assessment) and `triage` (separate blocking from polish)
- **New flows:** `qa-deploy`, `qa-fix`, `deploy`
- **`cycle_start_iteration` on Wave** — recorded when a wave transitions from idle/paused to running. The loop ticker compares cycle-relative iteration count against `max_iterations`.
- **`max_iterations` on Stimulus** — passed through API, client, and stored via new migration. Cron stimuli now also participate in the loop ticker for mid-cycle re-triggers.
- **CLI flow runner** prints `[branch]` with a note that branch routing requires lfd
- **DB migrations** 022 (stimulus max_iterations) and 023 (wave cycle_start_iteration)