### PR TITLE
release: strip whitespace from R2 credentials

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,9 +56,9 @@ jobs:
           version = os.environ["GITHUB_REF_NAME"].lstrip("v")
           client = boto3.client(
               "s3",
-              endpoint_url=f"https://{os.environ['R2_ACCOUNT_ID']}.r2.cloudflarestorage.com",
-              aws_access_key_id=os.environ["R2_ACCESS_KEY_ID"],
-              aws_secret_access_key=os.environ["R2_SECRET_ACCESS_KEY"],
+              endpoint_url=f"https://{os.environ['R2_ACCOUNT_ID'].strip()}.r2.cloudflarestorage.com",
+              aws_access_key_id=os.environ["R2_ACCESS_KEY_ID"].strip(),
+              aws_secret_access_key=os.environ["R2_SECRET_ACCESS_KEY"].strip(),
               region_name="auto",
           )
           bucket = "loopflow-downloads"


### PR DESCRIPTION
## Summary

Adds `.strip()` calls to the R2 credential environment variables (`R2_ACCOUNT_ID`, `R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY`) in the release workflow.

Trailing whitespace in GitHub secrets can cause silent S3 authentication failures during release uploads. This defensively strips whitespace before using the values to construct the endpoint URL and authenticate.