### PR TITLE
deploy: add cron host bootstrap script

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -52,7 +52,27 @@ The script uses Doppler automatically when the Doppler CLI is configured or `DOP
 
 Public hosts leave `LF_TLS_MODE` empty and use `deploy/Caddyfile`, letting Caddy request public ACME certificates. Private or Tailscale-only hosts set `LF_TLS_MODE=internal`; the deploy script mounts `deploy/Caddyfile.internal` for Caddy's internal CA.
 
-## Linux host
+## Bootstrap cron host
+
+`bootstrap-cron-host.sh` is the one-command host setup. It installs the host service, starts `lfd`, waits for health, and creates or shows the root wave on the self-hosted daemon.
+
+```bash
+export LF_DOMAIN='lfd.example.com'
+export LF_TLS_MODE=internal
+export LFD_AUTH_TOKEN=$(openssl rand -hex 32)
+
+# Mac mini / Tailscale
+deploy/bootstrap-cron-host.sh --host mac
+
+# Linux host
+deploy/bootstrap-cron-host.sh --host linux
+```
+
+Use Doppler for maintained hosts. On Linux the bootstrap writes `/etc/loopflow-server.env` with `0600` permissions so systemd can reach either `DOPPLER_TOKEN` or host-local fallback secrets. On macOS it writes the same launch environment into `~/Library/LaunchAgents/loopflow.server.plist`; prefer a Doppler service token over embedding long-lived provider credentials there.
+
+The update timer refreshes Linux hosts nightly. The macOS launch agent checks the stack every five minutes. Keep local dev binaries fresh with `scripts/pull-local-bin.sh`; server restarts should be predictable.
+
+## Manual Linux service install
 
 ```bash
 sudo install -m 0600 /dev/null /etc/loopflow-server.env
@@ -65,22 +85,20 @@ sudo systemctl enable --now loopflow-server.service
 sudo systemctl enable --now loopflow-server-update.timer
 ```
 
-The update timer refreshes the server nightly. Keep local dev binaries fresh with `scripts/pull-local-bin.sh`; server restarts should be predictable.
-
-## Mac mini + Tailscale
+## Manual Mac mini + Tailscale install
 
 ```bash
 mkdir -p ~/Library/LaunchAgents
 cp deploy/launchd/loopflow.server.plist ~/Library/LaunchAgents/
 plutil -replace ProgramArguments.0 -string "$PWD/deploy/loopflow-server.sh" ~/Library/LaunchAgents/loopflow.server.plist
-launchctl load ~/Library/LaunchAgents/loopflow.server.plist
+launchctl bootstrap "gui/$(id -u)" ~/Library/LaunchAgents/loopflow.server.plist
 ```
 
-Use `LF_TLS_MODE=internal` for a Tailscale-only hostname; the deploy script mounts `deploy/Caddyfile.internal`. Leave `LF_TLS_MODE` empty for public ACME and it uses `deploy/Caddyfile`. Docker Desktop must be running; the launch agent keeps the stack up every five minutes.
+Use `LF_TLS_MODE=internal` for a Tailscale-only hostname; the deploy script mounts `deploy/Caddyfile.internal`. Leave `LF_TLS_MODE` empty for public ACME and it uses `deploy/Caddyfile`. Docker Desktop must be running.
 
-## Enable repo crons
+## Enable repo crons manually
 
-Create waves on the self-hosted daemon from the host or from a trusted client:
+The bootstrap script does this when `lfq` is installed. To do it by hand from the host or a trusted client:
 
 ```bash
 export LFD_URL=https://lfd.example.com

--- a/deploy/bootstrap-cron-host.sh
+++ b/deploy/bootstrap-cron-host.sh
@@ -1,0 +1,258 @@
+#!/usr/bin/env bash
+# Bootstrap this checkout as a maintained self-hosted loopflow cron host.
+# Secrets come from Doppler when configured. Use LOOPFLOW_SECRETS=env to force
+# plain environment variables.
+
+set -euo pipefail
+
+usage() {
+    cat >&2 <<'USAGE'
+Usage: bootstrap-cron-host.sh [--repo PATH] [--host auto|linux|mac] [--no-service] [--no-wave]
+
+Installs host service wiring, starts the self-hosted lfd stack, waits for
+health, and creates/shows the root wave on the remote daemon.
+
+Environment:
+  LOOPFLOW_SECRETS=auto|doppler|env   default: auto
+  LF_DOMAIN=lfd.example.com           required host name for remote clients
+  LF_TLS_MODE=internal                private/Tailscale TLS; leave empty for public ACME
+  LFD_AUTH_TOKEN=...                  required bearer token for remote lfd
+  LFD_URL=https://lfd.example.com     optional override for wave setup
+USAGE
+}
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo="$(cd "$script_dir/.." && pwd)"
+host="auto"
+install_service=1
+create_wave=1
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --repo)
+            if [[ $# -lt 2 ]]; then
+                echo "--repo requires a path" >&2
+                usage
+                exit 1
+            fi
+            repo="$2"
+            shift 2
+            ;;
+        --repo=*)
+            repo="${1#--repo=}"
+            shift
+            ;;
+        --host)
+            if [[ $# -lt 2 ]]; then
+                echo "--host requires linux, mac, or auto" >&2
+                usage
+                exit 1
+            fi
+            host="$2"
+            shift 2
+            ;;
+        --host=*)
+            host="${1#--host=}"
+            shift
+            ;;
+        --no-service)
+            install_service=0
+            shift
+            ;;
+        --no-wave)
+            create_wave=0
+            shift
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "unknown argument: $1" >&2
+            usage
+            exit 1
+            ;;
+    esac
+done
+
+repo="$(git -C "$repo" rev-parse --show-toplevel)"
+
+case "$host" in
+    auto)
+        case "$(uname -s)" in
+            Darwin) host="mac" ;;
+            Linux) host="linux" ;;
+            *) echo "cannot infer host type; pass --host linux or --host mac" >&2; exit 1 ;;
+        esac
+        ;;
+    linux|mac)
+        ;;
+    *)
+        echo "invalid --host: $host" >&2
+        usage
+        exit 1
+        ;;
+esac
+
+has_doppler_config() {
+    command -v doppler >/dev/null 2>&1 || return 1
+    [[ -n "${DOPPLER_TOKEN:-}" ]] && return 0
+    (cd "$repo" && doppler configure get project --plain >/dev/null 2>&1)
+}
+
+run_with_secrets() {
+    case "${LOOPFLOW_SECRETS:-auto}" in
+        env)
+            "$@"
+            ;;
+        doppler)
+            command -v doppler >/dev/null 2>&1 || {
+                echo "LOOPFLOW_SECRETS=doppler but doppler is not installed" >&2
+                exit 1
+            }
+            (cd "$repo" && doppler run -- "$@")
+            ;;
+        auto)
+            if has_doppler_config; then
+                (cd "$repo" && doppler run -- "$@")
+            else
+                "$@"
+            fi
+            ;;
+        *)
+            echo "invalid LOOPFLOW_SECRETS: ${LOOPFLOW_SECRETS}" >&2
+            exit 1
+            ;;
+    esac
+}
+
+preflight_bootstrap_env() {
+    run_with_secrets bash -c '
+        missing=0
+        for name in LF_DOMAIN LFD_AUTH_TOKEN; do
+            if [ -z "${!name:-}" ]; then
+                echo "$name is required for cron-host bootstrap" >&2
+                missing=1
+            fi
+        done
+        exit "$missing"
+    '
+}
+
+install_mac_launch_agent() {
+    local dest="$HOME/Library/LaunchAgents/loopflow.server.plist"
+    mkdir -p "$(dirname "$dest")"
+    cp "$repo/deploy/launchd/loopflow.server.plist" "$dest"
+    plutil -replace ProgramArguments.0 -string "$repo/deploy/loopflow-server.sh" "$dest"
+    python3 - "$dest" <<'PY_PLIST'
+import os
+import plistlib
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+with path.open("rb") as handle:
+    data = plistlib.load(handle)
+
+env = data.setdefault("EnvironmentVariables", {})
+for name in ["DOPPLER_TOKEN", "LOOPFLOW_SECRETS", "LF_DOMAIN", "LF_TLS_MODE", "LFD_AUTH_TOKEN", "LFD_PORT"]:
+    value = os.environ.get(name)
+    if value:
+        env[name] = value
+
+with path.open("wb") as handle:
+    plistlib.dump(data, handle)
+PY_PLIST
+    launchctl bootout "gui/$(id -u)" "$dest" >/dev/null 2>&1 || true
+    launchctl bootstrap "gui/$(id -u)" "$dest"
+    launchctl enable "gui/$(id -u)/loopflow.server"
+}
+
+write_linux_env_file() {
+    local sudo_cmd=("$@")
+    local tmp
+    tmp="$(mktemp)"
+    {
+        printf 'LOOPFLOW_SECRETS=%q\n' "${LOOPFLOW_SECRETS:-auto}"
+        for name in DOPPLER_TOKEN LF_DOMAIN LF_TLS_MODE LFD_AUTH_TOKEN LFD_PORT; do
+            if [[ -n "${!name:-}" ]]; then
+                printf '%s=%q\n' "$name" "${!name}"
+            fi
+        done
+    } > "$tmp"
+    "${sudo_cmd[@]}" install -m 0600 "$tmp" /etc/loopflow-server.env
+    rm -f "$tmp"
+}
+
+install_linux_systemd_units() {
+    local sudo_cmd=()
+    if [[ "$(id -u)" -ne 0 ]]; then
+        sudo_cmd=(sudo)
+    fi
+
+    write_linux_env_file "${sudo_cmd[@]}"
+
+    for unit in loopflow-server.service loopflow-server-update.service loopflow-server-update.timer; do
+        local src="$repo/deploy/systemd/$unit"
+        local tmp
+        tmp="$(mktemp)"
+        sed "s#/opt/loopflow#$repo#g" "$src" > "$tmp"
+        "${sudo_cmd[@]}" install -m 0644 "$tmp" "/etc/systemd/system/$unit"
+        rm -f "$tmp"
+    done
+
+    "${sudo_cmd[@]}" systemctl daemon-reload
+    "${sudo_cmd[@]}" systemctl enable --now loopflow-server.service
+    "${sudo_cmd[@]}" systemctl enable --now loopflow-server-update.timer
+}
+
+wait_for_health() {
+    local attempts=30
+    until "$repo/deploy/loopflow-server.sh" --repo "$repo" health >/dev/null 2>&1; do
+        attempts=$((attempts - 1))
+        if [[ "$attempts" -le 0 ]]; then
+            echo "lfd did not become healthy" >&2
+            echo "Run: $repo/deploy/loopflow-server.sh logs" >&2
+            exit 1
+        fi
+        sleep 2
+    done
+}
+
+create_root_wave() {
+    if ! command -v lfq >/dev/null 2>&1; then
+        echo "lfq not found; skipping root wave creation" >&2
+        return 0
+    fi
+
+    run_with_secrets bash -c '
+        set -euo pipefail
+        export LFD_URL="${LFD_URL:-https://${LF_DOMAIN}}"
+        export LFD_TOKEN="$LFD_AUTH_TOKEN"
+        if lfq show root >/dev/null 2>&1; then
+            lfq show root
+        else
+            lfq create root "$1"
+            lfq show root
+        fi
+    ' bash "$repo"
+}
+
+preflight_bootstrap_env
+
+if [[ "$install_service" -eq 1 ]]; then
+    case "$host" in
+        mac) install_mac_launch_agent ;;
+        linux) install_linux_systemd_units ;;
+    esac
+else
+    "$repo/deploy/loopflow-server.sh" --repo "$repo" up
+fi
+
+wait_for_health
+
+if [[ "$create_wave" -eq 1 ]]; then
+    create_root_wave
+fi
+
+run_with_secrets bash -c 'echo "loopflow cron host ready: ${LFD_URL:-https://${LF_DOMAIN}}"'

--- a/python/tests/test_release_automation.py
+++ b/python/tests/test_release_automation.py
@@ -112,16 +112,28 @@ def test_self_hosted_server_primitives_are_documented_and_runnable():
         text=True,
         capture_output=True,
     )
+    bootstrap_help = subprocess.run(
+        [str(ROOT / "deploy/bootstrap-cron-host.sh"), "--help"],
+        check=True,
+        text=True,
+        capture_output=True,
+    )
 
     assert "up|update|down|status|logs|health" in help_result.stderr
     assert "LOOPFLOW_SECRETS=auto|doppler|env" in help_result.stderr
     assert "LFD_AUTH_TOKEN=..." in help_result.stderr
+    assert "bootstrap-cron-host.sh [--repo PATH]" in bootstrap_help.stderr
+    assert "--host auto|linux|mac" in bootstrap_help.stderr
+    assert "--no-wave" in bootstrap_help.stderr
 
     readme = (ROOT / "deploy/README.md").read_text()
     assert "doppler secrets set LFD_AUTH_TOKEN" in readme
     assert "openssl rand -hex 32" in readme
     assert "leave `LF_TLS_MODE` empty" in readme
     assert "Mac mini + Tailscale" in readme
+    assert "bootstrap-cron-host.sh" in readme
+    assert "one-command host setup" in readme
+    assert "/etc/loopflow-server.env" in readme
     assert "loopflow-server-update.timer" in readme
     assert "lfq create root /opt/loopflow" in readme
 
@@ -143,6 +155,13 @@ def test_self_hosted_server_primitives_are_documented_and_runnable():
     assert "LFD_AUTH_TOKEN is required for self-hosted remote execution" in script
     assert '(cd "$repo" && doppler run -- "$@")' in script
     assert 'export CADDYFILE="$repo/deploy/Caddyfile.internal"' in script
+
+    bootstrap = (ROOT / "deploy/bootstrap-cron-host.sh").read_text()
+    assert "is required for cron-host bootstrap" in bootstrap
+    assert "systemctl enable --now loopflow-server.service" in bootstrap
+    assert "launchctl bootstrap" in bootstrap
+    assert "lfq create root" in bootstrap
+    assert "install -m 0600" in bootstrap
 
     service = (ROOT / "deploy/systemd/loopflow-server.service").read_text()
     assert "ExecStart=/opt/loopflow/deploy/loopflow-server.sh up" in service


### PR DESCRIPTION
## Usage

```bash
export LF_DOMAIN='lfd.example.com'
export LF_TLS_MODE=internal
export LFD_AUTH_TOKEN=$(openssl rand -hex 32)

# Mac mini / Tailscale
deploy/bootstrap-cron-host.sh --host mac

# Linux host
deploy/bootstrap-cron-host.sh --host linux
```

## Summary

Adds `deploy/bootstrap-cron-host.sh`, a one-command setup for a maintained self-hosted loopflow cron host. It installs the host service wiring (systemd units on Linux, a launchd agent on macOS), starts the `lfd` stack, waits for health, and creates or shows the root wave on the remote daemon. Secrets come from Doppler when configured, with `LOOPFLOW_SECRETS=auto|doppler|env` to control the source. This replaces the previous manual, multi-step host setup with a single entry point.

## Changes

- New `bootstrap-cron-host.sh` with `--repo`, `--host auto|linux|mac`, `--no-service`, and `--no-wave` flags; preflights required env (`LF_DOMAIN`, `LFD_AUTH_TOKEN`) before doing anything.
- Linux path writes `/etc/loopflow-server.env` at `0600` and installs the server + nightly update timer units, rewriting `/opt/loopflow` to the actual repo path.
- macOS path installs the launch agent via `launchctl bootstrap`, injecting the launch environment into the plist.
- `deploy/README.md` reorganized around the bootstrap script, with the prior steps kept as "manual" install sections.
- Extends `test_release_automation.py` to assert the bootstrap script's help output, docs, and key behaviors stay in sync.
