### PR TITLE
flow: remove `flow` from `lf flow` subcommands

### DIFF
--- a/.agents/skills/design/SKILL.md
+++ b/.agents/skills/design/SKILL.md
@@ -80,7 +80,7 @@ This is the natural session exit point. The user's answer determines what to run
 7. Run `git add scratch/ wave/ && git commit -m "design: <branch>"`
 8. End session and tell the user what to run next:
    - `lf implement` (for stage 1)
-   - `lf flow ship-wave`
+   - `lf ship-wave`
 
 Once breaking things up, be aggressive about commit boundaries—each stage should be independently shippable.
 

--- a/.agents/skills/init/SKILL.md
+++ b/.agents/skills/init/SKILL.md
@@ -121,7 +121,7 @@ def flow():
     return Flow("design", "implement", "polish")
 ```
 
-Run with `lf flow ship`.
+Run with `lf ship`.
 
 ## Parallel Branches
 

--- a/.lf/steps/design.md
+++ b/.lf/steps/design.md
@@ -83,7 +83,7 @@ This is the natural session exit point. The user's answer determines what to run
 7. Run `git add scratch/ wave/ && git commit -m "design: <branch>"`
 8. End session and tell the user what to run next:
    - `lf implement` (for sprint 1)
-   - `lf flow ship-wave`
+   - `lf ship-wave`
 
 Once breaking things up, be aggressive about commit boundaries—each sprint should be independently shippable.
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Steps are prompts that run coding agents. Add your own in `.lf/steps/`.
 
 ```bash
 lf design && lf implement && lf gate    # chain steps manually
-lf flow build                           # or use a named flow
+lf build                                # or use a named flow
 ```
 
 Steps chain into flows. Flows feed into waves.
@@ -130,7 +130,7 @@ Steps chain into flows. Flows feed into waves.
 Forks run a step in parallel with different directions, then synthesize the results.
 
 ```bash
-lf flow wave-reduce    # runs reduce 3x with different perspectives
+lf wave-reduce    # runs reduce 3x with different perspectives
 ```
 
 `wave-reduce` forks `reduce` across infra, ux, and ceo directions, then reconciles results with `update-wave`.

--- a/rust/loopflow/src/engine/builtins/steps/interactive/design.md
+++ b/rust/loopflow/src/engine/builtins/steps/interactive/design.md
@@ -85,7 +85,7 @@ This is the natural session exit point. The user's answer determines what to run
 7. Run `git add scratch/ wave/ && git commit -m "design: <branch>"`
 8. End session and tell the user what to run next:
    - `lf implement` (for stage 1)
-   - `lf flow ship-wave`
+   - `lf ship-wave`
 
 Once breaking things up, be aggressive about commit boundaries—each stage should be independently shippable.
 


### PR DESCRIPTION
## Usage

```bash
lf build              # was: lf flow build
lf ship-wave          # was: lf flow ship-wave
lf wave-reduce        # was: lf flow wave-reduce
```

## Summary

Updates docs to reflect that flows are now invoked directly as `lf <flow-name>` instead of `lf flow <flow-name>`. The `flow` subcommand layer has been removed, so commands like `lf flow build` and `lf flow ship-wave` become `lf build` and `lf ship-wave`.

## Changes

- Updated README examples to drop the `flow` prefix
- Updated design step docs (builtin, `.lf/steps/`, and skill copies) to reference `lf ship-wave` instead of `lf flow ship-wave`
- Updated init skill to reference `lf ship` instead of `lf flow ship`