### PR TITLE
fix: remove accidental worktree gitlink breaking CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ swift/dist/
 
 # Claude Code (personal state)
 .claude/settings.local.json
+.claude/worktrees/
 
 # Loopflow (generated)
 .lf/log/


### PR DESCRIPTION
## Summary

- `.claude/worktrees/voicecontrol-qa` was tracked as a gitlink (mode 160000) with no `.gitmodules` entry
- `actions/checkout@v4` tries to init all submodules recursively and fails on this phantom entry
- Remove the gitlink and add `.claude/worktrees/` to `.gitignore` to prevent recurrence

Fixes https://github.com/loopflowstudio/loopflow/actions/runs/22553001959/job/65325808021