### PR TITLE
concerto: fix font loading and extract release script

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,8 +80,7 @@ jobs:
       - name: Install create-dmg
         run: brew install create-dmg
       - name: Build, sign, and notarize DMG
-        run: python3 scripts/concerto-dev.py release
-        working-directory: ${{ github.workspace }}
+        run: python3 scripts/release-concerto.py
       - name: Upload DMG to R2
         run: |
           uv run --with boto3 python3 - <<'SCRIPT'

--- a/scripts/concerto-dev.py
+++ b/scripts/concerto-dev.py
@@ -15,7 +15,7 @@ Commands:
     run-ios         Build and launch in iOS Simulator
     run-ios --device "iPad Pro 13-inch (M4)"
                     Target a specific simulator device
-    release         Build release .app and .dmg
+    release         Build release .app and .dmg (delegates to release-concerto.py)
     clean           Remove dev app and reset permissions
     xcode           Open in Xcode
     logs            Tail the app logs
@@ -521,172 +521,11 @@ def cmd_run_ios(device: str | None = None) -> int:
     ).returncode
 
 
-def _detect_signing_identity() -> str | None:
-    """Find a Developer ID Application identity in the keychain."""
-    result = run_capture(["security", "find-identity", "-v", "-p", "codesigning"])
-    for line in result.stdout.splitlines():
-        if "Developer ID Application" in line:
-            # Extract the hex hash between quotes isn't needed — use the name
-            start = line.find('"')
-            end = line.rfind('"')
-            if start != -1 and end > start:
-                return line[start + 1:end]
-    return None
-
-
-def _codesign_app(app_path: Path, identity: str, entitlements: Path | None = None) -> int:
-    """Codesign an .app bundle with hardened runtime."""
-    cmd = [
-        "codesign", "--force", "--deep", "--sign", identity,
-        "--options", "runtime",
-        "--timestamp",
-    ]
-    if entitlements and entitlements.exists():
-        cmd += ["--entitlements", str(entitlements)]
-    cmd.append(str(app_path))
-    print(f"Signing with: {identity}")
-    result = run(cmd, check=False)
-    return result.returncode
-
-
-def _notarize_dmg(dmg_path: Path) -> int:
-    """Notarize a DMG and staple the ticket. Reads credentials from env."""
-    key = os.environ.get("NOTARY_KEY")
-    key_id = os.environ.get("NOTARY_KEY_ID")
-    issuer = os.environ.get("NOTARY_ISSUER")
-
-    if not all([key, key_id, issuer]):
-        print("Skipping notarization (NOTARY_KEY, NOTARY_KEY_ID, NOTARY_ISSUER not set)")
-        return 0
-
-    # Write the key to a temp file (notarytool needs a file path)
-    with tempfile.NamedTemporaryFile(mode="w", suffix=".p8", delete=False) as f:
-        f.write(key)
-        key_path = f.name
-
-    try:
-        print("Submitting for notarization...")
-        result = run([
-            "xcrun", "notarytool", "submit", str(dmg_path),
-            "--key", key_path,
-            "--key-id", key_id,
-            "--issuer", issuer,
-            "--wait",
-        ], check=False)
-        if result.returncode != 0:
-            return result.returncode
-
-        print("Stapling notarization ticket...")
-        result = run(["xcrun", "stapler", "staple", str(dmg_path)], check=False)
-        return result.returncode
-    finally:
-        os.unlink(key_path)
-
-
 def cmd_release() -> int:
-    """Build release .app and .dmg."""
-    print("Building Concerto release...")
-
-    result = run(["swift", "build", "-c", "release"], cwd=SWIFT_DIR, check=False)
-    if result.returncode != 0:
-        return result.returncode
-
-    app_name = "Loopflow Concerto"
-    dist_dir = SWIFT_DIR / "dist"
-    app_dir = dist_dir / f"{app_name}.app" / "Contents"
-
-    # Clean and create directories
-    if dist_dir.exists():
-        shutil.rmtree(dist_dir)
-    (app_dir / "MacOS").mkdir(parents=True)
-    (app_dir / "Resources").mkdir(parents=True)
-
-    # Copy files
-    build_dir = SWIFT_DIR / ".build" / "release"
-    shutil.copy(build_dir / "Concerto", app_dir / "MacOS")
-    shutil.copy(SWIFT_DIR / "Concerto" / "Info.plist", app_dir)
-    shutil.copy(SWIFT_DIR / "Concerto" / "Concerto.sdef", app_dir / "Resources")
-    shutil.copy(SWIFT_DIR / "Concerto" / "AppIcon.icns", app_dir / "Resources")
-    _copy_bundled_tools(app_dir / "MacOS", profile="release")
-    (app_dir / "PkgInfo").write_text("APPL????")
-
-    # Copy SPM resource bundles (fonts, etc.) into Contents/Resources/
-    # so they're inside the sealed bundle (codesign rejects files at the .app root)
-    for bundle in build_dir.glob("*.bundle"):
-        shutil.copytree(bundle, app_dir / "Resources" / bundle.name)
-
-    print(f"Created dist/{app_name}.app")
-
-    # Codesign the .app
-    identity = _detect_signing_identity()
-    if identity:
-        entitlements = SWIFT_DIR / "Concerto" / "Concerto.entitlements"
-        app_path = dist_dir / f"{app_name}.app"
-        rc = _codesign_app(app_path, identity, entitlements)
-        if rc != 0:
-            print("Codesigning failed")
-            return rc
-    else:
-        print("No Developer ID found — signing ad-hoc (DMG will trigger Gatekeeper)")
-        run(["codesign", "--force", "--deep", "--sign", "-",
-             str(dist_dir / f"{app_name}.app")])
-
-    # Create DMG
-    dmg_path = dist_dir / "LoopflowConcerto.dmg"
-    dmg_staging = dist_dir / "dmg_staging"
-    dmg_staging.mkdir()
-    shutil.copytree(dist_dir / f"{app_name}.app", dmg_staging / f"{app_name}.app")
-
-    bg_image = SWIFT_DIR / "Concerto" / "dmg-background.png"
-    has_create_dmg = shutil.which("create-dmg") is not None
-
-    if has_create_dmg and bg_image.exists():
-        # Polished DMG with background and drag-to-install layout
-        cmd = [
-            "create-dmg",
-            "--volname", app_name,
-            "--window-pos", "200", "120",
-            "--window-size", "660", "400",
-            "--icon-size", "128",
-            "--icon", f"{app_name}.app", "180", "185",
-            "--app-drop-link", "480", "185",
-            "--background", str(bg_image),
-            "--hide-extension", f"{app_name}.app",
-            "--no-internet-enable",
-            str(dmg_path),
-            str(dmg_staging),
-        ]
-        result = run(cmd, check=False)
-        # create-dmg exits 2 when it can't set custom icon (non-fatal)
-        if result.returncode not in (0, 2):
-            shutil.rmtree(dmg_staging)
-            return result.returncode
-    else:
-        # Fallback: plain hdiutil
-        (dmg_staging / "Applications").symlink_to("/Applications")
-        run([
-            "hdiutil", "create",
-            "-volname", app_name,
-            "-srcfolder", str(dmg_staging),
-            "-ov", "-format", "UDZO",
-            str(dmg_path),
-        ])
-
-    shutil.rmtree(dmg_staging)
-
-    # Sign and notarize the DMG
-    if identity:
-        run(["codesign", "--force", "--sign", identity, "--timestamp", str(dmg_path)])
-        rc = _notarize_dmg(dmg_path)
-        if rc != 0:
-            print("Notarization failed")
-            return rc
-
-    print()
-    print("Release built:")
-    print(f"  App: dist/{app_name}.app")
-    print(f"  DMG: {dmg_path}")
-    return 0
+    """Build release .app and .dmg. Delegates to scripts/release-concerto.py."""
+    script = REPO_ROOT / "scripts" / "release-concerto.py"
+    result = run([sys.executable, str(script)], check=False)
+    return result.returncode
 
 
 def cmd_clean() -> int:

--- a/scripts/release-concerto.py
+++ b/scripts/release-concerto.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+"""Build, sign, notarize, and package Concerto as a DMG.
+
+Usage:
+    python3 scripts/release-concerto.py
+
+Expects to run from the repo root. On CI, signing credentials come from
+environment variables (NOTARY_KEY, NOTARY_KEY_ID, NOTARY_ISSUER). Locally,
+it uses whatever Developer ID Application identity is in the keychain.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).parent.parent
+SWIFT_DIR = REPO_ROOT / "swift"
+
+
+def run(
+    cmd: list[str], cwd: Path | None = None, check: bool = True
+) -> subprocess.CompletedProcess:
+    return subprocess.run(cmd, cwd=cwd, check=check)
+
+
+def run_capture(cmd: list[str], cwd: Path | None = None) -> subprocess.CompletedProcess:
+    return subprocess.run(cmd, cwd=cwd, capture_output=True, text=True)
+
+
+def _detect_signing_identity() -> str | None:
+    result = run_capture(["security", "find-identity", "-v", "-p", "codesigning"])
+    for line in result.stdout.splitlines():
+        if "Developer ID Application" in line:
+            start = line.find('"')
+            end = line.rfind('"')
+            if start != -1 and end > start:
+                return line[start + 1 : end]
+    return None
+
+
+def _codesign_app(app_path: Path, identity: str, entitlements: Path | None = None) -> int:
+    cmd = [
+        "codesign", "--force", "--deep", "--sign", identity,
+        "--options", "runtime",
+        "--timestamp",
+    ]
+    if entitlements and entitlements.exists():
+        cmd += ["--entitlements", str(entitlements)]
+    cmd.append(str(app_path))
+    print(f"Signing with: {identity}")
+    result = run(cmd, check=False)
+    return result.returncode
+
+
+def _notarize_dmg(dmg_path: Path) -> int:
+    key = os.environ.get("NOTARY_KEY")
+    key_id = os.environ.get("NOTARY_KEY_ID")
+    issuer = os.environ.get("NOTARY_ISSUER")
+
+    if not all([key, key_id, issuer]):
+        print("Skipping notarization (NOTARY_KEY, NOTARY_KEY_ID, NOTARY_ISSUER not set)")
+        return 0
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".p8", delete=False) as f:
+        f.write(key)
+        key_path = f.name
+
+    try:
+        print("Submitting for notarization...")
+        result = run([
+            "xcrun", "notarytool", "submit", str(dmg_path),
+            "--key", key_path,
+            "--key-id", key_id,
+            "--issuer", issuer,
+            "--wait",
+        ], check=False)
+        if result.returncode != 0:
+            return result.returncode
+
+        print("Stapling notarization ticket...")
+        result = run(["xcrun", "stapler", "staple", str(dmg_path)], check=False)
+        return result.returncode
+    finally:
+        os.unlink(key_path)
+
+
+def _copy_bundled_tools(app_macos_dir: Path) -> None:
+    cargo_cmd = ["cargo", "build", "--release", "--bin", "lf", "--bin", "lfd"]
+    bin_dir = REPO_ROOT / "target" / "release"
+
+    result = run(cargo_cmd, cwd=REPO_ROOT, check=False)
+    if result.returncode != 0:
+        raise RuntimeError("Failed to build bundled lf/lfd binaries")
+
+    for binary in ("lf", "lfd"):
+        source = bin_dir / binary
+        if not source.exists():
+            raise RuntimeError(f"Missing built binary: {source}")
+        shutil.copy(source, app_macos_dir / binary)
+
+
+def release() -> int:
+    print("Building Concerto release...")
+
+    result = run(["swift", "build", "-c", "release"], cwd=SWIFT_DIR, check=False)
+    if result.returncode != 0:
+        return result.returncode
+
+    app_name = "Loopflow Concerto"
+    dist_dir = SWIFT_DIR / "dist"
+    app_dir = dist_dir / f"{app_name}.app" / "Contents"
+
+    if dist_dir.exists():
+        shutil.rmtree(dist_dir)
+    (app_dir / "MacOS").mkdir(parents=True)
+    (app_dir / "Resources").mkdir(parents=True)
+
+    build_dir = SWIFT_DIR / ".build" / "release"
+    shutil.copy(build_dir / "Concerto", app_dir / "MacOS")
+    shutil.copy(SWIFT_DIR / "Concerto" / "Info.plist", app_dir)
+    shutil.copy(SWIFT_DIR / "Concerto" / "Concerto.sdef", app_dir / "Resources")
+    shutil.copy(SWIFT_DIR / "Concerto" / "AppIcon.icns", app_dir / "Resources")
+    _copy_bundled_tools(app_dir / "MacOS")
+    (app_dir / "PkgInfo").write_text("APPL????")
+
+    # Copy SPM resource bundles (fonts, etc.) into Contents/Resources/
+    for bundle in build_dir.glob("*.bundle"):
+        shutil.copytree(bundle, app_dir / "Resources" / bundle.name)
+
+    print(f"Created dist/{app_name}.app")
+
+    # Codesign
+    identity = _detect_signing_identity()
+    if identity:
+        entitlements = SWIFT_DIR / "Concerto" / "Concerto.entitlements"
+        app_path = dist_dir / f"{app_name}.app"
+        rc = _codesign_app(app_path, identity, entitlements)
+        if rc != 0:
+            print("Codesigning failed")
+            return rc
+    else:
+        print("No Developer ID found — signing ad-hoc (DMG will trigger Gatekeeper)")
+        run(["codesign", "--force", "--deep", "--sign", "-",
+             str(dist_dir / f"{app_name}.app")])
+
+    # Create DMG
+    dmg_path = dist_dir / "LoopflowConcerto.dmg"
+    dmg_staging = dist_dir / "dmg_staging"
+    dmg_staging.mkdir()
+    shutil.copytree(dist_dir / f"{app_name}.app", dmg_staging / f"{app_name}.app")
+
+    bg_image = SWIFT_DIR / "Concerto" / "dmg-background.png"
+    has_create_dmg = shutil.which("create-dmg") is not None
+
+    if has_create_dmg and bg_image.exists():
+        cmd = [
+            "create-dmg",
+            "--volname", app_name,
+            "--window-pos", "200", "120",
+            "--window-size", "660", "400",
+            "--icon-size", "128",
+            "--icon", f"{app_name}.app", "180", "185",
+            "--app-drop-link", "480", "185",
+            "--background", str(bg_image),
+            "--hide-extension", f"{app_name}.app",
+            "--no-internet-enable",
+            str(dmg_path),
+            str(dmg_staging),
+        ]
+        result = run(cmd, check=False)
+        if result.returncode not in (0, 2):
+            shutil.rmtree(dmg_staging)
+            return result.returncode
+    else:
+        (dmg_staging / "Applications").symlink_to("/Applications")
+        run([
+            "hdiutil", "create",
+            "-volname", app_name,
+            "-srcfolder", str(dmg_staging),
+            "-ov", "-format", "UDZO",
+            str(dmg_path),
+        ])
+
+    shutil.rmtree(dmg_staging)
+
+    # Sign and notarize the DMG
+    if identity:
+        run(["codesign", "--force", "--sign", identity, "--timestamp", str(dmg_path)])
+        rc = _notarize_dmg(dmg_path)
+        if rc != 0:
+            print("Notarization failed")
+            return rc
+
+    print()
+    print("Release built:")
+    print(f"  App: dist/{app_name}.app")
+    print(f"  DMG: {dmg_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(release())

--- a/swift/Concerto/ConcertoApp.swift
+++ b/swift/Concerto/ConcertoApp.swift
@@ -24,15 +24,9 @@ extension AppearanceMode {
 }
 
 private enum AppFontRegistration {
-    private static var fontBundle: Bundle {
-        #if SWIFT_PACKAGE
-        Bundle.module
-        #else
-        Bundle.main
-        #endif
-    }
-
     static func registerBundledFonts() {
+        guard let fontsDir = findFontsDirectory() else { return }
+
         let fontFiles = [
             "CormorantGaramond-Regular.otf",
             "CormorantGaramond-Medium.otf",
@@ -43,11 +37,42 @@ private enum AppFontRegistration {
         ]
 
         for file in fontFiles {
-            guard let url = fontBundle.url(forResource: file, withExtension: nil, subdirectory: "Fonts") else {
-                continue
-            }
+            let url = fontsDir.appendingPathComponent(file)
+            guard FileManager.default.fileExists(atPath: url.path) else { continue }
             CTFontManagerRegisterFontsForURL(url as CFURL, .process, nil)
         }
+    }
+
+    private static func findFontsDirectory() -> URL? {
+        let fm = FileManager.default
+
+        // SPM resource bundle in Contents/Resources/ (release .app)
+        if let resourceURL = Bundle.main.resourceURL {
+            let spmBundle = resourceURL
+                .appendingPathComponent("LoopflowSwift_Concerto.bundle")
+                .appendingPathComponent("Fonts")
+            if fm.fileExists(atPath: spmBundle.path) {
+                return spmBundle
+            }
+        }
+
+        // SPM resource bundle adjacent to executable (dev builds via `swift run`)
+        let executableBundle = Bundle.main.bundleURL
+            .appendingPathComponent("LoopflowSwift_Concerto.bundle")
+            .appendingPathComponent("Fonts")
+        if fm.fileExists(atPath: executableBundle.path) {
+            return executableBundle
+        }
+
+        // Fonts directly in Resources/ (xcodegen builds)
+        if let resourceURL = Bundle.main.resourceURL {
+            let direct = resourceURL.appendingPathComponent("Fonts")
+            if fm.fileExists(atPath: direct.path) {
+                return direct
+            }
+        }
+
+        return nil
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes Concerto font registration to work across all build contexts (release .app, `swift run`, xcodegen) by searching for the Fonts directory at runtime instead of relying on `Bundle.module` with `#if SWIFT_PACKAGE` compile-time switching.

Also extracts the release build/sign/notarize logic into a standalone `scripts/release-concerto.py` so CI can call it directly without routing through `concerto-dev.py`.

## Changes

- **Font loading**: Replace `Bundle.module` / `Bundle.main` conditional with a `findFontsDirectory()` search that checks SPM resource bundles in `Contents/Resources/`, adjacent to the executable, and directly in `Resources/`
- **Release script**: Move release logic from `concerto-dev.py` into `scripts/release-concerto.py` as a standalone script; `concerto-dev.py release` now delegates to it
- **CI**: Simplify release workflow step to call the new script directly, removing the `working-directory` override