### PR TITLE
lf land: keep rotated branches fresh after squash merge

### DIFF
--- a/rust/loopflow/src/engine/worktrees.rs
+++ b/rust/loopflow/src/engine/worktrees.rs
@@ -341,8 +341,11 @@ pub fn list_worktrees_local(repo: &Path) -> Result<(String, Vec<WorktreeState>),
             .as_deref()
             .is_some_and(|b| !is_default && has_commits && squash_merged.contains(b));
         let dirty = !is_clean_ignoring_scratch(&path).unwrap_or(true);
-        let prunable = !is_default && (merged || squash_merged_flag);
-        let fresh = !is_default && !merged && !squash_merged_flag && !has_commits;
+        // "Fresh" means no net content delta against main yet.
+        // This includes newly-rotated branches that were forked from a landed
+        // branch (commit graph differs, but tree is identical to main).
+        let fresh = !is_default && !merged && (!has_commits || squash_merged_flag);
+        let prunable = !is_default && (merged || (squash_merged_flag && !fresh));
         results.push(WorktreeState {
             branch,
             path,
@@ -389,6 +392,15 @@ pub fn enrich_worktrees_network(repo: &Path, default_branch: &str, states: &mut 
     let pr_merged = pr_handle.join().unwrap_or_default();
     let remote_branches = remote_handle.join().unwrap_or_default();
 
+    apply_network_enrichment(states, default_branch, &pr_merged, &remote_branches);
+}
+
+fn apply_network_enrichment(
+    states: &mut [WorktreeState],
+    default_branch: &str,
+    pr_merged: &HashSet<String>,
+    remote_branches: &HashSet<String>,
+) {
     for state in states.iter_mut() {
         let is_default = state.branch.as_deref() == Some(default_branch);
         if is_default {
@@ -411,9 +423,12 @@ pub fn enrich_worktrees_network(repo: &Path, default_branch: &str, states: &mut 
                 .is_some_and(|b| !remote_branches.contains(b));
         }
 
-        if !state.prunable && (state.merged || state.squash_merged) {
+        if !state.prunable && state.merged {
             state.prunable = true;
             state.fresh = false;
+        }
+        if !state.prunable && state.squash_merged && !state.fresh {
+            state.prunable = true;
         }
         // remote_gone on a non-fresh worktree means the PR was likely merged
         // or the branch was deleted upstream — mark prunable.
@@ -600,7 +615,10 @@ pub fn preserve_worktree(
 
 #[cfg(test)]
 mod tests {
-    use super::{worktree_path, worktree_path_with_config};
+    use super::{
+        apply_network_enrichment, worktree_path, worktree_path_with_config, WorktreeState,
+    };
+    use std::collections::HashSet;
     use std::path::Path;
 
     #[test]
@@ -623,5 +641,55 @@ mod tests {
             None,
         );
         assert_eq!(path, Path::new("/tmp/repo.mobile"));
+    }
+
+    #[test]
+    fn network_enrichment_keeps_squash_fresh_branch_unprunable() {
+        let mut states = vec![
+            WorktreeState {
+                branch: Some("old".to_string()),
+                path: Path::new("/tmp/repo.old").to_path_buf(),
+                base_branch: None,
+                merged: false,
+                squash_merged: true,
+                prunable: false,
+                fresh: true,
+                dirty: false,
+                remote_gone: false,
+            },
+            WorktreeState {
+                branch: Some("new".to_string()),
+                path: Path::new("/tmp/repo.new").to_path_buf(),
+                base_branch: None,
+                merged: false,
+                squash_merged: true,
+                prunable: false,
+                fresh: true,
+                dirty: false,
+                remote_gone: false,
+            },
+        ];
+
+        let pr_merged = HashSet::from(["old".to_string()]);
+        let remote_branches = HashSet::from(["old".to_string(), "new".to_string()]);
+        apply_network_enrichment(&mut states, "main", &pr_merged, &remote_branches);
+
+        let old = states
+            .iter()
+            .find(|state| state.branch.as_deref() == Some("old"))
+            .unwrap();
+        assert!(old.merged, "merged PR branch should be marked merged");
+        assert!(old.prunable, "merged PR branch should be prunable");
+        assert!(!old.fresh, "merged PR branch should not stay fresh");
+
+        let new = states
+            .iter()
+            .find(|state| state.branch.as_deref() == Some("new"))
+            .unwrap();
+        assert!(
+            !new.prunable,
+            "new squashed-equivalent branch should stay unprunable while fresh"
+        );
+        assert!(new.fresh, "new branch should remain fresh");
     }
 }

--- a/rust/loopflow/src/lf/commands/ops/mod.rs
+++ b/rust/loopflow/src/lf/commands/ops/mod.rs
@@ -1,6 +1,6 @@
 use crate::engine::agent::{launch_agent, AgentCapabilities, ProcessConfig};
 use crate::engine::config::load_config_or_default;
-use crate::engine::git::{current_branch, delete_local_branch, get_default_branch};
+use crate::engine::git::{current_branch, delete_local_branch, get_default_branch, sync_main};
 use crate::engine::worktrees::{
     create_with_schema_synced, list_worktrees, main_repo_root, wave_name_from_worktree,
     wave_name_from_worktree_and_main, worktree_path,
@@ -472,6 +472,8 @@ fn wt_switch(name: &str) -> Result<()> {
 fn wt_list(format: Option<&str>) -> Result<()> {
     let repo_root = find_repo_root()?;
     let main_repo = main_repo_root(&repo_root)?;
+    let default_branch = get_default_branch(&main_repo)?;
+    let _ = sync_main(&main_repo, &default_branch);
     let worktrees = list_worktrees(&main_repo)?;
 
     if matches!(format, Some("json")) {
@@ -481,8 +483,6 @@ fn wt_list(format: Option<&str>) -> Result<()> {
     }
 
     let c = Colors::new();
-    let default_branch = get_default_branch(&main_repo)?;
-
     // Collect display info for all worktrees
     struct Row {
         name: String,
@@ -535,7 +535,7 @@ fn wt_list(format: Option<&str>) -> Result<()> {
     for row in &rows {
         let marker = if row.is_current { "*" } else { " " };
 
-        let any_merged = row.merged || row.squash_merged;
+        let any_merged = row.merged || (row.squash_merged && !row.fresh);
         let landed_dirty = any_merged && row.dirty;
         let name_color = if row.is_main || any_merged || row.fresh {
             c.dim
@@ -547,12 +547,12 @@ fn wt_list(format: Option<&str>) -> Result<()> {
             ("landed-dirty", c.red)
         } else if row.merged {
             ("merged", c.green)
+        } else if row.fresh {
+            ("fresh", c.dim)
         } else if row.squash_merged {
             ("squash-merged", c.green)
         } else if row.remote_gone {
             ("remote-gone", c.yellow)
-        } else if row.fresh {
-            ("fresh", c.dim)
         } else {
             ("active", c.cyan)
         };
@@ -681,7 +681,8 @@ fn wt_prune(dry_run: bool, include_fresh: bool) -> Result<()> {
     let repo_root = find_repo_root()?;
     let main_repo = main_repo_root(&repo_root)?;
     let current_path = repo_root;
-
+    let default_branch = get_default_branch(&main_repo)?;
+    let _ = sync_main(&main_repo, &default_branch);
     let prune_output = Command::new("git")
         .arg("-C")
         .arg(&main_repo)
@@ -693,9 +694,6 @@ fn wt_prune(dry_run: bool, include_fresh: bool) -> Result<()> {
             String::from_utf8_lossy(&prune_output.stderr).trim()
         ));
     }
-
-    let default_branch = get_default_branch(&main_repo)?;
-    let _ = crate::engine::git::fetch(&main_repo, "origin", &default_branch);
 
     let worktrees = list_worktrees(&main_repo)?;
     let targets: Vec<_> = worktrees
@@ -724,12 +722,12 @@ fn wt_prune(dry_run: bool, include_fresh: bool) -> Result<()> {
         for wt in &targets {
             let reason = if wt.merged {
                 "merged"
+            } else if wt.fresh {
+                "fresh"
             } else if wt.squash_merged {
                 "squash-merged"
             } else if wt.remote_gone {
                 "remote-gone"
-            } else if wt.fresh {
-                "fresh"
             } else {
                 "prunable"
             };

--- a/rust/loopflow/tests/worktree_tests.rs
+++ b/rust/loopflow/tests/worktree_tests.rs
@@ -379,3 +379,38 @@ fn worktree_with_commits_is_active_not_fresh() {
     assert!(!wt.prunable, "active worktree should not be prunable");
     assert!(!wt.merged, "active worktree is not merged");
 }
+
+#[test]
+fn branch_from_squash_merged_parent_stays_fresh() {
+    let repo = TestRepo::new();
+
+    let landed = create_with_schema(repo.path(), "rules-old", None, None).expect("create landed");
+    std::fs::write(landed.path.join("rules.txt"), "rule").expect("write");
+    git_stdout(&landed.path, &["add", "."]);
+    git_stdout(&landed.path, &["commit", "-m", "add rule"]);
+
+    // Simulate a squash merge into main.
+    git_stdout(repo.path(), &["merge", "--squash", landed.branch.as_str()]);
+    git_stdout(repo.path(), &["commit", "-m", "land rules"]);
+    git_stdout(repo.path(), &["push", "origin", "main"]);
+
+    // Create the next branch from the landed branch tip (land rotation behavior).
+    let fresh = create_with_schema(repo.path(), "rules-new", Some(landed.branch.as_str()), None)
+        .expect("create fresh from landed");
+
+    let (_, states) = list_worktrees_local(repo.path()).expect("list");
+    let wt = states
+        .iter()
+        .find(|wt| wt.branch.as_deref() == Some(&fresh.branch))
+        .expect("should find fresh worktree");
+
+    assert!(
+        wt.squash_merged,
+        "branch should be tree-equal to main after squash merge"
+    );
+    assert!(wt.fresh, "rotated branch should still be treated as fresh");
+    assert!(
+        !wt.prunable,
+        "fresh branch must not be pruned immediately after rotation"
+    );
+}


### PR DESCRIPTION
## Usage

```bash
lf wt list    # rotated branches show as "fresh", not "squash-merged"
lf wt prune   # rotated branches are no longer incorrectly pruned
```

## Summary

After `lf land` squash-merges a branch and rotates to a new one, the new branch's tree is identical to main — so it was incorrectly flagged as "squash-merged" and prunable. This meant freshly-rotated branches could be immediately pruned, losing the user's working context.

The fix redefines "fresh" to include branches that are tree-equal to main even if they have commits (the squash-merged-parent case), and prevents squash-merged branches from being marked prunable while they're still fresh. Network enrichment only promotes squash-merged branches to prunable once they lose their fresh status (e.g., after a PR merge is confirmed).

## Changes

- Reworked `fresh` and `prunable` logic in `list_worktrees_local` so freshness takes precedence over squash-merged status
- Extracted `apply_network_enrichment` from `enrich_worktrees_network` for testability
- `wt list` and `wt prune` now sync main before listing to ensure accurate merge detection
- Display logic prioritizes "fresh" over "squash-merged" in status output
- Added unit test for network enrichment and integration test for the land-rotation scenario