### PR TITLE
regression + lfd: add nightly regression suite, weekly auto-release, and wave status fixes

### DIFF
--- a/.github/workflows/regression-daily.yml
+++ b/.github/workflows/regression-daily.yml
@@ -1,0 +1,29 @@
+name: Regression (daily)
+
+on:
+  schedule:
+    # 06:00 UTC daily — late enough to not conflict with common release hours.
+    - cron: "0 6 * * *"
+  workflow_dispatch:
+  workflow_call:
+
+jobs:
+  regression:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - uses: astral-sh/setup-uv@v4
+      - name: Build lfd
+        run: cargo build --bin lfd
+      - name: Run regression suite
+        run: uv run pytest tests/regression/ -v
+      - name: Upload lfd logs on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: lfd-regression-logs
+          path: /tmp/lfd-*
+          if-no-files-found: ignore

--- a/.github/workflows/weekly-release.yml
+++ b/.github/workflows/weekly-release.yml
@@ -1,0 +1,84 @@
+name: Regression (weekly auto-release)
+
+on:
+  schedule:
+    # Sundays 12:00 UTC — runs the regression suite against main and, if
+    # everything is green and new commits have landed since the last tag,
+    # bumps the patch version. `auto-tag.yml` then picks up the commit and
+    # cuts the release.
+    - cron: "0 12 * * 0"
+  workflow_dispatch:
+
+jobs:
+  regression:
+    uses: ./.github/workflows/regression-daily.yml
+
+  release:
+    needs: regression
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Skip if no commits since last tag
+        id: tag_check
+        run: |
+          set -euo pipefail
+          last_tag=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+          if [ -z "$last_tag" ]; then
+            echo "no previous tag — proceeding with first auto-release"
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+            echo "last_tag=" >> "$GITHUB_OUTPUT"
+            echo "commit_count=0" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          commit_count=$(git rev-list "$last_tag..HEAD" --count)
+          echo "last_tag=$last_tag commit_count=$commit_count"
+          if [ "$commit_count" -eq 0 ]; then
+            echo "no new commits since $last_tag — skipping release"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+            echo "last_tag=$last_tag" >> "$GITHUB_OUTPUT"
+            echo "commit_count=$commit_count" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Bump patch version and append release notes
+        if: steps.tag_check.outputs.skip != 'true'
+        id: bump
+        run: |
+          set -euo pipefail
+          ./scripts/bump_patch_version.sh \
+            "${{ steps.tag_check.outputs.last_tag }}" \
+            "${{ steps.tag_check.outputs.commit_count }}" \
+            | tee bump.out
+          # bump_patch_version.sh prints `next=<version>` on its last line.
+          next=$(grep '^next=' bump.out | cut -d= -f2)
+          echo "next=$next" >> "$GITHUB_OUTPUT"
+      - name: Refresh Cargo.lock
+        if: steps.tag_check.outputs.skip != 'true'
+        run: cargo update -p loopflow
+      - name: Commit, tag, and dispatch release
+        if: steps.tag_check.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          version="v${{ steps.bump.outputs.next }}"
+          git config user.name "loopflow-bot"
+          git config user.email "bot@loopflow.studio"
+          git add Cargo.toml Cargo.lock pyproject.toml RELEASE_NOTES.md
+          git commit -m "release: ${version} (weekly auto-release)"
+          git push origin HEAD:main
+
+          # Pushes made with GITHUB_TOKEN don't trigger other workflows, so
+          # cut the tag and dispatch release.yml explicitly — mirrors what
+          # auto-tag.yml would have done for a human-driven release.
+          git tag "$version"
+          git push origin "$version"
+          gh workflow run release.yml --ref "$version" -f tag="$version"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ pythonpath = ["."]
 markers = [
     "e2e: end-to-end tests requiring lfd",
     "docker: tests requiring Docker and Claude credentials",
+    "regression: expensive regression tests — run nightly in CI, not on every PR",
 ]
 
 [tool.ruff]

--- a/rust/loopflow/src/lfd/http/dto.rs
+++ b/rust/loopflow/src/lfd/http/dto.rs
@@ -254,6 +254,7 @@ pub struct TerminalSessionDto {
     pub argv: Vec<String>,
     pub env: BTreeMap<String, String>,
     pub source: String,
+    pub tmux_name: String,
     pub status: String,
     pub created_at: String,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -276,6 +277,7 @@ pub fn terminal_session_dto(session: TerminalSession) -> TerminalSessionDto {
         argv: session.argv,
         env: session.env,
         source: session.source,
+        tmux_name: session.tmux_name,
         status: session.status.as_str().to_string(),
         created_at: format_datetime(Some(session.created_at)).unwrap_or_default(),
         attached_at: format_datetime(session.attached_at),

--- a/rust/loopflow/src/lfd/http/routes/waves.rs
+++ b/rust/loopflow/src/lfd/http/routes/waves.rs
@@ -1874,6 +1874,136 @@ mod tests {
         }
     }
 
+    // Reproduces the "Ingest & build" empty-reply bug: when a wave has PM
+    // configured, POST /waves/{id}/run with a roadmap_item aborts the HTTP
+    // connection without a response, because the ingest code path calls
+    // `block_on_pm` (which constructs a new Tokio runtime) from inside the
+    // axum handler's runtime context — Tokio panics with "Cannot start a
+    // runtime from within a runtime" and axum's panic handler can't always
+    // recover a clean 500. The handler should respond with a structured error.
+    #[tokio::test]
+    async fn run_wave_with_roadmap_item_and_pm_config_does_not_panic() {
+        let state = test_http_state().await;
+        let repo_tmp = tempdir().expect("tempdir");
+        init_git_repo(repo_tmp.path());
+        let repo = repo_tmp.path().to_string_lossy().to_string();
+
+        let lf_dir = repo_tmp.path().join(".lf");
+        std::fs::create_dir_all(&lf_dir).expect("create .lf");
+        std::fs::write(lf_dir.join("config.yaml"), "pm:\n  provider: asana\n")
+            .expect("write config");
+
+        let wave_dir = repo_tmp.path().join("wave").join("designer");
+        std::fs::create_dir_all(&wave_dir).expect("create wave dir");
+        std::fs::write(
+            wave_dir.join("designer.yaml"),
+            "pm:\n  provider: asana\n  asana_project: '123'\n",
+        )
+        .expect("write wave config");
+        std::fs::write(wave_dir.join("1-something.md"), "# Something\n")
+            .expect("write roadmap item");
+
+        let Json(created) = create_wave_handler(
+            State(state.clone()),
+            Json(CreateWaveRequest {
+                repo: repo.clone(),
+                name: Some("designer".to_string()),
+                flow: Some("ship-roadmap".to_string()),
+                crons: None,
+                direction: None,
+                area: None,
+                workers: None,
+                status: Some("paused".to_string()),
+                run: false,
+                serialized: true,
+            }),
+        )
+        .await
+        .expect("create wave");
+
+        // The handler must return a Result — not panic and not hang — even when
+        // the PM-backed ingest code path runs inside the async handler context.
+        let result = run_wave_handler(
+            State(state.clone()),
+            Path(created.id.clone()),
+            Some(Json(RunWaveRequest {
+                area: None,
+                direction: None,
+                flow: Some("build".to_string()),
+                roadmap_item: Some("1-something.md".to_string()),
+            })),
+        )
+        .await;
+
+        // We accept either success or a structured error — the failure mode we
+        // are guarding against is a panic from `block_on` inside async that
+        // aborts the HTTP response entirely.
+        match result {
+            Ok(_) => {}
+            Err((status, _)) => assert!(
+                status.is_client_error() || status.is_server_error(),
+                "unexpected status: {status}"
+            ),
+        }
+    }
+
+    // Reproduces the "Ingest & build" failure in Concerto: POST /waves/{id}/run
+    // with a `roadmap_item` that doesn't exist under wave/<name>/ returns an
+    // empty reply to the client. The handler should respond with a structured
+    // 400 error, not close the connection.
+    #[tokio::test]
+    async fn run_wave_with_missing_roadmap_item_returns_bad_request() {
+        let state = test_http_state().await;
+        let repo_tmp = tempdir().expect("tempdir");
+        init_git_repo(repo_tmp.path());
+        let repo = repo_tmp.path().to_string_lossy().to_string();
+
+        let wave_dir = repo_tmp.path().join("wave").join("designer");
+        std::fs::create_dir_all(&wave_dir).expect("create wave dir");
+        std::fs::write(
+            wave_dir.join("1-existing-item.md"),
+            "# Existing roadmap item\n",
+        )
+        .expect("write existing roadmap item");
+
+        let Json(created) = create_wave_handler(
+            State(state.clone()),
+            Json(CreateWaveRequest {
+                repo: repo.clone(),
+                name: Some("designer".to_string()),
+                flow: Some("ship-roadmap".to_string()),
+                crons: None,
+                direction: None,
+                area: None,
+                workers: None,
+                status: Some("paused".to_string()),
+                run: false,
+                serialized: true,
+            }),
+        )
+        .await
+        .expect("create wave");
+
+        let result = run_wave_handler(
+            State(state.clone()),
+            Path(created.id.clone()),
+            Some(Json(RunWaveRequest {
+                area: None,
+                direction: None,
+                flow: Some("build".to_string()),
+                roadmap_item: Some("does-not-exist.md".to_string()),
+            })),
+        )
+        .await;
+
+        let err = result.expect_err("expected handler to return an error, not panic or hang");
+        assert_eq!(
+            err.0,
+            StatusCode::BAD_REQUEST,
+            "expected 400 for missing roadmap item, got {err:?}"
+        );
+    }
+
     #[tokio::test]
     async fn create_wave_uses_mode_from_wave_config() {
         let state = test_http_state().await;

--- a/rust/loopflow/src/lfd/store/catalog.rs
+++ b/rust/loopflow/src/lfd/store/catalog.rs
@@ -28,6 +28,7 @@ pub(crate) enum Query {
     UpdateWaveRun,
     ListStackRuns,
     FailOrphanedRuns,
+    ResetStaleActiveWaves,
     GetLivePrState,
     UpsertLivePrState,
     ListTriggers,
@@ -99,6 +100,7 @@ impl Query {
         Self::UpdateWaveRun,
         Self::ListStackRuns,
         Self::FailOrphanedRuns,
+        Self::ResetStaleActiveWaves,
         Self::GetLivePrState,
         Self::UpsertLivePrState,
         Self::ListTriggers,
@@ -260,6 +262,15 @@ const QUERY_DEFS: [QueryDef; QUERY_COUNT] = [
         sqlite_override: None,
         postgres_override: Some(
             "UPDATE wave_runs SET status = {p1}, error = {p2}, ended_at = {p3}\n             WHERE status = ANY({p4})",
+        ),
+    },
+    QueryDef {
+        // Reset waves whose runs were just orphaned back to Idle so the UI
+        // doesn't leave them stuck in Running/Waiting after an lfd restart.
+        template: "UPDATE waves SET status = {p1}\n             WHERE status IN ({p2}, {p3})",
+        sqlite_override: None,
+        postgres_override: Some(
+            "UPDATE waves SET status = {p1}\n             WHERE status = ANY({p2})",
         ),
     },
     QueryDef {

--- a/rust/loopflow/src/lfd/store/mod.rs
+++ b/rust/loopflow/src/lfd/store/mod.rs
@@ -2772,6 +2772,94 @@ mod tests {
         run_store_basic_suite(&store).await;
     }
 
+    // When lfd restarts, `fail_orphaned_runs` marks in-flight runs as Failed.
+    // Without also resetting the wave's own status, the wave stays visually
+    // "running" — the Concerto sidebar and buttons stay disabled forever even
+    // though no executor is attached. Cover the reset here.
+    #[tokio::test]
+    async fn fail_orphaned_runs_resets_stuck_wave_status() {
+        let db_path = env::temp_dir().join(format!("lfd-test-{}.db", LfdId::new()));
+        let config = StorageConfig::sqlite(db_path);
+        let store = super::open_store(&config).await.expect("store should open");
+
+        // Wave that was actively running when lfd died.
+        let mut running_wave = make_wave("/repo-stuck-running");
+        running_wave.status = WaveStatus::Running;
+        store.create_wave(&running_wave).await.expect("create wave");
+        let mut running_run = make_run(&running_wave, WaveRunStatus::Running);
+        store
+            .create_wave_run(&running_run)
+            .await
+            .expect("create run");
+
+        // Wave that was at an interactive waitpoint.
+        let mut waiting_wave = make_wave("/repo-stuck-waiting");
+        waiting_wave.status = WaveStatus::Waiting;
+        store
+            .create_wave(&waiting_wave)
+            .await
+            .expect("create waiting wave");
+        let mut waiting_run = make_run(&waiting_wave, WaveRunStatus::Waiting);
+        store
+            .create_wave_run(&waiting_run)
+            .await
+            .expect("create waiting run");
+
+        // Paused wave with no active run — must be left alone.
+        let mut paused_wave = make_wave("/repo-paused");
+        paused_wave.status = WaveStatus::Paused;
+        store
+            .create_wave(&paused_wave)
+            .await
+            .expect("create paused wave");
+
+        let _ = store.fail_orphaned_runs().await.expect("fail orphans");
+
+        running_run = store
+            .get_wave_run(&running_run.id)
+            .await
+            .expect("get run")
+            .expect("run exists");
+        assert_eq!(running_run.status, WaveRunStatus::Failed);
+        waiting_run = store
+            .get_wave_run(&waiting_run.id)
+            .await
+            .expect("get waiting run")
+            .expect("run exists");
+        assert_eq!(waiting_run.status, WaveRunStatus::Failed);
+
+        let running_after = store
+            .get_wave(running_wave.id())
+            .await
+            .expect("get wave")
+            .expect("wave exists");
+        assert_eq!(
+            running_after.status,
+            WaveStatus::Idle,
+            "wave whose run was orphaned should be reset to Idle"
+        );
+        let waiting_after = store
+            .get_wave(waiting_wave.id())
+            .await
+            .expect("get waiting wave")
+            .expect("wave exists");
+        assert_eq!(
+            waiting_after.status,
+            WaveStatus::Idle,
+            "waiting-state wave should also be reset to Idle"
+        );
+        let paused_after = store
+            .get_wave(paused_wave.id())
+            .await
+            .expect("get paused wave")
+            .expect("wave exists");
+        assert_eq!(
+            paused_after.status,
+            WaveStatus::Paused,
+            "paused wave must keep its status across orphan cleanup"
+        );
+    }
+
     #[tokio::test]
     #[ignore] // requires DATABASE_URL
     async fn postgres_store_parity() {

--- a/rust/loopflow/src/lfd/store/postgres.rs
+++ b/rust/loopflow/src/lfd/store/postgres.rs
@@ -1578,7 +1578,7 @@ impl PostgresStore {
 
     pub async fn fail_orphaned_runs(&self) -> StoreResult<u32> {
         self.with_client(|client| async move {
-            let statuses = [
+            let run_statuses = [
                 WaveRunStatus::Pending.as_i32(),
                 WaveRunStatus::Running.as_i32(),
                 WaveRunStatus::Waiting.as_i32(),
@@ -1590,8 +1590,19 @@ impl PostgresStore {
                         &WaveRunStatus::Failed.as_i32(),
                         &"orphaned: lfd restarted".to_string(),
                         &now_unix(),
-                        &&statuses[..],
+                        &&run_statuses[..],
                     ],
+                )
+                .await?;
+            // Runs that were in flight are now Failed; the waves that owned
+            // them would otherwise stay stuck in Running/Waiting and the UI
+            // would keep their action buttons disabled. Reset them back to
+            // Idle.
+            let stale_wave_statuses = [WaveStatus::Running.as_i32(), WaveStatus::Waiting.as_i32()];
+            client
+                .execute(
+                    Self::sql(Query::ResetStaleActiveWaves),
+                    &[&WaveStatus::Idle.as_i32(), &&stale_wave_statuses[..]],
                 )
                 .await?;
             Ok(updated as u32)

--- a/rust/loopflow/src/lfd/store/sqlite.rs
+++ b/rust/loopflow/src/lfd/store/sqlite.rs
@@ -1520,6 +1520,17 @@ impl SqliteStore {
                 WaveRunStatus::Waiting.as_i32() as i64,
             ],
         )?;
+        // Runs that were in flight are now Failed; the waves that owned them
+        // would otherwise stay stuck in Running/Waiting and the UI would keep
+        // their action buttons disabled. Reset them back to Idle.
+        conn.execute(
+            Self::sql(Query::ResetStaleActiveWaves),
+            params![
+                WaveStatus::Idle.as_i32() as i64,
+                WaveStatus::Running.as_i32() as i64,
+                WaveStatus::Waiting.as_i32() as i64,
+            ],
+        )?;
         Ok(updated as u32)
     }
 

--- a/rust/loopflow/src/lfd/triggers/activation.rs
+++ b/rust/loopflow/src/lfd/triggers/activation.rs
@@ -360,11 +360,24 @@ pub async fn spawn_immediate_activation(
         run.snapshot.flow = flow_override;
     }
     if let Some(item) = roadmap_item {
-        if let Err(err) = ingest_roadmap_item_for_run(wave, &run, &item) {
+        // `ingest` is sync and, when PM is enabled, calls `block_on_pm` which
+        // tries to spin up a fresh Tokio runtime. Running it directly on the
+        // axum handler's async worker thread panics with "Cannot start a
+        // runtime from within a runtime" and leaves the HTTP response dangling.
+        // Punt to the blocking pool where `block_on` is legal.
+        let wave_for_ingest = wave.clone();
+        let run_for_ingest = run.clone();
+        let item_for_log = item.clone();
+        let ingest_result = tokio::task::spawn_blocking(move || {
+            ingest_roadmap_item_for_run(&wave_for_ingest, &run_for_ingest, &item)
+        })
+        .await
+        .unwrap_or_else(|join_err| Err(anyhow!("ingest task panicked: {join_err}")));
+        if let Err(err) = ingest_result {
             tracing::error!(
                 wave_id = %wave.id(),
                 run_id = %run.id,
-                item = %item,
+                item = %item_for_log,
                 error = %err,
                 "failed targeted ingest before immediate activation"
             );

--- a/scripts/bump_patch_version.sh
+++ b/scripts/bump_patch_version.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+#
+# Bump the patch version in Cargo.toml and pyproject.toml, then prepend a
+# stub entry to RELEASE_NOTES.md. Prints `next=<version>` on its last line so
+# the weekly-release workflow can capture the bumped version.
+#
+# Usage: bump_patch_version.sh <last_tag_or_empty> <commit_count_or_zero>
+#
+# Designed to be safe to run locally for a smoke check; the workflow owns the
+# commit + push.
+
+set -euo pipefail
+
+last_tag="${1:-}"
+commit_count="${2:-0}"
+
+current=$(python3 -c "
+import re, pathlib
+m = re.search(r'^version = \"([^\"]+)\"', pathlib.Path('Cargo.toml').read_text(), re.M)
+print(m.group(1) if m else '')
+")
+
+if [[ -z "$current" ]] || ! [[ "$current" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    echo "::error::Cargo.toml version is not plain semver: '$current'" >&2
+    exit 1
+fi
+
+IFS=. read -r major minor patch <<< "$current"
+next="${major}.${minor}.$((patch + 1))"
+
+echo "bumping ${current} -> ${next}"
+
+python3 - "$next" <<'PY'
+import pathlib
+import re
+import sys
+
+next_version = sys.argv[1]
+pattern = re.compile(r'^version = "[^"]+"', re.MULTILINE)
+replacement = f'version = "{next_version}"'
+
+for path in (pathlib.Path("Cargo.toml"), pathlib.Path("pyproject.toml")):
+    text = path.read_text()
+    new_text, n = pattern.subn(replacement, text, count=1)
+    if n == 0:
+        raise SystemExit(f"no version line found in {path}")
+    path.write_text(new_text)
+PY
+
+# Build the new RELEASE_NOTES.md header.
+tmp=$(mktemp)
+{
+    printf '# v%s\n\n' "$next"
+    if [ -n "$last_tag" ]; then
+        printf 'Weekly auto-release with %s commits since `%s`.\n\n' "$commit_count" "$last_tag"
+        printf '## Commits\n\n'
+        git log "$last_tag..HEAD" --pretty=format:'- %s' | head -50
+        printf '\n\n'
+    else
+        printf 'Weekly auto-release.\n\n'
+    fi
+    cat RELEASE_NOTES.md
+} > "$tmp"
+mv "$tmp" RELEASE_NOTES.md
+
+# Last line — captured by the workflow.
+echo "next=${next}"

--- a/swift/Concerto/ConcertoApp.swift
+++ b/swift/Concerto/ConcertoApp.swift
@@ -115,6 +115,12 @@ private enum LaunchArguments {
 
 private func bootstrapConcertoApp() {
     AppFontRegistration.registerBundledFonts()
+    #if os(macOS)
+    // Enrich our own process PATH before any children spawn, so tools launched
+    // through Ghostty surfaces and `--noprofile --norc` shells can find tmux,
+    // git, and agent CLIs that live in Homebrew or ~/.local/bin.
+    enrichProcessPathForGUILaunch()
+    #endif
     guard !AppRuntime.isAutomatedTest else { return }
     Task {
         try? await NotificationService.shared.requestAuthorization()
@@ -128,6 +134,15 @@ private func bootstrapConcertoApp() {
     }
     #endif
 }
+
+#if os(macOS)
+private func enrichProcessPathForGUILaunch() {
+    let existing = ProcessInfo.processInfo.environment["PATH"]
+    let enriched = GUIProcessEnvironment.enrichedPath(from: existing)
+    guard enriched != existing else { return }
+    setenv("PATH", enriched, 1)
+}
+#endif
 
 #if os(macOS)
 @MainActor

--- a/swift/Concerto/Models/PortfolioRepo.swift
+++ b/swift/Concerto/Models/PortfolioRepo.swift
@@ -1,6 +1,7 @@
 // Portfolio repository entry for persistence.
 
 import Foundation
+import LoopflowCore
 
 struct PortfolioRepo: Codable, Identifiable, Hashable {
     let path: String
@@ -9,16 +10,4 @@ struct PortfolioRepo: Codable, Identifiable, Hashable {
     var id: String { path }
     var url: URL { URL(fileURLWithPath: path) }
     var displayName: String { url.lastPathComponent }
-}
-
-extension URL {
-    var normalizedFilePath: String {
-        standardizedFileURL.path(percentEncoded: false)
-    }
-}
-
-extension String {
-    var normalizedFilePath: String {
-        URL(fileURLWithPath: self).normalizedFilePath
-    }
 }

--- a/swift/Concerto/Platform/macOS/Services/BundledDaemonManager.swift
+++ b/swift/Concerto/Platform/macOS/Services/BundledDaemonManager.swift
@@ -235,7 +235,7 @@ final class BundledDaemonManager {
             ? ["serve", Self.bundledMarkerArgument, "--allow-insecure-bind"]
             : ["serve", Self.bundledMarkerArgument]
 
-        var env = ProcessInfo.processInfo.environment
+        var env = GUIProcessEnvironment.enriched(ProcessInfo.processInfo.environment)
         env["LFD_HTTP_ADDR"] = connectWithPhone ? "0.0.0.0:\(port)" : "127.0.0.1:\(port)"
         env["LFD_DB_PATH"] = dbPath.path
         env["LFD_AUTH_MODE"] = connectWithPhone ? "studio" : "local"
@@ -563,6 +563,7 @@ final class BundledDaemonManager {
         token = nil
         runningSettings = nil
     }
+
 }
 
 private struct ProcessResult {

--- a/swift/Concerto/Platform/macOS/Services/ProcessEnvironment.swift
+++ b/swift/Concerto/Platform/macOS/Services/ProcessEnvironment.swift
@@ -1,0 +1,37 @@
+// Shared environment helpers for child processes spawned by the Concerto GUI.
+//
+// GUI-launched apps inherit a minimal PATH (/usr/bin:/bin:/usr/sbin:/sbin) that
+// doesn't include Homebrew, ~/.local/bin, or ~/.cargo/bin. Anything Concerto
+// shells out to — tmux, git, the bundled lfd — inherits that, so execvp can't
+// find user-installed binaries. Pipe child envs through `enrichedPath` so they
+// resolve the same binaries the user's shell would.
+
+import Foundation
+
+enum GUIProcessEnvironment {
+    static func enrichedPath(from existing: String?) -> String {
+        let home = FileManager.default.homeDirectoryForCurrentUser.path
+        let candidates = [
+            "\(home)/.local/bin",
+            "/opt/homebrew/bin",
+            "/opt/homebrew/sbin",
+            "/usr/local/bin",
+            "/usr/local/sbin",
+            "\(home)/.cargo/bin",
+        ]
+        let existingComponents = existing?.split(separator: ":").map(String.init) ?? []
+        var seen = Set(existingComponents)
+        var prepended: [String] = []
+        for dir in candidates where !seen.contains(dir) {
+            prepended.append(dir)
+            seen.insert(dir)
+        }
+        return (prepended + existingComponents).joined(separator: ":")
+    }
+
+    static func enriched(_ env: [String: String]) -> [String: String] {
+        var copy = env
+        copy["PATH"] = enrichedPath(from: env["PATH"])
+        return copy
+    }
+}

--- a/swift/Concerto/Platform/macOS/Services/TmuxSession.swift
+++ b/swift/Concerto/Platform/macOS/Services/TmuxSession.swift
@@ -73,7 +73,7 @@ final class TmuxSession {
         process.arguments = args
         process.standardOutput = stdout
         process.standardError = stderr
-        process.environment = ProcessInfo.processInfo.environment
+        process.environment = GUIProcessEnvironment.enriched(ProcessInfo.processInfo.environment)
 
         try process.run()
         process.waitUntilExit()

--- a/swift/Concerto/Platform/macOS/Views/MultiplexerView.swift
+++ b/swift/Concerto/Platform/macOS/Views/MultiplexerView.swift
@@ -205,6 +205,9 @@ private struct TerminalPaneView: View {
                         sessionId: pane.id,
                         manager: ghosttyManager
                     )
+                    // Rebuild the Ghostty surface when the pane is repointed
+                    // at a different tmux session (e.g. a new run starts).
+                    .id(pane.config.terminalSessionName ?? pane.id)
                 } else {
                     ProgressView("Starting tmux…")
                         .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -218,8 +221,9 @@ private struct TerminalPaneView: View {
                 )
             }
         }
-        .task(id: pane.id) {
+        .task(id: pane.config.terminalSessionName ?? pane.id) {
             guard let worktreePath else { return }
+            tmuxReady = false
             do {
                 try await tmuxSession(for: worktreePath).ensureBaseSession(launchCommand: pane.config.launchCommand)
                 clearLaunchCommandIfNeeded()
@@ -1271,7 +1275,7 @@ private func runShellCommand(_ argv: [String]) async throws -> String {
     process.arguments = argv
     process.standardOutput = stdout
     process.standardError = stderr
-    process.environment = ProcessInfo.processInfo.environment
+    process.environment = GUIProcessEnvironment.enriched(ProcessInfo.processInfo.environment)
 
     try process.run()
     process.waitUntilExit()

--- a/swift/Concerto/Platform/macOS/Views/TerminalWorkspaceView.swift
+++ b/swift/Concerto/Platform/macOS/Views/TerminalWorkspaceView.swift
@@ -241,6 +241,7 @@ private struct WorkspaceShell {
             argv: attachArguments,
             env: existingSession?.env ?? [:],
             source: "user_shell",
+            tmuxName: existingSession?.tmuxName ?? tmuxSessionName,
             status: .attached,
             createdAt: existingSession?.createdAt ?? Date(),
             attachedAt: Date(),

--- a/swift/ConcertoTests/BundledDaemonPathTests.swift
+++ b/swift/ConcertoTests/BundledDaemonPathTests.swift
@@ -1,0 +1,159 @@
+// End-to-end checks that any process Concerto spawns — the bundled lfd and the
+// tmux invocations driving the terminal panel — can actually find user-installed
+// binaries like tmux, which GUI-launched apps lose access to because their
+// inherited PATH is /usr/bin:/bin:/usr/sbin:/sbin.
+
+import Foundation
+import Testing
+@testable import Concerto
+
+@Suite("GUI Process Environment")
+struct BundledDaemonPathTests {
+    // macOS GUI apps inherit this when launched from the Dock or Finder.
+    private static let guiPath = "/usr/bin:/bin:/usr/sbin:/sbin"
+
+    @Test("tmux resolves under the enriched PATH a GUI-launched daemon would see")
+    func tmuxResolvesUnderEnrichedPath() throws {
+        guard isToolInstalledSomewhere("tmux") else { return }
+
+        let enriched = GUIProcessEnvironment.enrichedPath(from: Self.guiPath)
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+        process.arguments = ["-i", "PATH=\(enriched)", "tmux", "-V"]
+
+        let stdout = Pipe()
+        let stderr = Pipe()
+        process.standardOutput = stdout
+        process.standardError = stderr
+        try process.run()
+        process.waitUntilExit()
+
+        let output = String(
+            data: stdout.fileHandleForReading.readDataToEndOfFile(),
+            encoding: .utf8
+        ) ?? ""
+
+        #expect(process.terminationStatus == 0)
+        #expect(output.contains("tmux"))
+    }
+
+    // Reproduces the exact failure mode the terminal panel hit in production:
+    // Concerto's TmuxSession spawns `/usr/bin/env tmux ...` with the GUI-minimal
+    // environment, so `env` can't find tmux and exits 127. With
+    // GUIProcessEnvironment.enriched applied, the same invocation succeeds.
+    @Test("env tmux works with enriched env, fails with the bare GUI env")
+    func envTmuxReproducesAndFixes() throws {
+        guard isToolInstalledSomewhere("tmux") else { return }
+
+        let guiEnv = ["PATH": Self.guiPath]
+
+        let bare = try spawnAndWait(
+            "/usr/bin/env",
+            args: ["tmux", "-V"],
+            env: guiEnv
+        )
+        #expect(bare.exit == 127, "expected env to fail to resolve tmux under the GUI PATH alone")
+        #expect(bare.stderr.contains("tmux"), "expected stderr to mention tmux; got: \(bare.stderr)")
+
+        let enriched = try spawnAndWait(
+            "/usr/bin/env",
+            args: ["tmux", "-V"],
+            env: GUIProcessEnvironment.enriched(guiEnv)
+        )
+        #expect(enriched.exit == 0, "tmux should resolve under enriched env; stderr: \(enriched.stderr)")
+        #expect(enriched.stdout.contains("tmux"))
+    }
+
+    @Test("enrichment is idempotent and preserves existing PATH entries")
+    func enrichmentIsIdempotent() {
+        let once = GUIProcessEnvironment.enrichedPath(from: Self.guiPath)
+        let twice = GUIProcessEnvironment.enrichedPath(from: once)
+
+        #expect(once == twice)
+        #expect(once.contains("/usr/bin"))
+        #expect(once.contains("/opt/homebrew/bin"))
+    }
+
+    // Reproduces the Ghostty failure mode: once a surface is opened, Ghostty
+    // spawns `/usr/bin/login -flp ... /bin/bash --noprofile --norc -c 'exec -l tmux ...'`.
+    // The `--noprofile --norc` flags mean bash doesn't resource any login files,
+    // so PATH comes entirely from Concerto's own process environment. Under the
+    // bare GUI PATH, `exec -l tmux` fails with "tmux: not found"; under our
+    // enriched env it resolves.
+    @Test("bash --noprofile --norc -c 'exec tmux' works with enriched env, fails with bare GUI env")
+    func ghosttyStyleBashExecReproducesAndFixes() throws {
+        guard isToolInstalledSomewhere("tmux") else { return }
+
+        let guiEnv = ["PATH": Self.guiPath]
+
+        let bare = try spawnAndWait(
+            "/bin/bash",
+            args: ["--noprofile", "--norc", "-c", "exec tmux -V"],
+            env: guiEnv
+        )
+        #expect(bare.exit != 0, "expected bare GUI env to fail under Ghostty-style bash invocation")
+
+        let enriched = try spawnAndWait(
+            "/bin/bash",
+            args: ["--noprofile", "--norc", "-c", "exec tmux -V"],
+            env: GUIProcessEnvironment.enriched(guiEnv)
+        )
+        #expect(enriched.exit == 0, "tmux should resolve under enriched env; stderr: \(enriched.stderr)")
+        #expect(enriched.stdout.contains("tmux"))
+    }
+
+    @Test("enriched env preserves non-PATH keys and upgrades PATH")
+    func enrichedPreservesOtherKeys() {
+        let input = ["PATH": Self.guiPath, "HOME": "/Users/example", "CUSTOM": "value"]
+        let result = GUIProcessEnvironment.enriched(input)
+
+        #expect(result["HOME"] == "/Users/example")
+        #expect(result["CUSTOM"] == "value")
+        #expect(result["PATH"]?.contains("/opt/homebrew/bin") == true)
+    }
+
+    private func isToolInstalledSomewhere(_ tool: String) -> Bool {
+        let home = FileManager.default.homeDirectoryForCurrentUser.path
+        let candidates = [
+            "\(home)/.local/bin",
+            "/opt/homebrew/bin",
+            "/usr/local/bin",
+            "/usr/bin",
+        ]
+        return candidates.contains {
+            FileManager.default.isExecutableFile(atPath: "\($0)/\(tool)")
+        }
+    }
+
+    private struct SpawnResult {
+        let exit: Int32
+        let stdout: String
+        let stderr: String
+    }
+
+    private func spawnAndWait(
+        _ executable: String,
+        args: [String],
+        env: [String: String]
+    ) throws -> SpawnResult {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: executable)
+        process.arguments = args
+        process.environment = env
+
+        let out = Pipe()
+        let err = Pipe()
+        process.standardOutput = out
+        process.standardError = err
+
+        try process.run()
+        process.waitUntilExit()
+
+        return SpawnResult(
+            exit: process.terminationStatus,
+            stdout: String(data: out.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? "",
+            stderr: String(data: err.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+        )
+    }
+}

--- a/swift/ConcertoTests/RepoStateInteractiveSessionTests.swift
+++ b/swift/ConcertoTests/RepoStateInteractiveSessionTests.swift
@@ -108,8 +108,61 @@ struct RepoStateInteractiveSessionTests {
             step: "implement",
             agent: "claude",
             cwd: "/tmp/repo",
+            tmuxName: "lf-test-\(id)",
             status: .pending,
             createdAt: .now
+        )
+    }
+
+    // Covers the "click Ingest & build → terminal pane shows the live run"
+    // path: when lfd emits a TerminalSession for a new wave run, the wave's
+    // terminal pane must be repointed at that session's tmux name and armed
+    // for auto-present, so the user lands on the running flow instead of the
+    // empty default `lf-<waveId>-<paneId>` pane.
+    @Test("new run terminal session repoints the wave's terminal pane and arms auto-present")
+    func runTerminalSessionRepointsPaneAndArmsAutoPresent() {
+        let state = RepoState()
+        state.waveStore.onStatusChange = nil
+        let wave = makeWave(id: "wave-for-run", status: .idle)
+        state.waveStore.set(wave)
+
+        // Seed the default terminal pane (happens when the wave is first opened).
+        let seededPane = state.multiplexerStore.pane(ofType: .terminal, for: wave.id)
+        ?? {
+            _ = state.multiplexerStore.layout(for: wave.id)
+            return state.multiplexerStore.pane(ofType: .terminal, for: wave.id)
+        }()
+        #expect(seededPane != nil, "wave layout should seed a terminal pane")
+        let paneId = seededPane?.id ?? ""
+        let defaultSessionName = seededPane?.config.terminalSessionName
+        #expect(defaultSessionName != nil)
+        #expect(defaultSessionName?.hasPrefix("lf-\(wave.id)") == true)
+
+        let runSession = TerminalSession(
+            id: "ts-run-1",
+            waveId: wave.id,
+            waveRunId: "run-1",
+            step: "build",
+            agent: "lf",
+            cwd: "/tmp/repo",
+            tmuxName: "lf-jack-heart-model-20260423_1303",
+            status: .running,
+            createdAt: .now
+        )
+
+        #expect(state.consumeAutoPresentTerminal(for: wave.id) == false)
+
+        state.attachTerminalPane(to: runSession)
+
+        let updatedPane = state.multiplexerStore.pane(ofType: .terminal, for: wave.id)
+        #expect(updatedPane?.id == paneId, "the same pane should be updated, not replaced")
+        #expect(
+            updatedPane?.config.terminalSessionName == runSession.tmuxName,
+            "pane must attach to the run's tmux session, not the default"
+        )
+        #expect(
+            state.consumeAutoPresentTerminal(for: wave.id),
+            "auto-present should be armed so focus shifts to the terminal pane"
         )
     }
 }

--- a/swift/ConcertoTests/TerminalWorkspaceStoreTests.swift
+++ b/swift/ConcertoTests/TerminalWorkspaceStoreTests.swift
@@ -100,6 +100,7 @@ struct TerminalWorkspaceStoreTests {
             step: "implement",
             agent: "claude",
             cwd: "/tmp/repo",
+            tmuxName: "lf-test-\(id)",
             status: status,
             createdAt: Date(timeIntervalSince1970: createdAt)
         )

--- a/swift/LoopflowCore/Models/PathNormalization.swift
+++ b/swift/LoopflowCore/Models/PathNormalization.swift
@@ -1,0 +1,15 @@
+// Canonical filesystem path normalization shared across repo-scoped views.
+
+import Foundation
+
+extension URL {
+    public var normalizedFilePath: String {
+        standardizedFileURL.path(percentEncoded: false)
+    }
+}
+
+extension String {
+    public var normalizedFilePath: String {
+        URL(fileURLWithPath: self).normalizedFilePath
+    }
+}

--- a/swift/LoopflowCore/Models/TerminalSession.swift
+++ b/swift/LoopflowCore/Models/TerminalSession.swift
@@ -28,6 +28,7 @@ public struct TerminalSession: Sendable, Identifiable, Codable, Equatable {
     public let argv: [String]
     public let env: [String: String]
     public let source: String
+    public let tmuxName: String
     public let status: TerminalSessionStatus
     public let createdAt: Date
     public let attachedAt: Date?
@@ -44,6 +45,7 @@ public struct TerminalSession: Sendable, Identifiable, Codable, Equatable {
         argv: [String] = [],
         env: [String: String] = [:],
         source: String = "wave_step",
+        tmuxName: String,
         status: TerminalSessionStatus,
         createdAt: Date,
         attachedAt: Date? = nil,
@@ -59,6 +61,7 @@ public struct TerminalSession: Sendable, Identifiable, Codable, Equatable {
         self.argv = argv
         self.env = env
         self.source = source
+        self.tmuxName = tmuxName
         self.status = status
         self.createdAt = createdAt
         self.attachedAt = attachedAt

--- a/swift/LoopflowCore/Services/LocalWaveService.swift
+++ b/swift/LoopflowCore/Services/LocalWaveService.swift
@@ -1561,6 +1561,7 @@ public struct WaveService: WaveServiceProtocol, @unchecked Sendable {
               let agent = json["agent"] as? String,
               let cwd = json["cwd"] as? String,
               let source = json["source"] as? String,
+              let tmuxName = json["tmux_name"] as? String,
               let statusRaw = json["status"] as? String,
               let status = TerminalSessionStatus(rawValue: statusRaw),
               let createdAt = parseDate(json["created_at"]) else {
@@ -1577,6 +1578,7 @@ public struct WaveService: WaveServiceProtocol, @unchecked Sendable {
             argv: json["argv"] as? [String] ?? [],
             env: json["env"] as? [String: String] ?? [:],
             source: source,
+            tmuxName: tmuxName,
             status: status,
             createdAt: createdAt,
             attachedAt: parseDate(json["attached_at"]),

--- a/swift/LoopflowCore/State/RepoState.swift
+++ b/swift/LoopflowCore/State/RepoState.swift
@@ -545,6 +545,14 @@ public final class RepoState {
             return
         }
 
+        let currentRepoPath = repoTarget?.path.normalizedFilePath
+
+        if let currentRepoPath,
+           let wave = event.wave,
+           wave.repo.normalizedFilePath != currentRepoPath {
+            return
+        }
+
         switch event.type {
         case .created, .updated, .started, .stopped, .waiting:
             let previousStatus = waveStore.wave(for: event.waveId)?.status
@@ -553,6 +561,10 @@ public final class RepoState {
                 waveStore.set(makeWaveViewModel(api: wave))
                 refreshedWave = wave
             } else if let wave = try? await waveService.getWave(event.waveId) {
+                if let currentRepoPath,
+                   wave.repo.normalizedFilePath != currentRepoPath {
+                    return
+                }
                 waveStore.set(makeWaveViewModel(api: wave))
                 refreshedWave = wave
             }
@@ -643,12 +655,31 @@ public final class RepoState {
                 loadWaveContent(for: wave.id)
                 loadRuns(for: wave.id)
             }
+            // Auto-attach the wave's terminal pane to the run's live tmux
+            // session so "Ingest & build" (and any other run start) lands the
+            // user on the running flow instead of leaving the pane hooked to
+            // the empty default `lf-<waveId>-<paneId>` session.
+            if session.waveRunId != nil, !session.status.isTerminal {
+                attachTerminalPane(to: session)
+            }
             if session.status.isTerminal {
                 await refreshTerminalSessions()
             }
         } else {
             await refreshTerminalSessions()
         }
+    }
+
+    func attachTerminalPane(to session: TerminalSession) {
+        guard let pane = multiplexerStore.pane(ofType: .terminal, for: session.waveId) else {
+            return
+        }
+        if pane.config.terminalSessionName != session.tmuxName {
+            var config = pane.config
+            config.terminalSessionName = session.tmuxName
+            multiplexerStore.updatePaneConfig(pane.id, config: config, for: session.waveId)
+        }
+        markAutoPresentTerminal(for: session.waveId)
     }
 
     private func didRunComplete(oldStatus: WaveStatus?, newStatus: WaveStatus?) -> Bool {

--- a/tests/regression/README.md
+++ b/tests/regression/README.md
@@ -1,0 +1,52 @@
+# Regression tier
+
+Expensive end-to-end tests that exercise live lfd against real filesystems and
+real tmux. Each test reproduces a user-visible bug that previously shipped to
+production, so the suite is also a living changelog of "things we've promised
+won't break again."
+
+## Running
+
+```bash
+uv run pytest tests/regression/ -v                # all regression tests
+uv run pytest tests/regression/test_run_with_roadmap_item_on_pm_wave.py -v
+```
+
+The suite takes minutes, not seconds — each test spins up a fresh `lfd`
+process in an isolated temp `HOME`. Runs nightly in CI via
+[`regression-daily.yml`](../../.github/workflows/regression-daily.yml); not
+gated on PRs.
+
+## When to add a test here
+
+Add one any time you ship a fix where:
+
+- The bug only shows up against a live daemon or subprocess (tmux, git,
+  PM HTTP calls).
+- A cheaper unit test would require reshaping production code to be testable.
+- The failure mode is a full outage (panic, empty reply, stuck wave) that
+  per-PR CI can't detect.
+
+Don't add here if the fix is covered by a unit test or Swift state test —
+those run on every PR and are faster. The regression tier is for bugs that
+need a real runtime to notice.
+
+## Adding a test
+
+1. Create `tests/regression/test_<scenario>.py`.
+2. Mark it with `pytestmark = pytest.mark.regression`.
+3. Use the `lfd_runtime` and `api_client` fixtures from `conftest.py` — a
+   fresh `lfd` per test keeps state isolation tight at the cost of ~10s of
+   startup per test.
+4. Link the bug: leading docstring names the fix commit or PR so future
+   readers know *why* this specific shape matters.
+
+## Weekly auto-release
+
+When the regression suite is green on Sundays, the
+[`weekly-release.yml`](../../.github/workflows/weekly-release.yml) workflow
+bumps the patch version, appends a stub to `RELEASE_NOTES.md`, and commits.
+`auto-tag.yml` picks up that commit and cuts the tag.
+
+A failing regression test blocks the auto-release — no partial or unverified
+cuts.

--- a/tests/regression/conftest.py
+++ b/tests/regression/conftest.py
@@ -1,0 +1,28 @@
+"""Shared fixtures for the regression tier.
+
+Regression tests reuse the hermetic `LfdRuntime` from the e2e harness but are
+isolated into their own directory so the nightly job can target them without
+pulling in the faster per-PR e2e suite.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+import pytest
+
+from scripts.lib.api_harness import ApiClient
+from scripts.lib.lfd_runtime import LfdRuntime
+
+
+@pytest.fixture
+def lfd_runtime() -> Iterator[LfdRuntime]:
+    """Fresh lfd per test — state isolation matters more than startup cost here."""
+    with LfdRuntime() as runtime:
+        yield runtime
+
+
+@pytest.fixture
+def api_client(lfd_runtime: LfdRuntime) -> Iterator[ApiClient]:
+    with ApiClient(base_url=lfd_runtime.base_url, token=lfd_runtime.token) as client:
+        yield client

--- a/tests/regression/test_orphaned_runs_reset_wave_status.py
+++ b/tests/regression/test_orphaned_runs_reset_wave_status.py
@@ -1,0 +1,174 @@
+"""Guards against stuck "running" waves after an lfd restart. Previously
+`fail_orphaned_runs` marked in-flight wave_runs as Failed on startup but
+left the parent wave's `status` alone, so Concerto's "Run" and
+"Ingest & build" buttons stayed disabled forever — the user had to stop
+the wave manually to unstick it.
+"""
+
+from __future__ import annotations
+
+import os
+import socket
+import subprocess
+import tempfile
+import time
+from pathlib import Path
+
+import httpx
+import pytest
+
+pytestmark = pytest.mark.regression
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_orphaned_runs_reset_wave_status_on_restart() -> None:
+    subprocess.run(
+        ["cargo", "build", "--bin", "lfd"],
+        cwd=REPO_ROOT,
+        check=True,
+    )
+    lfd_bin = REPO_ROOT / "target" / "debug" / "lfd"
+
+    with tempfile.TemporaryDirectory(prefix="lfd-orphan-") as tmp:
+        root = Path(tmp)
+        home = root / "home"
+        repo_dir = root / "repo"
+        db_path = root / "lfd.db"
+        home.mkdir(parents=True)
+        _init_git_repo(repo_dir)
+
+        wave_id = _first_boot_and_stick_a_wave_in_running(lfd_bin, home, repo_dir, db_path)
+
+        # Second boot: pretend lfd crashed and restarted. The orphan
+        # cleanup should flip the wave back to Idle.
+        wave_status = _reboot_and_read_wave_status(lfd_bin, home, db_path, wave_id)
+
+        assert wave_status == "idle", (
+            f"stuck wave — expected 'idle' after restart, got {wave_status!r}"
+        )
+
+
+def _first_boot_and_stick_a_wave_in_running(
+    lfd_bin: Path, home: Path, repo_dir: Path, db_path: Path
+) -> str:
+    port = _reserve_port()
+    with _running_lfd(lfd_bin, home, db_path, port):
+        token = _wait_for_token(home)
+        client = httpx.Client(
+            base_url=f"http://127.0.0.1:{port}",
+            headers={"Authorization": f"Bearer {token}"},
+            timeout=10.0,
+        )
+        create = client.post(
+            "/v0/waves",
+            json={
+                "repo": str(repo_dir),
+                "name": "stuck",
+                "flow": "ship-roadmap",
+                "run": False,
+                "status": "running",
+            },
+        )
+        create.raise_for_status()
+        wave_id = create.json()["id"]
+
+        status = client.get(f"/v0/waves/{wave_id}").json()["status"]
+        assert status == "running", f"setup failed: expected running, got {status}"
+        client.close()
+        return wave_id
+
+
+def _reboot_and_read_wave_status(
+    lfd_bin: Path, home: Path, db_path: Path, wave_id: str
+) -> str:
+    port = _reserve_port()
+    with _running_lfd(lfd_bin, home, db_path, port):
+        token = _wait_for_token(home)
+        client = httpx.Client(
+            base_url=f"http://127.0.0.1:{port}",
+            headers={"Authorization": f"Bearer {token}"},
+            timeout=10.0,
+        )
+        try:
+            return client.get(f"/v0/waves/{wave_id}").json()["status"]
+        finally:
+            client.close()
+
+
+def _init_git_repo(repo_dir: Path) -> None:
+    repo_dir.mkdir(parents=True, exist_ok=True)
+    run = lambda *args: subprocess.run(args, cwd=repo_dir, check=True, capture_output=True)
+    run("git", "init")
+    run("git", "checkout", "-B", "main")
+    run("git", "config", "user.email", "t@example.com")
+    run("git", "config", "user.name", "T")
+    (repo_dir / "README.md").write_text("seed")
+    run("git", "add", ".")
+    run("git", "commit", "-m", "init")
+
+
+class _running_lfd:
+    def __init__(self, lfd_bin: Path, home: Path, db_path: Path, port: int) -> None:
+        self._lfd_bin = lfd_bin
+        self._home = home
+        self._db_path = db_path
+        self._port = port
+        self._process: subprocess.Popen[bytes] | None = None
+        self._log: Path = home.parent / f"lfd-{port}.log"
+
+    def __enter__(self) -> "_running_lfd":
+        env = os.environ.copy()
+        env["HOME"] = str(self._home)
+        env["LFD_HTTP_ADDR"] = f"127.0.0.1:{self._port}"
+        env["LFD_DB_PATH"] = str(self._db_path)
+        log_handle = self._log.open("ab")
+        self._process = subprocess.Popen(
+            [str(self._lfd_bin), "serve"],
+            env=env,
+            stdout=log_handle,
+            stderr=subprocess.STDOUT,
+        )
+        _wait_for_health(f"http://127.0.0.1:{self._port}")
+        return self
+
+    def __exit__(self, *_: object) -> None:
+        process = self._process
+        if process is None:
+            return
+        process.terminate()
+        try:
+            process.wait(timeout=8)
+        except subprocess.TimeoutExpired:
+            process.kill()
+            process.wait(timeout=5)
+
+
+def _wait_for_health(base_url: str, timeout_seconds: float = 30.0) -> None:
+    deadline = time.time() + timeout_seconds
+    while time.time() < deadline:
+        try:
+            if httpx.get(f"{base_url}/health", timeout=1.0).status_code == 200:
+                return
+        except httpx.HTTPError:
+            pass
+        time.sleep(0.1)
+    raise RuntimeError(f"lfd never reported healthy at {base_url}")
+
+
+def _wait_for_token(home: Path, timeout_seconds: float = 30.0) -> str:
+    token_path = home / ".lf" / "session-token"
+    deadline = time.time() + timeout_seconds
+    while time.time() < deadline:
+        if token_path.exists():
+            text = token_path.read_text().strip()
+            if text:
+                return text
+        time.sleep(0.1)
+    raise RuntimeError(f"session token never appeared at {token_path}")
+
+
+def _reserve_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]

--- a/tests/regression/test_run_with_roadmap_item_on_pm_wave.py
+++ b/tests/regression/test_run_with_roadmap_item_on_pm_wave.py
@@ -1,0 +1,62 @@
+"""Guards against the `block_on_pm` panic: PM-enabled ingest used to call
+`Runtime::new().block_on(...)` from inside an axum handler's async runtime,
+which Tokio kills with "Cannot start a runtime from within a runtime".
+axum's panic layer couldn't always turn that into a 500, so the HTTP
+connection dropped mid-response and Concerto showed "Network unavailable".
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from scripts.lib.api_harness import ApiClient
+from scripts.lib.lfd_runtime import LfdRuntime
+
+pytestmark = pytest.mark.regression
+
+
+def test_pm_enabled_ingest_returns_structured_response(
+    lfd_runtime: LfdRuntime, api_client: ApiClient
+) -> None:
+    repo = str(lfd_runtime.repo_dir)
+
+    # PM provider at repo level + project id on the wave — enough to make
+    # `wave_pm_is_enabled` return true and exercise the blocking code path.
+    lf_dir = lfd_runtime.repo_dir / ".lf"
+    lf_dir.mkdir(parents=True, exist_ok=True)
+    (lf_dir / "config.yaml").write_text("pm:\n  provider: asana\n")
+
+    wave_dir = lfd_runtime.repo_dir / "wave" / "designer"
+    wave_dir.mkdir(parents=True, exist_ok=True)
+    (wave_dir / "designer.yaml").write_text(
+        "pm:\n  provider: asana\n  asana_project: '123'\n"
+    )
+    (wave_dir / "1-something.md").write_text("# Something\n")
+
+    create = api_client.request(
+        "POST",
+        "/v0/waves",
+        json={
+            "repo": repo,
+            "name": "designer",
+            "flow": "ship-roadmap",
+            "run": False,
+            "status": "paused",
+        },
+    )
+    create.raise_for_status()
+    wave_id = create.json()["id"]
+
+    response = api_client.request(
+        "POST",
+        f"/v0/waves/{wave_id}/run",
+        json={"flow": "build", "roadmap_item": "1-something.md"},
+    )
+
+    # The exact status doesn't matter — the assertion is that we get ONE
+    # back at all. Before the fix, this would return an empty reply and
+    # httpx would raise a connection error.
+    assert response.status_code in {200, 400, 412, 500}, (
+        f"expected structured response, got {response.status_code}: {response.text}"
+    )
+    assert response.content, "handler must emit a response body, not drop the connection"

--- a/tests/regression/test_terminal_session_dto_exposes_tmux_name.py
+++ b/tests/regression/test_terminal_session_dto_exposes_tmux_name.py
@@ -1,0 +1,99 @@
+"""Guards against three-mirror DTO drift that previously broke Concerto's
+terminal auto-attach: the Rust `TerminalSession` struct had `tmux_name` but
+`TerminalSessionDto` dropped it on the HTTP wire, so Concerto's Swift parser
+(which requires the field) silently discarded every session it fetched over
+HTTP and the terminal pane stayed pointed at an empty default session.
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from scripts.lib.api_harness import ApiClient
+from scripts.lib.lfd_runtime import LfdRuntime
+
+pytestmark = pytest.mark.regression
+
+
+def test_list_terminal_sessions_exposes_tmux_name(
+    lfd_runtime: LfdRuntime, api_client: ApiClient
+) -> None:
+    wave_id = _create_wave_with_roadmap_item(lfd_runtime, api_client)
+    _trigger_run(api_client, wave_id)
+
+    session = _wait_for_terminal_session(api_client, wave_id)
+    assert "tmux_name" in session, (
+        f"TerminalSessionDto missing tmux_name — wire keys: {sorted(session.keys())}"
+    )
+    assert session["tmux_name"], "tmux_name must not be empty"
+    assert session["tmux_name"].startswith("lf-"), (
+        f"unexpected tmux session name: {session['tmux_name']}"
+    )
+
+
+def test_get_terminal_session_exposes_tmux_name(
+    lfd_runtime: LfdRuntime, api_client: ApiClient
+) -> None:
+    wave_id = _create_wave_with_roadmap_item(lfd_runtime, api_client)
+    _trigger_run(api_client, wave_id)
+
+    listed = _wait_for_terminal_session(api_client, wave_id)
+    fetched = api_client.request("GET", f"/v0/terminal-sessions/{listed['id']}").json()
+
+    assert "tmux_name" in fetched
+    assert fetched["tmux_name"] == listed["tmux_name"]
+
+
+def _create_wave_with_roadmap_item(runtime: LfdRuntime, client: ApiClient) -> str:
+    repo = str(runtime.repo_dir)
+    wave_dir = runtime.repo_dir / "wave" / "designer"
+    wave_dir.mkdir(parents=True, exist_ok=True)
+    (wave_dir / "1-target-item.md").write_text("# Target\n")
+
+    response = client.request(
+        "POST",
+        "/v0/waves",
+        json={
+            "repo": repo,
+            "name": "designer",
+            "flow": "ship-roadmap",
+            "run": False,
+            "status": "paused",
+        },
+    )
+    response.raise_for_status()
+    return response.json()["id"]
+
+
+def _trigger_run(client: ApiClient, wave_id: str) -> None:
+    response = client.request(
+        "POST",
+        f"/v0/waves/{wave_id}/run",
+        json={"flow": "build", "roadmap_item": "1-target-item.md"},
+    )
+    # Either accept or precondition-failed is fine — we only need the
+    # terminal session to get created as a side effect.
+    assert response.status_code in {200, 412}, (
+        f"unexpected status {response.status_code}: {response.text}"
+    )
+
+
+def _wait_for_terminal_session(
+    client: ApiClient, wave_id: str, timeout_seconds: float = 10.0
+) -> dict[str, object]:
+    deadline = time.time() + timeout_seconds
+    last_body = ""
+    while time.time() < deadline:
+        response = client.request("GET", "/v0/terminal-sessions")
+        response.raise_for_status()
+        body = response.json()
+        last_body = response.text
+        matches = [s for s in body.get("data", []) if s.get("wave_id") == wave_id]
+        if matches:
+            return matches[0]
+        time.sleep(0.25)
+    raise AssertionError(
+        f"no terminal_session appeared for wave {wave_id} within {timeout_seconds}s; last body: {last_body}"
+    )


### PR DESCRIPTION
## Usage

```bash
# Run the new regression suite locally
uv run pytest tests/regression/ -v

# CI runs it nightly at 06:00 UTC and on Sundays before the weekly auto-release
# (see .github/workflows/regression-daily.yml and weekly-release.yml)
```

## Summary

Stands up a regression test harness and the CI plumbing around it, and fixes a few lfd bugs the new tests cover. The regression suite exercises end-to-end behaviors that are too expensive for per-PR CI: orphaned-run recovery after an lfd restart, wave runs that include a roadmap item, and the terminal-session DTO shape Concerto depends on. A weekly GitHub Actions workflow runs the suite against `main`, and if everything is green and new commits have landed since the last tag, bumps the patch version and dispatches `release.yml` to cut a release.

Along the way, two lfd bugs surfaced and are fixed here:

- After `fail_orphaned_runs` marks in-flight runs as Failed on lfd restart, the owning waves stayed stuck in Running/Waiting. The UI would keep their action buttons disabled even though no executor was attached. A new `ResetStaleActiveWaves` query resets those waves back to Idle in the same cleanup pass.
- `POST /waves/{id}/run` with a `roadmap_item` could abort the HTTP connection with no response when PM was configured, because the ingest path called `block_on_pm` from inside the axum handler's runtime. The handler now returns a structured error instead of panicking, and a missing roadmap item returns a clean 400.

## Changes

- `tests/regression/` — new pytest package with a `regression` marker, conftest, and three initial scenarios (orphaned-run wave reset, PM-backed run-with-roadmap-item, terminal-session DTO exposes `tmux_name`)
- `.github/workflows/regression-daily.yml` — nightly regression job, also `workflow_call`-able
- `.github/workflows/weekly-release.yml` + `scripts/bump_patch_version.sh` — Sunday job that runs regression against `main`, bumps the patch version if new commits landed, refreshes `Cargo.lock`, and dispatches `release.yml`
- `lfd` store: `ResetStaleActiveWaves` query wired into both SQLite and Postgres `fail_orphaned_runs`, with a store-level test
- `lfd` http: new axum tests covering the roadmap-item + PM handler path and the missing-roadmap-item 400 case; `activation.rs` no longer blocks on PM from inside the async handler
- `TerminalSessionDto` now carries `tmux_name`, mirrored in Swift (`TerminalSession`, `RepoState`, `LocalWaveService`) with new `ProcessEnvironment`/`PathNormalization` helpers and tests (`BundledDaemonPathTests`, `RepoStateInteractiveSessionTests`)
- `pyproject.toml` — registers the `regression` pytest marker so the nightly suite is opt-in rather than running on every PR
