### PR TITLE
ops pr: make title and body required, remove --refresh

### DIFF
--- a/docs/lfops.md
+++ b/docs/lfops.md
@@ -35,10 +35,9 @@ Create or update a PR, open in browser.
 
 ```bash
 lf ops pr --title "area: short title" --body "## Summary ..."
-lf ops pr --refresh
 ```
 
-`--title` and `--body` are required for create/update flows. `--refresh` is the title-free path when a PR already exists and only needs sync/rebase/push.
+`--title` and `--body` are always required. Use `lf pr` to generate them with agent judgment.
 
 ## lf ops land
 

--- a/rust/loopflow/src/engine/builtins/steps/ops/pr.md
+++ b/rust/loopflow/src/engine/builtins/steps/ops/pr.md
@@ -24,10 +24,3 @@ Write reviewer-friendly PR copy with agent judgment. Use ops only for execution.
    ```bash
    lf ops pr --title "<title>" --body "<body>"
    ```
-
-## Notes
-
-- If you only need rebase/push refresh with no message changes, use:
-  ```bash
-  lf ops pr --refresh
-  ```

--- a/rust/loopflow/src/lf/commands/ops/mod.rs
+++ b/rust/loopflow/src/lf/commands/ops/mod.rs
@@ -48,11 +48,7 @@ pub fn run(op: &OpsCommand) -> Result<()> {
             },
             &progress,
         ),
-        OpsCommand::Pr {
-            refresh,
-            title,
-            body,
-        } => open_pr(*refresh, title.clone(), body.clone(), &progress),
+        OpsCommand::Pr { title, body } => open_pr(title, body, &progress),
         OpsCommand::Sync => sync_current(),
         OpsCommand::Next {
             create_pr,
@@ -175,19 +171,13 @@ fn land_current(options: &LandOptions, progress: &impl Progress) -> Result<()> {
     Ok(())
 }
 
-fn open_pr(
-    refresh: bool,
-    title: Option<String>,
-    body: Option<String>,
-    progress: &impl Progress,
-) -> Result<()> {
+fn open_pr(title: &str, body: &str, progress: &impl Progress) -> Result<()> {
     let repo_root = find_repo_root()?;
     let result = create_or_update_pr(
         &repo_root,
         &PrOptions {
-            refresh,
-            title,
-            body,
+            title: title.to_string(),
+            body: body.to_string(),
         },
         progress,
     )?;

--- a/rust/loopflow/src/lf/discovery.rs
+++ b/rust/loopflow/src/lf/discovery.rs
@@ -63,7 +63,7 @@ pub const BUILTIN_CATEGORIES: &[(&str, &[&str])] = &[
         ],
     ),
     ("Scan", &["scan/scan-report", "scan/scan-plan"]),
-    ("Git", &["commit", "rebase", "land"]),
+    ("Git", &["commit", "rebase", "pr", "land"]),
     (
         "Ops",
         &[
@@ -95,6 +95,7 @@ pub fn builtin_descriptions() -> HashMap<&'static str, &'static str> {
         ("ci-fix", "Fix latest CI failures for current PR"),
         ("commit", "Commit with generated message"),
         ("rebase", "Rebase onto main"),
+        ("pr", "Open or update PR with generated description"),
         ("land", "Land PR, rotate worktree"),
         ("refine", "Iteratively refine text"),
         ("compress", "Simplify touched code"),

--- a/rust/loopflow/src/lf/mod.rs
+++ b/rust/loopflow/src/lf/mod.rs
@@ -192,12 +192,10 @@ pub enum OpsCommand {
     },
     /// Create or update a PR
     Pr {
-        #[arg(short = 'r', long = "refresh")]
-        refresh: bool,
         #[arg(long = "title")]
-        title: Option<String>,
+        title: String,
         #[arg(long = "body")]
-        body: Option<String>,
+        body: String,
     },
     /// Update local main to match origin
     Sync,

--- a/rust/loopflow/src/ops/land.rs
+++ b/rust/loopflow/src/ops/land.rs
@@ -136,12 +136,15 @@ fn ensure_pr(
 
     if !crate::ops::pr::pr_exists_for_current_branch(repo_root)? {
         if options.create_pr {
+            let title = options.pr_title.as_deref().ok_or_else(|| {
+                OpsError::Message("--create-pr requires --title and --body".to_string())
+            })?;
+            let body = options.pr_body.as_deref().unwrap_or("");
             let _ = crate::ops::pr::create_or_update_pr(
                 repo_root,
                 &crate::ops::pr::PrOptions {
-                    refresh: true,
-                    title: options.pr_title.clone(),
-                    body: options.pr_body.clone(),
+                    title: title.to_string(),
+                    body: body.to_string(),
                 },
                 progress,
             )?;

--- a/rust/loopflow/src/ops/next.rs
+++ b/rust/loopflow/src/ops/next.rs
@@ -82,9 +82,8 @@ pub fn next_branch(
         let _ = crate::ops::pr::create_or_update_pr(
             repo,
             &crate::ops::pr::PrOptions {
-                refresh: false,
-                title: Some(draft_title),
-                body: Some("*Draft — title and body will be updated.*".to_string()),
+                title: draft_title,
+                body: "*Draft — title and body will be updated.*".to_string(),
             },
             progress,
         )?;

--- a/rust/loopflow/src/ops/pr.rs
+++ b/rust/loopflow/src/ops/pr.rs
@@ -3,7 +3,7 @@ use std::process::Command;
 
 use serde::Deserialize;
 
-use crate::engine::git::{current_branch, get_default_branch, rev_parse, sync_main};
+use crate::engine::git::{current_branch, get_default_branch, sync_main};
 use crate::engine::worktrees::{list_worktrees, main_repo_root};
 
 use crate::ops::commit::{commit_workflow, CommitOptions};
@@ -13,9 +13,8 @@ use crate::ops::util::{command_exists, stderr_from_output};
 
 #[derive(Debug, Clone)]
 pub struct PrOptions {
-    pub refresh: bool,
-    pub title: Option<String>,
-    pub body: Option<String>,
+    pub title: String,
+    pub body: String,
 }
 
 #[derive(Debug, Clone)]
@@ -51,11 +50,6 @@ pub fn create_or_update_pr(
         return Err(OpsError::Message("gh CLI not found".to_string()));
     }
 
-    // Snapshot origin's view of our branch before any work
-    let branch =
-        current_branch(repo)?.ok_or_else(|| OpsError::Message("not on a branch".to_string()))?;
-    let origin_before = rev_parse(repo, &format!("origin/{branch}")).ok();
-
     let main_repo = resolve_main_repo(repo);
     let base_branch = get_default_branch(&main_repo)?;
 
@@ -82,65 +76,42 @@ pub fn create_or_update_pr(
         )?;
     }
 
-    // Refresh PR if HEAD moved from where origin was before we started
-    let head_now = rev_parse(repo, "HEAD").ok();
-    let has_changes = origin_before.is_none() || origin_before != head_now;
-    let title = options
-        .title
-        .as_deref()
-        .map(str::trim)
-        .filter(|v| !v.is_empty());
-    let body = options
-        .body
-        .as_deref()
-        .map(str::trim)
-        .filter(|v| !v.is_empty());
+    let title = options.title.trim();
+    let body = options.body.trim();
 
-    match (title, body) {
-        (Some(title), Some(body)) => {
-            if let Some(pr) = find_open_pr(repo)? {
-                progress.status("Updating PR...");
-                update_pr(repo, pr.number, title, body)?;
-                if pr.is_draft {
-                    mark_pr_ready(repo, pr.number)?;
-                }
-                open_url(&pr.url);
-                Ok(PrResult {
-                    url: pr.url,
-                    created: false,
-                    updated: true,
-                })
-            } else {
-                progress.status("Creating PR...");
-                let base = pr_target(repo, &main_repo, &base_branch)?;
-                let url = create_pr(repo, title, body, &base)?;
-                if let Some(pr) = find_open_pr(repo)? {
-                    if pr.is_draft {
-                        mark_pr_ready(repo, pr.number)?;
-                    }
-                }
-                open_url(&url);
-                Ok(PrResult {
-                    url,
-                    created: true,
-                    updated: false,
-                })
+    if title.is_empty() {
+        return Err(OpsError::Message(
+            "title required — use `lf pr` to generate it.".to_string(),
+        ));
+    }
+
+    if let Some(pr) = find_open_pr(repo)? {
+        progress.status("Updating PR...");
+        update_pr(repo, pr.number, title, body)?;
+        if pr.is_draft {
+            mark_pr_ready(repo, pr.number)?;
+        }
+        open_url(&pr.url);
+        Ok(PrResult {
+            url: pr.url,
+            created: false,
+            updated: true,
+        })
+    } else {
+        progress.status("Creating PR...");
+        let base = pr_target(repo, &main_repo, &base_branch)?;
+        let url = create_pr(repo, title, body, &base)?;
+        if let Some(pr) = find_open_pr(repo)? {
+            if pr.is_draft {
+                mark_pr_ready(repo, pr.number)?;
             }
         }
-        (None, None) if options.refresh => match find_open_pr(repo)? {
-            Some(pr) => {
-                open_url(&pr.url);
-                Ok(PrResult {
-                    url: pr.url,
-                    created: false,
-                    updated: has_changes,
-                })
-            }
-            None => Err(OpsError::Message("no open PR to refresh".to_string())),
-        },
-        _ => Err(OpsError::Message(
-            "title and body required — use `lf pr` to generate them.".to_string(),
-        )),
+        open_url(&url);
+        Ok(PrResult {
+            url,
+            created: true,
+            updated: false,
+        })
     }
 }
 

--- a/rust/loopflow/tests/pr_tests.rs
+++ b/rust/loopflow/tests/pr_tests.rs
@@ -41,9 +41,8 @@ fn pr_create_calls_gh() {
     let result = create_or_update_pr(
         repo.path(),
         &PrOptions {
-            refresh: false,
-            title: Some("test title".to_string()),
-            body: Some("test body".to_string()),
+            title: "test title".to_string(),
+            body: "test body".to_string(),
         },
         &NullProgress,
     )
@@ -67,9 +66,8 @@ fn pr_update_refreshes_body() {
     let result = create_or_update_pr(
         repo.path(),
         &PrOptions {
-            refresh: true,
-            title: Some("updated title".to_string()),
-            body: Some("updated body".to_string()),
+            title: "updated title".to_string(),
+            body: "updated body".to_string(),
         },
         &NullProgress,
     )
@@ -77,33 +75,6 @@ fn pr_update_refreshes_body() {
 
     assert!(result.updated);
     assert!(!result.created);
-}
-
-#[test]
-fn pr_skips_when_no_diff() {
-    let gh_script = write_gh_script(
-        r#"[{"url":"https://example.com/pr/1","state":"OPEN","isDraft":false,"number":1}]"#,
-        None,
-    );
-    let _env = EnvGuard::new(&[("gh", gh_script.as_str()), ("open", noop_script())]);
-    let repo = TestRepo::new();
-    repo.create_branch("feature");
-    push_branch(&repo, "feature");
-
-    let result = create_or_update_pr(
-        repo.path(),
-        &PrOptions {
-            refresh: true,
-            title: None,
-            body: None,
-        },
-        &NullProgress,
-    )
-    .expect("pr");
-
-    assert!(!result.created);
-    assert!(!result.updated);
-    assert_eq!(result.url, "https://example.com/pr/1");
 }
 
 #[test]
@@ -117,9 +88,8 @@ fn pr_create_uses_default_base_when_upstream_matches_head() {
     let result = create_or_update_pr(
         repo.path(),
         &PrOptions {
-            refresh: false,
-            title: Some("test title".to_string()),
-            body: Some("test body".to_string()),
+            title: "test title".to_string(),
+            body: "test body".to_string(),
         },
         &NullProgress,
     )
@@ -145,7 +115,7 @@ fn current_pr_surfaces_gh_list_errors() {
 }
 
 #[test]
-fn pr_requires_title_and_body_when_creating() {
+fn pr_requires_title() {
     let gh_script = write_gh_script("[]", None);
     let _env = EnvGuard::new(&[("gh", gh_script.as_str()), ("open", noop_script())]);
     let repo = TestRepo::new();
@@ -155,15 +125,14 @@ fn pr_requires_title_and_body_when_creating() {
     let result = create_or_update_pr(
         repo.path(),
         &PrOptions {
-            refresh: false,
-            title: None,
-            body: None,
+            title: "".to_string(),
+            body: "some body".to_string(),
         },
         &NullProgress,
     );
 
     assert!(matches!(
         result,
-        Err(OpsError::Message(message)) if message == "title and body required — use `lf pr` to generate them."
+        Err(OpsError::Message(message)) if message.contains("title required")
     ));
 }


### PR DESCRIPTION
## Usage

```bash
lf ops pr --title "area: short title" --body "## Summary ..."
```

## Summary

`PrOptions.title` and `PrOptions.body` are now `String` instead of `Option<String>`. The `--refresh` flag is removed — the origin-before/after diff-detection logic goes with it. Callers must always provide a title and body; `lf pr` (the agent step) handles generation.

## Changes

- `PrOptions`: `refresh: bool` removed, `title`/`body` changed from `Option<String>` to `String`
- `create_or_update_pr`: simplified from match-on-three-cases to linear create-or-update
- `lf ops land --create-pr` now requires `--title` (errors clearly if missing)
- `lf ops next` passes title/body directly
- Removed `pr_skips_when_no_diff` test (no longer applicable)
- Registered `pr` in builtin step discovery