### PR TITLE
install: pass --wheel to uv build

### DIFF
--- a/scripts/install.py
+++ b/scripts/install.py
@@ -51,7 +51,7 @@ def _stream_process(
 
 def _build_wheel() -> tuple[bool, str]:
     typer.echo("Building wheel...")
-    result = _stream_process(["uv", "build"], "wheel", cwd=ROOT)
+    result = _stream_process(["uv", "build", "--wheel"], "wheel", cwd=ROOT)
     if result.returncode != 0:
         return False, "uv build failed (see output above)"
     return True, "Wheel built."


### PR DESCRIPTION
## Summary

The install script was running `uv build` without flags, which builds both sdist and wheel. This adds `--wheel` to skip the sdist and only build what's needed.

## Changes

- Pass `--wheel` flag to `uv build` in `scripts/install.py` to avoid unnecessary sdist build