### PR TITLE
release: v0.9.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1540,7 +1540,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "loopflow"
-version = "0.9.7"
+version = "0.9.8"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -1592,7 +1592,7 @@ dependencies = [
 
 [[package]]
 name = "loopflow-test-support"
-version = "0.9.7"
+version = "0.9.8"
 dependencies = [
  "tempfile",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.9.7"
+version = "0.9.8"
 edition = "2021"
 license = "MIT"
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,16 +1,26 @@
-# v0.9.7
+# v0.9.8
 
-Loopflow 0.9.7 strips ~1600 lines of ops scaffolding, signs the macOS installer, and moves agents closer to self-directed execution — they assemble their own context, discover their own checks, and author their own PRs.
+Loopflow 0.9.8 makes flows mechanical where they should be, encrypts secrets at rest, and deletes ~13,000 lines of stale artifacts. Agents and ops split the work cleanly — agents handle judgment, `ops:` items handle plumbing.
 
-## Simplification
+Changes since `v0.9.7`.
 
-- **Agents own their context** — deleted `ops/messages.rs`, `ops/lint.rs`, `ops/agent.rs`, and `ops/combine.rs` (~1400 lines). Agents now assemble context directly through steps instead of the engine pre-building it. Release nests under five focused subcommands: `lf ops release check`, `notes`, `bump`, `tag`, `status`
-- **Agents own their checks** — removed `lf ops lint` and `lf ops test` commands along with the `lint:` and `test:` config fields. Agents discover what to run from `TESTING.md` and CI config, which is where the information already lived
-- **Simpler PR creation** — `lf ops pr` now requires `--title` and `--body` (no more `Option`). Removed the `--refresh` flag and its origin-before/after diff-detection logic. The `lf pr` step handles generation
-- **Prompt handoff renamed** — `.lf/log/` → `.lf/prompts/` for clarity on what it holds (agent-readable prompt files). Diagnostic output moves to `~/.lf/logs/<repo>/<worktree>/` outside the repo, preventing accidental commits
+## Flows own their plumbing
 
-## Infrastructure
+- **`ops:` is a first-class flow item** — flows can now execute `land`, `rebase`, and `release` directly via Rust functions instead of spinning up an agent session. Gate writes PR copy to `scratch/`; land reads it, validates freshness, and clears it after use
+- **`lf ops land` auto-generates PR copy** — title and body are produced via Claude API from the diff when not provided explicitly. No more required `--title`/`--body` flags
+- **One-shot release** — `lf ops release run patch` owns the full lifecycle: check PRs, bump manifests, generate notes, create and land a release PR, tag the merged commit, and wait for the release workflow
 
-- **Signed macOS installer** — `concerto-dev.py release` codesigns the .app with Developer ID, signs the DMG, and submits for Apple notarization. CI imports the signing certificate from Doppler and cleans up the keychain afterward. R2 credentials also moved from GitHub Secrets to Doppler
-- **Sibling worktree enforcement** — `wave_name_from_worktree_and_main` now requires worktrees to share the same parent directory as the main repo. Worktrees created inside the repo (e.g., `.claude/worktrees/`) return `None` instead of incorrectly producing a wave name
-- **Land step rewritten** — single `lf ops land` call replaces the manual git/gh sequence. Headless surface detection added for non-interactive sessions
+## Trust
+
+- **Tokens encrypted at rest** — provider tokens in SQLite/Postgres are now AES-256-GCM encrypted with keys stored in the OS keychain (macOS Keychain, Linux secret-tool, file fallback). Existing plaintext tokens migrate automatically on startup
+- **Secret redaction** — sensitive values are masked in logs and agent output
+
+## Context visibility
+
+- **Session context UI in Concerto** — expandable panel showing which files, area docs, and diff chunks are loaded into an agent's prompt, with per-document token counts and trimmed/included status. `ContextBreakdown` now tracks structured per-document metadata through the HTTP API
+
+## Cleanup
+
+- **~13,000 lines of stale artifacts deleted** — `.agents/skills/`, `proto/`, `reports/`, and `bin/` scripts removed. Unused config fields (`push`, `include_loopflow_doc`) stripped from the `Config` struct
+- **Init separates repo and user config** — `lf init` now distinguishes repo config (agent, harnesses, exclude) from user config (yolo, ide, chrome) and offers to create `~/.lf/config.yaml` when missing
+- **Worktree rotation improved** — creation syncs the default branch from origin before branching; archived worktrees use the branch's own timestamp instead of current time; squash-merge detection tightened to avoid false positives

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "loopflow"
-version = "0.9.7"
+version = "0.9.8"
 description = "Run LLM coding agents from reusable prompt files"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/uv.lock
+++ b/uv.lock
@@ -328,7 +328,7 @@ wheels = [
 
 [[package]]
 name = "loopflow"
-version = "0.9.7"
+version = "0.9.8"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

Bump version to 0.9.8 across all manifests and update release notes.

## Changes

- Version bump from 0.9.7 → 0.9.8 in `Cargo.toml`, `Cargo.lock`, `pyproject.toml`, and `uv.lock`
- Rewritten `RELEASE_NOTES.md` covering: first-class `ops:` flow items, token encryption at rest, session context UI, ~13k lines of stale artifact cleanup, and worktree rotation improvements