### PR TITLE
land: accept --title and --body flags for PR content

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,14 +104,14 @@ Steps chain into flows. Flows feed into waves.
 |------|-------|
 | `build` | implement → compress → lint → gate → update-wave |
 | `design-and-ship` | design → implement → reduce → polish |
-| `ship` | design → build → review |
+| `ship` | design → build → review → land |
 | `pair` | design → build |
 | `grind` | research → iterate → build → gate |
 | `integrate` | rebase → integrate-upstream |
 | `incident` | debug → 5whys → build |
 | `start` | ingest → kickoff |
 | `ship-wave` | start → build |
-| `ship-roadmap` | ingest → kickoff → review-design → build → review |
+| `ship-roadmap` | ingest → kickoff → review-design → build → review → land |
 | `qa-deploy` | qa → triage → branch(fix: qa-fix, deploy: deploy) |
 | `qa-fix` | implement → compress → lint → gate |
 | `deploy` | gate → update-wave |

--- a/rust/loopflow/src/engine/builtins/flows/README.md
+++ b/rust/loopflow/src/engine/builtins/flows/README.md
@@ -9,7 +9,7 @@ Flows that produce code changes.
 | Flow | Steps | Use case |
 |------|-------|----------|
 | `build` | implement → compress → lint → gate → update-wave | Headless build and wave reconciliation |
-| `ship` | design → build → review | Interactive design, headless build, interactive review |
+| `ship` | design → build → review → land | Interactive design, headless build, interactive review, then land |
 | `pair` | design → build | Interactive design then build |
 | `grind` | research → iterate → build → gate | Research-driven iteration |
 | `incident` | debug → 5whys → build | Fix bug, analyze root cause, build fixes |

--- a/rust/loopflow/src/engine/builtins/flows/code/ship-roadmap.yaml
+++ b/rust/loopflow/src/engine/builtins/flows/code/ship-roadmap.yaml
@@ -3,3 +3,4 @@
 - review-design
 - build
 - review
+- land

--- a/rust/loopflow/src/engine/builtins/flows/code/ship.yaml
+++ b/rust/loopflow/src/engine/builtins/flows/code/ship.yaml
@@ -1,3 +1,4 @@
 - design
 - build
 - review
+- land

--- a/rust/loopflow/src/engine/builtins/steps/ops/land.md
+++ b/rust/loopflow/src/engine/builtins/steps/ops/land.md
@@ -1,24 +1,86 @@
 ---
-fast-path: lf ops land
+requires: code on branch
 produces: landed PR + rotated worktree
 ---
-Land the current PR: rebase, lint, enable auto-merge, rotate worktree.
+Land the current branch. Write PR content, rebase, and merge.
+
+## Goal
+
+Get this branch merged. Write a PR title and body that help reviewers understand the change, rebase onto main, and submit to the merge queue.
 
 ## API
 
 ```
-lf ops land [--local] [--create-pr] [--no-lint]
-lf ops wt move <worktree> <new-path>
-lf ops wt create <name> [--base BRANCH]
-lf ops wt list [--format json]
+lf ops land --title "..." --body "..." [-m "commit message"] [--create-pr] [--no-lint] [--local]
+lf ops rebase
+lf ops commit -m "message"
 ```
 
 ## Workflow
 
-1. Read the error output from the failed fast-path attempt.
-2. Diagnose the issue — common failures:
-   - Merge conflicts: resolve them, then retry `lf ops land`
-   - No PR: run `lf ops land --create-pr`
-   - Lint failures: fix lint issues, then retry
-   - CI failures: investigate and fix
-3. After the underlying issue is resolved, run `lf ops land` to complete.
+### 1. Understand the branch
+
+```bash
+git log origin/main..HEAD --oneline
+git diff origin/main...HEAD --stat
+```
+
+Check `scratch/` for context. If `scratch/<branch>-review.md` exists (from gate), use it to understand the change and inform the PR body.
+
+### 2. Commit uncommitted changes
+
+```bash
+git status
+```
+
+If the working tree is dirty, write a clear commit message and commit:
+
+```bash
+git add -A
+git commit -m "descriptive message"
+```
+
+### 3. Rebase onto main
+
+```bash
+lf ops rebase
+```
+
+If rebase fails with conflicts, spawn a subagent to resolve them. The subagent should:
+- Read conflicting files with `git status`
+- For files central to this branch: keep the branch's changes
+- For files outside the branch's scope: accept main's version
+- Run `git add <file>` then `git rebase --continue`
+- Push with `git push --force-with-lease`
+
+If conflicts are too complex, abort with `git rebase --abort` and note the issue in `scratch/questions.md`.
+
+### 4. Write PR title and body
+
+**Title:** lowercase, concise, area prefix when focused.
+
+Examples:
+- `mobile: quote replies on iOS`
+- `cost: add analytics dashboard with timeseries API`
+- `fix worktree cleanup on branch delete`
+
+**Body:** markdown. Structure:
+
+1. **Usage** — code block showing how to try it or see it in action
+2. **Summary** — one paragraph on what changed and why
+3. **Changes** — optional bullet list for larger PRs
+
+### 5. Land
+
+```bash
+lf ops land --title "<title>" --body "<body>" --create-pr
+```
+
+Include `-m "<message>"` if you committed changes in step 2.
+
+If lint or CI failures prevent landing, fix them and retry.
+
+## Notes
+
+- Do not ask questions. Make decisions and proceed.
+- If the PR already has a good title and body, you may run `lf ops land` without `--title`/`--body` to keep the existing content.

--- a/rust/loopflow/src/lf/commands/ops/mod.rs
+++ b/rust/loopflow/src/lf/commands/ops/mod.rs
@@ -33,12 +33,20 @@ pub fn run(op: &OpsCommand) -> Result<()> {
             create_pr,
             worktree,
             no_lint,
+            message,
+            title,
+            body,
         } => land_current(
-            *strict,
-            *local,
-            *create_pr,
-            worktree.as_deref(),
-            !no_lint,
+            &LandOptions {
+                strict: *strict,
+                local: *local,
+                create_pr: *create_pr,
+                worktree: worktree.clone(),
+                lint: !no_lint,
+                commit_message: message.clone(),
+                pr_title: title.clone(),
+                pr_body: body.clone(),
+            },
             &progress,
         ),
         OpsCommand::Pr { refresh, no_lint } => open_pr(*refresh, !no_lint, &progress),
@@ -146,27 +154,10 @@ fn push_current(force: bool) -> Result<()> {
     crate::engine::git::push(&repo_root, force).map_err(Into::into)
 }
 
-fn land_current(
-    strict: bool,
-    local: bool,
-    create_pr: bool,
-    worktree: Option<&str>,
-    lint: bool,
-    progress: &impl Progress,
-) -> Result<()> {
+fn land_current(options: &LandOptions, progress: &impl Progress) -> Result<()> {
     let repo_root = find_repo_root()?;
     let main_repo = main_repo_root(&repo_root).unwrap_or_else(|_| repo_root.clone());
-    let result = land(
-        &repo_root,
-        &LandOptions {
-            strict,
-            local,
-            create_pr,
-            worktree: worktree.map(str::to_string),
-            lint,
-        },
-        progress,
-    )?;
+    let result = land(&repo_root, options, progress)?;
 
     match result.rotation {
         Some(RotationResult::Advanced { new_path, .. }) => {

--- a/rust/loopflow/src/lf/mod.rs
+++ b/rust/loopflow/src/lf/mod.rs
@@ -185,6 +185,12 @@ pub enum OpsCommand {
         worktree: Option<String>,
         #[arg(long = "no-lint")]
         no_lint: bool,
+        #[arg(short = 'm', long = "message")]
+        message: Option<String>,
+        #[arg(long = "title")]
+        title: Option<String>,
+        #[arg(long = "body")]
+        body: Option<String>,
     },
     /// Create or update a PR
     Pr {

--- a/rust/loopflow/src/lfd/http/routes/waves.rs
+++ b/rust/loopflow/src/lfd/http/routes/waves.rs
@@ -1216,6 +1216,9 @@ pub async fn land_wave_handler(
                     create_pr,
                     worktree: Some(worktree),
                     lint,
+                    commit_message: None,
+                    pr_title: None,
+                    pr_body: None,
                 },
                 &progress,
             )

--- a/rust/loopflow/src/ops/land.rs
+++ b/rust/loopflow/src/ops/land.rs
@@ -12,7 +12,7 @@ use crate::engine::worktrees::{
 use crate::engine::command::run_command;
 use crate::ops::commit::{commit_workflow, CommitOptions};
 use crate::ops::error::{OpsError, OpsResult};
-use crate::ops::messages::{generate_pr_message, resolve_wave_name};
+
 use crate::ops::progress::Progress;
 
 #[derive(Debug, Clone)]
@@ -22,6 +22,9 @@ pub struct LandOptions {
     pub create_pr: bool,
     pub worktree: Option<String>,
     pub lint: bool,
+    pub commit_message: Option<String>,
+    pub pr_title: Option<String>,
+    pub pr_body: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -53,7 +56,12 @@ pub fn land(repo: &Path, options: &LandOptions, progress: &impl Progress) -> Ops
         finalize_local(&repo_root, &main_branch, &feature_branch, progress)?;
     } else {
         ensure_pr(&repo_root, &feature_branch, options, progress)?;
-        finalize_remote(&repo_root, progress)?;
+        finalize_remote(
+            &repo_root,
+            options.pr_title.as_deref(),
+            options.pr_body.as_deref(),
+            progress,
+        )?;
     }
 
     let rotation = rotate_worktree(&repo_root, &main_repo, progress)?;
@@ -79,11 +87,16 @@ fn prepare_land(
     }
 
     if !options.strict {
+        let message = options
+            .commit_message
+            .clone()
+            .unwrap_or_else(|| "lf land: stage uncommitted changes".to_string());
         let commit_options = CommitOptions {
             add: true,
             push: true,
             create_draft_pr: true,
-            ..CommitOptions::for_task("commit")
+            message: Some(message),
+            ..CommitOptions::for_task("land")
         };
         let _ = commit_workflow(repo_root, &commit_options, progress)?;
     }
@@ -146,13 +159,23 @@ fn ensure_pr(
     Ok(())
 }
 
-fn finalize_remote(repo_root: &Path, progress: &impl Progress) -> OpsResult<()> {
-    progress.status("Updating PR...");
-    let wave = resolve_wave_name(repo_root, None);
-    let message = generate_pr_message(repo_root, wave.as_deref())?;
-    update_pr_message(repo_root, &message.title, &message.body)?;
-    mark_ready(repo_root)?;
-    enable_auto_merge(repo_root, &message.title, &message.body)?;
+fn finalize_remote(
+    repo_root: &Path,
+    pr_title: Option<&str>,
+    pr_body: Option<&str>,
+    progress: &impl Progress,
+) -> OpsResult<()> {
+    if let Some(title) = pr_title {
+        let body = pr_body.unwrap_or("");
+        progress.status("Updating PR...");
+        update_pr_message(repo_root, title, body)?;
+        mark_ready(repo_root)?;
+        enable_auto_merge(repo_root, title, body)?;
+    } else {
+        progress.status("Enabling auto-merge...");
+        mark_ready(repo_root)?;
+        enable_auto_merge_existing(repo_root)?;
+    }
 
     if let Some(url) = current_pr_url(repo_root)? {
         progress.status(&format!("\n{url}\n"));
@@ -265,6 +288,22 @@ fn enable_auto_merge(repo: &Path, title: &str, body: &str) -> OpsResult<()> {
         cmd.arg("--body").arg(body);
     }
     cmd.current_dir(repo);
+    if let Err(err) = run_command(&mut cmd) {
+        return Err(OpsError::CommandFailed {
+            command: err.command_line(),
+            stderr: err.stderr,
+        });
+    }
+    Ok(())
+}
+
+fn enable_auto_merge_existing(repo: &Path) -> OpsResult<()> {
+    let mut cmd = Command::new("gh");
+    cmd.arg("pr")
+        .arg("merge")
+        .arg("--squash")
+        .arg("--auto")
+        .current_dir(repo);
     if let Err(err) = run_command(&mut cmd) {
         return Err(OpsError::CommandFailed {
             command: err.command_line(),

--- a/rust/loopflow/src/ops/release.rs
+++ b/rust/loopflow/src/ops/release.rs
@@ -1267,6 +1267,9 @@ fn publish_in_worktree(
             create_pr: true,
             worktree: None,
             lint: false,
+            commit_message: None,
+            pr_title: None,
+            pr_body: None,
         },
         progress,
     )?;

--- a/rust/loopflow/tests/land_tests.rs
+++ b/rust/loopflow/tests/land_tests.rs
@@ -66,6 +66,9 @@ fn land_local_squash_merges_to_main() {
             create_pr: false,
             worktree: None,
             lint: false,
+            commit_message: None,
+            pr_title: None,
+            pr_body: None,
         },
         &NullProgress,
     )
@@ -108,6 +111,9 @@ fn land_preserves_main_on_failure() {
             create_pr: false,
             worktree: None,
             lint: false,
+            commit_message: None,
+            pr_title: None,
+            pr_body: None,
         },
         &NullProgress,
     );
@@ -142,6 +148,9 @@ fn land_cleans_up_remote_branch() {
             create_pr: false,
             worktree: None,
             lint: false,
+            commit_message: None,
+            pr_title: None,
+            pr_body: None,
         },
         &NullProgress,
     )
@@ -170,6 +179,9 @@ fn land_with_lint_gate() {
             create_pr: false,
             worktree: None,
             lint: true,
+            commit_message: None,
+            pr_title: None,
+            pr_body: None,
         },
         &NullProgress,
     );
@@ -195,6 +207,9 @@ fn land_missing_pr_error_includes_branch_name() {
             create_pr: false,
             worktree: None,
             lint: false,
+            commit_message: None,
+            pr_title: None,
+            pr_body: None,
         },
         &NullProgress,
     );


### PR DESCRIPTION
## Usage

```bash
lf ops land --title "fix widget rendering" --body "Resolves off-by-one in layout calc" --create-pr
```

Or land without updating the PR message (keeps existing title/body):

```bash
lf ops land
```

## Summary

Gives the agent control over PR messaging during the land step. Previously `lf ops land` always auto-generated the PR title and body. Now the land step prompt instructs the agent to review the branch, write a title and body, and pass them as flags. When no `--title` is provided, land skips the PR update and just enables auto-merge on the existing PR.

The `ship` and `ship-roadmap` flows now end with a `land` step so the full cycle — design, build, review, land — completes without manual intervention.

## Changes

- Add `--title`, `--body`, and `-m` flags to `lf ops land`
- Rewrite the land step prompt to guide agents through branch review, PR authoring, rebase, and merge
- Append `land` to `ship` and `ship-roadmap` flows
- Add `enable_auto_merge_existing` for landing without overwriting PR content
- Remove the auto-generated PR message path from `finalize_remote`