### PR TITLE
cadenza launchboard: design + loopflow lessons from dogfooding

### DIFF
--- a/scratch/jack-heart.cadenz.20260629_1347.md
+++ b/scratch/jack-heart.cadenz.20260629_1347.md
@@ -1,0 +1,196 @@
+# Cadenza Launchboard — design
+
+## Dream
+
+Make Concerto (the loopflow desktop app) ruthlessly optimized for one job:
+building Cadenza. Today Concerto is the generic multi-wave / governance
+surface. This redesign narrows it into a **dashboard + launchboard** for a
+single project — the place Jack opens to start, continue, and ship Cadenza work.
+
+> "I want to make the Desktop app ruthlessly optimized for the experience of
+> building Cadenza specifically."
+
+Three work-shapes the launchboard must handle:
+
+1. **One-off fix** → one PR, fully deployed (incl. release).
+2. **Start a project** → `lf design --ide` → kickoff → wave.
+3. **Continue the next** → ingest the next item on any project and build.
+
+Backing object for a unit of work = an Asana task. Cadenza is the place to get
+opinionated about the design tradeoffs the generic model leaves open.
+
+### Goal context
+
+- Primary: drive adoption in Jack's own daily music practice.
+- Next: onboard his son.
+- Overhang: product is more capable than current use; the "killer feature" is
+  still moving — expect the daily-practice area to churn.
+- Long-term tech depth: "understanding" the music — an interface built around
+  LLM integration + MusicXML. Pays off in adoption later, needs investment now.
+
+Constraint: areas/projects must be **cheap to rename and split** over time.
+
+## What I found (grounding)
+
+Two repos, two surfaces:
+
+- **loopflow** (this repo, this branch) — Concerto / the launchboard. The *tool*.
+- **cadenza** (`~/src/cadenza`) — SwiftUI app + FastAPI server, "music practice
+  app for teachers and students." The *content*. Existing waves: `progress`,
+  `score`, `video` — detailed, mature plans.
+
+Existing Cadenza waves are cut by feature surface (progress / score / video).
+The new cut: **Core** as trunk, with **Scores** and **Feedback** as sub-projects
+(see Decisions). The earlier "LLMs" area folded into Feedback as its tech stack.
+
+## Method (Jack's plan)
+
+1. Decide a **starting roadmap** to use as the test launching area.
+2. **Dogfood** it — drive Cadenza work through Concerto and find where the
+   loopflow infra + UI hold it back. That friction defines the launchboard work.
+
+## Decisions
+
+- **This session = roadmap first**, in `~/src/cadenza`. Launchboard comes after,
+  designed against a real roadmap and the friction of dogfooding it.
+- **Core is the trunk; two sub-projects, not three.** LLMs folds *into* Feedback
+  as its tech stack — the intelligence isn't a sibling, it's how Feedback works.
+  - `Core` — make daily practice a habit I (and my son) keep   [progress: momentum, history]
+    - `Scores` — work on the written page (mark up, isolate, manipulate)
+    - `Feedback` — understand my practice and respond; LLM / musical-language /
+      multimodal stack lives here   [video]
+  - Existing waves: `progress` → Core; `video` → Feedback; `score`
+    reading/annotation → Scores; `score` MusicXML + notation-intelligence → Feedback's stack.
+  - Daily-practice & son-onboarding aren't areas — they're the adoption spine.
+  - Launchboard consequence: **projects nest** — a trunk with sub-projects.
+
+- **Two postures — and they're the two work-shapes the launchboard must handle.**
+  - `Scores` = **product**. Decide the most important UXes and ship them. Drives
+    daily-practice adoption now. (Annotate, isolate, manipulate — partly built.)
+  - `Feedback` = **research + data collection**. Build and experiment with the
+    tech stack; use Cadenza's UI to easily collect data from Jack's own practice.
+    **Not** trying to make it work in-product yet. Long-running, exploratory.
+  - This is the duality from the kickoff: one-off shippable increments (Scores)
+    vs a long-running project (Feedback). Cadenza tests both shapes at once.
+- **Frame around behaviors to drive, not cartography of the solution.** A roadmap
+  item is "someone can now do X," ordered by which X earns daily use.
+
+## Behaviors to drive
+
+Spine: **me first, my son next.** Every behavior is judged by "does this make
+someone open Cadenza tomorrow."
+
+**Core — the daily loop becomes a habit**
+- I open Cadenza and know exactly what to practice today.
+- I finish and can see I'm building something (history I trust, not gamified noise).
+- My son sits down and practices without me hovering.
+
+**Scores — I mark up and reshape the music** (perform/pedal is shipped baseline, not the edge)
+- I annotate a score — fingerings, reminders, a teacher's marks layered over mine — persisted and synced.
+- I reshape how a piece reads — crop, reorder, pull passages out as loop-able practice regions.
+- I change the music itself — edit, transpose, simplify a piece down for my son.
+
+**Feedback — understand my practice and respond** *(research track: build the stack
+and collect data; not a product feature yet)*
+- While I play, I say in words how it feels / what I'm struggling with — hands-free.
+- Cadenza captures the take: audio + video + my voice notes + score context.
+- That data feeds an experimental stack — musical-language understanding,
+  multimodal LLM feedback — built and tested offline.
+- North star (later, when the stack earns it): named struggle → targeted exercise
+  → daily loop. **For now: collect good data from my own practice.**
+
+## Lead behavior: turn a passage into an exercise
+
+The first behavior to drive, and the through-line that unifies all three areas:
+
+> Highlight 4 bars of a real score → turn it into musical language →
+> apply a musical transformation → get an exercise I can practice.
+
+Jack already does the input by hand: marks chords, fingerings, shifts. The
+unlock is everything downstream of "isolate a passage." This is the resolution
+of the overhang — the app stops storing music and starts working on it.
+
+**Pipeline** — splits across the two postures:
+
+1. **Mark it up, fast** — chords, fingerings, shifts, by hand. (**Scores** —
+   product, partly exists.)
+2. **Highlight & isolate** — select a passage (e.g. 4 bars). (**Scores** —
+   product; near practice-regions.)
+3. **Turn it into musical language** — selected region → structured notation
+   (MusicXML). *The keystone.* (**Feedback** stack — research.)
+4. **Apply a transformation → exercise** — inversion, harmony, rhythmic changes,
+   bow patterns, shift strategies. (**Feedback** stack — research.)
+5. **Practice it** — renders, playable, enters the daily loop. (**Core**.)
+
+Steps 1–2 are shippable Scores product now; 3–5 are Feedback's research north
+star, not near-term shippable.
+
+**Two flavors of transformation:**
+- *Note-changing* (inversion, reharmonization, rhythmic variation) → a new phrase.
+  Deterministic theory — `music21` on the FastAPI server.
+- *Practice-strategy* (bow patterns, shift strategies, fingerings) → same notes,
+  new practice instruction. Pedagogical judgment — where the LLM earns its place.
+
+**Keystone risk:** step 3 trust. Wrong transcription → garbage exercise. Scoping
+lever: Jack plays strings — single-line / double-stops make 4-bar transcription
+tractable. Start monophonic, human-in-the-loop confirm.
+
+## Feedback v1 — the capture instrument
+
+Goal: make Cadenza a great instrument for collecting Jack's own practice data.
+Record everything, experiment offline, don't ship feedback-as-feature yet.
+
+**Nested units (auto-anchored to the music):**
+- **Segment** = one routine step. Recording starts on practice-session launch and
+  **restarts every time you move through the routine** (scheduled or user-controlled).
+  ~5–10 min A/V by default, anchored to its routine item for free — no manual tagging.
+  *The routine data model is the label.*
+- **Clip** = a short excerpt marked for feedback. Easy to make. Max clip length
+  bounds what's sent to the LLM.
+
+**Record everything, send clips.** Full segments → research corpus. Clips → the
+bounded thing the model sees.
+
+**Experiment dials (config-driven — experimentation is the point):**
+- modality: video-only / audio-only / both
+- size/duration: segment length, clip cap, resolution / bitrate
+- the question they answer: what makes the LLM problem workable to start?
+
+**Foundations:** `video` already persists `VideoSubmission` → S3. The corpus needs
+a home Jack can pull from for offline experimentation (export / server endpoints),
+not just in-app playback.
+
+## Decision — clips are made in practice review
+
+- **Clips are made after the fact in practice review**, not live. During play,
+  Cadenza only records (segmented by routine step). Clipping is a **practice-review**
+  surface: scrub a segment, pull excerpts.
+- Two-for-one: review-time clipping is a real **self-review** behavior on day one
+  *and* the mechanism that generates clipped data for the research corpus. The
+  self-review loop is usable before any AI exists ("starts with self").
+- So **Feedback v1 = capture instrument + review surface.** AI is downstream of both.
+
+## Decision — roadmap representation
+
+**Flat waves** (`core` / `scores` / `feedback`) with the trunk/sub-project
+hierarchy documented in each README. Tooling-safe, trivially re-cuttable; the
+launchboard renders the tree from metadata later.
+
+## Next action — flush to cadenza (delegated to a subagent)
+
+In a cadenza worktree created with `lf op wt create`, deployed via `lf op land`:
+- Recut `progress` / `score` / `video` → `core` / `scores` / `feedback`, carrying
+  existing item content forward where it fits.
+- `core` — practice-session spine + momentum/history (from `progress`).
+- `scores` — product UXes: annotate, isolate, manipulate. Behavior-framed items.
+- `feedback` — research + data collection. First item = **capture instrument +
+  practice-review surface** (segmented A/V recording, review-time clipping, config
+  dials, corpus export). Notation / musical-language work is feedback's stack.
+- Each README documents the Core-trunk hierarchy and posture (product vs research).
+
+## Parked
+
+- Trusted path INTO musical language (deep path, later): MusicXML-only vs
+  OMR/LLM transcription + confirm vs assisted manual entry.
+- Backing-object specifics: does Asana-task-as-unit hold for the research track
+  and nested projects? (Bleeds into loopflow — see launchboard implications.)

--- a/scratch/loopflow-from-cadenza.md
+++ b/scratch/loopflow-from-cadenza.md
@@ -1,0 +1,62 @@
+# Loopflow — what designing Cadenza taught us
+
+Probe: design a real roadmap (Cadenza), watch where loopflow's model + tooling
+strain. Cadenza recut into **Core** (trunk) ⊃ { **Scores** [product], **Feedback**
+[research] }, landed live as cadenza **PR #21 (merged)**.
+
+## Structural gaps (the model)
+
+1. **Projects nest; waves are flat.** Core is a trunk with sub-projects. No
+   containment relation in the wave model — chord = waves *watching* waves, not
+   *containing* them. Needs a mutable parent/child relation; the launchboard
+   renders a tree with rolled-up child state. Constraint: cheap to rename/split.
+
+2. **Work-shapes are plural; every flow assumes "ship a PR."** Product track
+   (Scores: increment → PR → deploy → release) vs research track (Feedback:
+   instrument → collect → experiment → evaluate; output = dataset/findings; "not
+   shipping yet"). No research archetype. Needs a **research flow** (done =
+   artifact, not merge) and a declared **posture** per project/track that changes
+   its flows, its definition of "next," and how progress is shown.
+   *Highest leverage — sits directly under the most-invested track.*
+
+3. **Launchboard is single-project + opinionated; Concerto is generic +
+   multi-wave.** Open it, see *Cadenza* — its tree, next actions, attention — and
+   launch in. Three first-class affordances: **start new** (`lf design --ide`),
+   **continue next** (ingest next item), **one-off → full deploy** (fix → PR →
+   release in one motion). Targets an arbitrary repo (≠ loopflow itself).
+   *The visible prize, but downstream of #1 and #2.*
+
+4. **Roadmaps are behaviors, not cartography.** Items as "X can now do Y,"
+   ordered by impact; progress = "can the user do X yet." Lean the item model and
+   the design/kickoff steps harder into behavior-framing.
+
+5. **Directions are personas.** Adoption spine (me → son) = project-scoped
+   directions (`daily-practice`, `son-onboarding`); view the roadmap *through* a
+   lens.
+
+## Live tooling friction (observed while flushing PR #21)
+
+- **`lf op wt create` leaks the `lf()` shell-function body to stdout** before the
+  "Created worktree" line. Reads like an error. Suppress the directive-sourcing echo.
+- **`lf op land` merges to main with no clear "MERGED ✓ / queue-state" line.**
+  Had to `gh pr view` to learn it merged (not queued). A command that merges must
+  say so — and this is the engine behind the launchboard's "one-off → full deploy."
+- **Worktree renamed under the active cwd on land** (→ `…roadmap.20260629_1429`),
+  staling the cwd mid-session. Footgun for any scripted follow-up.
+- `lf op land` auto-lowercased the PR title vs the commit subject. Minor.
+- No `.lf/` in cadenza → the flat-wave re-cut was pure filesystem. Validates the
+  design's "trivially re-cuttable" claim.
+
+## Surfaced design wrinkle (feeds #2)
+
+Feedback ended up holding **both** research (capture/notation) and shipped-product
+human-response (video messaging) — a posture conflict *inside one sub-project*.
+Suggests **posture attaches to items/tracks, not just whole projects** (or
+video-comms belongs in Core). Work-shape pluralism biting on day one.
+
+## Leverage call
+
+Pull **#2 (posture + research flow)** first — the gap under the most-invested
+track, and the flush already showed it biting. #1 (nesting) is plumbing; #3
+(launchboard) is the prize but downstream. The friction items are a parallel
+quick-wins lane.


### PR DESCRIPTION
## What this is

Two design docs under `scratch/`, captured from a dogfooding session that designed a real Cadenza roadmap and watched where loopflow's model and tooling strained.

```bash
ls scratch/
# jack-heart.cadenz.20260629_1347.md   — Cadenza launchboard design
# loopflow-from-cadenza.md             — what designing Cadenza taught loopflow
```

## Summary

The goal is to make Concerto ruthlessly optimized for building one project (Cadenza) rather than being the generic multi-wave governance surface. The first doc works the Cadenza side: recut the existing `progress`/`score`/`video` waves into a **Core** trunk with **Scores** (product) and **Feedback** (research) sub-projects, frame the roadmap around behaviors to drive ("someone can now do X") instead of solution cartography, and pick a lead behavior — turn a highlighted passage into a practiceable exercise. The second doc turns that experience back on loopflow: a prioritized list of structural gaps and live tooling friction observed while flushing the Cadenza recut (landed as cadenza PR #21).

## Notable points

- **Launchboard design** — single-project dashboard with three affordances: start new (`lf design --ide`), continue next, and one-off → full deploy.
- **Two postures** — product (increment → PR → deploy) vs research (instrument → collect → experiment; done = artifact, not merge); flagged as the highest-leverage gap since every flow currently assumes "ship a PR."
- **Structural gaps for loopflow** — waves are flat but projects need to nest; roadmaps should be behavior-framed; directions can act as adoption personas.
- **Tooling friction** — `lf op wt create` leaks the `lf()` shell-function body to stdout; `lf op land` lacks a clear merged/queued status line and renamed the worktree under the active cwd mid-session.

These are scratch artifacts only — no code changes. They're cleared on merge by `lf op pr land`, so the leverage call (pull research-posture/flow first) should graduate into a tracked roadmap item before landing.