### PR TITLE
release: v0.9.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1485,7 +1485,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "loopflow"
-version = "0.9.8"
+version = "0.9.9"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -1536,7 +1536,7 @@ dependencies = [
 
 [[package]]
 name = "loopflow-test-support"
-version = "0.9.8"
+version = "0.9.9"
 dependencies = [
  "tempfile",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.9.8"
+version = "0.9.9"
 edition = "2021"
 license = "MIT"
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,36 +1,14 @@
-# v0.9.8
+# v0.9.9
 
-Loopflow 0.9.8 makes flows mechanical where they should be, encrypts secrets at rest, and recovers from rebase conflicts without stopping. Agents handle judgment; `ops:` items handle plumbing.
+Loopflow 0.9.9 lets agents write their own commit messages and catches release collisions before they waste a CI cycle.
 
-Changes since `v0.9.7`.
+Changes since `v0.9.8`.
 
-## Flows own their plumbing
+## Commits without `-m`
 
-- **`ops:` is a first-class flow item** — flows can now execute `land`, `rebase`, and `release` directly via Rust functions instead of spinning up an agent session. Gate writes PR copy to `scratch/`; land reads it, validates freshness, and clears it after use
-- **`lf ops land` auto-generates PR copy** — title and body are produced via Claude API from the diff when not provided explicitly. No more required `--title`/`--body` flags
-- **One-shot release** — `lf ops release run patch` owns the full lifecycle: check PRs, bump manifests, generate notes, create and land a release PR, tag the merged commit, and wait for the release workflow. CI release is re-runnable: auto-tag dispatches the release workflow explicitly, and publish steps tolerate already-published versions
+- **`lf commit` auto-generates messages** — when no `-m` is provided, the staged diff is sent to a lightweight agent (claude:haiku) that produces a formatted `lf <task>: <title>` message. Explicit `-m` still works. Falls back to a prefix-only message if generation fails
+- **Internal commits use the same path** — `auto_commit_if_dirty` and `post_step_sync` now go through `commit_workflow` instead of calling raw git helpers, so auto-commits get meaningful messages too
 
-## Ops recover from conflicts
+## Release safety
 
-- **Rebase conflict auto-recovery** — `lf ops rebase`, `land`, and `pr` now launch a step agent to resolve rebase conflicts instead of failing. The agent gets structured conflict context and fixes things up, then the original command retries
-- **`land` stages uncommitted changes** — no more forgetting to `git add` before landing
-- **Worktree pruning simplified** — merged worktrees prune without confirmation; `--force` replaced by `--include-fresh` for worktrees with no commits beyond main
-
-## Trust
-
-- **Tokens encrypted at rest** — provider tokens in SQLite/Postgres are now AES-256-GCM encrypted with keys stored in the OS keychain (macOS Keychain, Linux secret-tool, file fallback). Existing plaintext tokens migrate automatically on startup
-- **Secret redaction** — sensitive values are masked in logs and agent output
-
-## Context visibility
-
-- **Session context UI in Concerto** — expandable panel showing which files, area docs, and diff chunks are loaded into an agent's prompt, with per-document token counts and trimmed/included status. `ContextBreakdown` now tracks structured per-document metadata through the HTTP API
-
-## Cleanup
-
-- **~13,000 lines of stale artifacts deleted** — `.agents/skills/`, `proto/`, `reports/`, and `bin/` scripts removed. Unused config fields (`push`, `include_loopflow_doc`) stripped from the `Config` struct
-- **`lf ops lint` and `lf ops test` removed** — agents discover lint/test commands from `TESTING.md` and CI config directly. The `lint:` and `test:` config fields are gone
-- **Init separates repo and user config** — `lf init` now distinguishes repo config (agent, harnesses, exclude) from user config (yolo, ide, chrome) and offers to create `~/.lf/config.yaml` when missing
-- **DMG codesigning pipeline** — `concerto-dev.py release` codesigns the .app with Developer ID, signs the DMG, and submits for Apple notarization. Resource bundles moved into `Contents/Resources/` to fix unsealed-contents errors
-- **Worktree rotation improved** — creation syncs the default branch from origin before branching; archived worktrees use the branch's own timestamp; squash-merge detection tightened to avoid false positives; sibling directory layout enforced
-- **Install builds only wheel** — `uv build --wheel` skips unnecessary sdist during install
-- **`git2` crate removed** — replaced by git CLI calls
+- **`lf ops land` fails fast on existing tags** — if a release tag already exists on origin, land aborts immediately instead of proceeding to a merge queue that will fail later

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "loopflow"
-version = "0.9.8"
+version = "0.9.9"
 description = "Run LLM coding agents from reusable prompt files"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/uv.lock
+++ b/uv.lock
@@ -328,7 +328,7 @@ wheels = [
 
 [[package]]
 name = "loopflow"
-version = "0.9.8"
+version = "0.9.9"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Usage

```bash
lf ops release run patch
```

Bumps version to 0.9.9 across all manifests and updates release notes.

## Summary

Release v0.9.9 introduces auto-generated commit messages via a lightweight agent and adds a fail-fast check when a release tag already exists on origin.

## Changes

- Version bump to 0.9.9 in `Cargo.toml`, `Cargo.lock`, `pyproject.toml`, and `uv.lock`
- Updated `RELEASE_NOTES.md` with v0.9.9 notes covering `lf commit` auto-generation and release tag collision detection