### PR TITLE
release: v0.9.8

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,6 @@
 # v0.9.8
 
-Loopflow 0.9.8 makes flows mechanical where they should be, encrypts secrets at rest, and deletes ~13,000 lines of stale artifacts. Agents and ops split the work cleanly — agents handle judgment, `ops:` items handle plumbing.
+Loopflow 0.9.8 makes flows mechanical where they should be, encrypts secrets at rest, and recovers from rebase conflicts without stopping. Agents handle judgment; `ops:` items handle plumbing.
 
 Changes since `v0.9.7`.
 
@@ -8,7 +8,13 @@ Changes since `v0.9.7`.
 
 - **`ops:` is a first-class flow item** — flows can now execute `land`, `rebase`, and `release` directly via Rust functions instead of spinning up an agent session. Gate writes PR copy to `scratch/`; land reads it, validates freshness, and clears it after use
 - **`lf ops land` auto-generates PR copy** — title and body are produced via Claude API from the diff when not provided explicitly. No more required `--title`/`--body` flags
-- **One-shot release** — `lf ops release run patch` owns the full lifecycle: check PRs, bump manifests, generate notes, create and land a release PR, tag the merged commit, and wait for the release workflow
+- **One-shot release** — `lf ops release run patch` owns the full lifecycle: check PRs, bump manifests, generate notes, create and land a release PR, tag the merged commit, and wait for the release workflow. CI release is re-runnable: auto-tag dispatches the release workflow explicitly, and publish steps tolerate already-published versions
+
+## Ops recover from conflicts
+
+- **Rebase conflict auto-recovery** — `lf ops rebase`, `land`, and `pr` now launch a step agent to resolve rebase conflicts instead of failing. The agent gets structured conflict context and fixes things up, then the original command retries
+- **`land` stages uncommitted changes** — no more forgetting to `git add` before landing
+- **Worktree pruning simplified** — merged worktrees prune without confirmation; `--force` replaced by `--include-fresh` for worktrees with no commits beyond main
 
 ## Trust
 
@@ -22,5 +28,8 @@ Changes since `v0.9.7`.
 ## Cleanup
 
 - **~13,000 lines of stale artifacts deleted** — `.agents/skills/`, `proto/`, `reports/`, and `bin/` scripts removed. Unused config fields (`push`, `include_loopflow_doc`) stripped from the `Config` struct
+- **`lf ops lint` and `lf ops test` removed** — agents discover lint/test commands from `TESTING.md` and CI config directly. The `lint:` and `test:` config fields are gone
 - **Init separates repo and user config** — `lf init` now distinguishes repo config (agent, harnesses, exclude) from user config (yolo, ide, chrome) and offers to create `~/.lf/config.yaml` when missing
-- **Worktree rotation improved** — creation syncs the default branch from origin before branching; archived worktrees use the branch's own timestamp instead of current time; squash-merge detection tightened to avoid false positives
+- **DMG codesigning pipeline** — `concerto-dev.py release` codesigns the .app with Developer ID, signs the DMG, and submits for Apple notarization. Resource bundles moved into `Contents/Resources/` to fix unsealed-contents errors
+- **Worktree rotation improved** — creation syncs the default branch from origin before branching; archived worktrees use the branch's own timestamp; squash-merge detection tightened to avoid false positives; sibling directory layout enforced
+- **`git2` crate removed** — replaced by git CLI calls


### PR DESCRIPTION
## Summary

Updates release notes for v0.9.8 with additional changes that landed since the initial draft: rebase conflict auto-recovery, codesigning pipeline, lint/test command removal, and `git2` crate removal.

## Notable additions to release notes

- **Ops recover from conflicts** — new section covering rebase conflict auto-recovery via step agent, auto-staging before land, and simplified worktree pruning
- **CI release is re-runnable** — auto-tag dispatches the release workflow explicitly, publish steps tolerate already-published versions
- **DMG codesigning pipeline** — codesign, sign DMG, and Apple notarization
- **`lf ops lint` and `lf ops test` removed** — agents discover commands from `TESTING.md` and CI config directly
- **`git2` crate removed** — replaced by git CLI calls
- Trimmed stale-artifact line count claim and tightened the intro paragraph