### PR TITLE
lf land: stage uncommitted changes and fix stacked branch rebase after squash merge

### DIFF
--- a/rust/loopflow/src/engine/builtins/steps/ops/update-wave.md
+++ b/rust/loopflow/src/engine/builtins/steps/ops/update-wave.md
@@ -8,9 +8,9 @@ Single owner of `wave/<wave>/`. Creates, updates, and deletes wave state.
 
 `wave/<wave>/` is planning scaffolding — it tracks what's left to build, not what's been built. This step is the only writer. Whether you're creating a wave from analysis, cleaning up after a build, or reconciling both at once:
 
-- Shipped sprints are deleted, not marked as complete
-- Context that upcoming sprints need is folded into those sprints before deletion
-- New work from `scratch/` is folded into wave sprints or becomes new sprint files
+- Shipped items are deleted, not marked as complete
+- Context that upcoming items need is folded into those items before deletion
+- New work from `scratch/` is folded into wave items or becomes new item files
 - When nothing remains, the wave directory is deleted
 
 ## Bias: fold, don't drop
@@ -18,9 +18,9 @@ Single owner of `wave/<wave>/`. Creates, updates, and deletes wave state.
 `scratch/` is cleared on land. Anything left there is lost. Anything folded into `wave/` survives. **Dropping content is a worse failure mode than duplicating it.**
 
 Every scratch file with planned work or future-relevant analysis must be folded into wave:
-- Proposals, open questions, analysis of upcoming work → fold into existing sprint items or create new ones
-- Reviews with forward-looking recommendations → fold into relevant sprint items
-- Questions about future work → fold into sprint items or wave README risks/strategy
+- Proposals, open questions, analysis of upcoming work → fold into existing items or create new ones
+- Reviews with forward-looking recommendations → fold into relevant items
+- Questions about future work → fold into items or wave README risks/strategy
 - If content overlaps with what's already in wave, merge it — don't skip it
 
 Design docs for already-shipped work and other purely historical content can be left for git history. The test: does this content inform future work? If yes, fold it. If it only describes what was already built, let it go.
@@ -28,11 +28,11 @@ Design docs for already-shipped work and other purely historical content can be 
 ## Workflow
 
 1. Read the diff (if any) to understand what was built on this branch.
-2. Read `wave/<wave>/` — README and sprint files — to understand current state.
-3. Verify each sprint against the actual codebase. Check `git log main`, read relevant files, run relevant commands. For each sprint: is the finish line crossed? If yes, treat it as shipped. For unshipped sprints: are file paths, function signatures, data structures, and technical approach still accurate given what's on main? Update sprint content to reflect the codebase as it actually is — not as it was when the sprint was written.
+2. Read `wave/<wave>/` — README and item files — to understand current state.
+3. Verify each item against the actual codebase. Check `git log main`, read relevant files, run relevant commands. For each item: is the finish line crossed? If yes, treat it as shipped. For unshipped items: are file paths, function signatures, data structures, and technical approach still accurate given what's on main? Update item content to reflect the codebase as it actually is — not as it was when the item was written.
 4. Read `scratch/` — every file, completely.
-5. Delete shipped sprints. Before deleting, fold context that remaining sprints need into those sprints.
-6. Fold scratch content into `wave/<wave>/`. Merge into existing sprint items where there's a clear match. Create new sprint items for content that doesn't fit existing ones. Skip only purely historical content (shipped design docs with nothing forward-looking).
+5. Delete shipped items. Before deleting, fold context that remaining items need into those items.
+6. Fold scratch content into `wave/<wave>/`. Merge into existing items where there's a clear match. Create new items for content that doesn't fit existing ones. Skip only purely historical content (shipped design docs with nothing forward-looking).
 7. If destination files already exist, merge/dedupe — but keep both sides' content. When in doubt, include it.
 8. **Trim scratch docs for shipped work.** Don't delete them — `lf ops land` handles that. But strip implementation details that are now in the code. Keep only:
    - **Validation procedures** — "Done when" checks, commands to run, expected output
@@ -46,8 +46,8 @@ Design docs for already-shipped work and other purely historical content can be 
 
 When `scratch/` contains analysis or a proposal and no wave exists yet, create one:
 
-1. Write `wave/<wave>/README.md` — the anchor that survives when plans change. Vision, strategy, goals, risks, metrics. **No roadmap tables or phase lists** — the sprint files are the roadmap.
-2. Write numbered sprint files (`01-name.md`, `02-name.md`, ...) — the roadmap. **Create every sprint file**, even sketches (title + finish line + one paragraph) — `ingest` needs them to exist.
+1. Write `wave/<wave>/README.md` — the anchor that survives when plans change. Vision, strategy, goals, risks, metrics. **No roadmap tables or phase lists** — the item files are the roadmap.
+2. Write numbered item files (`01-name.md`, `02-name.md`, ...) — the roadmap. **Create every item file**, even sketches (title + finish line + one paragraph) — `ingest` needs them to exist.
 
 ### README.md
 
@@ -66,15 +66,15 @@ Additional free sections are welcome — data models, tech direction, guardrails
 **README.md must not contain:**
 
 - Status indicators (shipped / in-progress / planned)
-- Retrospectives — context for remaining sprints gets folded into those sprints
+- Retrospectives — context for remaining items gets folded into those items
 
 If the README has any of these, delete them.
 
-### Sprints
+### Items
 
-Roadmaps are made up of sprints. Each sprint is a numbered file (`01-*.md`, `02-*.md`, ...) with a clear finish line — a concrete deliverable you're racing to reach. Not a phase, not a layer, not a bucket of tasks.
+Roadmaps are made up of items. Each item is a numbered file (`01-*.md`, `02-*.md`, ...) with a clear finish line — a concrete deliverable you're racing to reach. Not a phase, not a layer, not a bucket of tasks.
 
-**Every sprint must open with a bold finish line.** What's true when this sprint is done that isn't true now? Make it specific enough that you know when you've crossed it.
+**Every item must open with a bold finish line.** What's true when this item is done that isn't true now? Make it specific enough that you know when you've crossed it.
 
 ```markdown
 # 01: Audit Breakdown
@@ -87,17 +87,17 @@ Roadmaps are made up of sprints. Each sprint is a numbered file (`01-*.md`, `02-
 - **Frontload the risk.** Start with the thing you need to try to see if it works. Don't pre-build infrastructure before you've proven the core idea.
 - **Sequence by learning, not dependencies.** What are you most uncertain about? Build that first.
 - **Defer abstractions.** Build the concrete thing, then extract the pattern.
-- **Encode uncertainty.** Each sprint should state what you expect to learn and what might change.
+- **Encode uncertainty.** Each item should state what you expect to learn and what might change.
 
 ## What counts as "shipped"
 
-A sprint is shipped when the code is on main (or will be when this branch merges) and its finish line has been crossed. Don't keep sprints around to admire — if the work is done, delete the file.
+An item is shipped when the code is on main (or will be when this branch merges) and its finish line has been crossed. Don't keep items around to admire — if the work is done, delete the file.
 
 ## Preserving context
 
-Shipped sprints often contain history that upcoming sprints build on — decisions made, alternatives rejected, patterns established. That context belongs in the remaining sprint files as free text, not as standalone shipped files.
+Shipped items often contain history that upcoming items build on — decisions made, alternatives rejected, patterns established. That context belongs in the remaining item files as free text, not as standalone shipped files.
 
-If there are no remaining sprints, the context doesn't need a home. Git has the history.
+If there are no remaining items, the context doesn't need a home. Git has the history.
 
 ## Output
 

--- a/rust/loopflow/src/engine/git.rs
+++ b/rust/loopflow/src/engine/git.rs
@@ -417,6 +417,34 @@ pub fn is_squash_merged(repo: &Path, branch: &str, target: &str) -> Result<bool,
     Ok(result_tree == target_tree)
 }
 
+/// Find the fork point for a stacked branch whose parent was squash-merged.
+///
+/// When branch B is stacked on A, and A gets squash-merged into `target`,
+/// a plain rebase replays A's commits (already in target) causing conflicts.
+/// This function finds the last commit whose patch is already in `target`,
+/// so we can `rebase --onto target <fork_point>` to skip them.
+///
+/// Returns `None` if no commits are already in target (normal case).
+pub fn squash_merge_fork_point(repo: &Path, target: &str) -> Result<Option<String>, GitError> {
+    // `git cherry target HEAD` marks commits whose patches are already in target with `-`.
+    // We want the last `-` commit in a leading run — once we hit a `+` commit, stop.
+    let output = run_git(repo, &["cherry", target, "HEAD"])?;
+    if !output.status.success() {
+        return Ok(None);
+    }
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let mut last_absorbed = None;
+    for line in stdout.lines() {
+        if let Some(sha) = line.strip_prefix("- ") {
+            last_absorbed = Some(sha.trim().to_string());
+        } else {
+            // Hit a `+` (not-in-target) commit — stop scanning.
+            break;
+        }
+    }
+    Ok(last_absorbed)
+}
+
 pub fn rebase(
     worktree: &Path,
     onto: &str,

--- a/rust/loopflow/src/ops/land.rs
+++ b/rust/loopflow/src/ops/land.rs
@@ -445,6 +445,11 @@ fn rotate_worktree(
         return Ok(None);
     }
 
+    // Check wave items from the worktree (feature branch) before preserving,
+    // since update-wave removes shipped items on the branch, not on main.
+    let wave_dir = repo_root.join("wave").join(&wave_name);
+    let has_items = wave_dir.exists() && has_wave_items(&wave_dir)?;
+
     // Use the branch's timestamp for the preserved directory name so it
     // matches the work it contains, not when it was archived.
     let branch_suffix = parse_branch_name(feature_branch, None).and_then(|parts| parts.timestamp);
@@ -454,9 +459,6 @@ fn rotate_worktree(
         repo_root.display(),
         preserved.display()
     ));
-
-    let wave_dir = main_repo.join("wave").join(&wave_name);
-    let has_items = wave_dir.exists() && has_wave_items(&wave_dir)?;
 
     if has_items {
         let result = create_with_schema(main_repo, &wave_name, Some(feature_branch), None)?;
@@ -564,8 +566,9 @@ mod tests {
             ],
         );
 
-        // Add wave items so rotation creates a new worktree.
-        let wave_dir = main_repo.join("wave").join("mywave");
+        // Add wave items to the worktree (feature branch) so rotation detects them.
+        // rotate_worktree checks repo_root (the worktree), not main_repo.
+        let wave_dir = wt_path.join("wave").join("mywave");
         std::fs::create_dir_all(&wave_dir).unwrap();
         std::fs::write(wave_dir.join("01-next-item.md"), "# Next").unwrap();
 

--- a/rust/loopflow/src/ops/rebase.rs
+++ b/rust/loopflow/src/ops/rebase.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
 
-use crate::engine::git::{fetch, rebase};
+use crate::engine::git::{fetch, rebase, squash_merge_fork_point};
 
 use crate::ops::error::{OpsError, OpsResult};
 use crate::ops::progress::Progress;
@@ -20,10 +20,17 @@ pub fn rebase_with_recovery(
         let _ = fetch(repo, "origin", branch);
     }
 
-    // Try auto-rebase first. rebase() aborts on conflict and returns the conflict list.
+    // When a stacked branch's parent was squash-merged into the target,
+    // a plain rebase replays the parent's commits (already in target) and
+    // hits conflicts. Detect this and use --onto to skip them.
+    let fork_point = squash_merge_fork_point(repo, &options.onto).unwrap_or(None);
+
     progress.status(&format!("Rebasing onto {}...", options.onto));
-    let result = rebase(repo, &options.onto, None)?;
+    let result = rebase(repo, &options.onto, fork_point.as_deref())?;
     if result.success {
+        if fork_point.is_some() {
+            progress.status("Skipped squash-merged parent commits");
+        }
         if options.push {
             crate::ops::commit::push_with_upstream_if_needed(repo)?;
         }

--- a/rust/loopflow/tests/rebase_tests.rs
+++ b/rust/loopflow/tests/rebase_tests.rs
@@ -1,5 +1,21 @@
 use loopflow::ops::{rebase_with_recovery, NullProgress, OpsError, RebaseOptions};
 use loopflow_test_support::TestRepo;
+use std::process::Command;
+
+fn git(repo: &std::path::Path, args: &[&str]) -> String {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(repo)
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "git {:?} failed: {}",
+        args,
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8_lossy(&output.stdout).trim().to_string()
+}
 
 #[test]
 fn rebase_onto_main_succeeds() {
@@ -83,4 +99,57 @@ fn rebase_with_push() {
         &NullProgress,
     )
     .expect("rebase");
+}
+
+#[test]
+fn rebase_stacked_branch_after_squash_merge() {
+    let repo = TestRepo::new();
+
+    // Branch A: two commits on top of main.
+    repo.create_branch("branch-a");
+    repo.create_file("a1.txt", "a1");
+    repo.stage_all();
+    repo.commit("a1");
+    repo.create_file("a2.txt", "a2");
+    repo.stage_all();
+    repo.commit("a2");
+
+    // Branch B: stacked on A with its own commits.
+    repo.create_branch("branch-b");
+    repo.create_file("b1.txt", "b1");
+    repo.stage_all();
+    repo.commit("b1");
+
+    let b_head = repo.head_sha();
+
+    // Simulate squash-merge of A into main.
+    repo.checkout("main");
+    git(repo.path(), &["merge", "--squash", "branch-a"]);
+    git(repo.path(), &["commit", "-m", "squash merge branch-a"]);
+    repo.push();
+
+    // Rebase B onto origin/main — without fork-point detection this would conflict.
+    repo.checkout("branch-b");
+    rebase_with_recovery(
+        repo.path(),
+        &RebaseOptions {
+            onto: "origin/main".to_string(),
+            push: false,
+        },
+        &NullProgress,
+    )
+    .expect("rebase of stacked branch after squash-merge should succeed");
+
+    // B's commit (b1.txt) should be present.
+    assert!(
+        repo.path().join("b1.txt").exists(),
+        "b1.txt should exist after rebase"
+    );
+    // A's changes should also be present (from the squash merge on main).
+    assert!(
+        repo.path().join("a1.txt").exists(),
+        "a1.txt should exist from squash merge"
+    );
+    // HEAD should have changed (rebased onto new main).
+    assert_ne!(repo.head_sha(), b_head, "HEAD should differ after rebase");
 }

--- a/wave/concerto/README.md
+++ b/wave/concerto/README.md
@@ -14,7 +14,7 @@ Concerto is one multiplatform app — Mac, iPad, iPhone. Mobile is a fast check-
 
 ## Strategy
 
-Start with small, low-risk sprints that teach the Swift codebase (queue management, API key entry), then build up to more complex interaction patterns (release UI, voice auto-send).
+Start with small, low-risk items that teach the Swift codebase (queue management, API key entry), then build up to more complex interaction patterns (release UI, voice auto-send).
 
 ## Goals
 

--- a/wave/context/02-context-ui-polish.md
+++ b/wave/context/02-context-ui-polish.md
@@ -2,7 +2,7 @@
 
 **Finish line:** Concerto's context panel shows all files (not capped at 10), budget is customizable from the UI, and small sources render visibly in the stacked bar.
 
-Polish items from the context UI sprint. The data path is already wired — `ContextSnapshot` serializes the full document list per source. These are display-layer improvements.
+Polish items from the context UI work. The data path is already wired — `ContextSnapshot` serializes the full document list per source. These are display-layer improvements.
 
 ## What to build
 

--- a/wave/foundation/01-code-cleanup.md
+++ b/wave/foundation/01-code-cleanup.md
@@ -16,4 +16,4 @@
 
 **Config env override.** `output_log_retention_days` has no `LFD_OUTPUT_LOG_RETENTION_DAYS` env override — every other config field supports env overrides via `apply_env_overrides()`.
 
-**Release tag test gap.** `tag_and_push_ref` with a non-HEAD `target_ref` (used by `release_run` when tagging a merged commit) is exercised by the full flow but not unit-tested in isolation. Added during ops orchestration (sprint 05).
+**Release tag test gap.** `tag_and_push_ref` with a non-HEAD `target_ref` (used by `release_run` when tagging a merged commit) is exercised by the full flow but not unit-tested in isolation. Added during ops orchestration (item 05).

--- a/wave/foundation/README.md
+++ b/wave/foundation/README.md
@@ -14,7 +14,7 @@ The system works correctly. Tests cover the important paths, code is clean, APIs
 
 Map the gaps first (test coverage), then clean up (dead code, layer violations), then validate on real infrastructure (dogfood), then fill API gaps (remote APIs), then harden the container boundary.
 
-Each sprint is a standalone PR that makes the system measurably more solid.
+Each item is a standalone PR that makes the system measurably more solid.
 
 ## Goals
 
@@ -26,7 +26,7 @@ Each sprint is a standalone PR that makes the system measurably more solid.
 
 ## Risks
 
-- Test coverage sprints could produce tests that test implementation rather than behavior
+- Test coverage items could produce tests that test implementation rather than behavior
 - Remote dogfooding may surface issues that cascade into other waves
 - API expansion scope could creep beyond what remote Concerto needs
 

--- a/wave/scale/01-flowrun-container.md
+++ b/wave/scale/01-flowrun-container.md
@@ -12,7 +12,7 @@ Key decisions that carry forward:
 
 - **Incremental migration path.** Signal cleanup used ALTER TABLE + table recreation (migration 022). Trigger rename used ALTER TABLE + DROP COLUMN (migration 026, requires SQLite 3.35.0+). FlowRun can follow the same pattern or consolidate into a hard reset if the migration count becomes unwieldy.
 - **`ActivationEnvelope.trigger_id` is already `Option<LfdId>`.** No further activation-layer changes needed.
-- **Cron `last_triggered_at` tracking lost.** The old code tracked this on the trigger. Currently cron waves attempt activation on every 30-second tick, relying on dedup to coalesce. Correct but noisy — add `last_cron_triggered_at` to the wave as part of this sprint.
+- **Cron `last_triggered_at` tracking lost.** The old code tracked this on the trigger. Currently cron waves attempt activation on every 30-second tick, relying on dedup to coalesce. Correct but noisy — add `last_cron_triggered_at` to the wave as part of this item.
 - **No cron active-run check.** Unlike the loop ticker (which checks for active runs before dispatching), the cron ticker always dispatches. Address alongside FlowRun or accept the noise.
 - **API field asymmetry.** Input APIs (`CreateWaveRequest`, `UpdateWaveRequest`) accept `flow`. Output (`WaveDto`) returns `primary_flow`. Intentional but the DTO layer should be consistent — decide whether to rename input to `primary_flow` or keep the asymmetry and document it.
 - **Python API doesn't expose `mode`/`cron` yet.** The Python model deserializes them, but `create_wave`/`update_wave` don't accept them as parameters. Add when building FlowRun Python models.

--- a/wave/scale/02-cross-repo-commits.md
+++ b/wave/scale/02-cross-repo-commits.md
@@ -8,7 +8,7 @@ lf already doesn't prevent writing to other repos — if an area points at `/oth
 
 This stage makes commits multi-repo-aware. No new access control — lf takes paths, lfd provides convenience, neither enforces write boundaries.
 
-## Context from prior sprints
+## Context from prior items
 
 `resolve_related_repos(store, repo_id)` returns `Vec<RelatedRepoContext>` with `repo_id: RepoId` and `path: PathBuf` for each related repo. This provides the repo roots needed for file classification.
 

--- a/wave/scale/README.md
+++ b/wave/scale/README.md
@@ -11,7 +11,7 @@ Loopflow manages an org's work, not just one task. Cross-repo portfolios, wave c
 
 ## Strategy
 
-Build the execution model first (FlowRun container), then cross-repo primitives (commits, stimulus), then surfaces (chord UI, portfolio UI). Each layer teaches what the next layer needs. Vertical UI sprints (chord grouping, portfolio view) live here — you can't build chord UI without understanding FlowRun.
+Build the execution model first (FlowRun container), then cross-repo primitives (commits, stimulus), then surfaces (chord UI, portfolio UI). Each layer teaches what the next layer needs. Vertical UI items (chord grouping, portfolio view) live here — you can't build chord UI without understanding FlowRun.
 
 ## Goals
 

--- a/wave/trust/04-sandbox-integration.md
+++ b/wave/trust/04-sandbox-integration.md
@@ -1,6 +1,6 @@
 # 04: Sandbox Integration and Validation
 
-**Status (2026-03-04):** Experimental track. Host validation passes on Docker Sandbox CLI v0.12.0, but DinD validation is blocked because the bundled lfd image lacks the sandbox CLI plugin. lfd container now runs as non-root user `lfd` (hardened in trust sprint 01-03).
+**Status (2026-03-04):** Experimental track. Host validation passes on Docker Sandbox CLI v0.12.0, but DinD validation is blocked because the bundled lfd image lacks the sandbox CLI plugin. lfd container now runs as non-root user `lfd` (hardened in trust items 01-03).
 
 **Finish line:** Sandbox executor runs Claude end-to-end on macOS (self-hosted + Concerto), and cleanup works across all lifecycle events.
 

--- a/wave/trust/05-sandbox-rollout.md
+++ b/wave/trust/05-sandbox-rollout.md
@@ -15,7 +15,7 @@ Is sandbox reliable enough to be the only container executor? What breaks when w
 - Full restart rehydration for active sandbox runs (stream reattach)
 - Bollard removal (delete `DockerExecutor` and Bollard dependency)
 
-## Context from validation (sprint 04)
+## Context from validation (item 04)
 
 ### DinD decision
 


### PR DESCRIPTION
## Usage

```bash
# Stacked branches now rebase cleanly after their parent is squash-merged
lf ops rebase  # automatically detects and skips squash-merged parent commits
```

## Summary

When branch B is stacked on branch A, and A gets squash-merged into main, rebasing B onto main would replay A's commits and hit conflicts. This PR adds fork-point detection using `git cherry` to identify commits already absorbed into the target, then uses `rebase --onto` to skip them.

Also fixes `rotate_worktree` to check wave items from the feature branch worktree (where update-wave runs) instead of from main, where shipped items have already been removed.

## Changes

- New `squash_merge_fork_point()` in `git.rs` — uses `git cherry` to find the last commit whose patch is already in the target branch
- `rebase_with_recovery` uses fork-point detection to skip squash-merged parent commits automatically
- `rotate_worktree` reads wave items from the worktree (feature branch) instead of main repo
- Integration test covering stacked branch rebase after squash merge
- Terminology cleanup in wave docs: "sprint" → "item" throughout