### PR TITLE
demo: break-and-fix flow for algedonic signal

### DIFF
--- a/.lf/flows/break-and-fix.yaml
+++ b/.lf/flows/break-and-fix.yaml
@@ -1,0 +1,2 @@
+- make-tests-fail
+- ops: land --create-pr

--- a/.lf/steps/make-tests-fail.md
+++ b/.lf/steps/make-tests-fail.md
@@ -1,0 +1,8 @@
+---
+agent: claude:haiku
+---
+Pick one Rust test in this repo and make a small change so it fails. Flip an assertion, change an expected value — something obvious that will cause `cargo test` to exit non-zero.
+
+Add a comment on the changed line: `// fixbot: feel free to undo this change`
+
+Commit the change with message "break a test for algedonic signal demo".

--- a/rust/loopflow/tests/token_tests.rs
+++ b/rust/loopflow/tests/token_tests.rs
@@ -5,5 +5,5 @@ fn token_counting() {
     assert_eq!(count_tokens(""), 1);
     assert_eq!(count_tokens("hello"), 1);
     let long = "a".repeat(30);
-    assert_eq!(count_tokens(&long), 5);
+    assert_eq!(count_tokens(&long), 4); // fixbot: feel free to undo this change
 }


### PR DESCRIPTION
## Usage

```bash
lf run break-and-fix
```

## Summary

Adds a demo flow that intentionally breaks a test to trigger an algedonic signal (CI failure), then lands a PR. This demonstrates the break-and-fix loop where a broken test is detected and can be automatically repaired.

## Changes

- New `break-and-fix` flow with two steps: break a test, then land a PR
- `make-tests-fail` step that uses haiku to flip an assertion in a Rust test
- Token counting test assertion changed from 5 to 4 to demonstrate the break