### PR TITLE
review prompts: orient the human before evaluating

### DIFF
--- a/rust/loopflow/src/engine/builtins/steps/interactive/review-design.md
+++ b/rust/loopflow/src/engine/builtins/steps/interactive/review-design.md
@@ -11,7 +11,21 @@ Kickoff produced a bold, opinionated design. This step checks whether the boldne
 
 ## Voice
 
-Every design review should feel different. Vary your structure, tone, and entry point. Start with whatever is most interesting or surprising about this design — not a formulaic summary. Be genuinely curious, not procedural. High variance in style keeps reviews from becoming rubber stamps.
+The human is here to guide the architectural decisions. Open by orienting them in the decision space: what's been decided, what's still open, where their judgment is needed. Not your editorial reaction — their re-entry point into the work.
+
+Don't open by narrowing in on one thing based on interestingness ("The most interesting thing here is...", "What jumps out is...", "The boldest decision..."). Start broad — cover what the design proposes — then let the human decide where to focus.
+
+Vary structure and emphasis based on what this design actually needs. A review that feels the same every time becomes a rubber stamp the human stops reading.
+
+## Opening
+
+Before any evaluation or recommendations, orient the human:
+
+1. **What the design proposes** — the problem, the approach, and the core decisions everything else hinges on.
+2. **Key types and APIs** — the data structures and interfaces the design introduces. Quote them from the doc.
+3. **What's still open** — decisions that need the human's judgment.
+
+This grounds the conversation. Everything else — alternatives, failure modes, scope — comes after.
 
 ## Approach
 
@@ -21,9 +35,8 @@ Pause after each major point. Let the human steer depth and order.
 
 Pick the lenses that matter most here. Combine or skip as needed:
 
-- **Intent and core decisions** — summarize the problem, approach, and the decisions that everything else hinges on.
-- **Scope and seams** — is this the right unit of work? Bias toward keeping architectural chunks whole. Splitting creates backwards-compatibility adapters, dual states, and integration risk that often costs more than a larger change.
 - **Model quality** — are data structures and APIs the clearest expression of product semantics?
+- **Scope and seams** — is this the right unit of work? Bias toward keeping architectural chunks whole. Splitting creates backwards-compatibility adapters, dual states, and integration risk that often costs more than a larger change.
 - **Alternatives and tradeoffs** — surface real options and sketch them.
 - **Failure modes** — identify where this is most likely to break.
 - **Execution path** — decide what to fix now vs defer to the wave roadmap.

--- a/rust/loopflow/src/engine/builtins/steps/interactive/review.md
+++ b/rust/loopflow/src/engine/builtins/steps/interactive/review.md
@@ -7,11 +7,22 @@ action_style: procedural
 ---
 Walk the human through the current diff and help them decide the next right move.
 
-If `scratch/<branch>-review.md` exists (from gate), use it as the briefing. Otherwise, read the diff cold.
-
 ## Voice
 
-Each review should open with whatever is most striking about this diff — not a routine summary. Vary your structure and emphasis. A review that feels the same every time trains the human to skim past it.
+The human is juggling many threads and context-switching back into this work. Open by orienting them: what changed, what's the decision space, where their judgment is needed. Not your editorial reaction — their re-entry point.
+
+Don't open by narrowing in on one thing based on interestingness ("The most striking thing here is...", "What jumps out is...", "The boldest decision..."). Start broad — cover what was implemented — then let the human decide where to focus.
+
+Vary structure and emphasis based on what this diff actually needs. A review that feels the same every time trains the human to skim past it.
+
+## Opening
+
+Before any evaluation or recommendations, orient the human:
+
+1. **What was implemented** — what's new, what moved, what was removed. Concrete, not abstract.
+2. **Key types and APIs** — the data structures, public interfaces, and signatures introduced or changed. Quote them from the diff.
+
+This grounds the conversation. Everything else — model quality, simplifications, tradeoffs — comes after.
 
 ## Approach
 
@@ -21,9 +32,8 @@ Pause often. Present one chunk, get reaction, adapt. Keep momentum without turni
 
 Pick the lenses that matter most for this change. Combine or skip lenses as needed:
 
-- **Shape and intent** — summarize what's new, what moved, and the core intent.
-- **Confidence and demo path** — show how to verify behavior quickly.
 - **Model quality** — assess data structures, API boundaries, and naming clarity.
+- **Confidence and demo path** — show how to verify behavior quickly.
 - **Simplification opportunities** — show concrete alternatives, not abstract advice.
 - **Tradeoffs and contentious calls** — frame key decisions as explicit tradeoffs.
 - **Execution path** — decide what to fix now vs defer to the wave roadmap.
@@ -76,9 +86,8 @@ it's a conscious choice, not an oversight.
 
 ## Guidance
 
-- Focus on structural decisions, not formatting or style. Gate already handled polish.
+- Focus on structural decisions, not formatting or style.
 - If something should change, change it directly or propose a design doc. No review artifacts.
-- The gate doc is the agenda, not a script.
 - Read every changed file, but focus attention on new types, new public APIs, and changed signatures. Mechanical changes (imports, formatting) aren't worth discussing.
 - When proposing simplifications, be concrete. Show the alternative type or signature, not just "this could be simpler."
 - Quote the diff when discussing specific decisions. Make it easy to see what you're referring to.

--- a/tests/goldens/builtin_review.md
+++ b/tests/goldens/builtin_review.md
@@ -361,11 +361,22 @@ The step.
 <lf:step:review>
 Walk the human through the current diff and help them decide the next right move.
 
-If `scratch/<branch>-review.md` exists (from gate), use it as the briefing. Otherwise, read the diff cold.
-
 ## Voice
 
-Each review should open with whatever is most striking about this diff — not a routine summary. Vary your structure and emphasis. A review that feels the same every time trains the human to skim past it.
+The human is juggling many threads and context-switching back into this work. Open by orienting them: what changed, what's the decision space, where their judgment is needed. Not your editorial reaction — their re-entry point.
+
+Don't open by narrowing in on one thing based on interestingness ("The most striking thing here is...", "What jumps out is...", "The boldest decision..."). Start broad — cover what was implemented — then let the human decide where to focus.
+
+Vary structure and emphasis based on what this diff actually needs. A review that feels the same every time trains the human to skim past it.
+
+## Opening
+
+Before any evaluation or recommendations, orient the human:
+
+1. **What was implemented** — what's new, what moved, what was removed. Concrete, not abstract.
+2. **Key types and APIs** — the data structures, public interfaces, and signatures introduced or changed. Quote them from the diff.
+
+This grounds the conversation. Everything else — model quality, simplifications, tradeoffs — comes after.
 
 ## Approach
 
@@ -375,9 +386,8 @@ Pause often. Present one chunk, get reaction, adapt. Keep momentum without turni
 
 Pick the lenses that matter most for this change. Combine or skip lenses as needed:
 
-- **Shape and intent** — summarize what's new, what moved, and the core intent.
-- **Confidence and demo path** — show how to verify behavior quickly.
 - **Model quality** — assess data structures, API boundaries, and naming clarity.
+- **Confidence and demo path** — show how to verify behavior quickly.
 - **Simplification opportunities** — show concrete alternatives, not abstract advice.
 - **Tradeoffs and contentious calls** — frame key decisions as explicit tradeoffs.
 - **Execution path** — decide what to fix now vs defer to the wave roadmap.
@@ -430,9 +440,8 @@ it's a conscious choice, not an oversight.
 
 ## Guidance
 
-- Focus on structural decisions, not formatting or style. Gate already handled polish.
+- Focus on structural decisions, not formatting or style.
 - If something should change, change it directly or propose a design doc. No review artifacts.
-- The gate doc is the agenda, not a script.
 - Read every changed file, but focus attention on new types, new public APIs, and changed signatures. Mechanical changes (imports, formatting) aren't worth discussing.
 - When proposing simplifications, be concrete. Show the alternative type or signature, not just "this could be simpler."
 - Quote the diff when discussing specific decisions. Make it easy to see what you're referring to.


### PR DESCRIPTION
## Summary

Rewrites the opening guidance for both design review and code review prompts. Instead of leading with whatever the reviewer finds "most interesting" or "most striking" (which became a formulaic pattern), reviews now open by orienting the human in the decision space — what changed, what's open, where judgment is needed.

## Changes

- **review-design.md** — adds an explicit Opening section (what the design proposes, key types/APIs, what's still open) before any evaluation. Moves "intent and core decisions" out of the lenses list since it's now covered in the opening.
- **review.md** — adds a parallel Opening section (what was implemented, key types/APIs). Removes references to the gate doc as agenda/briefing. Reorders lenses to lead with model quality.
- Both prompts now explicitly warn against the "narrowing in on one thing based on interestingness" anti-pattern.