### PR TITLE
lf land: auto-generate PR copy and improve worktree rotation

### DIFF
--- a/rust/loopflow/src/engine/worktrees.rs
+++ b/rust/loopflow/src/engine/worktrees.rs
@@ -2,7 +2,7 @@ use crate::engine::config::BranchNameConfig;
 use crate::engine::error::GitError;
 use crate::engine::git::{
     get_default_branch, has_commits_beyond, is_ancestor, is_clean_ignoring_scratch,
-    is_squash_merged, rev_parse, worktree_add, worktree_move, WorktreeBranch,
+    is_squash_merged, rev_parse, sync_main, worktree_add, worktree_move, WorktreeBranch,
 };
 use crate::engine::naming::{format_branch_name, generate_timestamp, wave_name_from_branch};
 use crate::lfd::security::sanitize_fs_component;
@@ -445,6 +445,31 @@ pub fn create_with_schema(
     base: Option<&str>,
     branch_config: Option<&BranchNameConfig>,
 ) -> Result<CreateWorktreeResult, GitError> {
+    create_with_schema_internal(repo, short_name, base, branch_config, false)
+}
+
+pub fn create_with_schema_synced(
+    repo: &Path,
+    short_name: &str,
+    base: Option<&str>,
+    branch_config: Option<&BranchNameConfig>,
+) -> Result<CreateWorktreeResult, GitError> {
+    create_with_schema_internal(repo, short_name, base, branch_config, true)
+}
+
+fn create_with_schema_internal(
+    repo: &Path,
+    short_name: &str,
+    base: Option<&str>,
+    branch_config: Option<&BranchNameConfig>,
+    sync_default_base: bool,
+) -> Result<CreateWorktreeResult, GitError> {
+    if sync_default_base {
+        if let Ok(default_branch) = get_default_branch(repo) {
+            let _ = sync_main(repo, &default_branch);
+        }
+    }
+
     let remote_branch = format!("origin/{short_name}");
     let has_remote_branch = rev_parse(repo, &remote_branch).is_ok();
     let branch_name = if has_remote_branch {

--- a/rust/loopflow/src/engine/worktrees.rs
+++ b/rust/loopflow/src/engine/worktrees.rs
@@ -337,7 +337,7 @@ pub fn list_worktrees_local(repo: &Path) -> Result<(String, Vec<WorktreeState>),
         });
         let squash_merged_flag = branch
             .as_deref()
-            .is_some_and(|b| !is_default && squash_merged.contains(b));
+            .is_some_and(|b| !is_default && has_commits && squash_merged.contains(b));
         let dirty = !is_clean_ignoring_scratch(&path).unwrap_or(true);
         let mut prunable = !is_default && (merged || squash_merged_flag || !has_commits);
 
@@ -545,7 +545,7 @@ pub fn schedule_upstream_sync(worktree: PathBuf, branch: String) {
     });
 }
 
-fn push_branch_with_upstream(worktree: &Path, branch: &str) -> Result<(), GitError> {
+pub fn push_branch_with_upstream(worktree: &Path, branch: &str) -> Result<(), GitError> {
     let output = Command::new("git")
         .arg("-C")
         .arg(worktree)
@@ -562,8 +562,14 @@ fn push_branch_with_upstream(worktree: &Path, branch: &str) -> Result<(), GitErr
     Ok(())
 }
 
-pub fn preserve_worktree(repo: &Path, worktree: &Path) -> Result<PathBuf, GitError> {
-    let ts = generate_timestamp();
+pub fn preserve_worktree(
+    repo: &Path,
+    worktree: &Path,
+    suffix: Option<&str>,
+) -> Result<PathBuf, GitError> {
+    let ts = suffix
+        .map(|s| s.to_string())
+        .unwrap_or_else(generate_timestamp);
     let name = worktree
         .file_name()
         .and_then(|n| n.to_str())

--- a/rust/loopflow/src/lf/commands/ops/mod.rs
+++ b/rust/loopflow/src/lf/commands/ops/mod.rs
@@ -1,6 +1,6 @@
 use crate::engine::git::{current_branch, delete_local_branch, get_default_branch};
 use crate::engine::worktrees::{
-    create_with_schema, list_worktrees, main_repo_root, wave_name_from_worktree,
+    create_with_schema_synced, list_worktrees, main_repo_root, wave_name_from_worktree,
     wave_name_from_worktree_and_main, worktree_path,
 };
 use crate::lf::commands::util::find_repo_root;
@@ -48,7 +48,7 @@ pub fn run(op: &OpsCommand) -> Result<()> {
             },
             &progress,
         ),
-        OpsCommand::Pr { title, body } => open_pr(title, body, &progress),
+        OpsCommand::Pr { title, body } => open_pr(title.clone(), body.clone(), &progress),
         OpsCommand::Sync => sync_current(),
         OpsCommand::Next {
             create_pr,
@@ -147,16 +147,9 @@ fn land_current(options: &LandOptions, progress: &impl Progress) -> Result<()> {
     Ok(())
 }
 
-fn open_pr(title: &str, body: &str, progress: &impl Progress) -> Result<()> {
+fn open_pr(title: Option<String>, body: Option<String>, progress: &impl Progress) -> Result<()> {
     let repo_root = find_repo_root()?;
-    let result = create_or_update_pr(
-        &repo_root,
-        &PrOptions {
-            title: title.to_string(),
-            body: body.to_string(),
-        },
-        progress,
-    )?;
+    let result = create_or_update_pr(&repo_root, &PrOptions { title, body }, progress)?;
     println!("{}", result.url);
     Ok(())
 }
@@ -368,7 +361,8 @@ fn wt_create(name: &str, base: Option<&str>, stack: bool) -> Result<()> {
         .ok()
         .flatten();
     let branch_config = config.as_ref().and_then(|c| c.branch_names.as_ref());
-    let result = create_with_schema(&main_repo, name, base_branch.as_deref(), branch_config)?;
+    let result =
+        create_with_schema_synced(&main_repo, name, base_branch.as_deref(), branch_config)?;
 
     println!("Created worktree: {}", result.path.display());
     if result.branch != name {
@@ -861,7 +855,8 @@ fn write_shell_directive(command: &str) -> Result<bool> {
 
 const SHELL_INIT_ZSH: &str = r#"# loopflow shell integration for zsh
 #
-# Enables directory switching after `lf ops wt create`.
+# Enables directory switching after commands that emit shell directives
+# (for example `lf ops wt create`, `lf ops wt switch`, `lf ops land`).
 
 if command -v lf >/dev/null 2>&1; then
     lf() {
@@ -885,7 +880,8 @@ fi
 
 const SHELL_INIT_BASH: &str = r#"# loopflow shell integration for bash
 #
-# Enables directory switching after `lf ops wt create`.
+# Enables directory switching after commands that emit shell directives
+# (for example `lf ops wt create`, `lf ops wt switch`, `lf ops land`).
 
 if command -v lf >/dev/null 2>&1; then
     lf() {

--- a/rust/loopflow/src/lf/commands/ops/mod.rs
+++ b/rust/loopflow/src/lf/commands/ops/mod.rs
@@ -133,14 +133,15 @@ fn land_current(options: &LandOptions, progress: &impl Progress) -> Result<()> {
     let main_repo = main_repo_root(&repo_root).unwrap_or_else(|_| repo_root.clone());
     let result = land(&repo_root, options, progress)?;
 
-    match result.rotation {
-        Some(RotationResult::Advanced { new_path, .. }) => {
-            let _ = write_shell_directive(&format!("cd {}", new_path.display()));
+    let cd_target = match &result.rotation {
+        Some(RotationResult::Advanced { new_path, .. }) => Some(new_path.clone()),
+        Some(RotationResult::Complete { .. }) => Some(main_repo),
+        None => None,
+    };
+    if let Some(target) = cd_target {
+        if !write_shell_directive(&format!("cd {}", target.display()))? {
+            println!("cd {}", target.display());
         }
-        Some(RotationResult::Complete { .. }) => {
-            let _ = write_shell_directive(&format!("cd {}", main_repo.display()));
-        }
-        None => {}
     }
 
     Ok(())

--- a/rust/loopflow/src/lf/mod.rs
+++ b/rust/loopflow/src/lf/mod.rs
@@ -193,9 +193,9 @@ pub enum OpsCommand {
     /// Create or update a PR
     Pr {
         #[arg(long = "title")]
-        title: String,
+        title: Option<String>,
         #[arg(long = "body")]
-        body: String,
+        body: Option<String>,
     },
     /// Update local main to match origin
     Sync,

--- a/rust/loopflow/src/lfd/executor/helpers.rs
+++ b/rust/loopflow/src/lfd/executor/helpers.rs
@@ -21,7 +21,7 @@ use crate::engine::naming::{format_branch_name, generate_word_pair};
 use crate::engine::prompt::write_prompt_log;
 use crate::engine::prompt::Surface;
 use crate::engine::worktrees::{
-    branch_exists, create_with_schema, worktree_path as wave_worktree_path,
+    branch_exists, create_with_schema_synced, worktree_path as wave_worktree_path,
 };
 
 use crate::engine::launch::{prepare_launch_prompt, LaunchPromptInput};
@@ -201,7 +201,7 @@ pub fn ensure_wave_worktree(main_repo: &Path, wave_name: &str) -> anyhow::Result
 
     let config = load_config(Some(main_repo)).ok().flatten();
     let branch_config = config.as_ref().and_then(|c| c.branch_names.as_ref());
-    let result = create_with_schema(main_repo, wave_name, None, branch_config)?;
+    let result = create_with_schema_synced(main_repo, wave_name, None, branch_config)?;
     Ok((result.path.to_string_lossy().to_string(), result.branch))
 }
 
@@ -251,7 +251,7 @@ pub fn create_run_worktree(
     } else {
         let config = load_config(Some(main_repo)).ok().flatten();
         let branch_config = config.as_ref().and_then(|c| c.branch_names.as_ref());
-        let result = create_with_schema(main_repo, wave_name, None, branch_config)?;
+        let result = create_with_schema_synced(main_repo, wave_name, None, branch_config)?;
         result.branch
     };
 

--- a/rust/loopflow/src/ops/land.rs
+++ b/rust/loopflow/src/ops/land.rs
@@ -429,8 +429,7 @@ fn rotate_worktree(
 
     // Use the branch's timestamp for the preserved directory name so it
     // matches the work it contains, not when it was archived.
-    let branch_suffix = parse_branch_name(feature_branch, None)
-        .and_then(|parts| parts.timestamp);
+    let branch_suffix = parse_branch_name(feature_branch, None).and_then(|parts| parts.timestamp);
     let preserved = preserve_worktree(main_repo, repo_root, branch_suffix.as_deref())?;
     progress.status(&format!(
         "Preserved {} → {}",

--- a/rust/loopflow/src/ops/land.rs
+++ b/rust/loopflow/src/ops/land.rs
@@ -4,9 +4,10 @@ use std::process::Command;
 use crate::engine::git::{
     current_branch, get_default_branch, is_clean, land as git_land, LandStrategy,
 };
+use crate::engine::naming::parse_branch_name;
 use crate::engine::worktrees::{
-    create_with_schema, main_repo_root, preserve_worktree, wave_name_from_worktree_and_main,
-    worktree_path,
+    create_with_schema, main_repo_root, preserve_worktree, push_branch_with_upstream,
+    wave_name_from_worktree_and_main, worktree_path,
 };
 
 use crate::engine::command::run_command;
@@ -421,12 +422,16 @@ fn rotate_worktree(
     };
 
     // Only rotate shortname worktrees (no timestamp suffix).
-    // preserve_worktree() always produces {name}.{unix_ts}, so a dot means preserved.
+    // preserve_worktree() produces {name}.{suffix}, so a dot means preserved.
     if wave_name.contains('.') {
         return Ok(None);
     }
 
-    let preserved = preserve_worktree(main_repo, repo_root)?;
+    // Use the branch's timestamp for the preserved directory name so it
+    // matches the work it contains, not when it was archived.
+    let branch_suffix = parse_branch_name(feature_branch, None)
+        .and_then(|parts| parts.timestamp);
+    let preserved = preserve_worktree(main_repo, repo_root, branch_suffix.as_deref())?;
     progress.status(&format!(
         "Preserved {} → {}",
         repo_root.display(),
@@ -438,6 +443,12 @@ fn rotate_worktree(
 
     if has_items {
         let result = create_with_schema(main_repo, &wave_name, Some(feature_branch), None)?;
+
+        // Push synchronously so the branch exists on origin before we return.
+        // schedule_upstream_sync uses a background thread that would be killed
+        // when the CLI process exits.
+        let _ = push_branch_with_upstream(&result.path, &result.branch);
+
         progress.status(&format!(
             "Created new worktree at {}",
             result.path.display()
@@ -559,6 +570,56 @@ mod tests {
         assert_ne!(
             new_head, main_commit,
             "new worktree should NOT be based on main"
+        );
+    }
+
+    #[test]
+    fn rotate_worktree_preserves_with_branch_timestamp() {
+        let dir = TempDir::new().unwrap();
+        let main_repo = dir.path().join("repo");
+        std::fs::create_dir(&main_repo).unwrap();
+
+        git(&main_repo, &["init", "-b", "main"]);
+        git(&main_repo, &["config", "user.email", "test@test.com"]);
+        git(&main_repo, &["config", "user.name", "test"]);
+        std::fs::write(main_repo.join("file.txt"), "initial").unwrap();
+        git(&main_repo, &["add", "."]);
+        git(&main_repo, &["commit", "-m", "initial"]);
+
+        let feature_branch = "test.mywave.20260228_1500";
+        git(&main_repo, &["checkout", "-b", feature_branch]);
+        std::fs::write(main_repo.join("feature.txt"), "work").unwrap();
+        git(&main_repo, &["add", "."]);
+        git(&main_repo, &["commit", "-m", "feature"]);
+        git(&main_repo, &["checkout", "main"]);
+
+        let wt_path = dir.path().join("repo.mywave");
+        git(
+            &main_repo,
+            &[
+                "worktree",
+                "add",
+                "-b",
+                "wt-temp",
+                wt_path.to_str().unwrap(),
+                "main",
+            ],
+        );
+
+        // No wave items — rotation will produce Complete, which still preserves.
+        let result = rotate_worktree(&wt_path, &main_repo, feature_branch, &NullProgress)
+            .unwrap()
+            .expect("should produce a rotation");
+
+        let preserved = match result {
+            RotationResult::Complete { preserved } => preserved,
+            other => panic!("expected Complete (no wave items), got {:?}", other),
+        };
+
+        let dir_name = preserved.file_name().unwrap().to_string_lossy().to_string();
+        assert!(
+            dir_name.ends_with(".20260228_1500"),
+            "preserved dir should use the branch timestamp, got: {dir_name}"
         );
     }
 }

--- a/rust/loopflow/src/ops/land.rs
+++ b/rust/loopflow/src/ops/land.rs
@@ -13,6 +13,7 @@ use crate::engine::worktrees::{
 use crate::engine::command::run_command;
 use crate::ops::commit::{commit_workflow, CommitOptions};
 use crate::ops::error::{OpsError, OpsResult};
+use crate::ops::pr::generate_pr_copy;
 
 use crate::ops::progress::Progress;
 
@@ -48,9 +49,9 @@ pub fn land(repo: &Path, options: &LandOptions, progress: &impl Progress) -> Ops
     let (repo_root, main_repo) = resolve_repos(repo, options.worktree.as_deref())?;
     let feature_branch = current_branch(&repo_root)?
         .ok_or_else(|| OpsError::Message("not on a branch".to_string()))?;
-    let (pr_title, pr_body) = resolve_pr_copy(&repo_root, options, progress)?;
     prepare_land(&repo_root, options, progress)?;
     let main_branch = rebase_land(&repo_root, &main_repo, progress)?;
+    let (pr_title, pr_body) = resolve_pr_copy(&repo_root, options, progress)?;
     clear_scratch(&repo_root, progress)?;
 
     if options.local {
@@ -84,6 +85,10 @@ fn resolve_pr_copy(
     options: &LandOptions,
     progress: &impl Progress,
 ) -> OpsResult<(Option<String>, Option<String>)> {
+    if options.local {
+        return Ok((options.pr_title.clone(), options.pr_body.clone()));
+    }
+
     let mut pr_title = options.pr_title.clone();
     let mut pr_body = options.pr_body.clone();
 
@@ -97,8 +102,14 @@ fn resolve_pr_copy(
         if pr_body.is_none() {
             pr_body = Some(body);
         }
+        return Ok((pr_title, pr_body));
     }
 
+    let generated = generate_pr_copy(repo_root, progress)?;
+    pr_title = Some(generated.title);
+    if pr_body.is_none() {
+        pr_body = Some(generated.body);
+    }
     Ok((pr_title, pr_body))
 }
 
@@ -126,7 +137,7 @@ fn read_cached_pr_copy(
             return Ok(None);
         }
     };
-    if !is_ancestor(repo_root, &copied_for)? {
+    if !is_recent_ancestor(repo_root, &copied_for, 1)? {
         progress.status("Ignoring cached PR copy: branch changed since gate output");
         return Ok(None);
     }
@@ -135,15 +146,22 @@ fn read_cached_pr_copy(
     Ok(Some((title, body)))
 }
 
-/// Check if `commit` is an ancestor of HEAD. This is more tolerant than an
-/// exact SHA match — it accepts the case where the flow runner committed
-/// gate's output (moving HEAD one commit past the pr-copy-ref).
-fn is_ancestor(repo_root: &Path, commit: &str) -> OpsResult<bool> {
-    let status = Command::new("git")
-        .args(["merge-base", "--is-ancestor", commit, "HEAD"])
+/// Check if HEAD is no more than `max_ahead` commits ahead of `commit`.
+/// This tolerates one bookkeeping commit after gate output while still
+/// forcing regeneration if substantive commits were added later.
+fn is_recent_ancestor(repo_root: &Path, commit: &str, max_ahead: u32) -> OpsResult<bool> {
+    let output = Command::new("git")
+        .args(["rev-list", "--count", &format!("{commit}..HEAD")])
         .current_dir(repo_root)
-        .status()?;
-    Ok(status.success())
+        .output()?;
+    if !output.status.success() {
+        return Ok(false);
+    }
+    let ahead = String::from_utf8_lossy(&output.stdout)
+        .trim()
+        .parse::<u32>()
+        .unwrap_or(u32::MAX);
+    Ok(ahead <= max_ahead)
 }
 
 fn prepare_land(
@@ -223,8 +241,8 @@ fn ensure_pr(
             let _ = crate::ops::pr::create_or_update_pr(
                 repo_root,
                 &crate::ops::pr::PrOptions {
-                    title: title.to_string(),
-                    body: body.to_string(),
+                    title: Some(title.to_string()),
+                    body: Some(body.to_string()),
                 },
                 progress,
             )?;

--- a/rust/loopflow/src/ops/next.rs
+++ b/rust/loopflow/src/ops/next.rs
@@ -82,8 +82,8 @@ pub fn next_branch(
         let _ = crate::ops::pr::create_or_update_pr(
             repo,
             &crate::ops::pr::PrOptions {
-                title: draft_title,
-                body: "*Draft — title and body will be updated.*".to_string(),
+                title: Some(draft_title),
+                body: Some("*Draft — title and body will be updated.*".to_string()),
             },
             progress,
         )?;

--- a/rust/loopflow/src/ops/pr.rs
+++ b/rust/loopflow/src/ops/pr.rs
@@ -3,6 +3,9 @@ use std::process::Command;
 
 use serde::Deserialize;
 
+use crate::engine::agent::{launch_agent, AgentCapabilities, AgentConfig, ProcessConfig};
+use crate::engine::builtins::get_builtin_ops_prompt;
+use crate::engine::config::load_config_or_default;
 use crate::engine::git::{current_branch, get_default_branch, sync_main};
 use crate::engine::worktrees::{list_worktrees, main_repo_root};
 
@@ -13,8 +16,8 @@ use crate::ops::util::{command_exists, stderr_from_output};
 
 #[derive(Debug, Clone)]
 pub struct PrOptions {
-    pub title: String,
-    pub body: String,
+    pub title: Option<String>,
+    pub body: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -30,6 +33,12 @@ pub struct PrInfo {
     pub number: u64,
     pub state: String,
     pub branch: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct PrCopy {
+    pub title: String,
+    pub body: String,
 }
 
 #[derive(Debug, Deserialize)]
@@ -76,14 +85,9 @@ pub fn create_or_update_pr(
         )?;
     }
 
-    let title = options.title.trim();
-    let body = options.body.trim();
-
-    if title.is_empty() {
-        return Err(OpsError::Message(
-            "title required — use `lf pr` to generate it.".to_string(),
-        ));
-    }
+    let copy = resolve_pr_copy(repo, options, progress)?;
+    let title = copy.title.trim();
+    let body = copy.body.trim();
 
     if let Some(pr) = find_open_pr(repo)? {
         progress.status("Updating PR...");
@@ -113,6 +117,89 @@ pub fn create_or_update_pr(
             updated: false,
         })
     }
+}
+
+fn resolve_pr_copy(
+    repo: &Path,
+    options: &PrOptions,
+    progress: &impl Progress,
+) -> OpsResult<PrCopy> {
+    if let Some(title) = options
+        .title
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        return Ok(PrCopy {
+            title: title.to_string(),
+            body: options.body.clone().unwrap_or_default(),
+        });
+    }
+
+    let mut generated = generate_pr_copy(repo, progress)?;
+    if let Some(body_override) = options.body.as_deref() {
+        generated.body = body_override.to_string();
+    }
+    Ok(generated)
+}
+
+pub fn generate_pr_copy(repo: &Path, progress: &impl Progress) -> OpsResult<PrCopy> {
+    let template = get_builtin_ops_prompt("pr_message")
+        .ok_or_else(|| OpsError::Message("builtin pr_message prompt not found".to_string()))?;
+    let main_repo = resolve_main_repo(repo);
+    let base_branch = get_default_branch(&main_repo)?;
+    let log = git_stdout(
+        repo,
+        &["log", &format!("origin/{base_branch}..HEAD"), "--oneline"],
+    )?;
+    let stat = git_stdout(
+        repo,
+        &["diff", &format!("origin/{base_branch}...HEAD"), "--stat"],
+    )?;
+    let diff = git_stdout(repo, &["diff", &format!("origin/{base_branch}...HEAD")])?;
+    let diff = truncate_chars(&diff, 20_000);
+
+    let prompt = format!(
+        "{template}\n\n## Base branch\n{base_branch}\n\n## Commits\n```\n{log}\n```\n\n## Diff stat\n```\n{stat}\n```\n\n## Unified diff\n```diff\n{diff}\n```\n\nReturn exactly one JSON object with this schema:\n{{\"title\":\"...\",\"body\":\"...\"}}\nNo markdown fences. No explanation."
+    );
+
+    let config = load_config_or_default(Some(repo));
+    let agent = config
+        .agent
+        .clone()
+        .unwrap_or_else(|| "claude:opus".to_string());
+    progress.status("Generating PR title/body...");
+
+    let launch = AgentConfig {
+        task_prompt: prompt,
+        agent: Some(agent),
+        cwd: Some(repo.to_path_buf()),
+        skip_permissions: config.yolo,
+        ..Default::default()
+    };
+    let process = ProcessConfig {
+        auto: true,
+        stream: false,
+        ..Default::default()
+    };
+    let capabilities = AgentCapabilities {
+        chrome: config.chrome,
+    };
+
+    let result = launch_agent(&launch, &process, &capabilities)
+        .map_err(|err| OpsError::Message(format!("failed to generate PR copy: {err}")))?;
+    if result.exit_code != 0 {
+        return Err(OpsError::Message(format!(
+            "PR copy generation failed (exit {}): {}",
+            result.exit_code,
+            result.stderr.trim()
+        )));
+    }
+
+    let combined = format!("{}\n{}", result.stdout, result.stderr);
+    parse_generated_pr_copy(&combined).ok_or_else(|| {
+        OpsError::Message("failed to parse generated PR copy from agent output".to_string())
+    })
 }
 
 pub fn gh_available() -> bool {
@@ -298,4 +385,68 @@ fn resolve_pr_target(repo: &Path, base_branch: &str) -> OpsResult<String> {
 
 fn open_url(url: &str) {
     crate::engine::platform::open_url(url);
+}
+
+#[derive(Debug, Deserialize)]
+struct GeneratedPrCopy {
+    title: String,
+    body: String,
+}
+
+fn parse_generated_pr_copy(raw: &str) -> Option<PrCopy> {
+    parse_json_copy(raw)
+        .or_else(|| extract_fenced_json(raw).and_then(parse_json_copy))
+        .or_else(|| extract_json_object(raw).and_then(parse_json_copy))
+}
+
+fn parse_json_copy(raw: &str) -> Option<PrCopy> {
+    let parsed: GeneratedPrCopy = serde_json::from_str(raw.trim()).ok()?;
+    let title = parsed.title.trim().to_string();
+    if title.is_empty() {
+        return None;
+    }
+    Some(PrCopy {
+        title,
+        body: parsed.body,
+    })
+}
+
+fn extract_fenced_json(raw: &str) -> Option<&str> {
+    let start = raw.find("```json")?;
+    let rest = &raw[start + "```json".len()..];
+    let end = rest.find("```")?;
+    Some(rest[..end].trim())
+}
+
+fn extract_json_object(raw: &str) -> Option<&str> {
+    let start = raw.find('{')?;
+    let end = raw.rfind('}')?;
+    if end <= start {
+        return None;
+    }
+    Some(&raw[start..=end])
+}
+
+fn git_stdout(repo: &Path, args: &[&str]) -> OpsResult<String> {
+    let output = Command::new("git").args(args).current_dir(repo).output()?;
+    if !output.status.success() {
+        return Err(OpsError::CommandFailed {
+            command: format!("git {}", args.join(" ")),
+            stderr: stderr_from_output(&output),
+        });
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).to_string())
+}
+
+fn truncate_chars(text: &str, max_chars: usize) -> String {
+    let mut iter = text.char_indices();
+    if iter.nth(max_chars).is_none() {
+        return text.to_string();
+    }
+    let end = text
+        .char_indices()
+        .nth(max_chars)
+        .map(|(idx, _)| idx)
+        .unwrap_or(text.len());
+    format!("{}\n\n[diff truncated]", &text[..end])
 }

--- a/rust/loopflow/src/ops/release.rs
+++ b/rust/loopflow/src/ops/release.rs
@@ -11,7 +11,7 @@ use serde::{Deserialize, Serialize};
 use crate::engine::command::run_command;
 use crate::engine::config::{load_config_or_default, Config, ReleaseTargetConfig};
 use crate::engine::git::{delete_local_branch, get_default_branch, worktree_remove};
-use crate::engine::worktrees::{create_with_schema, main_repo_root};
+use crate::engine::worktrees::{create_with_schema_synced, main_repo_root};
 use crate::ops::commit::{commit_workflow, CommitOptions};
 use crate::ops::error::{OpsError, OpsResult};
 use crate::ops::land::{land, LandOptions};
@@ -321,7 +321,7 @@ pub fn release_run(
     };
 
     progress.status(&format!("Creating release worktree {wt_name}..."));
-    let wt = create_with_schema(&main_repo, &wt_name, Some(&main_branch), None)?;
+    let wt = create_with_schema_synced(&main_repo, &wt_name, Some(&main_branch), None)?;
     let wt_path = wt.path;
     let wt_branch = wt.branch;
 

--- a/rust/loopflow/tests/land_tests.rs
+++ b/rust/loopflow/tests/land_tests.rs
@@ -3,6 +3,7 @@ mod support;
 use std::fs;
 use std::process::{Command, Stdio};
 
+use loopflow::engine::worktrees::create_with_schema;
 use loopflow::ops::{land, LandOptions, NullProgress, OpsError};
 use loopflow_test_support::TestRepo;
 use support::EnvGuard;
@@ -50,6 +51,10 @@ exit 0
 "#
 }
 
+fn noop_open_script() -> &'static str {
+    "#!/bin/sh\nexit 0\n"
+}
+
 fn gh_land_script(log_path: &str) -> String {
     format!(
         r#"#!/bin/sh
@@ -76,6 +81,10 @@ fi
 exit 0
 "#
     )
+}
+
+fn claude_script() -> &'static str {
+    "#!/bin/sh\necho '{\"title\":\"generated title\",\"body\":\"generated body\"}'\nexit 0\n"
 }
 
 #[test]
@@ -187,7 +196,11 @@ fn land_cleans_up_remote_branch() {
 
 #[test]
 fn land_missing_pr_error_includes_branch_name() {
-    let _env = EnvGuard::new(&[("gh", gh_no_pr_script())]);
+    let _env = EnvGuard::new(&[
+        ("gh", gh_no_pr_script()),
+        ("claude", claude_script()),
+        ("open", noop_open_script()),
+    ]);
     let repo = TestRepo::new();
     repo.create_branch("feature");
     repo.create_file("feature.txt", "feature");
@@ -232,7 +245,7 @@ fn land_uses_cached_pr_copy_when_available() {
 
     let log_path = repo.path().join("gh.log");
     let script = gh_land_script(log_path.to_string_lossy().as_ref());
-    let _env = EnvGuard::new(&[("gh", script.as_str())]);
+    let _env = EnvGuard::new(&[("gh", script.as_str()), ("open", noop_open_script())]);
 
     let result = land(
         repo.path(),
@@ -256,8 +269,12 @@ fn land_uses_cached_pr_copy_when_available() {
 }
 
 #[test]
-fn land_requires_title_when_cached_pr_copy_is_stale() {
-    let _env = EnvGuard::new(&[("gh", gh_no_pr_script())]);
+fn land_generates_copy_when_cached_pr_copy_is_stale() {
+    let _env = EnvGuard::new(&[
+        ("gh", gh_no_pr_script()),
+        ("claude", claude_script()),
+        ("open", noop_open_script()),
+    ]);
     let repo = TestRepo::new();
     repo.create_branch("feature");
     repo.create_file("feature.txt", "feature");
@@ -287,11 +304,60 @@ fn land_requires_title_when_cached_pr_copy_is_stale() {
             pr_body: None,
         },
         &NullProgress,
-    );
+    )
+    .expect("land with stale cached copy should regenerate");
 
-    let Err(OpsError::Message(message)) = result else {
-        panic!("expected stale copy error");
-    };
-    assert!(message.contains("no PR title provided"));
-    assert!(message.contains("lf gate"));
+    assert!(result.merged);
+}
+
+#[test]
+fn lf_ops_land_writes_cd_directive_for_complete_rotation() {
+    let repo = TestRepo::new();
+    let log_path = repo.path().join("gh.log");
+    let script = gh_land_script(log_path.to_string_lossy().as_ref());
+    let _env = EnvGuard::new(&[("gh", script.as_str()), ("open", noop_open_script())]);
+
+    let worktree = create_with_schema(repo.path(), "land", None, None).expect("create worktree");
+
+    fs::write(worktree.path.join("feature.txt"), "feature").expect("write feature file");
+    let status = Command::new("git")
+        .args(["add", "."])
+        .current_dir(&worktree.path)
+        .status()
+        .expect("git add");
+    assert!(status.success(), "git add should succeed");
+    let status = Command::new("git")
+        .args(["commit", "-m", "feature work"])
+        .current_dir(&worktree.path)
+        .status()
+        .expect("git commit");
+    assert!(status.success(), "git commit should succeed");
+    push_branch(&repo, &worktree.branch);
+
+    let directive_path = repo.path().join("directive.txt");
+    let status = Command::new(env!("CARGO_BIN_EXE_lf"))
+        .args([
+            "ops",
+            "land",
+            "--strict",
+            "--create-pr",
+            "--title",
+            "test title",
+            "--body",
+            "test body",
+        ])
+        .current_dir(&worktree.path)
+        .env("LOOPFLOW_DIRECTIVE_FILE", &directive_path)
+        .status()
+        .expect("run lf ops land");
+    assert!(status.success(), "lf ops land should succeed");
+
+    let directive = fs::read_to_string(&directive_path).expect("read directive file");
+    let target = directive
+        .trim()
+        .strip_prefix("cd ")
+        .expect("directive should start with cd");
+    let actual = fs::canonicalize(target).expect("canonicalize directive path");
+    let expected = fs::canonicalize(repo.path()).expect("canonicalize main repo");
+    assert_eq!(actual, expected);
 }

--- a/rust/loopflow/tests/pr_tests.rs
+++ b/rust/loopflow/tests/pr_tests.rs
@@ -17,6 +17,10 @@ fn noop_script() -> &'static str {
     "#!/bin/sh\nexit 0\n"
 }
 
+fn claude_script() -> &'static str {
+    "#!/bin/sh\necho '{\"title\":\"generated title\",\"body\":\"generated body\"}'\nexit 0\n"
+}
+
 fn write_gh_script_reject_base(expected_reject: &str) -> String {
     format!(
         "#!/bin/sh\ncase \"$1 $2\" in\n  'pr list')\n    echo '[]'; exit 0;;\n  'pr diff') exit 1;;\n  'pr create')\n    base=\"\"\n    while [ \"$#\" -gt 0 ]; do\n      if [ \"$1\" = \"--base\" ]; then\n        shift\n        base=\"$1\"\n      fi\n      shift\n    done\n    if [ \"$base\" = \"{expected_reject}\" ]; then\n      echo \"base branch matches head\" >&2\n      exit 1\n    fi\n    echo 'https://example.com/pr/1'\n    exit 0;;\n  'pr edit') exit 0;;\n  'pr ready') exit 0;;\n  'pr view') echo 'OPEN'; exit 0;;\nesac\nexit 0\n"
@@ -33,7 +37,11 @@ fn push_branch(repo: &TestRepo, name: &str) {
 #[test]
 fn pr_create_calls_gh() {
     let gh_script = write_gh_script("[]", None);
-    let _env = EnvGuard::new(&[("gh", gh_script.as_str()), ("open", noop_script())]);
+    let _env = EnvGuard::new(&[
+        ("gh", gh_script.as_str()),
+        ("open", noop_script()),
+        ("claude", claude_script()),
+    ]);
     let repo = TestRepo::new();
     repo.create_branch("feature");
     push_branch(&repo, "feature");
@@ -41,8 +49,8 @@ fn pr_create_calls_gh() {
     let result = create_or_update_pr(
         repo.path(),
         &PrOptions {
-            title: "test title".to_string(),
-            body: "test body".to_string(),
+            title: Some("test title".to_string()),
+            body: Some("test body".to_string()),
         },
         &NullProgress,
     )
@@ -58,7 +66,11 @@ fn pr_update_refreshes_body() {
         r#"[{"url":"https://example.com/pr/1","state":"OPEN","isDraft":false,"number":1}]"#,
         Some("diff"),
     );
-    let _env = EnvGuard::new(&[("gh", gh_script.as_str()), ("open", noop_script())]);
+    let _env = EnvGuard::new(&[
+        ("gh", gh_script.as_str()),
+        ("open", noop_script()),
+        ("claude", claude_script()),
+    ]);
     let repo = TestRepo::new();
     repo.create_branch("feature");
     push_branch(&repo, "feature");
@@ -66,8 +78,8 @@ fn pr_update_refreshes_body() {
     let result = create_or_update_pr(
         repo.path(),
         &PrOptions {
-            title: "updated title".to_string(),
-            body: "updated body".to_string(),
+            title: Some("updated title".to_string()),
+            body: Some("updated body".to_string()),
         },
         &NullProgress,
     )
@@ -80,7 +92,11 @@ fn pr_update_refreshes_body() {
 #[test]
 fn pr_create_uses_default_base_when_upstream_matches_head() {
     let gh_script = write_gh_script_reject_base("feature");
-    let _env = EnvGuard::new(&[("gh", gh_script.as_str()), ("open", noop_script())]);
+    let _env = EnvGuard::new(&[
+        ("gh", gh_script.as_str()),
+        ("open", noop_script()),
+        ("claude", claude_script()),
+    ]);
     let repo = TestRepo::new();
     repo.create_branch("feature");
     push_branch(&repo, "feature");
@@ -88,8 +104,8 @@ fn pr_create_uses_default_base_when_upstream_matches_head() {
     let result = create_or_update_pr(
         repo.path(),
         &PrOptions {
-            title: "test title".to_string(),
-            body: "test body".to_string(),
+            title: Some("test title".to_string()),
+            body: Some("test body".to_string()),
         },
         &NullProgress,
     )
@@ -115,9 +131,13 @@ fn current_pr_surfaces_gh_list_errors() {
 }
 
 #[test]
-fn pr_requires_title() {
+fn pr_auto_generates_title_when_missing() {
     let gh_script = write_gh_script("[]", None);
-    let _env = EnvGuard::new(&[("gh", gh_script.as_str()), ("open", noop_script())]);
+    let _env = EnvGuard::new(&[
+        ("gh", gh_script.as_str()),
+        ("open", noop_script()),
+        ("claude", claude_script()),
+    ]);
     let repo = TestRepo::new();
     repo.create_branch("feature");
     push_branch(&repo, "feature");
@@ -125,14 +145,14 @@ fn pr_requires_title() {
     let result = create_or_update_pr(
         repo.path(),
         &PrOptions {
-            title: "".to_string(),
-            body: "some body".to_string(),
+            title: None,
+            body: Some("some body".to_string()),
         },
         &NullProgress,
     );
 
-    assert!(matches!(
-        result,
-        Err(OpsError::Message(message)) if message.contains("title required")
-    ));
+    let Ok(result) = result else {
+        panic!("expected auto-generated title to succeed");
+    };
+    assert!(result.created);
 }

--- a/rust/loopflow/tests/worktree_tests.rs
+++ b/rust/loopflow/tests/worktree_tests.rs
@@ -2,7 +2,8 @@ use std::process::Command;
 
 use loopflow::engine::git::{is_clean, worktree_move, worktree_remove};
 use loopflow::engine::worktrees::{
-    create_with_schema, list_worktrees, preserve_worktree, wave_name_from_worktree_and_main,
+    create_with_schema, list_worktrees, list_worktrees_local, preserve_worktree,
+    wave_name_from_worktree_and_main,
 };
 use loopflow_test_support::TestRepo;
 
@@ -188,7 +189,7 @@ fn preserve_worktree_uses_human_readable_timestamp() {
     let repo = TestRepo::new();
     let result = create_with_schema(repo.path(), "feature", None, None).expect("create");
 
-    let preserved = preserve_worktree(repo.path(), &result.path).expect("preserve");
+    let preserved = preserve_worktree(repo.path(), &result.path, None).expect("preserve");
     let dir_name = preserved.file_name().unwrap().to_string_lossy().to_string();
 
     // Should end with .YYYYMMDD_HHMM, not a unix epoch
@@ -208,5 +209,48 @@ fn preserve_worktree_uses_human_readable_timestamp() {
     assert!(
         time.chars().all(|c| c.is_ascii_digit()),
         "time should be all digits: {time}"
+    );
+}
+
+#[test]
+fn preserve_worktree_uses_explicit_suffix_when_provided() {
+    let repo = TestRepo::new();
+    let result = create_with_schema(repo.path(), "feature", None, None).expect("create");
+
+    let preserved =
+        preserve_worktree(repo.path(), &result.path, Some("20260304_1442")).expect("preserve");
+    let dir_name = preserved
+        .file_name()
+        .unwrap()
+        .to_string_lossy()
+        .to_string();
+
+    assert!(
+        dir_name.ends_with(".20260304_1442"),
+        "should use the provided suffix, got: {dir_name}"
+    );
+}
+
+#[test]
+fn branch_at_main_not_detected_as_squash_merged() {
+    let repo = TestRepo::new();
+    // Create a worktree whose branch points to the same commit as main.
+    let result = create_with_schema(repo.path(), "fresh", None, None).expect("create");
+    // Make the worktree dirty (simulates lf ingest writing to scratch/).
+    std::fs::write(result.path.join("scratch.txt"), "notes").expect("write");
+
+    let (_, states) = list_worktrees_local(repo.path()).expect("list");
+    let wt = states
+        .iter()
+        .find(|wt| wt.branch.as_deref() == Some(&result.branch))
+        .expect("should find worktree");
+
+    assert!(
+        !wt.squash_merged,
+        "branch at same commit as main should not be squash-merged"
+    );
+    assert!(
+        !wt.prunable,
+        "dirty worktree that hasn't diverged should not be prunable"
     );
 }

--- a/rust/loopflow/tests/worktree_tests.rs
+++ b/rust/loopflow/tests/worktree_tests.rs
@@ -2,10 +2,25 @@ use std::process::Command;
 
 use loopflow::engine::git::{is_clean, worktree_move, worktree_remove};
 use loopflow::engine::worktrees::{
-    create_with_schema, list_worktrees, list_worktrees_local, preserve_worktree,
-    wave_name_from_worktree_and_main,
+    create_with_schema, create_with_schema_synced, list_worktrees, list_worktrees_local,
+    preserve_worktree, wave_name_from_worktree_and_main,
 };
 use loopflow_test_support::TestRepo;
+
+fn git_stdout(repo: &std::path::Path, args: &[&str]) -> String {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(repo)
+        .output()
+        .expect("git command should run");
+    assert!(
+        output.status.success(),
+        "git {:?} failed: {}",
+        args,
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8_lossy(&output.stdout).trim().to_string()
+}
 
 #[test]
 fn worktree_add_creates_directory() {
@@ -72,6 +87,67 @@ fn worktree_move_preserves_content() {
     assert!(!result.path.exists());
     assert!(new_path.exists());
     assert!(new_path.join("note.txt").exists());
+}
+
+#[test]
+fn create_with_schema_synced_updates_main_before_creation() {
+    let repo = TestRepo::new();
+    let original_head = git_stdout(repo.path(), &["rev-parse", "HEAD"]);
+
+    let clone_dir = tempfile::TempDir::new().expect("temp clone dir");
+    let status = Command::new("git")
+        .args([
+            "clone",
+            repo.bare_path().to_str().expect("remote path"),
+            clone_dir.path().to_str().expect("clone path"),
+        ])
+        .status()
+        .expect("clone remote");
+    assert!(status.success(), "clone should succeed");
+    let status = Command::new("git")
+        .args(["config", "user.email", "test@test.com"])
+        .current_dir(clone_dir.path())
+        .status()
+        .expect("set email");
+    assert!(status.success(), "git config user.email should succeed");
+    let status = Command::new("git")
+        .args(["config", "user.name", "test"])
+        .current_dir(clone_dir.path())
+        .status()
+        .expect("set name");
+    assert!(status.success(), "git config user.name should succeed");
+    std::fs::write(clone_dir.path().join("remote.txt"), "remote update").expect("write file");
+    let status = Command::new("git")
+        .args(["add", "."])
+        .current_dir(clone_dir.path())
+        .status()
+        .expect("git add");
+    assert!(status.success(), "git add should succeed");
+    let status = Command::new("git")
+        .args(["commit", "-m", "remote update"])
+        .current_dir(clone_dir.path())
+        .status()
+        .expect("git commit");
+    assert!(status.success(), "git commit should succeed");
+    let status = Command::new("git")
+        .args(["push", "origin", "main"])
+        .current_dir(clone_dir.path())
+        .status()
+        .expect("git push");
+    assert!(status.success(), "git push should succeed");
+
+    let _ = create_with_schema_synced(repo.path(), "sync-check", None, None).expect("create");
+
+    let updated_head = git_stdout(repo.path(), &["rev-parse", "HEAD"]);
+    let origin_head = git_stdout(repo.path(), &["rev-parse", "origin/main"]);
+    assert_ne!(
+        original_head, updated_head,
+        "main head should advance after sync"
+    );
+    assert_eq!(
+        updated_head, origin_head,
+        "main should be reset to origin/main before worktree creation"
+    );
 }
 
 #[test]

--- a/rust/loopflow/tests/worktree_tests.rs
+++ b/rust/loopflow/tests/worktree_tests.rs
@@ -219,11 +219,7 @@ fn preserve_worktree_uses_explicit_suffix_when_provided() {
 
     let preserved =
         preserve_worktree(repo.path(), &result.path, Some("20260304_1442")).expect("preserve");
-    let dir_name = preserved
-        .file_name()
-        .unwrap()
-        .to_string_lossy()
-        .to_string();
+    let dir_name = preserved.file_name().unwrap().to_string_lossy().to_string();
 
     assert!(
         dir_name.ends_with(".20260304_1442"),

--- a/scripts/dev-lf
+++ b/scripts/dev-lf
@@ -11,4 +11,19 @@ REPO="$(git rev-parse --show-toplevel)"
 export RUST_LOG="${RUST_LOG:-lf=debug,loopflow=debug}"
 cargo build -p loopflow --bin lf --manifest-path "$REPO/Cargo.toml" </dev/null 2>&1 | grep -E '^   Compiling|^    Finished|^error' >&2
 echo "running: $REPO/target/debug/lf $*" >&2
-exec "$REPO/target/debug/lf" "$@"
+
+# Mirror the lf() shell function so directives (cd after land, wt create) work.
+# dev-lf runs as a child process so it can't change the parent shell's cwd,
+# but it prints the directive so the user can copy-paste.
+directive_file="$(mktemp)"
+LOOPFLOW_DIRECTIVE_FILE="$directive_file" "$REPO/target/debug/lf" "$@"
+exit_code=$?
+
+if [[ -s "$directive_file" ]]; then
+    while IFS= read -r line; do
+        echo "$line" >&2
+    done < "$directive_file"
+fi
+
+rm -f "$directive_file"
+exit "$exit_code"

--- a/scripts/dev-lf
+++ b/scripts/dev-lf
@@ -16,8 +16,8 @@ echo "running: $REPO/target/debug/lf $*" >&2
 # dev-lf runs as a child process so it can't change the parent shell's cwd,
 # but it prints the directive so the user can copy-paste.
 directive_file="$(mktemp)"
-LOOPFLOW_DIRECTIVE_FILE="$directive_file" "$REPO/target/debug/lf" "$@"
-exit_code=$?
+exit_code=0
+LOOPFLOW_DIRECTIVE_FILE="$directive_file" "$REPO/target/debug/lf" "$@" || exit_code=$?
 
 if [[ -s "$directive_file" ]]; then
     while IFS= read -r line; do


### PR DESCRIPTION
## Usage

```bash
# land now generates PR title/body automatically if not provided
lf ops land

# pr create/update also auto-generates when --title is omitted
lf ops pr
```

## Summary

`lf ops land` and `lf ops pr` now auto-generate PR title and body via the Claude API when not explicitly provided. Previously both commands required `--title` and `--body` flags. The generation uses the diff against the base branch to produce structured PR copy.

Worktree creation now syncs the default branch from origin before branching, and worktree rotation during land uses the branch's own timestamp for the preserved directory name instead of the current time.

## Changes

- `lf ops pr` `--title`/`--body` are now optional; omitting them triggers LLM-based generation from the diff
- `lf ops land` generates PR copy after rebase (so the diff is final) and falls back to LLM generation when no cached gate output exists
- Cached PR copy validation tightened: only accepted if HEAD is at most 1 commit ahead of the cached ref, not just any ancestor
- `create_with_schema_synced` variant syncs origin/main before creating worktrees
- `preserve_worktree` accepts an optional suffix, used to name archived worktrees by their branch timestamp
- Worktree rotation pushes the new branch synchronously instead of via background thread
- Shell directive comment updated to mention `lf ops land` alongside other cd-emitting commands
- Squash-merged detection in `list_worktrees_local` now also requires `has_commits` to avoid false positives