### PR TITLE
chatgui: draft

### DIFF
--- a/scratch/chatgui-animation-smoothness.md
+++ b/scratch/chatgui-animation-smoothness.md
@@ -1,0 +1,28 @@
+---
+status: in-progress
+claimed_by: jack-heart.chatgui.20260423_1303
+claimed_at: 2026-04-23T21:03:04.202487Z
+---
+# 01: Animation and Smoothness
+
+With the hot path fixed (streaming state is incremental in SessionState), address the visual polish that makes streaming feel fluid.
+
+## Done when
+
+Streaming a long response with tool calls looks smooth — no layout jumps, no animation restarts, no scroll fights. Side-by-side with Claude's web UI, Concerto holds up.
+
+## Already done
+
+- Scroll auto-scroll uses `DesignAnimation.fast(reduceMotion)` instead of bare `withAnimation`
+- `StreamingCursorView` identity is pinned via `.id("streaming-cursor-\(message.id)")` — no flicker on deltas
+- `DesignAnimation.pulse(_:duration:)` helper for forever-repeating autoreverse animations (DesignSystem.swift)
+- `SessionThinkingIndicator` pulsing animation migrated to `DesignAnimation.pulse`
+- `StreamingCursorView` visibility animation migrated to `DesignAnimation.pulse`
+- Thinking indicator fades + slides in/out on `isLoading` toggles instead of popping
+- Tool run groups (`ToolRunView`) animate expand/collapse with opacity + move-from-top transition
+- Transcript item details (`TranscriptItemCardView`) animate expand/collapse with opacity + move-from-top transition
+
+## Remaining
+
+- Message appearance animation for new messages vs. streamed content — the row identity is stable across streaming deltas, so a naive `.transition` on the message row would either do nothing (append) or fire on every delta (wrong). Needs a "first render" flag or a separate wrapper view keyed on message.id insertion before wiring the transition.
+- Context snapshot expand/collapse already uses `DesignAnimation.standard` + `.transition(.opacity)`. The remaining "transition gap" referenced in the earlier note would need a visual repro before choosing a fix; layout height jumps are the most likely culprit.

--- a/scratch/chatgui-markdown-rendering.md
+++ b/scratch/chatgui-markdown-rendering.md
@@ -1,0 +1,25 @@
+---
+status: in-progress
+claimed_by: jack-heart.chatgui.20260423_1303
+claimed_at: 2026-04-23T21:03:10.020991Z
+---
+# 02: Markdown Rendering
+
+Rich text in assistant messages. Currently plain text + code fences.
+
+## Done when
+
+Assistant messages render bold, italic, links, lists, headers, and inline code. Code blocks get syntax highlighting for common languages (Swift, Python, Rust, TypeScript, bash).
+
+## Approach
+
+Evaluate existing SwiftUI markdown options:
+- `Text` with `AttributedString` from `Foundation` (limited but built-in)
+- `swift-markdown` + custom `AttributedString` renderer
+- Third-party: MarkdownUI, swift-markdown-ui
+
+## Constraint from streaming work
+
+`MessageRow` caches parsed segments keyed on `content.count` (content length as staleness check). Markdown parsing must either integrate with or replace this cache. If the markdown renderer produces `AttributedString` or a view tree, the segment cache may become the markdown cache — same invalidation strategy, different output type.
+
+If assistant content is ever edited in-place (not just appended), the content-length cache key won't detect the change. For now streaming is append-only so this is fine, but markdown rendering should not depend on this assumption if it can be avoided cheaply.

--- a/swift/Concerto/Views/WaveSessionView.swift
+++ b/swift/Concerto/Views/WaveSessionView.swift
@@ -48,6 +48,7 @@ struct WaveSessionView: View {
                                 awaitingSessionJoin: state.awaitingSessionJoin
                             )
                             .padding(.top, Spacing.sm)
+                            .transition(.opacity.combined(with: .move(edge: .bottom)))
                         }
 
                         Color.clear
@@ -58,6 +59,7 @@ struct WaveSessionView: View {
                     }
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .padding(Spacing.lg)
+                    .animation(DesignAnimation.standard(reduceMotion), value: state.isLoading)
                 }
                 .background(palette.background)
                 .overlay {
@@ -387,7 +389,7 @@ private struct SessionThinkingIndicator: View {
                     .onAppear {
                         guard !reduceMotion else { return }
                         isPulsing = false
-                        withAnimation(.easeInOut(duration: 1.2).repeatForever(autoreverses: true)) {
+                        withAnimation(DesignAnimation.pulse(reduceMotion, duration: 1.2)) {
                             isPulsing = true
                         }
                     }
@@ -447,7 +449,7 @@ struct StreamingCursorView: View {
                     return
                 }
                 isVisible = false
-                withAnimation(.easeInOut(duration: 0.6).repeatForever(autoreverses: true)) {
+                withAnimation(DesignAnimation.pulse(reduceMotion, duration: 0.6)) {
                     isVisible = true
                 }
             }
@@ -555,6 +557,7 @@ private struct CopyButton: View {
 private struct TranscriptItemCardView: View {
     @Environment(\.palette) private var palette
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     let item: TranscriptItem
     let isExpanded: Bool
@@ -591,7 +594,9 @@ private struct TranscriptItemCardView: View {
 
                 if card.detail != nil {
                     Button {
-                        onToggleExpanded()
+                        withAnimation(DesignAnimation.standard(reduceMotion)) {
+                            onToggleExpanded()
+                        }
                     } label: {
                         Image(systemName: isExpanded ? "chevron.down" : "chevron.right")
                             .font(Typography.caption())
@@ -606,6 +611,7 @@ private struct TranscriptItemCardView: View {
                 if card.type == .file {
                     DiffLinesView(diff: detail)
                         .hoverTracking { hovering in isHoveringDetail = hovering }
+                        .transition(.opacity.combined(with: .move(edge: .top)))
                 } else {
                     VStack(alignment: .leading, spacing: Spacing.xs) {
                         HStack {
@@ -633,6 +639,7 @@ private struct TranscriptItemCardView: View {
                     .hoverTracking { hovering in
                         isHoveringDetail = hovering
                     }
+                    .transition(.opacity.combined(with: .move(edge: .top)))
                 }
             }
         }
@@ -644,6 +651,7 @@ private struct TranscriptItemCardView: View {
 
 private struct ToolRunView: View {
     @Environment(\.palette) private var palette
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     let items: [TranscriptItem]
     let isExpanded: Bool
@@ -653,7 +661,9 @@ private struct ToolRunView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             Button {
-                onToggleRun()
+                withAnimation(DesignAnimation.standard(reduceMotion)) {
+                    onToggleRun()
+                }
             } label: {
                 HStack(spacing: Spacing.sm) {
                     Image(systemName: isExpanded ? "chevron.down" : "chevron.right")
@@ -683,6 +693,7 @@ private struct ToolRunView: View {
                         )
                     }
                 }
+                .transition(.opacity.combined(with: .move(edge: .top)))
             }
         }
     }

--- a/swift/LoopflowCore/Design/DesignSystem.swift
+++ b/swift/LoopflowCore/Design/DesignSystem.swift
@@ -71,6 +71,10 @@ public enum DesignAnimation {
     public static func spring(_ reduceMotion: Bool) -> Animation? {
         reduceMotion ? nil : .spring(response: 0.3, dampingFraction: 0.7)
     }
+
+    public static func pulse(_ reduceMotion: Bool, duration: Double = 1.2) -> Animation? {
+        reduceMotion ? nil : .easeInOut(duration: duration).repeatForever(autoreverses: true)
+    }
 }
 
 public extension View {

--- a/wave/chatgui/MEMORY.md
+++ b/wave/chatgui/MEMORY.md
@@ -1,0 +1,20 @@
+# chatgui — wave memory
+
+## Patterns
+
+- **Animation abstraction**: UI animations in Concerto must route through `DesignAnimation` (in `swift/LoopflowCore/Design/DesignSystem.swift`) so `reduceMotion` is respected uniformly. New repeating patterns (pulse, blink, shimmer) should be added as helpers — don't sprinkle bare `withAnimation(.easeInOut(...).repeatForever(...))` calls in views.
+- **Transitions need an anchor**: `.transition(...)` only fires when the containing view tree sees an explicit animation. Typical pattern:
+  - child: `.transition(.opacity.combined(with: .move(edge: ...)))`
+  - parent: `.animation(DesignAnimation.standard(reduceMotion), value: <trigger>)` OR wrap the toggling mutation in `withAnimation(DesignAnimation.standard(reduceMotion)) { ... }`.
+- **Transcript transition traps**: `state.groupedTranscript` rows are stable across streaming deltas (same id, growing content). Adding a naive insertion `.transition` on rows causes either no-op (append) or flicker-every-delta (updates). If we later want new-message entry animation, we need to separate "newly inserted row" from "content updated row" — likely via a small wrapper view keyed on message.id that only animates `.onAppear`.
+- **SourceKit noise**: Live-editing WaveSessionView.swift and DesignSystem.swift surfaces spurious SourceKit diagnostics about `@Bindable init(wrappedValue:)` and missing colors (`loopflowCream`, `statusError`). These resolve on a full build; ignore them while editing.
+
+## Preferences
+
+- Headless runs claim a scratch doc via frontmatter (`status`, `claimed_by`, `claimed_at`) before touching it. Keep the frontmatter when updating; only edit the body.
+- Prefer small, complete milestones per commit in headless mode — doc updates and code changes land together so review sees a consistent delta.
+
+## Learnings
+
+- `swift test --package-path swift` is the fast feedback loop for this area. Took ~40s here with 325 tests passing.
+- `DesignAnimation.pulse(_:duration:)` covers both the thinking indicator (1.2s) and streaming cursor (0.6s). Parameterizing duration keeps one helper instead of two (pulse/blink).


### PR DESCRIPTION
Add DesignAnimation.pulse for forever-repeating autoreverse animations so
the thinking indicator and streaming cursor no longer bypass the reduceMotion
abstraction. Animate tool-run and transcript-item expand/collapse with
opacity + move-from-top transitions, and fade the thinking indicator in/out
when isLoading toggles so it stops popping into the transcript.
