### PR TITLE
release: one-shot release command and CI re-runnability

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -10,6 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      actions: write
+    env:
+      GH_TOKEN: ${{ github.token }}
     steps:
       - uses: actions/checkout@v4
       - name: Extract version and create tag
@@ -41,3 +44,7 @@ jobs:
 
           git tag "$version"
           git push origin "$version"
+
+          # GITHUB_TOKEN tag pushes don't trigger other workflows,
+          # so explicitly dispatch the release workflow.
+          gh workflow run release.yml --ref "$version" -f tag="$version"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,14 @@ on:
   push:
     tags:
       - "v*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to release (e.g. v0.9.8). Re-runs publish for an existing tag."
+        required: true
+
+env:
+  RELEASE_TAG: ${{ inputs.tag || github.ref_name }}
 
 jobs:
   # --- Stage 1: Build (failable work) ---
@@ -23,6 +31,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ env.RELEASE_TAG }}
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
@@ -45,6 +55,8 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ env.RELEASE_TAG }}
       - uses: astral-sh/setup-uv@v4
       - name: Fetch secrets
         uses: dopplerhq/secrets-fetch-action@v1.3.1
@@ -74,7 +86,7 @@ jobs:
         run: |
           uv run --with boto3 python3 - <<'SCRIPT'
           import boto3, os
-          version = os.environ["GITHUB_REF_NAME"].lstrip("v")
+          version = os.environ["RELEASE_TAG"].lstrip("v")
           client = boto3.client(
               "s3",
               endpoint_url=f"https://{os.environ['R2_ACCOUNT_ID'].strip()}.r2.cloudflarestorage.com",
@@ -111,6 +123,8 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ env.RELEASE_TAG }}
       - uses: actions/download-artifact@v4
         with:
           pattern: native-*
@@ -213,7 +227,9 @@ jobs:
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
+          tag_name: ${{ env.RELEASE_TAG }}
           body_path: RELEASE_NOTES.md
+          make_latest: true
           files: |
             dist/native/*.tar.gz
             dist/dmg/*.dmg
@@ -224,6 +240,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ env.RELEASE_TAG }}
       - uses: dtolnay/rust-toolchain@stable
       - name: Fetch secrets
         uses: dopplerhq/secrets-fetch-action@v1.3.1
@@ -233,7 +251,15 @@ jobs:
           doppler-project: loopflow
           doppler-config: prd
       - name: Publish to crates.io
-        run: cargo publish -p loopflow
+        run: |
+          output=$(cargo publish -p loopflow 2>&1) && exit 0
+          # Tolerate "already uploaded" so re-runs succeed
+          if echo "$output" | grep -q "already uploaded"; then
+            echo "Version already on crates.io, skipping"
+          else
+            echo "$output"
+            exit 1
+          fi
 
   publish-pypi:
     needs: [build-dmg]
@@ -244,6 +270,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          ref: ${{ env.RELEASE_TAG }}
           fetch-depth: 0
       - uses: astral-sh/setup-uv@v4
       - name: Build package
@@ -252,3 +279,4 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: dist/
+          skip-existing: true

--- a/rust/loopflow/src/engine/builtins/steps/ops/release.md
+++ b/rust/loopflow/src/engine/builtins/steps/ops/release.md
@@ -3,7 +3,7 @@ requires: optional version input in message text (patch|minor|major|vX.Y.Z)
 produces: RELEASE_NOTES.md, tagged release
 diff_files: false
 ---
-Run the full release workflow: check, bump, notes, commit, land, tag, verify.
+Run release as a one-shot operation that owns the full lifecycle.
 
 ## Input
 
@@ -16,52 +16,29 @@ If no input is provided, default to `patch`.
 
 ## Workflow
 
-1. **Check for changes.** Skip if nothing merged since last tag.
-   ```bash
-   lf ops release check
-   ```
-   Exit 1 means nothing merged — stop here.
+Run exactly one command:
 
-2. **Resolve version.** If input is `patch`/`minor`/`major`, determine the next version from the latest tag. For the remaining steps, use the resolved version.
+```bash
+lf ops release run <version>
+```
 
-3. **Bump manifests.**
-   ```bash
-   lf ops release bump <version>
-   ```
-
-4. **Generate release notes.** Analyze the merged PRs and write narrative notes.
-   ```bash
-   lf ops release notes <version>
-   ```
-
-5. **Commit and land.**
-   ```bash
-   lf ops commit -m "release: v<version>"
-   lf ops land
-   ```
-
-6. **Tag and push.**
-   ```bash
-   lf ops release tag <version>
-   ```
-
-7. **Verify.** Confirm the release workflow passes.
-   ```bash
-   lf ops release status
-   ```
-   If the workflow fails, report the failure and stop.
+That command is responsible for:
+- checking there are merged PRs since the previous tag
+- bumping manifests and generating release notes
+- creating and landing the release PR
+- waiting for merge queue completion
+- tagging the merged commit
+- waiting for release workflow completion
 
 ## Re-entry
 
-Each command is idempotent. Before re-running phases:
-- Check if the version commit already exists on main before re-bumping.
-- Check if the tag already exists before re-tagging.
+`lf ops release run` should be safe to re-run after interruptions.
 
 ## Guardrails
 
 - The version comes from the human or wave config. Don't decide it.
 - Be concrete in release notes: include real shipped changes, not vague summaries.
-- If required data is missing (tags/gh auth), state exactly what command failed and what to run.
+- If required data is missing (tags/gh auth/workflows), state exactly what command failed and what to run.
 
 ## Adaptation
 

--- a/rust/loopflow/src/lf/commands/ops/mod.rs
+++ b/rust/loopflow/src/lf/commands/ops/mod.rs
@@ -8,9 +8,9 @@ use crate::lf::output::Colors;
 use crate::lf::{OpsCommand, ReleaseCommand, ShellCommand, WtCommand};
 use crate::ops::{
     abandon_branch, commit_workflow, create_or_update_pr, ingest, land, next_branch,
-    rebase_with_recovery, release_bump, release_check, release_notes, release_status, release_tag,
-    AbandonOptions, CommitOptions, IngestOptions, LandOptions, NextOptions, PrOptions, Progress,
-    RebaseOptions, RotationResult,
+    rebase_with_recovery, release_bump, release_check, release_notes, release_run, release_status,
+    release_tag, AbandonOptions, CommitOptions, IngestOptions, LandOptions, NextOptions, PrOptions,
+    Progress, RebaseOptions, RotationResult,
 };
 use anyhow::{anyhow, Result};
 use std::io::{self, IsTerminal, Write};
@@ -65,6 +65,9 @@ pub fn run(op: &OpsCommand) -> Result<()> {
         OpsCommand::Wt { cmd } => run_worktree(cmd),
         OpsCommand::Shell { cmd } => run_shell(cmd),
         OpsCommand::Release { cmd } => match cmd {
+            ReleaseCommand::Run { version, target } => {
+                release_run_cmd(version.as_deref(), target.as_deref(), &progress)
+            }
             ReleaseCommand::Check { target } => release_check_cmd(target.as_deref()),
             ReleaseCommand::Notes {
                 version,
@@ -252,6 +255,26 @@ fn release_check_cmd(target_name: Option<&str>) -> Result<()> {
         println!("{}", json);
     }
 
+    Ok(())
+}
+
+fn release_run_cmd(
+    version_input: Option<&str>,
+    target_name: Option<&str>,
+    progress: &impl Progress,
+) -> Result<()> {
+    let repo_root = find_repo_root()?;
+    let input = version_input.unwrap_or("patch");
+    let result = release_run(&repo_root, input, target_name, progress)?;
+
+    println!("Released {} ({})", result.tag, result.target);
+    if let Some(url) = result.workflow_url.as_deref() {
+        println!("Workflow URL: {url}");
+    }
+    println!(
+        "GitHub Release: {}",
+        if result.release_exists { "yes" } else { "no" }
+    );
     Ok(())
 }
 

--- a/rust/loopflow/src/lf/discovery.rs
+++ b/rust/loopflow/src/lf/discovery.rs
@@ -106,7 +106,7 @@ pub fn builtin_descriptions() -> HashMap<&'static str, &'static str> {
         ("update-wave", "Create, update, or delete wave state"),
         ("synthesize", "Combine multiple perspectives"),
         ("validate", "Validate flows, steps, and directions"),
-        ("release", "Generate release notes from merged PRs"),
+        ("release", "Run one-shot release workflow"),
         ("scan/scan-report", "Scan deps and APIs for issues"),
         ("scan/scan-plan", "Turn scan report into action plan"),
     ])

--- a/rust/loopflow/src/lf/mod.rs
+++ b/rust/loopflow/src/lf/mod.rs
@@ -232,7 +232,7 @@ pub enum OpsCommand {
         #[command(subcommand)]
         cmd: ShellCommand,
     },
-    /// Release operations (check, notes, bump, tag, status)
+    /// Release operations (run, check, notes, bump, tag, status)
     Release {
         #[command(subcommand)]
         cmd: ReleaseCommand,
@@ -247,6 +247,13 @@ pub enum OpsCommand {
 
 #[derive(Subcommand, Debug)]
 pub enum ReleaseCommand {
+    /// Run the full release workflow end-to-end
+    Run {
+        /// Version to release: patch|minor|major|X.Y.Z (default: patch)
+        version: Option<String>,
+        #[arg(short = 't', long = "target")]
+        target: Option<String>,
+    },
     /// Check if PRs have merged since the last tag
     Check {
         #[arg(short = 't', long = "target")]

--- a/rust/loopflow/src/ops/mod.rs
+++ b/rust/loopflow/src/ops/mod.rs
@@ -23,7 +23,7 @@ pub use pr::{create_or_update_pr, current_pr, update_pr, PrInfo, PrOptions, PrRe
 pub use progress::{NullProgress, Progress};
 pub use rebase::{rebase_with_recovery, RebaseOptions};
 pub use release::{
-    bump_version, generate_release, release_bump, release_check, release_notes, release_status,
-    release_tag, MergedPr, ReleaseStatusResult,
+    bump_version, generate_release, release_bump, release_check, release_notes, release_run,
+    release_status, release_tag, MergedPr, ReleaseRunResult, ReleaseStatusResult,
 };
 pub use trace::{hash_prompt, trace_enabled, MockResponses, OpTrace, Tracer};

--- a/rust/loopflow/src/ops/release.rs
+++ b/rust/loopflow/src/ops/release.rs
@@ -2,15 +2,19 @@ use std::collections::HashSet;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output};
+use std::thread;
+use std::time::{Duration, Instant};
 
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 
 use crate::engine::command::run_command;
 use crate::engine::config::{load_config_or_default, Config, ReleaseTargetConfig};
-use crate::engine::git::get_default_branch;
-use crate::engine::worktrees::main_repo_root;
+use crate::engine::git::{delete_local_branch, get_default_branch, worktree_remove};
+use crate::engine::worktrees::{create_with_schema, main_repo_root};
+use crate::ops::commit::{commit_workflow, CommitOptions};
 use crate::ops::error::{OpsError, OpsResult};
+use crate::ops::land::{land, LandOptions};
 use crate::ops::progress::Progress;
 use crate::ops::util::command_exists;
 
@@ -66,6 +70,25 @@ struct GhRunListEntry {
     url: Option<String>,
 }
 
+#[derive(Debug, Deserialize)]
+struct GhPrSummary {
+    number: u64,
+}
+
+#[derive(Debug, Deserialize)]
+struct GhPrMergeCommit {
+    oid: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct GhPrView {
+    state: String,
+    #[serde(default, rename = "mergeCommit")]
+    merge_commit: Option<GhPrMergeCommit>,
+    #[serde(default)]
+    url: Option<String>,
+}
+
 impl From<GhMergedPr> for MergedPr {
     fn from(value: GhMergedPr) -> Self {
         Self {
@@ -100,6 +123,15 @@ pub struct ReleaseStatusResult {
     pub latest_tag: Option<String>,
     pub workflow_status: Option<String>,
     pub workflow_conclusion: Option<String>,
+    pub workflow_url: Option<String>,
+    pub release_exists: bool,
+}
+
+#[derive(Debug, Clone)]
+pub struct ReleaseRunResult {
+    pub target: String,
+    pub version: String,
+    pub tag: String,
     pub workflow_url: Option<String>,
     pub release_exists: bool,
 }
@@ -250,6 +282,272 @@ pub fn release_tag(repo: &Path, version: &str, target_name: Option<&str>) -> Ops
 
     let version = normalize_version(version);
     tag_and_push(&main_repo, &version, &target)
+}
+
+/// Run the full release workflow in one shot.
+///
+/// Flow:
+/// 1) check merged PRs since previous tag
+/// 2) bump manifests + generate notes in a temporary worktree
+/// 3) commit, open PR, and enqueue auto-merge
+/// 4) wait for merge queue completion
+/// 5) tag merged commit and push
+/// 6) wait for release workflow/release publication
+pub fn release_run(
+    repo: &Path,
+    version_input: &str,
+    target_name: Option<&str>,
+    progress: &impl Progress,
+) -> OpsResult<ReleaseRunResult> {
+    if !command_exists("gh") {
+        return Err(OpsError::Message("gh CLI not found".to_string()));
+    }
+
+    let (main_repo, target) = resolve_repo_and_target(repo, target_name)?;
+    let prev_tag = latest_tag(&main_repo, &target)?;
+    let merged_prs = merged_prs_since(&main_repo, &prev_tag, &target)?;
+    if merged_prs.is_empty() {
+        return Err(OpsError::Message(
+            "no PRs merged since last tag; nothing to release".to_string(),
+        ));
+    }
+
+    let version = resolve_version(&prev_tag, version_input, &target)?;
+    let main_branch = get_default_branch(&main_repo)?;
+    let wt_name = if target.name == "default" {
+        format!("release.default.v{version}")
+    } else {
+        format!("release.{}.v{version}", target.name)
+    };
+
+    progress.status(&format!("Creating release worktree {wt_name}..."));
+    let wt = create_with_schema(&main_repo, &wt_name, Some(&main_branch), None)?;
+    let wt_path = wt.path;
+    let wt_branch = wt.branch;
+
+    let prepared = prepare_release_in_worktree(&wt_path, &version, &target, progress);
+    cleanup_release_worktree(&main_repo, &wt_path, &wt_branch, progress);
+    let prepared = prepared?;
+
+    progress.status("Waiting for release PR to merge...");
+    let merged_commit = wait_for_pr_merge(&main_repo, prepared.pr_number, progress)?;
+
+    progress.status(&format!("Tagging {}...", target_tag(&target, &version)));
+    let tag = tag_and_push_ref(&main_repo, &version, &target, Some(&merged_commit))?;
+
+    progress.status(&format!("Waiting for release pipeline for {tag}..."));
+    let (workflow_url, release_exists) =
+        wait_for_release_publication(&main_repo, &tag, &target, progress)?;
+
+    Ok(ReleaseRunResult {
+        target: target.name,
+        version,
+        tag,
+        workflow_url,
+        release_exists,
+    })
+}
+
+#[derive(Debug)]
+struct PreparedRelease {
+    pr_number: u64,
+}
+
+fn prepare_release_in_worktree(
+    wt_path: &Path,
+    version: &str,
+    target: &ReleaseTarget,
+    progress: &impl Progress,
+) -> OpsResult<PreparedRelease> {
+    progress.status(&format!(
+        "Bumping manifests for {}...",
+        target_tag(target, version)
+    ));
+    bump_manifest_versions(wt_path, target, version, progress)?;
+
+    progress.status(&format!(
+        "Generating RELEASE_NOTES.md for {}...",
+        target_tag(target, version)
+    ));
+    generate_release_with_target(wt_path, version, target, progress)?;
+
+    progress.status("Committing release changes...");
+    let _ = commit_workflow(
+        wt_path,
+        &CommitOptions {
+            add: true,
+            push: true,
+            create_draft_pr: true,
+            message: Some(release_commit_message(target, version)),
+            ..CommitOptions::for_task("release")
+        },
+        progress,
+    )?;
+
+    let pr = current_pr_summary(wt_path)?;
+
+    progress.status("Enqueuing release PR for merge...");
+    land(
+        wt_path,
+        &LandOptions {
+            strict: true,
+            local: false,
+            create_pr: false,
+            worktree: None,
+            commit_message: None,
+            pr_title: None,
+            pr_body: None,
+        },
+        progress,
+    )?;
+
+    Ok(PreparedRelease {
+        pr_number: pr.number,
+    })
+}
+
+fn cleanup_release_worktree(
+    main_repo: &Path,
+    wt_path: &Path,
+    branch: &str,
+    progress: &impl Progress,
+) {
+    if let Err(err) = worktree_remove(main_repo, wt_path) {
+        progress.error(&format!(
+            "Warning: could not remove release worktree {}: {err}",
+            wt_path.display()
+        ));
+    }
+    let _ = delete_local_branch(main_repo, branch);
+}
+
+fn release_commit_message(target: &ReleaseTarget, version: &str) -> String {
+    if target.name == "default" {
+        format!("release: v{version}")
+    } else {
+        format!("release: {} v{version}", target.name)
+    }
+}
+
+fn current_pr_summary(repo: &Path) -> OpsResult<GhPrSummary> {
+    let output = run_stdout(repo, "gh", &["pr", "view", "--json", "number"])?;
+    serde_json::from_str(&output)
+        .map_err(|err| OpsError::Parse(format!("failed to parse PR summary: {err}")))
+}
+
+fn wait_for_pr_merge(repo: &Path, pr_number: u64, progress: &impl Progress) -> OpsResult<String> {
+    let started = Instant::now();
+    let timeout = Duration::from_secs(60 * 60);
+    let poll = Duration::from_secs(10);
+    let pr_number_arg = pr_number.to_string();
+    let mut attempt: u64 = 0;
+
+    loop {
+        let output = run_stdout(
+            repo,
+            "gh",
+            &[
+                "pr",
+                "view",
+                &pr_number_arg,
+                "--json",
+                "state,mergeCommit,url",
+            ],
+        )?;
+        let view: GhPrView = serde_json::from_str(&output)
+            .map_err(|err| OpsError::Parse(format!("failed to parse PR state: {err}")))?;
+
+        match view.state.as_str() {
+            "MERGED" => {
+                let commit = view.merge_commit.ok_or_else(|| {
+                    OpsError::Message(format!(
+                        "PR #{pr_number} is merged but merge commit is unavailable"
+                    ))
+                })?;
+                return Ok(commit.oid);
+            }
+            "CLOSED" => {
+                let url = view.url.unwrap_or_else(|| format!("PR #{pr_number}"));
+                return Err(OpsError::Message(format!(
+                    "{url} was closed without merging"
+                )));
+            }
+            _ => {}
+        }
+
+        if started.elapsed() >= timeout {
+            return Err(OpsError::Message(format!(
+                "timed out waiting for PR #{pr_number} to merge"
+            )));
+        }
+
+        if attempt.is_multiple_of(6) {
+            progress.status(&format!("PR #{pr_number} still in merge queue..."));
+        }
+        attempt += 1;
+        thread::sleep(poll);
+    }
+}
+
+fn wait_for_release_publication(
+    repo: &Path,
+    tag: &str,
+    target: &ReleaseTarget,
+    progress: &impl Progress,
+) -> OpsResult<(Option<String>, bool)> {
+    let started = Instant::now();
+    let timeout = Duration::from_secs(60 * 60);
+    let poll = Duration::from_secs(10);
+    let no_workflow_grace = Duration::from_secs(90);
+    let mut attempt: u64 = 0;
+    let mut saw_workflow = false;
+
+    loop {
+        let workflow = find_workflow_run(repo, tag, target)?;
+        let release_exists = github_release_exists(repo, tag)?;
+
+        if let Some(run) = workflow {
+            saw_workflow = true;
+            if run.status == "completed" {
+                let conclusion = run
+                    .conclusion
+                    .unwrap_or_else(|| "unknown".to_string())
+                    .to_lowercase();
+                if conclusion == "success" {
+                    return Ok((run.url, release_exists));
+                }
+
+                let url = run
+                    .url
+                    .unwrap_or_else(|| "(workflow URL unavailable)".to_string());
+                return Err(OpsError::Message(format!(
+                    "release workflow failed for {tag}: {conclusion} ({url})"
+                )));
+            }
+        } else if release_exists {
+            return Ok((None, true));
+        } else if !saw_workflow
+            && target.workflow.is_none()
+            && started.elapsed() >= no_workflow_grace
+        {
+            progress.status(&format!(
+                "No release workflow detected for {tag}; tag push complete"
+            ));
+            return Ok((None, false));
+        }
+
+        if started.elapsed() >= timeout {
+            return Err(OpsError::Message(format!(
+                "timed out waiting for release workflow for {tag}"
+            )));
+        }
+
+        if attempt.is_multiple_of(6) {
+            progress.status(&format!("Release workflow for {tag} still running..."));
+        }
+        attempt += 1;
+        thread::sleep(poll);
+    }
 }
 
 fn generate_release_with_target(
@@ -1016,10 +1314,95 @@ fn join_lines_like_original(original: &str, lines: Vec<String>) -> String {
 }
 
 fn tag_and_push(repo: &Path, version: &str, target: &ReleaseTarget) -> OpsResult<String> {
+    tag_and_push_ref(repo, version, target, None)
+}
+
+fn tag_and_push_ref(
+    repo: &Path,
+    version: &str,
+    target: &ReleaseTarget,
+    target_ref: Option<&str>,
+) -> OpsResult<String> {
     let tag = target_tag(target, version);
-    run_stdout(repo, "git", &["tag", &tag])?;
-    run_stdout(repo, "git", &["push", "origin", &tag])?;
-    Ok(tag)
+    let ref_name = target_ref.unwrap_or("HEAD");
+    let target_sha = run_stdout(repo, "git", &["rev-parse", ref_name])?;
+    let target_sha = target_sha.trim().to_string();
+
+    if let Some(remote_sha) = remote_tag_sha(repo, &tag)? {
+        if remote_sha == target_sha {
+            eprintln!("Tag {tag} already exists on origin at target commit, skipping");
+            return Ok(tag);
+        }
+        return Err(OpsError::Message(format!(
+            "tag {tag} already exists on origin at {remote_sha}, expected {target_sha}"
+        )));
+    }
+
+    match local_tag_sha(repo, &tag)? {
+        Some(local_sha) if local_sha == target_sha => {}
+        Some(local_sha) => {
+            return Err(OpsError::Message(format!(
+                "local tag {tag} exists at {local_sha}, expected {target_sha}"
+            )));
+        }
+        None => {
+            run_stdout(repo, "git", &["tag", &tag, ref_name])?;
+        }
+    }
+
+    let push_output = run_output(repo, "git", &["push", "origin", &tag])?;
+    if push_output.status.success() {
+        return Ok(tag);
+    }
+
+    let stderr = String::from_utf8_lossy(&push_output.stderr).to_string();
+    if stderr.contains("already exists")
+        && remote_tag_sha(repo, &tag)?
+            .as_deref()
+            .is_some_and(|remote_sha| remote_sha == target_sha)
+    {
+        eprintln!("Tag {tag} was created concurrently, continuing");
+        return Ok(tag);
+    }
+
+    Err(OpsError::CommandFailed {
+        command: format!("git push origin {tag}"),
+        stderr,
+    })
+}
+
+fn local_tag_sha(repo: &Path, tag: &str) -> OpsResult<Option<String>> {
+    let output = run_output(repo, "git", &["rev-list", "-n", "1", tag])?;
+    if !output.status.success() {
+        return Ok(None);
+    }
+
+    let sha = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if sha.is_empty() {
+        Ok(None)
+    } else {
+        Ok(Some(sha))
+    }
+}
+
+fn remote_tag_sha(repo: &Path, tag: &str) -> OpsResult<Option<String>> {
+    let pattern = format!("refs/tags/{tag}");
+    let output = run_output(repo, "git", &["ls-remote", "--tags", "origin", &pattern])?;
+    if !output.status.success() {
+        return Err(OpsError::CommandFailed {
+            command: format!("git ls-remote --tags origin {pattern}"),
+            stderr: String::from_utf8_lossy(&output.stderr).to_string(),
+        });
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let sha = stdout
+        .lines()
+        .next()
+        .and_then(|line| line.split_whitespace().next())
+        .map(str::to_string);
+
+    Ok(sha)
 }
 
 fn find_workflow_run(

--- a/scripts/concerto-dev.py
+++ b/scripts/concerto-dev.py
@@ -602,12 +602,19 @@ def cmd_release() -> int:
     (app_dir / "Resources").mkdir(parents=True)
 
     # Copy files
-    shutil.copy(SWIFT_DIR / ".build" / "release" / "Concerto", app_dir / "MacOS")
+    build_dir = SWIFT_DIR / ".build" / "release"
+    shutil.copy(build_dir / "Concerto", app_dir / "MacOS")
     shutil.copy(SWIFT_DIR / "Concerto" / "Info.plist", app_dir)
     shutil.copy(SWIFT_DIR / "Concerto" / "Concerto.sdef", app_dir / "Resources")
     shutil.copy(SWIFT_DIR / "Concerto" / "AppIcon.icns", app_dir / "Resources")
     _copy_bundled_tools(app_dir / "MacOS", profile="release")
     (app_dir / "PkgInfo").write_text("APPL????")
+
+    # Copy SPM resource bundles (fonts, etc.) — Bundle.module looks
+    # at Bundle.main.bundleURL/<name>.bundle, which is the .app root
+    app_root = app_dir.parent
+    for bundle in build_dir.glob("*.bundle"):
+        shutil.copytree(bundle, app_root / bundle.name)
 
     print(f"Created dist/{app_name}.app")
 


### PR DESCRIPTION
## Usage

```bash
lf ops release run patch    # full release in one command
lf ops release run 1.2.3    # explicit version
```

## Summary

Adds `lf ops release run`, a single command that owns the full release lifecycle: check merged PRs, bump manifests, generate notes, create and land a release PR, wait for merge, tag the merged commit, and wait for the release workflow to complete.

Also fixes CI release workflow re-runnability: auto-tag now dispatches release.yml explicitly (GITHUB_TOKEN tag pushes don't trigger workflows), release.yml accepts workflow_dispatch with a tag input, and publish steps tolerate already-published versions.

## Changes

- New `lf ops release run` command with worktree-based release PR flow
- Idempotent `tag_and_push_ref` with local/remote tag collision handling
- PR merge queue polling (`wait_for_pr_merge`) and release workflow polling (`wait_for_release_publication`)
- `auto-tag.yml`: dispatch release.yml after tag push
- `release.yml`: workflow_dispatch support, explicit ref checkout, skip-existing for pypi/crates
- Simplified `release.md` step to delegate entirely to `lf ops release run`
- SPM resource bundle copying in concerto-dev.py release build