### PR TITLE
wave: add release automation metadata

### DIFF
--- a/release/unreleased/DECISIONS.md
+++ b/release/unreleased/DECISIONS.md
@@ -203,3 +203,11 @@ built-in commands — skills fire there with `$step`.
 **Decision:** Delete studio auth, daemon registration, and hosted discovery. Remote `lfd` access is self-hosted bearer-token auth only; each repo owns its deployment config and keeps secrets in Doppler or host-local env.
 
 **Implications:** Concerto connects to explicit self-hosted URLs and tokens instead of studio sign-in. Container compose requires `LFD_AUTH_TOKEN`. Token rotation happens in the repo/host secret system, not through a studio connection-token ledger.
+
+## 2026-06-29 — Release automation gets its own wave
+
+**Context:** Release automation now spans CI cadence, self-hosted daemon infrastructure, local freshness, Cadenza parity, and future product replication. Keeping that intent only in conversation makes future agents rediscover scope and success criteria.
+
+**Decision:** Add `wave/release/` as the owner for daily verification, weekly publishing, self-hosted cron infrastructure, local updater freshness, and product-release parity. Root gardens it alongside desktop, mobile, and workflows.
+
+**Implications:** Release work is no longer incidental workflow plumbing. Changes to schedules, deploy shape, Doppler assumptions, or cross-repo parity should update the release wave metadata and include a Mitchell Hashimoto simulated review when they ship.

--- a/wave/release/README.md
+++ b/wave/release/README.md
@@ -1,0 +1,49 @@
+# Release
+
+Own the release and self-hosted automation spine for Loopflow first, then keep Cadenza in lockstep until the products truly need different machinery.
+
+## Goal
+
+Make releases boring: nightly verification proves packages without publishing, weekly release publishes only after verification, and repo-owned self-hosted `lfd` runs the crons. Secrets live in Doppler or host-local env. Deployment topology, scripts, schedules, and tests live in the repo.
+
+This wave exists because release automation is now product infrastructure, not a private studio deployment. Loopflow should carry the primitives; Cadenza should mirror the cadence and shape; other product repos can copy the pattern when they need cron-backed automation.
+
+## Success metrics
+
+- **Daily verification:** nightly workflow builds/tests official release artifacts and never deploys them.
+- **Weekly publishing:** weekly workflow publishes only after the same verification passes in that run.
+- **Self-hosted execution:** a maintained `lfd` host can run repo crons from committed deploy files plus Doppler secrets.
+- **No studio control plane:** secure remote execution uses self-hosted bearer-token auth; no hosted studio auth, registration, or daemon discovery path is required.
+- **Local freshness:** developers have one clear script for pulling the latest local `lf`/`lfd` or product app into their bin/app location.
+- **Parity:** Loopflow and Cadenza keep carbon-copy release schedules and infrastructure until a product-specific difference is deliberate and documented.
+
+## Cadence
+
+| Cadence | What happens | Gate |
+|---------|--------------|------|
+| Daily/nightly | Build packages, run release-grade tests, capture failures | No publishing or deploy side effects |
+| Weekly | Publish release artifacts and notes | Nightly-equivalent verification passed in the same workflow |
+| Continuous | Keep local tools fresh and self-hosted cron host healthy | One-command updater and status checks stay green |
+| Per infra PR | Run a Mitchell Hashimoto simulated review | PR body includes tradeoffs and operational failure modes |
+
+## Roadmap
+
+1. **Drain current buffer** — keep local `lf`/`lfd`, release scripts, and CI aligned with the latest merged release-infra work.
+2. **Cadenza parity** — mirror Loopflow's nightly/weekly cadence, local updater, tests, and self-hosted assumptions.
+3. **Bootstrap the first cron host** — start with Mac mini + Tailscale unless AWS/Fly becomes simpler; configure Doppler; run repo-owned `lfd`; create the root/conductor wave.
+4. **Close the feedback loop** — failed nightly/weekly jobs should surface as attention items or focused fix PRs, not disappear into Actions history.
+5. **Replicate intentionally** — apply the same skeleton to Manabot/Hootro when they need it; don't abstract before the second or third real deployment proves the shape.
+
+## Current operating decisions
+
+- Self-hosting is the default. Public repo carries containers, deploy scripts, service units, schedules, and docs.
+- Doppler hides secrets. Terraform, compose, Caddy, launchd/systemd, and scripts can be committed when they contain topology rather than credentials.
+- Secure remote execution stays: bind remote `lfd` with `LFD_AUTH_TOKEN`, TLS/Caddy/Tailscale around it, and explicit clients.
+- Studio auth and hosted discovery are gone. If pairing needs polish later, add QR/import UX on top of self-hosted URL + token rather than a global server.
+- Cadenza follows Loopflow's release cadence until divergence is worth writing down.
+
+## Not here
+
+- Product release content decisions — each product owns its changelog substance.
+- Provider-specific agent credentials beyond pass-through and secret wiring.
+- A generic multi-product deploy platform. Keep the repo-local shape boring before extracting anything.

--- a/wave/release/items/01-cadenza-release-parity.md
+++ b/wave/release/items/01-cadenza-release-parity.md
@@ -1,0 +1,19 @@
+---
+priority: p1
+status: open
+---
+# Cadenza release parity
+
+Mirror Loopflow's release automation shape in Cadenza.
+
+## Goal
+
+Cadenza has the same daily verification and weekly release cadence as Loopflow, with product-specific build/test commands documented rather than improvised.
+
+## Done when
+
+- Cadenza nightly workflow verifies release-grade artifacts without publishing.
+- Cadenza weekly workflow publishes only after same-run verification passes.
+- Local update script is one command and documented.
+- Any difference from Loopflow's release schedule or deploy shape is intentional and written down.
+- PR body includes a Mitchell Hashimoto simulated review.

--- a/wave/release/items/02-cron-host-bootstrap.md
+++ b/wave/release/items/02-cron-host-bootstrap.md
@@ -1,0 +1,18 @@
+---
+priority: p1
+status: open
+---
+# Cron host bootstrap
+
+Bring up the first maintained self-hosted `lfd` cron host.
+
+## Goal
+
+A real host runs Loopflow crons from committed deploy files and Doppler secrets. Mac mini + Tailscale is the default first target unless another host is simpler at implementation time.
+
+## Done when
+
+- Host has Doppler configured outside git.
+- `deploy/loopflow-server.sh up` or the host service unit starts `lfd` behind TLS/private networking.
+- Root/conductor wave exists on the host with scheduled garden/release checks.
+- Status, logs, and update commands are documented and runnable.

--- a/wave/release/items/03-release-feedback-loop.md
+++ b/wave/release/items/03-release-feedback-loop.md
@@ -1,0 +1,17 @@
+---
+priority: p2
+status: open
+---
+# Release feedback loop
+
+Turn release automation failures into work that gets handled.
+
+## Goal
+
+Nightly and weekly failures surface as attention items or focused fix PRs with enough context to act quickly.
+
+## Done when
+
+- Failed nightly/weekly runs can be discovered from Loopflow, not only GitHub Actions.
+- CI failure repair flows know which release workflow failed and why.
+- Human-facing status distinguishes package verification failure, publish failure, deploy/host failure, and stale-local-copy drift.

--- a/wave/release/release.yaml
+++ b/wave/release/release.yaml
@@ -1,0 +1,13 @@
+flow: build
+mode: manual
+workers: 0
+area:
+- .github/workflows/
+- deploy/
+- docker/
+- release/
+- scripts/
+- wave/release/
+direction:
+- clarity
+- care

--- a/wave/root/README.md
+++ b/wave/root/README.md
@@ -2,14 +2,14 @@
 
 Garden the active waves. Keep the whole system legible.
 
-Root is the conductor wave for this repo. It does not own a product surface of its own; it owns the rhythm between the other waves. The job is simple: keep `desktop`, `mobile`, and `workflows` moving in the right order, surface drift early, and make the morning status pass feel like one coherent ritual instead of three disconnected dashboards.
+Root is the conductor wave for this repo. It does not own a product surface of its own; it owns the rhythm between the other waves. The job is simple: keep `desktop`, `mobile`, `workflows`, and `release` moving in the right order, surface drift early, and make the morning status pass feel like one coherent ritual instead of disconnected dashboards.
 
 ## Active waves
 
 ```
 wave: root
 │
-│  area: wave/desktop/, wave/mobile/, wave/workflows/
+│  area: wave/desktop/, wave/mobile/, wave/workflows/, wave/release/
 │  flow: garden
 │
 ├── wave: desktop      Concerto macOS — embedded terminal build driver, then native chat UX
@@ -21,13 +21,14 @@ wave: root
 
 - **Garden the other waves** — scheduled `garden` and `govern-*` passes observe pressure, propose mutations, and keep the wave map honest
 - **Unify status language** — manual `review-open-work` and automated govern/garden passes should produce the same kinds of signals
-- **Keep scope clean** — desktop owns build-driving UX, mobile owns the read surface, workflows owns engine + governance machinery
+- **Keep scope clean** — desktop owns build-driving UX, mobile owns the read surface, workflows owns engine + governance machinery, release owns cadence + deploy spine
 
 ## Current priorities
 
 1. **`review-open-work-and-garden-parity`** — manual and automated status passes should read as one system
-2. **Calendar rhythm that earns trust** — scheduled scans need to be current enough to matter and quiet enough not to create noise
-3. **Mutation review that stays human-sized** — root should propose reviewable adjustments, not dump a strategy deck into a PR
+2. **Release automation spine** — daily verification, weekly publishing, and self-hosted cron hosting should stay visible as one operating rhythm
+3. **Calendar rhythm that earns trust** — scheduled scans need to be current enough to matter and quiet enough not to create noise
+4. **Mutation review that stays human-sized** — root should propose reviewable adjustments, not dump a strategy deck into a PR
 
 ## Boundaries
 
@@ -42,6 +43,7 @@ wave: root
 - Embedded terminal and chat implementation details — `desktop`
 - Remote iOS read-surface work — `mobile`
 - Flow engine, PM sync, and governance surfaces — `workflows`
+- Release cadence, local updater, and self-hosted cron deploy details — `release`
 
 ## What success looks like
 

--- a/wave/root/root.yaml
+++ b/wave/root/root.yaml
@@ -8,6 +8,7 @@ area:
 - wave/desktop/
 - wave/mobile/
 - wave/workflows/
+- wave/release/
 direction:
 - care
 - clarity


### PR DESCRIPTION
## Try it

```bash
lf op wt list                    # release work now tracked as its own wave
cat wave/release/README.md
```

## Summary

Adds `wave/release/` as a first-class wave that owns the release and self-hosted automation spine: nightly verification (build/test without publishing), weekly publishing gated on that verification, repo-owned self-hosted `lfd` crons with secrets in Doppler, local-tool freshness, and Cadenza parity. Release automation had grown across CI cadence, daemon infra, and cross-repo replication while its intent lived only in conversation — this metadata captures the scope, success metrics, and operating decisions so future agents don't rediscover them. Root is updated to garden `release` alongside `desktop`, `mobile`, and `workflows`.

## Changes

- New `wave/release/` with README (goal, success metrics, cadence table, roadmap, boundaries), `release.yaml` config, and three open work items: Cadenza release parity, cron host bootstrap, and the release feedback loop.
- Root wave (`README.md`, `root.yaml`) now includes `release` in its conducted set, scope boundaries, and priorities.
- `release/unreleased/DECISIONS.md` records the decision to make release automation its own wave.