### PR TITLE
lf: commit dirty files after standalone step runs

### DIFF
--- a/rust/loopflow/src/bin/lf.rs
+++ b/rust/loopflow/src/bin/lf.rs
@@ -246,11 +246,7 @@ fn run_target(
                     message: Some(format!("lf commit: {name}")),
                     ..loopflow::ops::CommitOptions::for_task(name)
                 };
-                loopflow::ops::commit_workflow(
-                    &repo_root,
-                    &options,
-                    &loopflow::ops::NullProgress,
-                )?;
+                loopflow::ops::commit_workflow(&repo_root, &options, &loopflow::ops::NullProgress)?;
                 Ok(())
             })
         }),

--- a/rust/loopflow/src/bin/lf.rs
+++ b/rust/loopflow/src/bin/lf.rs
@@ -237,7 +237,21 @@ fn run_target(
     match loopflow::lf::discovery::discover_target(&repo_root, name)? {
         loopflow::lf::discovery::Target::Step(_) => with_runtime(&repo_root, command, || {
             with_step_runtime(&repo_root, name, || {
-                loopflow::lf::commands::run::run(Some(name), message, cli)
+                loopflow::lf::commands::run::run(Some(name), message, cli)?;
+                // Commit any uncommitted changes left by the step.
+                // When running inside a flow, the flow executor handles this;
+                // for standalone steps we must do it here.
+                let options = loopflow::ops::CommitOptions {
+                    add: true,
+                    message: Some(format!("lf commit: {name}")),
+                    ..loopflow::ops::CommitOptions::for_task(name)
+                };
+                loopflow::ops::commit_workflow(
+                    &repo_root,
+                    &options,
+                    &loopflow::ops::NullProgress,
+                )?;
+                Ok(())
             })
         }),
         loopflow::lf::discovery::Target::Flow(flow) => with_runtime(&repo_root, command, || {


### PR DESCRIPTION
## Summary
- Standalone steps (`lf gate`, `lf implement`, etc.) didn't commit uncommitted files after the agent finished
- The flow executor called `commit_step_work` after each step, but the standalone `run_target` path skipped it
- Added `commit_workflow(add: true)` after standalone step success, matching flow executor behavior

## Test plan
- [ ] Run `lf gate` on a branch with uncommitted files — verify they're committed after the step
- [ ] Run a flow (`lf build`) — verify no double-commit (second commit_workflow no-ops)