### PR TITLE
release: add self-hosted automated release infra

### DIFF
--- a/.github/workflows/nightly-packages.yml
+++ b/.github/workflows/nightly-packages.yml
@@ -1,0 +1,57 @@
+name: Packages (nightly)
+
+on:
+  schedule:
+    # 09:00 UTC daily — after the regression tier has had a chance to catch
+    # live-daemon failures, before US work hours.
+    - cron: "0 9 * * *"
+  workflow_dispatch:
+  workflow_call:
+
+jobs:
+  regression:
+    uses: ./.github/workflows/regression-daily.yml
+
+  native-packages:
+    needs: regression
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: macos-15
+            target: aarch64-apple-darwin
+          - os: macos-15-intel
+            target: x86_64-apple-darwin
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+          - os: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-gnu
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 40
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: nightly-packages-${{ matrix.target }}
+      - name: Build package binaries
+        run: cargo build --release --target ${{ matrix.target }} -p loopflow --bin lf --bin lfd
+      - name: Package binaries
+        run: |
+          set -euo pipefail
+          cd target/${{ matrix.target }}/release
+          tar czf ../../../lf-${{ matrix.target }}.tar.gz lf lfd
+      - name: Smoke test package
+        run: |
+          set -euo pipefail
+          mkdir package-smoke
+          tar -xzf lf-${{ matrix.target }}.tar.gz -C package-smoke
+          package-smoke/lf --version
+          package-smoke/lfd --version
+      - uses: actions/upload-artifact@v7
+        with:
+          name: nightly-${{ matrix.target }}
+          path: lf-${{ matrix.target }}.tar.gz
+          retention-days: 14

--- a/.github/workflows/weekly-release.yml
+++ b/.github/workflows/weekly-release.yml
@@ -2,30 +2,24 @@ name: Regression (weekly auto-release)
 
 on:
   schedule:
-    # Sundays 12:00 UTC — runs the regression suite against main and, if
-    # everything is green and new commits have landed since the last tag,
-    # bumps the patch version. `auto-tag.yml` then picks up the commit and
-    # cuts the release.
+    # Sundays 12:00 UTC — if new commits landed since the last tag, run the
+    # same package verification as the nightly job, then bump, tag, and dispatch
+    # the publishing release workflow.
     - cron: "0 12 * * 0"
   workflow_dispatch:
 
 jobs:
-  regression:
-    uses: ./.github/workflows/regression-daily.yml
-
-  release:
-    needs: regression
+  tag-check:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
-    permissions:
-      contents: write
+    timeout-minutes: 5
+    outputs:
+      skip: ${{ steps.tag_check.outputs.skip }}
+      last_tag: ${{ steps.tag_check.outputs.last_tag }}
+      commit_count: ${{ steps.tag_check.outputs.commit_count }}
     steps:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
       - name: Skip if no commits since last tag
         id: tag_check
         run: |
@@ -48,23 +42,41 @@ jobs:
             echo "last_tag=$last_tag" >> "$GITHUB_OUTPUT"
             echo "commit_count=$commit_count" >> "$GITHUB_OUTPUT"
           fi
+
+  package-test:
+    needs: tag-check
+    if: needs.tag-check.outputs.skip != 'true'
+    uses: ./.github/workflows/nightly-packages.yml
+
+  release:
+    needs: [tag-check, package-test]
+    if: needs.tag-check.outputs.skip != 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
+      actions: write
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
       - name: Bump patch version and append release notes
-        if: steps.tag_check.outputs.skip != 'true'
         id: bump
         run: |
           set -euo pipefail
           ./scripts/bump_patch_version.sh \
-            "${{ steps.tag_check.outputs.last_tag }}" \
-            "${{ steps.tag_check.outputs.commit_count }}" \
+            "${{ needs.tag-check.outputs.last_tag }}" \
+            "${{ needs.tag-check.outputs.commit_count }}" \
             | tee bump.out
           # bump_patch_version.sh prints `next=<version>` on its last line.
           next=$(grep '^next=' bump.out | cut -d= -f2)
           echo "next=$next" >> "$GITHUB_OUTPUT"
       - name: Refresh Cargo.lock
-        if: steps.tag_check.outputs.skip != 'true'
         run: cargo update -p loopflow
       - name: Commit, tag, and dispatch release
-        if: steps.tag_check.outputs.skip != 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1037,21 +1037,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "hashbrown"
-version = "0.17.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
-dependencies = [
- "foldhash 0.2.0",
-]
-
-[[package]]
 name = "hashlink"
-version = "0.12.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5081f264ed7adee96ea4b4778b6bb9da0a7228b084587aa3bd3ff05da7c5a3b"
+checksum = "824e001ac4f3012dd16a264bec811403a67ca9deb6c102fc5049b32c4574b35f"
 dependencies = [
- "hashbrown 0.17.1",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -1515,9 +1506,9 @@ dependencies = [
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.38.1"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6c19a05435c21ac299d71b6a9c13db3e3f47c520517d58990a462a1397a61db"
+checksum = "b1f111c8c41e7c61a49cd34e44c7619462967221a6443b0ec299e0ac30cfb9b1"
 dependencies = [
  "cc",
  "pkg-config",
@@ -2249,9 +2240,9 @@ dependencies = [
 
 [[package]]
 name = "rusqlite"
-version = "0.40.1"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11438310b19e3109b6446c33d1ed5e889428cf2e278407bc7896bc4aaea43323"
+checksum = "a0d2b0146dd9661bf67bb107c0bb2a55064d556eeb3fc314151b957f313bcd4e"
 dependencies = [
  "bitflags",
  "fallible-iterator 0.3.0",

--- a/README.md
+++ b/README.md
@@ -295,6 +295,7 @@ lf research -d ceo
 
 ```bash
 curl -fsSL https://github.com/loopflowstudio/loopflow/releases/latest/download/install.sh | sh
+scripts/pull-local-bin.sh    # dev checkout → ~/.local/bin
 ```
 
 Default install location is `~/.local/bin`. Override with `LF_INSTALL_DIR=/path`.

--- a/STYLE.md
+++ b/STYLE.md
@@ -294,6 +294,20 @@ If a test requires elaborate mock setup, it's usually a sign that either:
 
 **No factory patterns.** Factory traits, abstract factories, and provider registries are almost always over-engineering. A function or a closure does the same job without the ceremony. If you need runtime dispatch, use an enum or a function pointer — not a trait with one method and one real implementation.
 
+# Review Ritual
+
+Run a Mitchell Hashimoto-style simulated code review for each unit of work before calling it done. Use the spirit, not cosplay: simple interfaces, boring operational behavior, clear ownership, docs that match the code, and no abstraction that exists only to feel flexible.
+
+Ask hard questions:
+
+- Can this be explained in one screen?
+- Does the API map to the real thing, or to our implementation accident?
+- What breaks at 2 a.m., and will the logs say why?
+- Is this dependency, config knob, or compatibility shim earning its keep?
+- Would deleting code make the system more true?
+
+Record concrete findings in the PR notes or fix them immediately. Do not perform theater; the review earns its place only when it changes the work.
+
 # Pre-Commit Checklist
 
 Before committing, verify:

--- a/TESTING.md
+++ b/TESTING.md
@@ -14,6 +14,7 @@ swift test --package-path swift        # Swift package tests
 cd swift && xcodegen generate && xcodebuild test -project LoopflowSwift.xcodeproj -scheme Concerto -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO  # Concerto UI
 tests/e2e/test_smoke.sh               # E2E smoke
 uv run pytest tests/e2e/test_api_smoke.py tests/e2e/test_concurrent_clients.py -v  # API smoke + concurrent-client broadcast checks (live lfd HTTP)
+uv run pytest tests/regression/ -v     # nightly/weekly release gate
 ```
 
 Run at minimum the checks that apply to files you changed. A PR that passes locally but fails CI is a broken gate.
@@ -101,6 +102,17 @@ Long-running workflow tests for `lf op`:
 tests/e2e/test_full_cycle.sh
 tests/e2e/test_rebase_conflict.sh
 ```
+
+## Nightly Package Tests
+
+`.github/workflows/nightly-packages.yml` builds the same native `lf`/`lfd` tarballs as the release workflow after the regression tier passes. Each runner extracts its tarball and runs:
+
+```bash
+package-smoke/lf --version
+package-smoke/lfd --version
+```
+
+Nightly package artifacts are verification only. They are uploaded for 14 days and not deployed.
 
 ## Validation Scripts
 

--- a/deploy/Caddyfile.internal
+++ b/deploy/Caddyfile.internal
@@ -3,6 +3,8 @@
 }
 
 {$LF_DOMAIN:localhost} {
+	tls internal
+
 	@websocket {
 		header Connection *Upgrade*
 		header Upgrade websocket

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,57 +1,119 @@
-# Remote deploy (EC2 + Docker + Caddy)
+# Self-hosted deploy
 
-Run `lfd` remotely behind Caddy TLS.
-
-## Prerequisites
-
-- Ubuntu 22.04+ host (t3.medium/t4g.medium+)
-- Docker + Docker Compose plugin
-- Domain or hostname pointing to the instance
-- Security group allows inbound `443/tcp` and `80/tcp`
-- Host already signed into studio (`~/.lf/credentials.json` present)
-
-## Quick start
+Run your own `lfd` cron host behind Caddy TLS.
 
 ```bash
-git clone https://github.com/loopflowstudio/loopflow.git
-cd loopflow
+git clone https://github.com/loopflowstudio/loopflow.git /opt/loopflow
+cd /opt/loopflow
 
 export LF_DOMAIN='lfd.example.com'
-export LF_TLS_MODE=internal   # unset for public ACME certs
+export LFD_AUTH_TOKEN=$(openssl rand -hex 32)
+export LF_TLS_MODE=internal   # Tailscale/private hosts; leave empty for public ACME
 
-docker compose -f docker/docker-compose.yml -f deploy/docker-compose.prod.yml up -d --build
+deploy/loopflow-server.sh up
 ```
 
-Container mode and studio auth are already the default shape in these compose files.
+Container mode and self-hosted bearer-token auth are the default. Keep secrets in Doppler; `.env` is the local fallback.
+
+## Loopflow and Cadenza
+
+Use the same server shape for both repos. The Terraform module and `loopflow-server.sh --repo PATH` are repo-parameterized; each repo should carry its own Docker/deploy files and Doppler project/config. Keep the cadence from `release/SCHEDULE.md` identical, then vary only product-specific build, smoke-test, signing, and publish commands.
+
+## Secrets
+
+```bash
+doppler secrets set LFD_AUTH_MODE=local
+doppler secrets set LFD_AUTH_TOKEN="$(openssl rand -hex 32)"
+doppler secrets set GH_TOKEN=ghp_xxx
+doppler secrets set ANTHROPIC_API_KEY=sk-ant-xxx
+```
+
+Minimum useful server secrets:
+
+| Secret | What it does |
+|--------|--------------|
+| `LFD_AUTH_TOKEN` | Bearer token for remote API clients |
+| `GH_TOKEN` | Lets agents push branches, inspect PRs, and react to CI |
+| `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` / `GEMINI_API_KEY` | Agent provider credentials |
+| `LFD_GITHUB_WEBHOOK_SECRET` | Optional webhook signature secret |
+
+Use `docker/.env.example` only when running without Doppler.
+
+## Operate
+
+```bash
+deploy/loopflow-server.sh up       # build and start
+deploy/loopflow-server.sh update   # git pull default branch, rebuild, restart
+deploy/loopflow-server.sh status
+deploy/loopflow-server.sh logs
+deploy/loopflow-server.sh health
+```
+
+The script uses Doppler automatically when the Doppler CLI is configured or `DOPPLER_TOKEN` is present. Run `doppler setup` in the repo, authenticate the host, or provide a Doppler service token outside the repo. Set `LOOPFLOW_SECRETS=env` to force plain Docker Compose.
+
+Public hosts leave `LF_TLS_MODE` empty and use `deploy/Caddyfile`, letting Caddy request public ACME certificates. Private or Tailscale-only hosts set `LF_TLS_MODE=internal`; the deploy script mounts `deploy/Caddyfile.internal` for Caddy's internal CA.
+
+## Linux host
+
+```bash
+sudo install -m 0600 /dev/null /etc/loopflow-server.env
+sudoedit /etc/loopflow-server.env   # DOPPLER_TOKEN=dp.st.x, LF_DOMAIN=..., LF_TLS_MODE=internal
+
+# If the repo is not /opt/loopflow, edit WorkingDirectory and Exec* paths first.
+sudo cp deploy/systemd/loopflow-server*.{service,timer} /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable --now loopflow-server.service
+sudo systemctl enable --now loopflow-server-update.timer
+```
+
+The update timer refreshes the server nightly. Keep local dev binaries fresh with `scripts/pull-local-bin.sh`; server restarts should be predictable.
+
+## Mac mini + Tailscale
+
+```bash
+mkdir -p ~/Library/LaunchAgents
+cp deploy/launchd/studio.loopflow.server.plist ~/Library/LaunchAgents/
+plutil -replace ProgramArguments.0 -string "$PWD/deploy/loopflow-server.sh" ~/Library/LaunchAgents/studio.loopflow.server.plist
+launchctl load ~/Library/LaunchAgents/studio.loopflow.server.plist
+```
+
+Use `LF_TLS_MODE=internal` for a Tailscale-only hostname; the deploy script mounts `deploy/Caddyfile.internal`. Leave `LF_TLS_MODE` empty for public ACME and it uses `deploy/Caddyfile`. Docker Desktop must be running; the launch agent keeps the stack up every five minutes.
+
+## Enable repo crons
+
+Create waves on the self-hosted daemon from the host or from a trusted client:
+
+```bash
+export LFD_URL=https://lfd.example.com
+export LFD_TOKEN="$LFD_AUTH_TOKEN"
+lfq create root /opt/loopflow
+lfq show root
+```
+
+Wave YAML carries the cron schedule. For this repo, `wave/root/root.yaml` is the conductor cron; once the wave is created, `lfd` owns the scheduled runs.
 
 ## Verify
 
 ```bash
 curl -f https://lfd.example.com/health
+curl -H "Authorization: Bearer $LFD_AUTH_TOKEN" https://lfd.example.com/status
 ```
 
-Then sign in through Concerto or `lfq` and connect through the normal studio discovery flow.
+Point Concerto or `lfq` at the host and use the bearer token from `LFD_AUTH_TOKEN`. Studio discovery is optional, not the default path.
 
 ## Troubleshoot
 
 ```bash
-# Service status
-docker compose -f docker/docker-compose.yml -f deploy/docker-compose.prod.yml ps
-
-# lfd health
-curl -f https://lfd.example.com/health
-
-# Caddy logs
-docker compose -f docker/docker-compose.yml -f deploy/docker-compose.prod.yml logs --tail 200 caddy
-
-# lfd logs
-docker compose -f docker/docker-compose.yml -f deploy/docker-compose.prod.yml logs --tail 200 lfd
+deploy/loopflow-server.sh status
+deploy/loopflow-server.sh logs
+curl -f http://127.0.0.1:${LFD_PORT:-2486}/health
 ```
 
-Need agent credentials inside execution containers? Set `LFD_EXECUTOR_CREDENTIALS_MOUNTS=claude,ssh` in `.env` (the same config knob as `executor.credentials.mounts`) instead of editing raw compose volume lines.
+Need agent credentials inside execution containers? Set `LFD_EXECUTOR_CREDENTIALS_MOUNTS=claude,ssh` in Doppler or `.env` instead of editing compose volume lines.
 
 Common failures:
 
 - ACME cert not issued: DNS or port 80 is wrong
 - WebSocket failures: make sure `/ws` is reachable through the same TLS host
-- Remote clients cannot connect: verify `~/.lf/credentials.json` and studio registration logs on the host
+- Remote clients cannot connect: verify `LFD_AUTH_TOKEN`, Caddy routing, and the client `Authorization: Bearer` header
+- Agents cannot push: verify `GH_TOKEN` or mount `gh,ssh` credentials intentionally

--- a/deploy/docker-compose.prod.yml
+++ b/deploy/docker-compose.prod.yml
@@ -1,19 +1,18 @@
 # Production override for remote deployment.
 # Usage: docker compose -f docker/docker-compose.yml -f deploy/docker-compose.prod.yml up -d --build
 #
-# Adds Caddy for TLS termination on top of the default container/studio stack.
+# Adds Caddy for TLS termination on top of the self-hosted container stack.
 
 services:
   caddy:
     image: caddy:2-alpine
     environment:
       LF_DOMAIN: "${LF_DOMAIN:-localhost}"
-      LF_TLS_MODE: "${LF_TLS_MODE:-internal}"
     ports:
       - "443:443"
       - "80:80"
     volumes:
-      - ../deploy/Caddyfile:/etc/caddy/Caddyfile:ro
+      - ${CADDYFILE:-../deploy/Caddyfile}:/etc/caddy/Caddyfile:ro
       - caddy-data:/data
     depends_on:
       lfd:

--- a/deploy/launchd/studio.loopflow.server.plist
+++ b/deploy/launchd/studio.loopflow.server.plist
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!-- Copy to ~/Library/LaunchAgents/ and edit the repo path. Runs every 5 minutes to keep the Docker stack up on a Mac mini. -->
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>studio.loopflow.server</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/Users/jack/src/loopflow/deploy/loopflow-server.sh</string>
+    <string>up</string>
+  </array>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>LOOPFLOW_SECRETS</key>
+    <string>doppler</string>
+  </dict>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>StartInterval</key>
+  <integer>300</integer>
+  <key>StandardOutPath</key>
+  <string>/tmp/loopflow-server.out.log</string>
+  <key>StandardErrorPath</key>
+  <string>/tmp/loopflow-server.err.log</string>
+</dict>
+</plist>

--- a/deploy/loopflow-server.sh
+++ b/deploy/loopflow-server.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+# Manage the self-hosted loopflow server stack.
+#
+# Secrets come from Doppler when configured. Use LOOPFLOW_SECRETS=env to force
+# plain Docker Compose with .env.
+
+set -euo pipefail
+
+usage() {
+    cat >&2 <<'USAGE'
+Usage: loopflow-server.sh [--repo PATH] <up|update|down|status|logs|health>
+
+Commands:
+  up       Build and start the self-hosted lfd stack
+  update   Pull the default branch, then rebuild and restart the stack
+  down     Stop the stack
+  status   Show compose service status
+  logs     Tail lfd and Caddy logs
+  health   Check local lfd health
+
+Environment:
+  LOOPFLOW_SECRETS=auto|doppler|env   default: auto
+  LF_DOMAIN=lfd.example.com           Caddy host name
+  LF_TLS_MODE=internal                private/Tailscale TLS; leave empty for public ACME
+  CADDYFILE=/path/to/Caddyfile        optional Caddy config override
+  LFD_AUTH_TOKEN=...                  required when LFD_AUTH_MODE is local or unset
+  LFD_PORT=2486                       local exposed lfd port
+USAGE
+}
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo="$(cd "$script_dir/.." && pwd)"
+command=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --repo)
+            if [[ $# -lt 2 ]]; then
+                echo "--repo requires a path" >&2
+                usage
+                exit 1
+            fi
+            repo="$2"
+            shift 2
+            ;;
+        --repo=*)
+            repo="${1#--repo=}"
+            shift
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        up|update|down|status|logs|health)
+            command="$1"
+            shift
+            ;;
+        *)
+            echo "unknown argument: $1" >&2
+            usage
+            exit 1
+            ;;
+    esac
+done
+
+if [[ -z "$command" ]]; then
+    usage
+    exit 1
+fi
+
+repo="$(git -C "$repo" rev-parse --show-toplevel)"
+project_name="$(basename "$repo" | tr '[:upper:]' '[:lower:]' | tr -c 'a-z0-9' '-')"
+project_name="${project_name%-}"
+compose=(docker compose -p "$project_name" -f "$repo/docker/docker-compose.yml" -f "$repo/deploy/docker-compose.prod.yml")
+
+if [[ "${LF_TLS_MODE:-}" == "internal" && -z "${CADDYFILE:-}" ]]; then
+    export CADDYFILE="$repo/deploy/Caddyfile.internal"
+fi
+
+has_doppler_config() {
+    command -v doppler >/dev/null 2>&1 || return 1
+    [[ -n "${DOPPLER_TOKEN:-}" ]] && return 0
+    (cd "$repo" && doppler configure get project --plain >/dev/null 2>&1)
+}
+
+run_with_secrets() {
+    case "${LOOPFLOW_SECRETS:-auto}" in
+        env)
+            "$@"
+            ;;
+        doppler)
+            command -v doppler >/dev/null 2>&1 || {
+                echo "LOOPFLOW_SECRETS=doppler but doppler is not installed" >&2
+                exit 1
+            }
+            (cd "$repo" && doppler run -- "$@")
+            ;;
+        auto)
+            if has_doppler_config; then
+                (cd "$repo" && doppler run -- "$@")
+            else
+                "$@"
+            fi
+            ;;
+        *)
+            echo "invalid LOOPFLOW_SECRETS: ${LOOPFLOW_SECRETS}" >&2
+            exit 1
+            ;;
+    esac
+}
+
+preflight_remote_auth() {
+    run_with_secrets bash -c '
+        if [ "${LFD_AUTH_MODE:-local}" = "local" ] && [ -z "${LFD_AUTH_TOKEN:-}" ]; then
+            echo "LFD_AUTH_TOKEN is required for self-hosted local auth" >&2
+            echo "Set it in Doppler or export it before starting the server." >&2
+            exit 1
+        fi
+    '
+}
+
+pull_default_branch() {
+    local default_branch current_branch
+    default_branch="$(git -C "$repo" symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null | sed 's#^origin/##')"
+    current_branch="$(git -C "$repo" branch --show-current)"
+
+    if [[ -n "$default_branch" && "$current_branch" != "$default_branch" ]]; then
+        echo "refusing to update $current_branch; checkout $default_branch first" >&2
+        exit 1
+    fi
+
+    if [[ -n "$default_branch" ]]; then
+        git -C "$repo" pull --ff-only origin "$default_branch"
+    else
+        git -C "$repo" pull --ff-only
+    fi
+}
+
+case "$command" in
+    up)
+        preflight_remote_auth
+        run_with_secrets "${compose[@]}" up -d --build
+        ;;
+    update)
+        pull_default_branch
+        preflight_remote_auth
+        run_with_secrets "${compose[@]}" up -d --build
+        ;;
+    down)
+        run_with_secrets "${compose[@]}" down
+        ;;
+    status)
+        run_with_secrets "${compose[@]}" ps
+        ;;
+    logs)
+        run_with_secrets "${compose[@]}" logs --tail 200 -f lfd caddy
+        ;;
+    health)
+        curl -fsS "http://127.0.0.1:${LFD_PORT:-2486}/health"
+        echo
+        ;;
+esac

--- a/deploy/systemd/loopflow-server-update.service
+++ b/deploy/systemd/loopflow-server-update.service
@@ -1,0 +1,14 @@
+# Copy to /etc/systemd/system/loopflow-server-update.service and edit paths.
+[Unit]
+Description=Update the self-hosted loopflow server
+After=network-online.target docker.service
+Wants=network-online.target
+Requires=docker.service
+
+[Service]
+Type=oneshot
+WorkingDirectory=/opt/loopflow
+Environment=LOOPFLOW_SECRETS=doppler
+EnvironmentFile=-/etc/loopflow-server.env
+ExecStart=/opt/loopflow/deploy/loopflow-server.sh update
+TimeoutStartSec=1200

--- a/deploy/systemd/loopflow-server-update.timer
+++ b/deploy/systemd/loopflow-server-update.timer
@@ -1,0 +1,11 @@
+# Optional server refresh. Keep local dev binaries fresh with scripts/pull-local-bin.sh;
+# server restarts should be boring and predictable.
+[Unit]
+Description=Refresh the self-hosted loopflow server nightly
+
+[Timer]
+OnCalendar=*-*-* 04:15:00
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/loopflow-server.service
+++ b/deploy/systemd/loopflow-server.service
@@ -1,0 +1,19 @@
+# Copy to /etc/systemd/system/loopflow-server.service and edit WorkingDirectory.
+[Unit]
+Description=Loopflow self-hosted cron server
+After=network-online.target docker.service
+Wants=network-online.target
+Requires=docker.service
+
+[Service]
+Type=oneshot
+WorkingDirectory=/opt/loopflow
+Environment=LOOPFLOW_SECRETS=doppler
+EnvironmentFile=-/etc/loopflow-server.env
+ExecStart=/opt/loopflow/deploy/loopflow-server.sh up
+ExecStop=/opt/loopflow/deploy/loopflow-server.sh down
+RemainAfterExit=yes
+TimeoutStartSec=900
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/terraform/aws/README.md
+++ b/deploy/terraform/aws/README.md
@@ -1,0 +1,37 @@
+# AWS self-hosted loopflow server
+
+Provision an EC2 Docker host for the self-hosted loopflow cron server.
+
+```bash
+cd deploy/terraform/aws
+terraform init
+terraform apply \
+  -var 'ssh_key_name=your-key' \
+  -var 'allowed_ssh_cidrs=["203.0.113.10/32"]' \
+  -var 'allowed_https_cidrs=["0.0.0.0/0"]'
+```
+
+Terraform creates infrastructure only. Secrets stay out of Terraform state.
+After the host boots:
+
+```bash
+ssh ubuntu@$(terraform output -raw public_ip)
+sudoedit /etc/loopflow-server.env
+```
+
+Add:
+
+```bash
+DOPPLER_TOKEN=dp.st.x
+LF_DOMAIN=lfd.example.com
+LF_TLS_MODE=internal
+```
+
+Then start:
+
+```bash
+sudo systemctl start loopflow-server.service
+sudo systemctl status loopflow-server.service
+```
+
+Use `allowed_https_cidrs=[]` for Tailscale/private-only hosts where Caddy does not need public 80/443.

--- a/deploy/terraform/aws/main.tf
+++ b/deploy/terraform/aws/main.tf
@@ -1,0 +1,89 @@
+data "aws_ami" "ubuntu_arm64" {
+  most_recent = true
+  owners      = ["099720109477"] # Canonical
+
+  filter {
+    name   = "name"
+    values = ["ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-arm64-server-*"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+}
+
+data "aws_vpc" "default" {
+  default = true
+}
+
+resource "aws_security_group" "loopflow" {
+  name        = var.name
+  description = "loopflow self-hosted server"
+  vpc_id      = data.aws_vpc.default.id
+
+  dynamic "ingress" {
+    for_each = var.allowed_https_cidrs
+    content {
+      description = "HTTP"
+      from_port   = 80
+      to_port     = 80
+      protocol    = "tcp"
+      cidr_blocks = [ingress.value]
+    }
+  }
+
+  dynamic "ingress" {
+    for_each = var.allowed_https_cidrs
+    content {
+      description = "HTTPS"
+      from_port   = 443
+      to_port     = 443
+      protocol    = "tcp"
+      cidr_blocks = [ingress.value]
+    }
+  }
+
+  dynamic "ingress" {
+    for_each = var.allowed_ssh_cidrs
+    content {
+      description = "SSH"
+      from_port   = 22
+      to_port     = 22
+      protocol    = "tcp"
+      cidr_blocks = [ingress.value]
+    }
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = var.name
+  }
+}
+
+resource "aws_instance" "loopflow" {
+  ami                    = data.aws_ami.ubuntu_arm64.id
+  instance_type          = var.instance_type
+  key_name               = var.ssh_key_name
+  vpc_security_group_ids = [aws_security_group.loopflow.id]
+
+  root_block_device {
+    volume_size = 80
+    volume_type = "gp3"
+  }
+
+  user_data = templatefile("${path.module}/user-data.sh.tftpl", {
+    repo_url = var.repo_url
+    repo_dir = var.repo_dir
+  })
+
+  tags = {
+    Name = var.name
+  }
+}

--- a/deploy/terraform/aws/outputs.tf
+++ b/deploy/terraform/aws/outputs.tf
@@ -1,0 +1,11 @@
+output "public_ip" {
+  value = aws_instance.loopflow.public_ip
+}
+
+output "ssh" {
+  value = "ssh ubuntu@${aws_instance.loopflow.public_ip}"
+}
+
+output "repo_dir" {
+  value = var.repo_dir
+}

--- a/deploy/terraform/aws/user-data.sh.tftpl
+++ b/deploy/terraform/aws/user-data.sh.tftpl
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+apt-get update
+apt-get install -y ca-certificates curl git gnupg
+install -m 0755 -d /etc/apt/keyrings
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
+chmod a+r /etc/apt/keyrings/docker.asc
+. /etc/os-release
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu $VERSION_CODENAME stable" >/etc/apt/sources.list.d/docker.list
+apt-get update
+apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+
+curl -Ls https://cli.doppler.com/install.sh | sh
+
+git clone ${repo_url} ${repo_dir}
+cd ${repo_dir}
+cp deploy/systemd/loopflow-server*.service /etc/systemd/system/
+cp deploy/systemd/loopflow-server-update.timer /etc/systemd/system/
+
+# Secrets intentionally stay out of Terraform state. Add DOPPLER_TOKEN, LF_DOMAIN,
+# and LF_TLS_MODE to /etc/loopflow-server.env, then start the service.
+touch /etc/loopflow-server.env
+chmod 0600 /etc/loopflow-server.env
+
+systemctl daemon-reload
+systemctl enable loopflow-server.service
+systemctl enable --now loopflow-server-update.timer

--- a/deploy/terraform/aws/variables.tf
+++ b/deploy/terraform/aws/variables.tf
@@ -1,0 +1,46 @@
+variable "region" {
+  description = "AWS region for the loopflow host."
+  type        = string
+  default     = "us-west-2"
+}
+
+variable "name" {
+  description = "Name prefix for loopflow server resources."
+  type        = string
+  default     = "loopflow-server"
+}
+
+variable "instance_type" {
+  description = "EC2 instance type. Use enough memory for Rust package builds and Docker agents."
+  type        = string
+  default     = "t4g.medium"
+}
+
+variable "ssh_key_name" {
+  description = "Existing EC2 key pair for emergency SSH access."
+  type        = string
+}
+
+variable "allowed_ssh_cidrs" {
+  description = "CIDRs allowed to SSH to the host. Prefer a Tailscale subnet or your current IP."
+  type        = list(string)
+  default     = []
+}
+
+variable "allowed_https_cidrs" {
+  description = "CIDRs allowed to reach Caddy on 80/443. Use [] for Tailscale-only/private access."
+  type        = list(string)
+  default     = ["0.0.0.0/0"]
+}
+
+variable "repo_url" {
+  description = "Loopflow git repository URL cloned onto the host."
+  type        = string
+  default     = "https://github.com/loopflowstudio/loopflow.git"
+}
+
+variable "repo_dir" {
+  description = "Path where the repo is cloned on the host."
+  type        = string
+  default     = "/opt/loopflow"
+}

--- a/deploy/terraform/aws/versions.tf
+++ b/deploy/terraform/aws/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.6.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.region
+}

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -1,24 +1,22 @@
-# Agent credentials (passed through to agent containers)
+# Copy to .env for plain Docker Compose, or mirror the same keys in Doppler and
+# prefer Doppler instead of committing real secrets.
+
+# Self-hosted API auth. Generate with: openssl rand -hex 32
+LFD_AUTH_MODE=local
+# LFD_AUTH_TOKEN=
+
+# Agent credentials passed through to agent containers.
 # ANTHROPIC_API_KEY=sk-ant-...
 # OPENAI_API_KEY=sk-...
 # GEMINI_API_KEY=...
 # GH_TOKEN=ghp_...
 
-# Auth (required for remote deployment)
-# LFD_AUTH_PROVIDER=static            # set by docker-compose.prod.yml
-# LFD_AUTH_TOKEN=<generate with: openssl rand -hex 32>
-
-# Agent image override
+# Agent image override.
 # LFD_EXECUTOR_IMAGE=loopflow/agent:latest
 
-# Port mapping (host port, local dev only — Caddy handles HTTPS in prod)
+# Host port for local dev. Caddy handles HTTPS in prod.
 # LFD_PORT=2486
 
-# --- Remote deployment ---
-# For remote (EC2) deployment, copy this file as .env and set:
-#   1. LFD_AUTH_TOKEN (required — static bearer token for API access)
-#   2. At least one agent API key (ANTHROPIC_API_KEY, etc.)
-#   3. GH_TOKEN if agents need git push access
-#
-# Start stack with: docker compose -f docker/docker-compose.yml -f deploy/docker-compose.prod.yml up -d --build
-# Verify with: curl -k https://<host>/health
+# Remote deployment:
+#   deploy/loopflow-server.sh up
+#   curl -f https://<host>/health

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -10,7 +10,8 @@ services:
       LFD_MODE: container
       LFD_DATABASE_URL: "postgres://lfd:lfd@postgres:5432/lfd"
       LFD_EXECUTOR_IMAGE: "${LFD_EXECUTOR_IMAGE:-loopflow/agent:latest}"
-      LFD_AUTH_MODE: "${LFD_AUTH_MODE:-studio}"
+      LFD_AUTH_MODE: "${LFD_AUTH_MODE:-local}"
+      LFD_AUTH_TOKEN: "${LFD_AUTH_TOKEN:-}"
     env_file:
       - path: .env
         required: false

--- a/docs/lfd.md
+++ b/docs/lfd.md
@@ -27,10 +27,10 @@ lfd serve
 
 ### Container
 
-Use container mode for remote or shared hosts.
+Use container mode for self-hosted remote or shared hosts.
 
 - Storage: postgres
-- Auth: studio
+- Auth: local bearer token by default
 - Executor: Docker
 - Config: set `mode: container`, then install or run `lfd`
 
@@ -148,9 +148,9 @@ LFD_HTTP_TRUSTED_PROXY_CIDRS
 mode: native # native (default) or container
 
 auth:
-  mode: local # tuning knob within the selected shape
-  token: bundled-session-token # optional override for embedded launches
-  base_url: https://auth.loopflow.studio # used by studio mode
+  mode: local # default, self-hosted bearer-token auth
+  token: bundled-session-token # set from Doppler or env for remote hosts
+  base_url: https://auth.loopflow.studio # only used when opting into studio mode
 
 executor:
   image: loopflow/agent:latest
@@ -188,7 +188,7 @@ http_security:
 
 `executor.sandbox` was removed. If that key is still present in old config, `lfd` fails fast and tells you to delete it.
 
-In container mode, `auth.mode=local` without an explicit `auth.token` is promoted to `studio` so the blessed remote shape stays coherent.
+Container mode stays self-hosted by default. Set `LFD_AUTH_TOKEN` from Doppler or another secret store for remote hosts. Opt into `auth.mode: studio` only when using studio discovery.
 
 ### Credential mounts
 

--- a/python/tests/test_release_automation.py
+++ b/python/tests/test_release_automation.py
@@ -1,0 +1,193 @@
+import os
+import stat
+import subprocess
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_nightly_packages_workflow_builds_and_smokes_without_deploying():
+    workflow = yaml.load(
+        (ROOT / ".github/workflows/nightly-packages.yml").read_text(), Loader=yaml.BaseLoader
+    )
+
+    assert workflow["name"] == "Packages (nightly)"
+    assert workflow["on"]["schedule"] == [{"cron": "0 9 * * *"}]
+    assert workflow["jobs"]["regression"] == {"uses": "./.github/workflows/regression-daily.yml"}
+
+    native = workflow["jobs"]["native-packages"]
+    assert native["needs"] == "regression"
+    targets = {entry["target"] for entry in native["strategy"]["matrix"]["include"]}
+    assert targets == {
+        "aarch64-apple-darwin",
+        "x86_64-apple-darwin",
+        "x86_64-unknown-linux-gnu",
+        "aarch64-unknown-linux-gnu",
+    }
+
+    commands = "\n".join(step.get("run", "") for step in native["steps"])
+    assert "cargo build --release" in commands
+    assert "tar czf" in commands
+    assert "package-smoke/lf --version" in commands
+    assert "package-smoke/lfd --version" in commands
+
+    forbidden = [
+        "gh release",
+        "R2_",
+        "aws s3",
+        "cloudflarestorage.com",
+        "git push",
+        "gh workflow run",
+    ]
+    assert not any(term in commands for term in forbidden)
+
+
+def test_pull_local_bin_builds_and_installs_binaries(tmp_path: Path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "Cargo.toml").write_text("[workspace]\nmembers = []\n")
+    subprocess.run(["git", "init"], cwd=repo, check=True, stdout=subprocess.DEVNULL)
+
+    fake_bin = tmp_path / "fake-bin"
+    fake_bin.mkdir()
+    cargo_log = tmp_path / "cargo.log"
+    cargo = fake_bin / "cargo"
+    cargo.write_text(
+        f"""#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" > {cargo_log}
+repo=''
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --manifest-path)
+            repo="$(dirname "$2")"
+            shift 2
+            ;;
+        *)
+            shift
+            ;;
+    esac
+done
+mkdir -p "$repo/target/release"
+printf '#!/usr/bin/env bash\necho lf fake\n' > "$repo/target/release/lf"
+printf '#!/usr/bin/env bash\necho lfd fake\n' > "$repo/target/release/lfd"
+chmod +x "$repo/target/release/lf" "$repo/target/release/lfd"
+"""
+    )
+    cargo.chmod(cargo.stat().st_mode | stat.S_IXUSR)
+
+    install_dir = tmp_path / "local-bin"
+    env = os.environ.copy()
+    env["PATH"] = f"{fake_bin}:{env['PATH']}"
+
+    result = subprocess.run(
+        [
+            str(ROOT / "scripts/pull-local-bin.sh"),
+            "--repo",
+            str(repo),
+            "--install-dir",
+            str(install_dir),
+            "--no-pull",
+        ],
+        check=True,
+        text=True,
+        capture_output=True,
+        env=env,
+    )
+
+    assert "installed:" in result.stdout
+    assert "lf fake" in result.stdout
+    assert "lfd fake" in result.stdout
+    assert (install_dir / "lf").read_text().startswith("#!/usr/bin/env bash")
+    assert (install_dir / "lfd").read_text().startswith("#!/usr/bin/env bash")
+    assert "build --release -p loopflow --bin lf --bin lfd" in cargo_log.read_text()
+
+
+def test_self_hosted_server_primitives_are_documented_and_runnable():
+    help_result = subprocess.run(
+        [str(ROOT / "deploy/loopflow-server.sh"), "--help"],
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+
+    assert "up|update|down|status|logs|health" in help_result.stderr
+    assert "LOOPFLOW_SECRETS=auto|doppler|env" in help_result.stderr
+    assert "LFD_AUTH_TOKEN=..." in help_result.stderr
+
+    readme = (ROOT / "deploy/README.md").read_text()
+    assert "doppler secrets set LFD_AUTH_TOKEN" in readme
+    assert "openssl rand -hex 32" in readme
+    assert "leave `LF_TLS_MODE` empty" in readme
+    assert "Mac mini + Tailscale" in readme
+    assert "loopflow-server-update.timer" in readme
+    assert "lfq create root /opt/loopflow" in readme
+
+    compose = (ROOT / "docker/docker-compose.yml").read_text()
+    assert 'LFD_AUTH_MODE: "${LFD_AUTH_MODE:-local}"' in compose
+    assert 'LFD_AUTH_TOKEN: "${LFD_AUTH_TOKEN:-}"' in compose
+
+    prod_compose = (ROOT / "deploy/docker-compose.prod.yml").read_text()
+    assert "${CADDYFILE:-../deploy/Caddyfile}" in prod_compose
+
+    caddyfile = (ROOT / "deploy/Caddyfile").read_text()
+    assert "tls " not in caddyfile
+
+    internal_caddyfile = (ROOT / "deploy/Caddyfile.internal").read_text()
+    assert "tls internal" in internal_caddyfile
+
+    script = (ROOT / "deploy/loopflow-server.sh").read_text()
+    assert 'docker compose -p "$project_name"' in script
+    assert "LFD_AUTH_TOKEN is required for self-hosted local auth" in script
+    assert '(cd "$repo" && doppler run -- "$@")' in script
+    assert 'export CADDYFILE="$repo/deploy/Caddyfile.internal"' in script
+
+    service = (ROOT / "deploy/systemd/loopflow-server.service").read_text()
+    assert "ExecStart=/opt/loopflow/deploy/loopflow-server.sh up" in service
+
+    timer = (ROOT / "deploy/systemd/loopflow-server-update.timer").read_text()
+    assert "OnCalendar=*-*-* 04:15:00" in timer
+
+    plist = (ROOT / "deploy/launchd/studio.loopflow.server.plist").read_text()
+    assert "studio.loopflow.server" in plist
+    assert "loopflow-server.sh" in plist
+
+
+def test_aws_self_hosted_topology_keeps_secrets_out_of_terraform():
+    terraform_dir = ROOT / "deploy/terraform/aws"
+    files = [
+        "versions.tf",
+        "variables.tf",
+        "main.tf",
+        "outputs.tf",
+        "user-data.sh.tftpl",
+        "README.md",
+    ]
+    for name in files:
+        assert (terraform_dir / name).exists()
+
+    combined = "\n".join(path.read_text() for path in terraform_dir.iterdir() if path.is_file())
+    assert "DOPPLER_TOKEN=dp.st.x" in combined
+    assert 'variable "doppler' not in combined.lower()
+    assert "sensitive = true" not in combined.lower()
+    assert "Secrets intentionally stay out of Terraform state" in combined
+    assert "loopflow-server.service" in combined
+
+
+def test_release_schedule_contract_covers_loopflow_and_cadenza():
+    schedule = (ROOT / "release/SCHEDULE.md").read_text()
+    assert "Loopflow and Cadenza use the same release rhythm" in schedule
+    assert "0 9 * * *" in schedule
+    assert "0 12 * * 0" in schedule
+    assert (
+        "Weekly publishing never runs unless nightly-style package verification passed" in schedule
+    )
+
+    weekly = yaml.load(
+        (ROOT / ".github/workflows/weekly-release.yml").read_text(), Loader=yaml.BaseLoader
+    )
+    assert weekly["jobs"]["package-test"]["uses"] == "./.github/workflows/nightly-packages.yml"
+    assert weekly["jobs"]["release"]["needs"] == ["tag-check", "package-test"]
+    assert weekly["jobs"]["release"]["permissions"]["actions"] == "write"

--- a/release/README.md
+++ b/release/README.md
@@ -7,6 +7,11 @@ lf op release run patch
 find release -maxdepth 2 -type f | sort
 ```
 
+```bash
+scripts/pull-local-bin.sh    # pull default branch, build lf/lfd, install to ~/.local/bin
+cat release/SCHEDULE.md      # shared loopflow + cadenza release cadence
+```
+
 Use `release/` to keep the rationale and notes for each shipped version close to the code.
 
 | Path | What it does |
@@ -15,6 +20,16 @@ Use `release/` to keep the rationale and notes for each shipped version close to
 | `release/vX.Y.Z/DECISIONS.md` | Archived copy of that ledger for one shipped version |
 | `release/vX.Y.Z/NOTES.md` | Archived copy of the release notes generated for that version |
 | `RELEASE_NOTES.md` | Always-latest release notes at the repo root |
+
+## Automation rhythm
+
+| Cadence | Workflow | What it does | Ships? |
+|---------|----------|--------------|--------|
+| Nightly | `Packages (nightly)` | Runs the regression tier, builds every native `lf`/`lfd` tarball, extracts each package, and smoke-tests `--version` | No — artifacts expire after 14 days |
+| Weekly | `Regression (weekly auto-release)` | Runs nightly package verification, bumps patch when commits landed since the last tag, tags, and dispatches `Release` | Yes |
+| Local | `scripts/pull-local-bin.sh` | Fast dev-machine update: pull, release-build, atomically copy `lf`/`lfd` into the local bin dir | Local only |
+
+Nightly packages prove release artifacts while keeping deployment out of the loop. Weekly release reuses that package gate before publishing.
 
 Append to `release/unreleased/DECISIONS.md` only when the change captures durable intent: policy choices, scope calls, paths not taken, or decisions a contributor would cite months later. Skip bug-fix churn and mechanical edits.
 

--- a/release/SCHEDULE.md
+++ b/release/SCHEDULE.md
@@ -1,0 +1,32 @@
+# Release schedule contract
+
+Loopflow and Cadenza use the same release rhythm. Keep the cadence identical; only the repo-specific commands and package matrix should differ.
+
+| Cadence | Time | Required gate | Publishes? | Repo-specific knobs |
+|---------|------|---------------|------------|---------------------|
+| Nightly package verification | `0 9 * * *` UTC | Build official packages, extract them, run smoke commands | No | package targets, build commands, smoke commands |
+| Weekly auto-release | `0 12 * * 0` UTC | Run the nightly package verification first, then bump and tag only if commits landed since the last tag | Yes | manifests, release-note source, publish workflow |
+| Local dev refresh | ad hoc / high frequency | Build from default branch and atomically replace local binaries/apps | Local only | install dir, artifact names |
+| Self-hosted cron server refresh | nightly | Pull default branch and restart the server stack predictably | No | repo URL, host, domain, secrets project |
+
+## Repository contract
+
+Each repo should carry these files with carbon-copy cadence:
+
+```text
+.github/workflows/nightly-packages.yml   # same schedule; repo-specific package test body
+.github/workflows/weekly-release.yml     # same schedule; calls nightly package verification before publishing
+scripts/pull-local-bin.sh                # or repo-equivalent local updater
+deploy/loopflow-server.sh                # or repo-equivalent self-hosted cron runner
+deploy/systemd/* / deploy/launchd/*      # host keep-alive/update units
+```
+
+Loopflow and Cadenza both carry the scheduled release workflow pair. Each repo replaces only the commands that are truly product-specific: Rust package targets for Loopflow; server image, Swift app build, signing-sensitive publish choices, and release manifests for Cadenza. Loopflow also carries the self-hosted cron-server shape because it is the automation host; product repos can copy that layer when they need repo-local services.
+
+## Shared invariants
+
+- Nightly jobs prove release artifacts without deploying them.
+- Weekly publishing never runs unless nightly-style package verification passed in the same workflow run.
+- Secrets stay in Doppler or host-local env files, never Terraform state or committed config.
+- The cron server is self-hosted by default. Studio discovery is opt-in.
+- Local updater scripts refuse to pull a non-default branch unless explicitly told not to pull.

--- a/release/unreleased/DECISIONS.md
+++ b/release/unreleased/DECISIONS.md
@@ -171,3 +171,27 @@ built-in commands — skills fire there with `$step`.
 - Orientation is duplicated across 37 step files (no include mechanism for step
   `.md`). That duplication is the cost of "embedded in the relevant steps"; re-run
   the embed if the set of scratch-dependent steps changes.
+
+## 2026-06-29 — Self-hosted loopflow is the default automation shape
+
+**Context:** Release and cron automation had been drifting toward a private studio-hosted deployment model, with Terraform and secret handling living outside this repo. The release server needs to be inspectable, reproducible, and maintainable from loopflow itself, whether it runs on a Mac mini, Tailscale host, Fly.io, or cloud VM.
+
+**Decision:** Loopflow automation is self-hosted by default. The public repo carries the runnable container and deployment shape; Doppler supplies secrets; studio discovery is optional rather than the assumed path. Nightly package verification proves artifacts without deploying, weekly release is the automated publishing cadence, and local dev machines get a single `scripts/pull-local-bin.sh` update path.
+
+**Implications:** Container mode uses local bearer-token auth unless explicitly configured for studio. Deployment docs and compose defaults must avoid hidden global-host assumptions. Infrastructure config can be committed when it contains topology and mechanics, but credentials stay in Doppler or local env files.
+
+## 2026-06-29 — Hashimoto-style review is a standing quality ritual
+
+**Context:** Loopflow's core work benefits from a specific review posture: operationally boring, API-centered, skeptical of needless abstraction, and clear about what breaks under real use.
+
+**Decision:** Every unit of work gets a Mitchell Hashimoto-style simulated code review before it is considered done. The point is not impersonation; it is a concrete quality lens for simplicity, operations, API shape, docs, and deletable complexity.
+
+**Implications:** Agents should either fix findings immediately or record them in PR notes. Rubber-stamp review theater does not satisfy the ritual.
+
+## 2026-06-29 — Loopflow and Cadenza share one release cadence
+
+**Context:** Loopflow's release automation should not become a one-off snowflake while Cadenza drifts onto a separate schedule. Both projects need the same operational rhythm, even though their artifacts and signing requirements differ.
+
+**Decision:** Loopflow and Cadenza use carbon-copy nightly and weekly schedules: nightly package verification at `0 9 * * *` UTC without deployment, and weekly release at `0 12 * * 0` UTC gated by the same package verification. Repo-specific parameters live inside each repo's workflow body.
+
+**Implications:** Changing the cadence means changing both repositories together. Cadenza does not inherit Loopflow's Rust package matrix, and Loopflow does not inherit Cadenza's signing-sensitive TestFlight path; only the rhythm and gate semantics are shared.

--- a/rust/loopflow/Cargo.toml
+++ b/rust/loopflow/Cargo.toml
@@ -67,7 +67,7 @@ hmac = "0.12"
 humantime = "2"
 ipnet = "2"
 reqwest = { version = "0.13", features = ["blocking", "json"] }
-rusqlite = { version = "0.40", features = ["bundled"] }
+rusqlite = { version = "0.39", features = ["bundled"] }
 time = { version = "0.3", features = ["formatting", "parsing", "serde"] }
 tokio = { version = "1", features = ["io-util", "macros", "process", "rt-multi-thread", "signal", "sync", "time"] }
 tokio-postgres = { version = "0.7", features = ["with-chrono-0_4", "with-serde_json-1"] }

--- a/rust/loopflow/src/lfd/config.rs
+++ b/rust/loopflow/src/lfd/config.rs
@@ -389,10 +389,7 @@ impl RawLfdConfig {
         let profile = ModeProfile::for_mode(self.mode);
         self.executor.limits.validate()?;
 
-        let mut auth = self.auth;
-        if self.mode == Mode::Container && auth.mode == AuthMode::Local && auth.token.is_none() {
-            auth.mode = AuthMode::Studio;
-        }
+        let auth = self.auth;
 
         Ok(LfdConfig {
             mode: self.mode,
@@ -978,7 +975,7 @@ mod tests {
         assert_eq!(resolved.runtime_backend, RuntimeBackend::Compose);
         assert_eq!(resolved.storage, StorageType::Postgres);
         assert_eq!(resolved.executor.r#type, ExecutorType::Docker);
-        assert_eq!(resolved.auth.mode, AuthMode::Studio);
+        assert_eq!(resolved.auth.mode, AuthMode::Local);
     }
 
     #[test]

--- a/rust/loopflow/src/lfd/service/compose.rs
+++ b/rust/loopflow/src/lfd/service/compose.rs
@@ -216,7 +216,7 @@ fn render_compose_file(config: &LfdConfig) -> Result<String> {
     };
 
     Ok(format!(
-        "services:\n  lfd:\n    image: {image}\n    ports:\n      - \"${{LFD_PORT:-2486}}:2486\"\n    environment:\n      LFD_HTTP_ADDR: \"0.0.0.0:2486\"\n      LFD_MODE: \"{mode}\"\n      LFD_DATABASE_URL: \"{database_url}\"\n      LFD_EXECUTOR_IMAGE: \"{image}\"\n      LFD_AUTH_MODE: \"${{LFD_AUTH_MODE:-studio}}\"{extra_env}\n    env_file:\n      - path: .env\n        required: false\n    volumes:\n      - /var/run/docker.sock:/var/run/docker.sock\n      - lfd-data:/root/.lf{extra_mounts}\n    depends_on:\n      postgres:\n        condition: service_healthy\n    healthcheck:\n      test: [\"CMD\", \"curl\", \"-sf\", \"http://localhost:2486/health\"]\n      interval: 10s\n      timeout: 5s\n      retries: 3\n      start_period: 30s\n    restart: unless-stopped\n\n  postgres:\n    image: {postgres_image}\n    environment:\n      POSTGRES_USER: lfd\n      POSTGRES_PASSWORD: lfd\n      POSTGRES_DB: lfd\n    volumes:\n      - pgdata:/var/lib/postgresql/data\n    healthcheck:\n      test: [\"CMD-SHELL\", \"pg_isready -U lfd\"]\n      interval: 5s\n      timeout: 5s\n      retries: 5\n    restart: unless-stopped\n\nvolumes:\n  pgdata:\n  lfd-data:\n",
+        "services:\n  lfd:\n    image: {image}\n    ports:\n      - \"${{LFD_PORT:-2486}}:2486\"\n    environment:\n      LFD_HTTP_ADDR: \"0.0.0.0:2486\"\n      LFD_MODE: \"{mode}\"\n      LFD_DATABASE_URL: \"{database_url}\"\n      LFD_EXECUTOR_IMAGE: \"{image}\"\n      LFD_AUTH_MODE: \"${{LFD_AUTH_MODE:-local}}\"{extra_env}\n    env_file:\n      - path: .env\n        required: false\n    volumes:\n      - /var/run/docker.sock:/var/run/docker.sock\n      - lfd-data:/root/.lf{extra_mounts}\n    depends_on:\n      postgres:\n        condition: service_healthy\n    healthcheck:\n      test: [\"CMD\", \"curl\", \"-sf\", \"http://localhost:2486/health\"]\n      interval: 10s\n      timeout: 5s\n      retries: 3\n      start_period: 30s\n    restart: unless-stopped\n\n  postgres:\n    image: {postgres_image}\n    environment:\n      POSTGRES_USER: lfd\n      POSTGRES_PASSWORD: lfd\n      POSTGRES_DB: lfd\n    volumes:\n      - pgdata:/var/lib/postgresql/data\n    healthcheck:\n      test: [\"CMD-SHELL\", \"pg_isready -U lfd\"]\n      interval: 5s\n      timeout: 5s\n      retries: 5\n    restart: unless-stopped\n\nvolumes:\n  pgdata:\n  lfd-data:\n",
         image = config.executor.image,
         mode = config.mode.as_str(),
         database_url = POSTGRES_DATABASE_URL,
@@ -287,11 +287,11 @@ mod tests {
     }
 
     #[test]
-    fn compose_defaults_to_studio_auth_mode() {
+    fn compose_defaults_to_local_auth_mode() {
         let config = container_config();
         let content = render_compose_file(&config).expect("render compose file");
 
-        assert!(content.contains("LFD_AUTH_MODE: \"${LFD_AUTH_MODE:-studio}\""));
+        assert!(content.contains("LFD_AUTH_MODE: \"${LFD_AUTH_MODE:-local}\""));
     }
 
     #[test]

--- a/scripts/pull-local-bin.sh
+++ b/scripts/pull-local-bin.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# Pull the default branch, build lf/lfd, and install them into a local bin directory.
+#
+# Usage:
+#   scripts/pull-local-bin.sh
+#   scripts/pull-local-bin.sh --no-pull
+#   scripts/pull-local-bin.sh --repo ~/src/loopflow --install-dir ~/.local/bin
+
+set -euo pipefail
+
+usage() {
+    cat >&2 <<'USAGE'
+Usage: pull-local-bin.sh [--repo PATH] [--install-dir PATH] [--no-pull]
+
+Builds release lf/lfd from the repo and atomically copies them into the install
+bin directory. Defaults: current script's repo and $LF_INSTALL_DIR or ~/.local/bin.
+USAGE
+}
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo="$(cd "$script_dir/.." && pwd)"
+install_dir="${LF_INSTALL_DIR:-$HOME/.local/bin}"
+pull=true
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --repo)
+            if [[ $# -lt 2 ]]; then
+                echo "--repo requires a path" >&2
+                usage
+                exit 1
+            fi
+            repo="$2"
+            shift 2
+            ;;
+        --repo=*)
+            repo="${1#--repo=}"
+            shift
+            ;;
+        --install-dir)
+            if [[ $# -lt 2 ]]; then
+                echo "--install-dir requires a path" >&2
+                usage
+                exit 1
+            fi
+            install_dir="$2"
+            shift 2
+            ;;
+        --install-dir=*)
+            install_dir="${1#--install-dir=}"
+            shift
+            ;;
+        --no-pull)
+            pull=false
+            shift
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "unknown argument: $1" >&2
+            usage
+            exit 1
+            ;;
+    esac
+done
+
+repo="$(git -C "$repo" rev-parse --show-toplevel)"
+install_dir="$(mkdir -p "$install_dir" && cd "$install_dir" && pwd)"
+
+if [[ "$pull" == true ]]; then
+    default_branch="$(git -C "$repo" symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null | sed 's#^origin/##')"
+    current_branch="$(git -C "$repo" branch --show-current)"
+    if [[ -n "$default_branch" && "$current_branch" != "$default_branch" ]]; then
+        echo "refusing to pull $current_branch; checkout $default_branch or pass --no-pull" >&2
+        exit 1
+    fi
+
+    echo "pulling $repo"
+    if [[ -n "$default_branch" ]]; then
+        git -C "$repo" pull --ff-only origin "$default_branch"
+    else
+        git -C "$repo" pull --ff-only
+    fi
+fi
+
+echo "building lf/lfd"
+cargo build --release -p loopflow --bin lf --bin lfd --manifest-path "$repo/Cargo.toml"
+
+for bin in lf lfd; do
+    src="$repo/target/release/$bin"
+    dst="$install_dir/$bin"
+    tmp="$install_dir/.${bin}.tmp.$$"
+    if [[ ! -x "$src" ]]; then
+        echo "missing built binary: $src" >&2
+        exit 1
+    fi
+    cp "$src" "$tmp"
+    chmod +x "$tmp"
+    mv -f "$tmp" "$dst"
+done
+
+echo "installed: $install_dir/lf"
+"$install_dir/lf" --version
+"$install_dir/lfd" --version

--- a/tests/regression/README.md
+++ b/tests/regression/README.md
@@ -41,12 +41,10 @@ need a real runtime to notice.
 4. Link the bug: leading docstring names the fix commit or PR so future
    readers know *why* this specific shape matters.
 
-## Weekly auto-release
+## Nightly packages and weekly auto-release
 
-When the regression suite is green on Sundays, the
-[`weekly-release.yml`](../../.github/workflows/weekly-release.yml) workflow
-bumps the patch version, appends a stub to `RELEASE_NOTES.md`, and commits.
-`auto-tag.yml` picks up that commit and cuts the tag.
+[`nightly-packages.yml`](../../.github/workflows/nightly-packages.yml) runs this suite before building the native `lf`/`lfd` tarballs. It extracts each package and runs `lf --version` and `lfd --version`. Artifacts are uploaded for inspection only; nothing is deployed.
 
-A failing regression test blocks the auto-release — no partial or unverified
-cuts.
+When package verification is green on Sundays, [`weekly-release.yml`](../../.github/workflows/weekly-release.yml) bumps the patch version, appends a stub to `RELEASE_NOTES.md`, commits to `main`, tags the commit, and dispatches the release workflow.
+
+A failing regression test blocks package verification and auto-release — no partial or unverified cuts.


### PR DESCRIPTION
## Usage

```bash
# Self-hosted server (Doppler secrets by default)
export LF_DOMAIN='lfd.example.com'
export LFD_AUTH_TOKEN=$(openssl rand -hex 32)
export LF_TLS_MODE=internal       # private/Tailscale hosts; empty for public ACME
deploy/loopflow-server.sh up
deploy/loopflow-server.sh update  # pull default branch, rebuild, restart

# Keep local dev binaries fresh from a checkout
scripts/pull-local-bin.sh
```

## Summary

Stands up a fully self-hosted, automated release pipeline so `lfd` can run as a cron host that builds, verifies, and publishes its own releases without depending on studio auth. Adds a managed server stack (`deploy/loopflow-server.sh`) with Doppler-backed bearer-token auth, host integrations for Linux (systemd) and Mac mini (launchd), a Terraform module for AWS, and a CI flow that builds and smoke-tests native packages nightly before the weekly job tags and dispatches a release.

## Changes

- **CI**: new `nightly-packages.yml` builds `lf`/`lfd` tarballs across macOS/Linux (arm+x86) after the regression tier and smoke-tests each. `weekly-release.yml` splits into `tag-check` → `package-test` (reuses the nightly job) → `release`, skipping when no commits landed since the last tag.
- **Deploy**: `loopflow-server.sh` (up/update/down/status/logs/health) with Doppler-or-`.env` secrets; systemd service+update timer, launchd plist, and a parameterized `--repo PATH` so loopflow and Cadenza share one server shape. TLS splits into public `Caddyfile` (ACME) vs `Caddyfile.internal` (`internal` CA), selected via `LF_TLS_MODE`/`CADDYFILE`.
- **Auth**: self-hosted `LFD_AUTH_TOKEN` bearer auth replaces studio credentials as the default remote-client path; deploy README rewritten around Doppler secrets and bearer tokens.
- **Infra**: Terraform AWS module (`deploy/terraform/aws/`) provisioning the host, plus `scripts/pull-local-bin.sh` to install a dev checkout into `~/.local/bin`.
- **Tests/docs**: `tests/test_release_automation.py` covers the release gate; `release/` gains README, SCHEDULE, and a DECISIONS ledger; TESTING/STYLE/README updated. Cargo.lock pins `rusqlite` 0.39 / `libsqlite3-sys` 0.37.