### PR TITLE
op pr: add -m/--model agent override

### DIFF
--- a/docs/lfop.md
+++ b/docs/lfop.md
@@ -34,8 +34,12 @@ Options:
 Create or update a PR, open in browser.
 
 ```bash
+lf -m codex op pr
+lf op pr -m codex
 lf op pr --title "area: short title" --body "## Summary ..."
 ```
+
+Use `-m/--model` for a one-off agent override when `lf op pr` needs a different harness than your configured default. When omitted, `lf op pr` uses `agent:` from `.lf/config.yaml` or `~/.lf/config.yaml`.
 
 `--title` and `--body` are always required. Use `lf pr` to generate them with agent judgment.
 

--- a/rust/loopflow/src/bin/lf.rs
+++ b/rust/loopflow/src/bin/lf.rs
@@ -295,9 +295,9 @@ fn main() -> anyhow::Result<()> {
                 loopflow::lf::commands::run::run(None, Some(&text), &cli)
             })
         }
-        Some(Commands::Op { op }) => {
-            in_repo_runtime(&args, |_| loopflow::lf::commands::ops::run(op))
-        }
+        Some(Commands::Op { op }) => in_repo_runtime(&args, |_| {
+            loopflow::lf::commands::ops::run(op, cli.model.as_deref())
+        }),
         Some(Commands::External(external_args)) => {
             let (name, step_args) = loopflow::lf::commands::run::split_step_args(external_args)?;
             let message = join_args(&step_args);

--- a/rust/loopflow/src/lf/commands/ops/mod.rs
+++ b/rust/loopflow/src/lf/commands/ops/mod.rs
@@ -26,7 +26,7 @@ use std::io::{self, IsTerminal, Write};
 use std::path::Path;
 use std::process::Command;
 
-pub fn run(op: &OpsCommand) -> Result<()> {
+pub fn run(op: &OpsCommand, cli_model: Option<&str>) -> Result<()> {
     let progress = CliProgress;
     match op {
         OpsCommand::Cp {
@@ -55,20 +55,26 @@ pub fn run(op: &OpsCommand) -> Result<()> {
                 commit_message: message.clone(),
                 pr_title: title.clone(),
                 pr_body: body.clone(),
+                agent: cli_model.map(str::to_string),
             },
             &progress,
         ),
-        OpsCommand::Pr { title, body } => open_pr(title.clone(), body.clone(), &progress),
+        OpsCommand::Pr { model, title, body } => open_pr(
+            title.clone(),
+            body.clone(),
+            model.as_deref().or(cli_model),
+            &progress,
+        ),
         OpsCommand::Sync => sync_current(),
         OpsCommand::Next {
             create_pr,
             no_rebase,
-        } => next_branch_cmd(*create_pr, !*no_rebase, &progress),
+        } => next_branch_cmd(*create_pr, !*no_rebase, cli_model, &progress),
         OpsCommand::Commit {
             message,
             push,
             no_add,
-        } => commit_current(message.as_deref(), *push, !no_add, &progress),
+        } => commit_current(message.as_deref(), *push, !no_add, cli_model, &progress),
         OpsCommand::Abandon { force, branch } => {
             abandon_current(branch.as_deref(), *force, &progress)
         }
@@ -187,13 +193,19 @@ fn land_current(options: &LandOptions, progress: &impl Progress) -> Result<()> {
     Ok(())
 }
 
-fn open_pr(title: Option<String>, body: Option<String>, progress: &impl Progress) -> Result<()> {
+fn open_pr(
+    title: Option<String>,
+    body: Option<String>,
+    agent_override: Option<&str>,
+    progress: &impl Progress,
+) -> Result<()> {
     let repo_root = find_repo_root()?;
     let result = match create_or_update_pr(
         &repo_root,
         &PrOptions {
             title: title.clone(),
             body: body.clone(),
+            agent: agent_override.map(str::to_string),
         },
         progress,
     ) {
@@ -205,7 +217,15 @@ fn open_pr(title: Option<String>, body: Option<String>, progress: &impl Progress
             progress.status("Launching rebase agent to resolve conflicts...");
             launch_step_agent(&repo_root, "rebase", Some(&context))?;
             progress.status("Retrying PR creation after rebase...");
-            create_or_update_pr(&repo_root, &PrOptions { title, body }, progress)?
+            create_or_update_pr(
+                &repo_root,
+                &PrOptions {
+                    title,
+                    body,
+                    agent: agent_override.map(str::to_string),
+                },
+                progress,
+            )?
         }
         Err(err) => return Err(err.into()),
     };
@@ -223,7 +243,12 @@ fn sync_current() -> Result<()> {
     Ok(())
 }
 
-fn next_branch_cmd(create_pr: bool, rebase: bool, progress: &impl Progress) -> Result<()> {
+fn next_branch_cmd(
+    create_pr: bool,
+    rebase: bool,
+    agent_override: Option<&str>,
+    progress: &impl Progress,
+) -> Result<()> {
     let repo_root = find_repo_root()?;
     let result = next_branch(
         &repo_root,
@@ -231,6 +256,7 @@ fn next_branch_cmd(create_pr: bool, rebase: bool, progress: &impl Progress) -> R
             create_pr,
             rebase,
             wave_name: None,
+            agent: agent_override.map(str::to_string),
         },
         progress,
     )?;
@@ -242,6 +268,7 @@ fn commit_current(
     message: Option<&str>,
     push: bool,
     add: bool,
+    agent_override: Option<&str>,
     progress: &impl Progress,
 ) -> Result<()> {
     let repo_root = find_repo_root()?;
@@ -252,6 +279,7 @@ fn commit_current(
             push,
             create_draft_pr: true,
             message: message.map(str::to_string),
+            agent: agent_override.map(str::to_string),
             ..CommitOptions::for_task("commit")
         },
         progress,

--- a/rust/loopflow/src/lf/mod.rs
+++ b/rust/loopflow/src/lf/mod.rs
@@ -192,6 +192,8 @@ pub enum OpsCommand {
     },
     /// Create or update a PR
     Pr {
+        #[arg(short = 'm', long = "model", short_alias = 'M')]
+        model: Option<String>,
         #[arg(long = "title")]
         title: Option<String>,
         #[arg(long = "body")]
@@ -715,5 +717,36 @@ mod tests {
         assert_eq!(wave.as_deref(), Some("redesign"));
         assert!(dry_run);
         assert!(yes);
+    }
+
+    #[test]
+    fn op_pr_accepts_model_override() {
+        let cli = Cli::try_parse_from(["lf", "op", "pr", "-m", "codex"]).expect("parse");
+        let Some(Commands::Op {
+            op: OpsCommand::Pr { model, title, body },
+        }) = cli.command
+        else {
+            panic!("expected pr command");
+        };
+
+        assert_eq!(model.as_deref(), Some("codex"));
+        assert_eq!(title, None);
+        assert_eq!(body, None);
+    }
+
+    #[test]
+    fn top_level_model_reaches_op_command() {
+        let cli = Cli::try_parse_from(["lf", "-m", "codex", "op", "pr"]).expect("parse");
+        let Some(Commands::Op {
+            op: OpsCommand::Pr { model, title, body },
+        }) = cli.command
+        else {
+            panic!("expected pr command");
+        };
+
+        assert_eq!(cli.model.as_deref(), Some("codex"));
+        assert_eq!(model, None);
+        assert_eq!(title, None);
+        assert_eq!(body, None);
     }
 }

--- a/rust/loopflow/src/lfd/http/routes/waves.rs
+++ b/rust/loopflow/src/lfd/http/routes/waves.rs
@@ -1259,6 +1259,7 @@ pub async fn land_wave_handler(
                     commit_message: None,
                     pr_title: None,
                     pr_body: None,
+                    agent: None,
                 },
                 &progress,
             )

--- a/rust/loopflow/src/ops/commit.rs
+++ b/rust/loopflow/src/ops/commit.rs
@@ -20,6 +20,7 @@ pub struct CommitOptions {
     pub task: String,
     pub flow_parents: Vec<String>,
     pub message: Option<String>,
+    pub agent: Option<String>,
 }
 
 impl CommitOptions {
@@ -31,6 +32,7 @@ impl CommitOptions {
             task: task.into(),
             flow_parents: Vec::new(),
             message: None,
+            agent: None,
         }
     }
 }
@@ -70,7 +72,7 @@ pub fn commit_workflow(
         message.to_string()
     } else {
         progress.status("Generating commit message...");
-        let generated = generate_commit_message(repo);
+        let generated = generate_commit_message(repo, options.agent.as_deref());
         format_commit_message(
             &options.task,
             &options.flow_parents,
@@ -121,7 +123,7 @@ struct CommitMessage {
     body: String,
 }
 
-fn generate_commit_message(repo: &Path) -> OpsResult<CommitMessage> {
+fn generate_commit_message(repo: &Path, agent_override: Option<&str>) -> OpsResult<CommitMessage> {
     let template = get_builtin_ops_prompt("commit_message")
         .ok_or_else(|| OpsError::Message("builtin commit_message prompt not found".to_string()))?;
 
@@ -136,9 +138,9 @@ fn generate_commit_message(repo: &Path) -> OpsResult<CommitMessage> {
     );
 
     let config = load_config_or_default(Some(repo));
-    let agent = config
-        .agent
-        .clone()
+    let agent = agent_override
+        .map(str::to_string)
+        .or_else(|| config.agent.clone())
         .unwrap_or_else(|| "claude:haiku".to_string());
 
     let launch = AgentConfig {

--- a/rust/loopflow/src/ops/flow.rs
+++ b/rust/loopflow/src/ops/flow.rs
@@ -82,6 +82,7 @@ fn execute_parsed_ops(repo: &Path, op: &OpsCommand, progress: &impl Progress) ->
                     commit_message: message.clone(),
                     pr_title: title.clone(),
                     pr_body: body.clone(),
+                    agent: None,
                 },
                 progress,
             )?;
@@ -103,12 +104,17 @@ fn execute_parsed_ops(repo: &Path, op: &OpsCommand, progress: &impl Progress) ->
             )?;
             Ok(())
         }
-        OpsCommand::Pr { title, body } => {
+        OpsCommand::Pr {
+            model: _,
+            title,
+            body,
+        } => {
             create_or_update_pr(
                 repo,
                 &PrOptions {
                     title: title.clone(),
                     body: body.clone(),
+                    agent: None,
                 },
                 progress,
             )?;
@@ -133,6 +139,7 @@ fn execute_parsed_ops(repo: &Path, op: &OpsCommand, progress: &impl Progress) ->
                     create_pr: *create_pr,
                     rebase: !*no_rebase,
                     wave_name: None,
+                    agent: None,
                 },
                 progress,
             )?;

--- a/rust/loopflow/src/ops/land.rs
+++ b/rust/loopflow/src/ops/land.rs
@@ -238,6 +238,7 @@ fn finalize_local(
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 fn ensure_pr(
     repo_root: &Path,
     pr_exists: bool,

--- a/rust/loopflow/src/ops/land.rs
+++ b/rust/loopflow/src/ops/land.rs
@@ -26,6 +26,7 @@ pub struct LandOptions {
     pub commit_message: Option<String>,
     pub pr_title: Option<String>,
     pub pr_body: Option<String>,
+    pub agent: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -77,6 +78,7 @@ pub fn land(repo: &Path, options: &LandOptions, progress: &impl Progress) -> Ops
             options.create_pr,
             pr_title.as_deref(),
             pr_body.as_deref(),
+            options.agent.as_deref(),
             progress,
         )?;
         finalize_remote(
@@ -122,7 +124,7 @@ fn resolve_pr_copy(
         return Ok((pr_title, pr_body));
     }
 
-    let generated = generate_pr_copy(repo_root, progress)?;
+    let generated = generate_pr_copy(repo_root, progress, options.agent.as_deref())?;
     pr_title = Some(generated.title);
     if pr_body.is_none() {
         pr_body = Some(generated.body);
@@ -202,6 +204,7 @@ fn prepare_land(
             push: true,
             create_draft_pr: true,
             message: Some(message),
+            agent: options.agent.clone(),
             ..CommitOptions::for_task("land")
         };
         let _ = commit_workflow(repo_root, &commit_options, progress)?;
@@ -242,6 +245,7 @@ fn ensure_pr(
     create_pr: bool,
     pr_title: Option<&str>,
     pr_body: Option<&str>,
+    agent_override: Option<&str>,
     progress: &impl Progress,
 ) -> OpsResult<()> {
     if !crate::ops::pr::gh_available() {
@@ -261,6 +265,7 @@ fn ensure_pr(
                 &crate::ops::pr::PrOptions {
                     title: Some(title.to_string()),
                     body: Some(body.to_string()),
+                    agent: agent_override.map(str::to_string),
                 },
                 progress,
             )?;

--- a/rust/loopflow/src/ops/next.rs
+++ b/rust/loopflow/src/ops/next.rs
@@ -18,6 +18,7 @@ pub struct NextOptions {
     pub rebase: bool,
     /// Wave name override (used when lfd orchestrates). If None, inferred from worktree or branch.
     pub wave_name: Option<String>,
+    pub agent: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -56,6 +57,7 @@ pub fn next_branch(
         push: true,
         create_draft_pr: true,
         message: Some("lf op next: checkpoint".to_string()),
+        agent: options.agent.clone(),
         ..CommitOptions::for_task("commit")
     };
     let _ = commit_workflow(repo, &commit_options, progress)?;
@@ -84,6 +86,7 @@ pub fn next_branch(
             &crate::ops::pr::PrOptions {
                 title: Some(draft_title),
                 body: Some("*Draft — title and body will be updated.*".to_string()),
+                agent: options.agent.clone(),
             },
             progress,
         )?;

--- a/rust/loopflow/src/ops/pr.rs
+++ b/rust/loopflow/src/ops/pr.rs
@@ -18,6 +18,7 @@ use crate::ops::util::{command_exists, stderr_from_output};
 pub struct PrOptions {
     pub title: Option<String>,
     pub body: Option<String>,
+    pub agent: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -67,6 +68,7 @@ pub fn create_or_update_pr(
         add: true,
         push: true,
         message: Some("lf op pr: prepare branch".to_string()),
+        agent: options.agent.clone(),
         ..CommitOptions::for_task("commit")
     };
     commit_workflow(repo, &commit_options, progress)?;
@@ -136,14 +138,18 @@ fn resolve_pr_copy(
         });
     }
 
-    let mut generated = generate_pr_copy(repo, progress)?;
+    let mut generated = generate_pr_copy(repo, progress, options.agent.as_deref())?;
     if let Some(body_override) = options.body.as_deref() {
         generated.body = body_override.to_string();
     }
     Ok(generated)
 }
 
-pub fn generate_pr_copy(repo: &Path, progress: &impl Progress) -> OpsResult<PrCopy> {
+pub fn generate_pr_copy(
+    repo: &Path,
+    progress: &impl Progress,
+    agent_override: Option<&str>,
+) -> OpsResult<PrCopy> {
     let template = get_builtin_ops_prompt("pr_message")
         .ok_or_else(|| OpsError::Message("builtin pr_message prompt not found".to_string()))?;
     let main_repo = resolve_main_repo(repo);
@@ -164,9 +170,9 @@ pub fn generate_pr_copy(repo: &Path, progress: &impl Progress) -> OpsResult<PrCo
     );
 
     let config = load_config_or_default(Some(repo));
-    let agent = config
-        .agent
-        .clone()
+    let agent = agent_override
+        .map(str::to_string)
+        .or_else(|| config.agent.clone())
         .unwrap_or_else(|| "claude:opus".to_string());
     progress.status("Generating PR title/body...");
 

--- a/rust/loopflow/src/ops/release.rs
+++ b/rust/loopflow/src/ops/release.rs
@@ -416,6 +416,7 @@ fn prepare_release_in_worktree(
             commit_message: None,
             pr_title: None,
             pr_body: None,
+            agent: None,
         },
         progress,
     )?;

--- a/rust/loopflow/tests/land_tests.rs
+++ b/rust/loopflow/tests/land_tests.rs
@@ -106,6 +106,7 @@ fn land_local_squash_merges_to_main() {
             commit_message: None,
             pr_title: None,
             pr_body: None,
+            agent: None,
         },
         &NullProgress,
     )
@@ -150,6 +151,7 @@ fn land_preserves_main_on_failure() {
             commit_message: None,
             pr_title: None,
             pr_body: None,
+            agent: None,
         },
         &NullProgress,
     );
@@ -186,6 +188,7 @@ fn land_cleans_up_remote_branch() {
             commit_message: None,
             pr_title: None,
             pr_body: None,
+            agent: None,
         },
         &NullProgress,
     )
@@ -231,6 +234,7 @@ fn land_clears_scratch_and_preserves_gitkeep() {
             commit_message: None,
             pr_title: None,
             pr_body: None,
+            agent: None,
         },
         &NullProgress,
     )
@@ -278,6 +282,7 @@ fn land_missing_pr_error_includes_branch_name() {
             commit_message: None,
             pr_title: Some("cached title".to_string()),
             pr_body: Some("cached body".to_string()),
+            agent: None,
         },
         &NullProgress,
     );
@@ -317,6 +322,7 @@ fn land_uses_cached_pr_copy_when_available() {
             commit_message: None,
             pr_title: None,
             pr_body: None,
+            agent: None,
         },
         &NullProgress,
     )
@@ -378,6 +384,7 @@ fn land_generates_copy_when_cached_pr_copy_is_stale() {
             commit_message: None,
             pr_title: None,
             pr_body: None,
+            agent: None,
         },
         &NullProgress,
     )

--- a/rust/loopflow/tests/next_tests.rs
+++ b/rust/loopflow/tests/next_tests.rs
@@ -40,6 +40,7 @@ fn next_creates_branch_from_current() {
             create_pr: false,
             rebase: false,
             wave_name: None,
+            agent: None,
         },
         &NullProgress,
     )
@@ -68,6 +69,7 @@ fn next_with_naming_schema() {
             create_pr: false,
             rebase: false,
             wave_name: Some("wave".to_string()),
+            agent: None,
         },
         &NullProgress,
     )
@@ -96,6 +98,7 @@ fn next_detects_merged_pr_starts_fresh() {
             create_pr: false,
             rebase: false,
             wave_name: None,
+            agent: None,
         },
         &NullProgress,
     )
@@ -122,6 +125,7 @@ fn next_appends_suffix_on_branch_name_collision() {
             create_pr: false,
             rebase: false,
             wave_name: Some("wave".to_string()),
+            agent: None,
         },
         &NullProgress,
     )

--- a/rust/loopflow/tests/pr_tests.rs
+++ b/rust/loopflow/tests/pr_tests.rs
@@ -59,6 +59,7 @@ fn pr_create_calls_gh() {
         &PrOptions {
             title: Some("test title".to_string()),
             body: Some("test body".to_string()),
+            agent: None,
         },
         &NullProgress,
     )
@@ -92,6 +93,7 @@ fn pr_update_refreshes_body() {
         &PrOptions {
             title: Some("updated title".to_string()),
             body: Some("updated body".to_string()),
+            agent: None,
         },
         &NullProgress,
     )
@@ -122,6 +124,7 @@ fn pr_create_uses_default_base_when_upstream_matches_head() {
         &PrOptions {
             title: Some("test title".to_string()),
             body: Some("test body".to_string()),
+            agent: None,
         },
         &NullProgress,
     )
@@ -167,6 +170,7 @@ fn pr_auto_generates_title_when_missing() {
         &PrOptions {
             title: None,
             body: Some("some body".to_string()),
+            agent: None,
         },
         &NullProgress,
     );
@@ -206,6 +210,7 @@ Body:
         &PrOptions {
             title: None,
             body: None,
+            agent: None,
         },
         &NullProgress,
     );


### PR DESCRIPTION
## Usage

```bash
lf -m codex op pr
lf op pr -m codex
lf op next
lf op commit
```

Adds a one-off agent override for `lf op` commands that generate text via an LLM. Both the top-level `lf -m <agent>` and the per-subcommand `lf op pr -m <agent>` flags now flow through to PR copy generation, commit message generation, and the commit/PR steps inside `next` and `land`. When omitted, behavior is unchanged: `agent:` from `.lf/config.yaml` (or `~/.lf/config.yaml`) wins, falling back to `claude:opus` for PR copy and `claude:haiku` for commit messages.

## Changes

- `OpsCommand::Pr` gains a `-m/--model` flag (with `-M` alias); top-level `cli.model` is plumbed into `commands::ops::run`
- `PrOptions`, `CommitOptions`, `LandOptions`, `NextOptions` each grow an `agent: Option<String>` field
- `generate_pr_copy` and `generate_commit_message` accept an `agent_override` that takes precedence over config
- `lf op pr` flow updated so the override survives the rebase-and-retry path
- Tests cover both flag positions (`lf op pr -m codex` and `lf -m codex op pr`); existing call sites updated to pass `agent: None`
- `docs/lfop.md` documents the new flag and override precedence