### PR TITLE
ops wt: prefer exact branch matches and support sourced dev-lf

### DIFF
--- a/docs/lfops.md
+++ b/docs/lfops.md
@@ -145,10 +145,11 @@ If the input matches an existing `origin/<branch>` name, `lf` checks out that br
 
 ### lf ops wt switch
 
-Switch to a worktree by its short directory name.
+Switch to a worktree by its short directory name or full branch name.
 
 ```bash
 lf ops wt switch my-feature       # switches to ../loopflow.my-feature
+lf ops wt switch jack.my-feature.20260316_1856  # resolves that exact branch's worktree
 ```
 
 ### lf ops wt list

--- a/rust/loopflow/src/lf/commands/ops/mod.rs
+++ b/rust/loopflow/src/lf/commands/ops/mod.rs
@@ -1,9 +1,11 @@
 use crate::engine::agent::{launch_agent, AgentCapabilities, ProcessConfig};
 use crate::engine::config::load_config_or_default;
-use crate::engine::git::{current_branch, delete_local_branch, get_default_branch, sync_main};
+use crate::engine::git::{
+    current_branch, delete_local_branch, get_default_branch, rev_parse, sync_main,
+};
 use crate::engine::worktrees::{
     create_with_schema_synced, list_worktrees, main_repo_root, wave_name_from_worktree,
-    wave_name_from_worktree_and_main, worktree_path,
+    wave_name_from_worktree_and_main, worktree_path, worktree_path_with_config,
 };
 use crate::engine::{prepare_launch_prompt, ContextSourceOverrides, LaunchPromptInput, Surface};
 use crate::lf::commands::util::find_repo_root;
@@ -560,34 +562,48 @@ fn wt_create(name: &str, base: Option<&str>, stack: bool) -> Result<()> {
 fn wt_switch(name: &str) -> Result<()> {
     let repo_root = find_repo_root()?;
     let main_repo = main_repo_root(&repo_root)?;
+    let config = load_config_or_default(Some(&main_repo));
+    let branch_config = config.branch_names.as_ref();
+    let worktrees = list_worktrees(&main_repo)?;
 
-    let target = worktree_path(&main_repo, name);
-    let path = if target.exists() {
-        target
+    let path = if let Some(exact_branch_match) = worktrees
+        .iter()
+        .find(|wt| wt.branch.as_deref() == Some(name))
+        .map(|wt| wt.path.clone())
+    {
+        exact_branch_match
     } else {
-        let worktrees = list_worktrees(&main_repo)?;
-        let mut matches = worktrees
-            .into_iter()
-            .filter(|wt| {
-                let wt_name = wave_name_from_worktree_and_main(&wt.path, &main_repo);
-                wt_name.as_deref() == Some(name)
-                    || wt_name
-                        .as_ref()
-                        .map(|n| n.starts_with(&format!("{name}.")))
-                        .unwrap_or(false)
-                    || wt
-                        .path
-                        .file_name()
-                        .map(|n| n.to_string_lossy() == name)
-                        .unwrap_or(false)
-            })
-            .collect::<Vec<_>>();
-        if matches.len() == 1 {
-            matches.remove(0).path
-        } else if matches.is_empty() {
-            return Err(anyhow!("no worktree found for '{}'", name));
+        let target = if branch_ref_exists(&main_repo, name) {
+            worktree_path_with_config(&main_repo, name, branch_config)
         } else {
-            return Err(anyhow!("multiple worktrees match '{}'", name));
+            worktree_path(&main_repo, name)
+        };
+        if target.exists() {
+            target
+        } else {
+            let mut matches = worktrees
+                .into_iter()
+                .filter(|wt| {
+                    let wt_name = wave_name_from_worktree_and_main(&wt.path, &main_repo);
+                    wt_name.as_deref() == Some(name)
+                        || wt_name
+                            .as_ref()
+                            .map(|n| n.starts_with(&format!("{name}.")))
+                            .unwrap_or(false)
+                        || wt
+                            .path
+                            .file_name()
+                            .map(|n| n.to_string_lossy() == name)
+                            .unwrap_or(false)
+                })
+                .collect::<Vec<_>>();
+            if matches.len() == 1 {
+                matches.remove(0).path
+            } else if matches.is_empty() {
+                return Err(anyhow!("no worktree found for '{}'", name));
+            } else {
+                return Err(anyhow!("multiple worktrees match '{}'", name));
+            }
         }
     };
 
@@ -595,6 +611,11 @@ fn wt_switch(name: &str) -> Result<()> {
         println!("cd {}", path.display());
     }
     Ok(())
+}
+
+fn branch_ref_exists(repo: &Path, branch: &str) -> bool {
+    rev_parse(repo, &format!("refs/heads/{branch}")).is_ok()
+        || rev_parse(repo, &format!("refs/remotes/origin/{branch}")).is_ok()
 }
 
 fn wt_list(format: Option<&str>) -> Result<()> {

--- a/rust/loopflow/src/lf/commands/ops/mod.rs
+++ b/rust/loopflow/src/lf/commands/ops/mod.rs
@@ -1,11 +1,9 @@
 use crate::engine::agent::{launch_agent, AgentCapabilities, ProcessConfig};
 use crate::engine::config::load_config_or_default;
-use crate::engine::git::{
-    current_branch, delete_local_branch, get_default_branch, rev_parse, sync_main,
-};
+use crate::engine::git::{current_branch, delete_local_branch, get_default_branch, sync_main};
 use crate::engine::worktrees::{
     create_with_schema_synced, list_worktrees, main_repo_root, wave_name_from_worktree,
-    wave_name_from_worktree_and_main, worktree_path, worktree_path_with_config,
+    wave_name_from_worktree_and_main, worktree_path,
 };
 use crate::engine::{prepare_launch_prompt, ContextSourceOverrides, LaunchPromptInput, Surface};
 use crate::lf::commands::util::find_repo_root;
@@ -562,8 +560,6 @@ fn wt_create(name: &str, base: Option<&str>, stack: bool) -> Result<()> {
 fn wt_switch(name: &str) -> Result<()> {
     let repo_root = find_repo_root()?;
     let main_repo = main_repo_root(&repo_root)?;
-    let config = load_config_or_default(Some(&main_repo));
-    let branch_config = config.branch_names.as_ref();
     let worktrees = list_worktrees(&main_repo)?;
 
     let path = if let Some(exact_branch_match) = worktrees
@@ -573,11 +569,7 @@ fn wt_switch(name: &str) -> Result<()> {
     {
         exact_branch_match
     } else {
-        let target = if branch_ref_exists(&main_repo, name) {
-            worktree_path_with_config(&main_repo, name, branch_config)
-        } else {
-            worktree_path(&main_repo, name)
-        };
+        let target = worktree_path(&main_repo, name);
         if target.exists() {
             target
         } else {
@@ -611,11 +603,6 @@ fn wt_switch(name: &str) -> Result<()> {
         println!("cd {}", path.display());
     }
     Ok(())
-}
-
-fn branch_ref_exists(repo: &Path, branch: &str) -> bool {
-    rev_parse(repo, &format!("refs/heads/{branch}")).is_ok()
-        || rev_parse(repo, &format!("refs/remotes/origin/{branch}")).is_ok()
 }
 
 fn wt_list(format: Option<&str>) -> Result<()> {

--- a/rust/loopflow/src/lf/mod.rs
+++ b/rust/loopflow/src/lf/mod.rs
@@ -369,7 +369,7 @@ pub enum WtCommand {
     },
     /// Switch to a worktree
     Switch {
-        /// Worktree name to switch to
+        /// Worktree name or full branch name to switch to
         name: String,
     },
     /// List worktrees

--- a/rust/loopflow/tests/worktree_tests.rs
+++ b/rust/loopflow/tests/worktree_tests.rs
@@ -1,4 +1,5 @@
 use std::process::Command;
+use std::{fs, path::PathBuf};
 
 use loopflow::engine::git::{is_clean, worktree_move, worktree_remove};
 use loopflow::engine::worktrees::{
@@ -239,6 +240,105 @@ fn wt_switch_finds_timestamped_worktree_by_short_name() {
         })
         .collect();
     assert_eq!(prefix.len(), 1);
+}
+
+#[test]
+fn wt_switch_prefers_exact_branch_match_over_wave_name_path() {
+    let repo = TestRepo::new();
+    let old_branch = "jack.chord-model.20260316_1856";
+    let new_branch = "jack.chord-model.20260318_0010";
+    let old_path = repo.path().parent().expect("repo parent").join(format!(
+        "{}.chord-model.20260316_1856",
+        repo.path().file_name().expect("repo dir").to_string_lossy()
+    ));
+    let new_path = repo.path().parent().expect("repo parent").join(format!(
+        "{}.chord-model",
+        repo.path().file_name().expect("repo dir").to_string_lossy()
+    ));
+
+    add_worktree(repo.path(), &old_path, old_branch);
+    add_worktree(repo.path(), &new_path, new_branch);
+
+    let directive_path = repo.path().join("directive.txt");
+    let status = Command::new(env!("CARGO_BIN_EXE_lf"))
+        .args(["ops", "wt", "switch", old_branch])
+        .current_dir(repo.path())
+        .env("LOOPFLOW_DIRECTIVE_FILE", &directive_path)
+        .status()
+        .expect("run lf ops wt switch");
+    assert!(status.success(), "lf ops wt switch should succeed");
+
+    let directive = fs::read_to_string(&directive_path).expect("read directive");
+    let target = PathBuf::from(
+        directive
+            .trim()
+            .strip_prefix("cd ")
+            .expect("directive should start with cd "),
+    );
+    assert_eq!(
+        fs::canonicalize(target).expect("canonicalize directive target"),
+        fs::canonicalize(old_path).expect("canonicalize old path")
+    );
+}
+
+#[test]
+fn wt_switch_uses_existing_worktree_for_saved_branch_with_custom_schema() {
+    let repo = TestRepo::new();
+    fs::create_dir_all(repo.path().join(".lf")).expect("create .lf");
+    fs::write(
+        repo.path().join(".lf/config.yaml"),
+        "branch_names:\n  schema: \"{user}/{name}\"\n",
+    )
+    .expect("write config");
+
+    let feature_path = repo.path().parent().expect("repo parent").join(format!(
+        "{}.feature",
+        repo.path().file_name().expect("repo dir").to_string_lossy()
+    ));
+    add_worktree(repo.path(), &feature_path, "feature-live");
+
+    let status = Command::new("git")
+        .args(["branch", "jack/feature"])
+        .current_dir(repo.path())
+        .status()
+        .expect("git branch");
+    assert!(status.success(), "git branch should succeed");
+
+    let directive_path = repo.path().join("directive.txt");
+    let status = Command::new(env!("CARGO_BIN_EXE_lf"))
+        .args(["ops", "wt", "switch", "jack/feature"])
+        .current_dir(repo.path())
+        .env("LOOPFLOW_DIRECTIVE_FILE", &directive_path)
+        .status()
+        .expect("run lf ops wt switch");
+    assert!(status.success(), "lf ops wt switch should succeed");
+
+    let directive = fs::read_to_string(&directive_path).expect("read directive");
+    let target = PathBuf::from(
+        directive
+            .trim()
+            .strip_prefix("cd ")
+            .expect("directive should start with cd "),
+    );
+    assert_eq!(
+        fs::canonicalize(target).expect("canonicalize directive target"),
+        fs::canonicalize(feature_path).expect("canonicalize feature path")
+    );
+}
+
+fn add_worktree(repo: &std::path::Path, path: &std::path::Path, branch: &str) {
+    let status = Command::new("git")
+        .args(["worktree", "add", "-b", branch])
+        .arg(path)
+        .arg("main")
+        .current_dir(repo)
+        .status()
+        .expect("git worktree add");
+    assert!(
+        status.success(),
+        "git worktree add should succeed for {}",
+        branch
+    );
 }
 
 #[test]

--- a/rust/loopflow/tests/worktree_tests.rs
+++ b/rust/loopflow/tests/worktree_tests.rs
@@ -282,7 +282,45 @@ fn wt_switch_prefers_exact_branch_match_over_wave_name_path() {
 }
 
 #[test]
-fn wt_switch_uses_existing_worktree_for_saved_branch_with_custom_schema() {
+fn wt_switch_finds_exact_branch_match_with_custom_schema() {
+    let repo = TestRepo::new();
+    fs::create_dir_all(repo.path().join(".lf")).expect("create .lf");
+    fs::write(
+        repo.path().join(".lf/config.yaml"),
+        "branch_names:\n  schema: \"{user}/{name}\"\n",
+    )
+    .expect("write config");
+
+    let feature_path = repo.path().parent().expect("repo parent").join(format!(
+        "{}.feature",
+        repo.path().file_name().expect("repo dir").to_string_lossy()
+    ));
+    add_worktree(repo.path(), &feature_path, "jack/feature");
+
+    let directive_path = repo.path().join("directive.txt");
+    let status = Command::new(env!("CARGO_BIN_EXE_lf"))
+        .args(["ops", "wt", "switch", "jack/feature"])
+        .current_dir(repo.path())
+        .env("LOOPFLOW_DIRECTIVE_FILE", &directive_path)
+        .status()
+        .expect("run lf ops wt switch");
+    assert!(status.success(), "lf ops wt switch should succeed");
+
+    let directive = fs::read_to_string(&directive_path).expect("read directive");
+    let target = PathBuf::from(
+        directive
+            .trim()
+            .strip_prefix("cd ")
+            .expect("directive should start with cd "),
+    );
+    assert_eq!(
+        fs::canonicalize(target).expect("canonicalize directive target"),
+        fs::canonicalize(feature_path).expect("canonicalize feature path")
+    );
+}
+
+#[test]
+fn wt_switch_does_not_map_branch_name_to_unrelated_worktree_path() {
     let repo = TestRepo::new();
     fs::create_dir_all(repo.path().join(".lf")).expect("create .lf");
     fs::write(
@@ -304,25 +342,20 @@ fn wt_switch_uses_existing_worktree_for_saved_branch_with_custom_schema() {
         .expect("git branch");
     assert!(status.success(), "git branch should succeed");
 
-    let directive_path = repo.path().join("directive.txt");
-    let status = Command::new(env!("CARGO_BIN_EXE_lf"))
+    let output = Command::new(env!("CARGO_BIN_EXE_lf"))
         .args(["ops", "wt", "switch", "jack/feature"])
         .current_dir(repo.path())
-        .env("LOOPFLOW_DIRECTIVE_FILE", &directive_path)
-        .status()
+        .output()
         .expect("run lf ops wt switch");
-    assert!(status.success(), "lf ops wt switch should succeed");
-
-    let directive = fs::read_to_string(&directive_path).expect("read directive");
-    let target = PathBuf::from(
-        directive
-            .trim()
-            .strip_prefix("cd ")
-            .expect("directive should start with cd "),
+    assert!(
+        !output.status.success(),
+        "lf ops wt switch should fail for unrelated branch/worktree reuse"
     );
-    assert_eq!(
-        fs::canonicalize(target).expect("canonicalize directive target"),
-        fs::canonicalize(feature_path).expect("canonicalize feature path")
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("no worktree found for 'jack/feature'"),
+        "unexpected stderr: {stderr}"
     );
 }
 

--- a/scripts/dev-lf
+++ b/scripts/dev-lf
@@ -1,29 +1,72 @@
 #!/bin/bash
 # Build and run lf from the current repo's source tree.
-# Usage: scripts/dev-lf [args...]   e.g.  scripts/dev-lf design
+# Usage: scripts/dev-lf [args...]             e.g.  scripts/dev-lf design
+#        source scripts/dev-lf [args...]      applies shell directives like `cd`
 #
 # Run directly — do NOT use `uv run scripts/dev-lf` (uv mangles args
 # and breaks TTY passthrough for interactive agents).
-set -e
-set -o pipefail
 
-REPO="$(git rev-parse --show-toplevel)"
-export RUST_LOG="${RUST_LOG:-lf=debug,loopflow=debug}"
-cargo build -p loopflow --bin lf --manifest-path "$REPO/Cargo.toml" </dev/null 2>&1 | grep -E '^   Compiling|^    Finished|^error' >&2
-echo "running: $REPO/target/debug/lf $*" >&2
+is_sourced() {
+    if [[ -n "${ZSH_EVAL_CONTEXT:-}" ]]; then
+        [[ "$ZSH_EVAL_CONTEXT" != "toplevel" ]]
+    else
+        [[ "${BASH_SOURCE[0]}" != "$0" ]]
+    fi
+}
 
-# Mirror the lf() shell function so directives (cd after land, wt create) work.
-# dev-lf runs as a child process so it can't change the parent shell's cwd,
-# but it prints the directive so the user can copy-paste.
-directive_file="$(mktemp)"
-exit_code=0
-LOOPFLOW_DIRECTIVE_FILE="$directive_file" "$REPO/target/debug/lf" "$@" || exit_code=$?
+return_or_exit() {
+    local code="$1"
+    if is_sourced; then
+        return "$code"
+    fi
+    exit "$code"
+}
 
-if [[ -s "$directive_file" ]]; then
-    while IFS= read -r line; do
-        echo "$line" >&2
-    done < "$directive_file"
-fi
+run_dev_lf() {
+    local repo directive_file status_file exit_code run_status
 
-rm -f "$directive_file"
-exit "$exit_code"
+    repo="$(git rev-parse --show-toplevel)" || return "$?"
+    directive_file="$(mktemp)"
+    status_file="$(mktemp)"
+
+    (
+        set -e
+        set -o pipefail
+
+        export RUST_LOG="${RUST_LOG:-lf=debug,loopflow=debug}"
+        cargo build -p loopflow --bin lf --manifest-path "$repo/Cargo.toml" </dev/null 2>&1 |
+            grep -E '^   Compiling|^    Finished|^error' >&2
+        echo "running: $repo/target/debug/lf $*" >&2
+
+        exit_code=0
+        LOOPFLOW_DIRECTIVE_FILE="$directive_file" "$repo/target/debug/lf" "$@" || exit_code=$?
+        printf '%s\n' "$exit_code" >"$status_file"
+    )
+    run_status=$?
+
+    if [[ -s "$status_file" ]]; then
+        exit_code="$(cat "$status_file")"
+    else
+        exit_code="$run_status"
+    fi
+
+    if [[ -s "$directive_file" ]]; then
+        if is_sourced; then
+            source "$directive_file"
+            if [[ "$exit_code" -eq 0 ]]; then
+                exit_code=$?
+            fi
+        else
+            while IFS= read -r line; do
+                echo "$line" >&2
+            done <"$directive_file"
+            echo "Tip: source scripts/dev-lf ... to apply shell directives in this shell." >&2
+        fi
+    fi
+
+    rm -f "$directive_file" "$status_file"
+    return "$exit_code"
+}
+
+run_dev_lf "$@"
+return_or_exit $?


### PR DESCRIPTION
## Usage

```bash
lf ops wt switch my-feature
lf ops wt switch jack.chord-model.20260316_1856

source scripts/dev-lf ops wt switch jack.chord-model.20260316_1856
```

`lf ops wt switch` now accepts either the short worktree name or the full branch name. When using the local dev wrapper, sourcing `scripts/dev-lf` applies generated shell directives like `cd` in the current shell instead of only printing them.

## Summary

This PR tightens worktree switching so branch-qualified names resolve to the intended worktree before falling back to wave-name and path heuristics. That avoids ambiguous or incorrect matches for timestamped branches and custom branch naming schemas. It also makes `scripts/dev-lf` behave more like the real shell integration by supporting sourced execution, which lets local development flows apply directives directly while still printing guidance when run as a normal script.

## Changes

- Update `lf ops wt switch` to prefer an exact branch-name match before checking derived worktree names or directory names
- Preserve the existing short-name behavior while preventing unrelated worktree-path reuse for branch names under custom schemas
- Add Rust integration tests covering exact branch precedence, custom schema branch names, and failure on unrelated matches
- Update CLI help and docs to document switching by full branch name
- Rework `scripts/dev-lf` so it can be sourced, apply `lf` shell directives in-place, and print a tip when invoked without sourcing