### PR TITLE
deploy: document Mac Mini remote setup

### DIFF
--- a/deploy/MAC_MINI.md
+++ b/deploy/MAC_MINI.md
@@ -1,0 +1,129 @@
+# Mac Mini cron host
+
+Target the Mac Mini first. Keep it cheap: Tailscale private networking, bearer-token auth, Docker Compose, and Doppler/host env for secrets.
+
+```bash
+export MINI=100.96.227.95
+alias mini="ssh jack@$MINI"
+```
+
+## Current target
+
+| Field | Value |
+|-------|-------|
+| Host | `mini-heart` |
+| Tailscale IP | `100.96.227.95` |
+| SSH user | `jack` |
+| Client URL | `http://100.96.227.95:2486` |
+| Auth | `Authorization: Bearer $LFD_AUTH_TOKEN` |
+
+Use HTTP over Tailscale for the first cut. Tailscale provides the encrypted private network; `lfd` still requires the bearer token for non-loopback requests. This avoids Caddy internal-CA setup blocking `lfq`, Concerto, Codex, or Claude-driven sessions. Caddy/TLS can remain available for public or polished remote access later.
+
+## Bring the Mini online
+
+From this machine:
+
+```bash
+/Applications/Tailscale\ 2.app/Contents/MacOS/tailscale status
+/Applications/Tailscale\ 2.app/Contents/MacOS/tailscale ping 100.96.227.95
+ssh jack@100.96.227.95
+```
+
+If the CLI shim is stale, call the app binary directly. The local `/usr/local/bin/tailscale` may point at `/Applications/Tailscale.app` while the installed app is `/Applications/Tailscale 2.app`.
+
+## Bootstrap lfd on the Mini
+
+On the Mini:
+
+```bash
+mkdir -p ~/src
+git clone https://github.com/loopflowstudio/loopflow.git ~/src/loopflow
+cd ~/src/loopflow
+
+export LF_DOMAIN=100.96.227.95
+export LF_TLS_MODE=internal
+export LFD_AUTH_TOKEN=$(openssl rand -hex 32)
+export LFD_EXECUTOR_CREDENTIALS_MOUNTS=claude,codex,ssh
+
+deploy/bootstrap-cron-host.sh --host mac
+```
+
+Use Doppler for maintained secrets once the host is reachable:
+
+```bash
+doppler setup
+doppler secrets set LFD_AUTH_TOKEN="$LFD_AUTH_TOKEN"
+doppler secrets set LFD_EXECUTOR_CREDENTIALS_MOUNTS=claude,codex,ssh
+```
+
+The launch agent keeps the stack up. Docker Desktop must be running.
+
+## Configure this Mac as a client
+
+After `LFD_AUTH_TOKEN` exists on the Mini, run locally:
+
+```bash
+deploy/setup-mini-client.sh --token "$LFD_AUTH_TOKEN"
+source ~/.lf/mini.env
+lfq status
+```
+
+The setup script writes:
+
+- `~/.lf/mini.env` with `MINI`, `LFD_URL`, `LFD_TOKEN`, and the `mini` SSH alias
+- Concerto remote connection settings in `com.loopflow.concerto`
+- Concerto token in Keychain service `loopflow.connection.token`, account `100.96.227.95:2486`
+
+Open Concerto after running the script. It should connect to the Mini remote `lfd` and discover repos registered on that daemon.
+
+## Remote sessions from local tools
+
+Use the Mini as the execution host. Local clients only send control traffic.
+
+```bash
+source ~/.lf/mini.env
+lfq create root /Users/jack/src/loopflow
+lfq show root
+```
+
+Concerto remote repo actions use the repo paths on the Mini. Remote terminal and IDE launches use SSH:
+
+```bash
+mini
+cursor --remote ssh-remote+jack@100.96.227.95 /Users/jack/src/loopflow
+code --remote ssh-remote+jack@100.96.227.95 /Users/jack/src/loopflow
+```
+
+Claude and Codex sessions run inside `lfd` executor containers when waves or sessions use those harnesses. Keep the Mini's Doppler config or mounted credentials able to provide Claude, Codex, GitHub, and SSH credentials; do not route those through a global studio host.
+
+## Verify
+
+```bash
+source ~/.lf/mini.env
+curl -f "$LFD_URL/health"
+curl -H "Authorization: Bearer $LFD_TOKEN" "$LFD_URL/status"
+lfq status
+uv run python scripts/test_remote_smoke.py --url "$LFD_URL" --token "$LFD_TOKEN" --repo /Users/jack/src/loopflow --insecure
+```
+
+`--insecure` is only for smoke scripts against a trusted Tailscale/private endpoint when TLS is involved. Plain Tailscale HTTP does not need it.
+
+## Repair
+
+On the Mini:
+
+```bash
+cd ~/src/loopflow
+deploy/loopflow-server.sh status
+deploy/loopflow-server.sh logs
+deploy/loopflow-server.sh update
+launchctl print gui/$(id -u)/loopflow.server
+```
+
+From this Mac:
+
+```bash
+source ~/.lf/mini.env
+lfq status
+ssh jack@$MINI 'cd ~/src/loopflow && deploy/loopflow-server.sh status'
+```

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,6 +1,6 @@
 # Self-hosted deploy
 
-Run your own `lfd` cron host behind Caddy TLS.
+Run your own `lfd` cron host. Use `deploy/MAC_MINI.md` for the first maintained Tailscale host; use the generic Docker/Caddy path below for public or non-Mac hosts.
 
 ```bash
 git clone https://github.com/loopflowstudio/loopflow.git /opt/loopflow
@@ -126,7 +126,7 @@ deploy/loopflow-server.sh logs
 curl -f http://127.0.0.1:${LFD_PORT:-2486}/health
 ```
 
-Need agent credentials inside execution containers? Set `LFD_EXECUTOR_CREDENTIALS_MOUNTS=claude,ssh` in Doppler or `.env` instead of editing compose volume lines.
+Need agent credentials inside execution containers? Set `LFD_EXECUTOR_CREDENTIALS_MOUNTS=claude,codex,ssh` in Doppler or `.env` instead of editing compose volume lines.
 
 Common failures:
 

--- a/deploy/setup-mini-client.sh
+++ b/deploy/setup-mini-client.sh
@@ -1,0 +1,182 @@
+#!/usr/bin/env bash
+# Configure this Mac to use the Mac Mini self-hosted lfd over Tailscale.
+# Stores the lfq environment in ~/.lf/mini.env and seeds Concerto's remote
+# connection + Keychain token for the same host.
+
+set -euo pipefail
+
+usage() {
+    cat >&2 <<'USAGE'
+Usage: setup-mini-client.sh [options]
+
+Options:
+  --host HOST        Mac Mini Tailscale IP or MagicDNS name (default: 100.96.227.95)
+  --ssh-user USER    SSH user for the mini alias (default: jack)
+  --port PORT        lfd port (default: 2486)
+  --https           Use https://HOST:PORT instead of http://HOST:PORT
+  --token TOKEN      lfd bearer token. Defaults to LFD_TOKEN or LFD_AUTH_TOKEN.
+  --token-file PATH  Read bearer token from PATH.
+  --env-file PATH    Write shell exports here (default: ~/.lf/mini.env)
+  --no-concerto      Do not seed Concerto UserDefaults/Keychain.
+  --verify           Run lfq status after writing local config.
+  -h, --help         Show this help.
+
+The env file contains secrets and is written with 0600 permissions.
+USAGE
+}
+
+host="100.96.227.95"
+ssh_user="jack"
+port="2486"
+use_tls=0
+token="${LFD_TOKEN:-${LFD_AUTH_TOKEN:-}}"
+token_file=""
+env_file="$HOME/.lf/mini.env"
+configure_concerto=1
+verify=0
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --host)
+            host="$2"
+            shift 2
+            ;;
+        --host=*)
+            host="${1#--host=}"
+            shift
+            ;;
+        --ssh-user)
+            ssh_user="$2"
+            shift 2
+            ;;
+        --ssh-user=*)
+            ssh_user="${1#--ssh-user=}"
+            shift
+            ;;
+        --port)
+            port="$2"
+            shift 2
+            ;;
+        --port=*)
+            port="${1#--port=}"
+            shift
+            ;;
+        --https)
+            use_tls=1
+            shift
+            ;;
+        --token)
+            token="$2"
+            shift 2
+            ;;
+        --token=*)
+            token="${1#--token=}"
+            shift
+            ;;
+        --token-file)
+            token_file="$2"
+            shift 2
+            ;;
+        --token-file=*)
+            token_file="${1#--token-file=}"
+            shift
+            ;;
+        --env-file)
+            env_file="$2"
+            shift 2
+            ;;
+        --env-file=*)
+            env_file="${1#--env-file=}"
+            shift
+            ;;
+        --no-concerto)
+            configure_concerto=0
+            shift
+            ;;
+        --verify)
+            verify=1
+            shift
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "unknown argument: $1" >&2
+            usage
+            exit 1
+            ;;
+    esac
+done
+
+if [[ -n "$token_file" ]]; then
+    token="$(<"$token_file")"
+fi
+
+token="$(printf '%s' "$token" | tr -d '\r\n')"
+if [[ -z "$token" ]]; then
+    echo "LFD token is required. Pass --token, --token-file, or set LFD_TOKEN/LFD_AUTH_TOKEN." >&2
+    exit 1
+fi
+
+if ! [[ "$port" =~ ^[0-9]+$ ]] || [[ "$port" -lt 1 || "$port" -gt 65535 ]]; then
+    echo "invalid port: $port" >&2
+    exit 1
+fi
+
+scheme="http"
+if [[ "$use_tls" -eq 1 ]]; then
+    scheme="https"
+fi
+url="$scheme://$host:$port"
+
+mkdir -p "$(dirname "$env_file")"
+tmp="$(mktemp)"
+cat > "$tmp" <<EOF_ENV
+# Source this file to point lfq and other loopflow clients at the Mac Mini lfd.
+export MINI=$host
+alias mini='ssh $ssh_user@\$MINI'
+export LFD_URL=$url
+export LFD_TOKEN=$token
+EOF_ENV
+install -m 0600 "$tmp" "$env_file"
+rm -f "$tmp"
+
+if [[ "$configure_concerto" -eq 1 ]]; then
+    json="$(python3 - "$host" "$port" "$use_tls" <<'PY'
+import json
+import sys
+host, port, use_tls = sys.argv[1], int(sys.argv[2]), sys.argv[3] == "1"
+value = {
+    "mode": "remote",
+    "remoteConnection": {
+        "host": host,
+        "port": port,
+        "useTLS": use_tls,
+        "authMode": "staticToken",
+    },
+}
+print(json.dumps(value, separators=(",", ":")))
+PY
+)"
+    hex="$(printf '%s' "$json" | xxd -p -c 256)"
+    defaults write com.loopflow.concerto concerto.connectionSettings.v2 -data "$hex"
+    security add-generic-password \
+        -U \
+        -s loopflow.connection.token \
+        -a "$host:$port" \
+        -w "$token" >/dev/null
+fi
+
+echo "wrote $env_file"
+echo "lfd url: $url"
+echo "ssh alias: source $env_file && mini"
+if [[ "$configure_concerto" -eq 1 ]]; then
+    echo "seeded Concerto remote connection for $host:$port"
+fi
+
+if [[ "$verify" -eq 1 ]]; then
+    # shellcheck disable=SC1090
+    source "$env_file"
+    lfq status
+fi

--- a/python/tests/test_release_automation.py
+++ b/python/tests/test_release_automation.py
@@ -118,6 +118,12 @@ def test_self_hosted_server_primitives_are_documented_and_runnable():
         text=True,
         capture_output=True,
     )
+    mini_client_help = subprocess.run(
+        [str(ROOT / "deploy/setup-mini-client.sh"), "--help"],
+        check=True,
+        text=True,
+        capture_output=True,
+    )
 
     assert "up|update|down|status|logs|health" in help_result.stderr
     assert "LOOPFLOW_SECRETS=auto|doppler|env" in help_result.stderr
@@ -125,6 +131,9 @@ def test_self_hosted_server_primitives_are_documented_and_runnable():
     assert "bootstrap-cron-host.sh [--repo PATH]" in bootstrap_help.stderr
     assert "--host auto|linux|mac" in bootstrap_help.stderr
     assert "--no-wave" in bootstrap_help.stderr
+    assert "setup-mini-client.sh" in mini_client_help.stderr
+    assert "--token-file PATH" in mini_client_help.stderr
+    assert "--no-concerto" in mini_client_help.stderr
 
     readme = (ROOT / "deploy/README.md").read_text()
     assert "doppler secrets set LFD_AUTH_TOKEN" in readme
@@ -136,6 +145,16 @@ def test_self_hosted_server_primitives_are_documented_and_runnable():
     assert "/etc/loopflow-server.env" in readme
     assert "loopflow-server-update.timer" in readme
     assert "lfq create root /opt/loopflow" in readme
+    assert "deploy/MAC_MINI.md" in readme
+    assert "claude,codex,ssh" in readme
+
+    mini_readme = (ROOT / "deploy/MAC_MINI.md").read_text()
+    assert "100.96.227.95" in mini_readme
+    assert "http://100.96.227.95:2486" in mini_readme
+    assert "deploy/setup-mini-client.sh --token" in mini_readme
+    assert "cursor --remote ssh-remote+jack@100.96.227.95" in mini_readme
+    assert "code --remote ssh-remote+jack@100.96.227.95" in mini_readme
+    assert "LFD_EXECUTOR_CREDENTIALS_MOUNTS=claude,codex,ssh" in mini_readme
 
     compose = (ROOT / "docker/docker-compose.yml").read_text()
     assert "LFD_AUTH_MODE" not in compose
@@ -162,6 +181,13 @@ def test_self_hosted_server_primitives_are_documented_and_runnable():
     assert "launchctl bootstrap" in bootstrap
     assert "lfq create root" in bootstrap
     assert "install -m 0600" in bootstrap
+
+    mini_client = (ROOT / "deploy/setup-mini-client.sh").read_text()
+    assert "100.96.227.95" in mini_client
+    assert "LFD_URL" in mini_client
+    assert "loopflow.connection.token" in mini_client
+    assert "concerto.connectionSettings.v2" in mini_client
+    assert "alias mini='ssh" in mini_client
 
     service = (ROOT / "deploy/systemd/loopflow-server.service").read_text()
     assert "ExecStart=/opt/loopflow/deploy/loopflow-server.sh up" in service

--- a/release/unreleased/DECISIONS.md
+++ b/release/unreleased/DECISIONS.md
@@ -211,3 +211,11 @@ built-in commands — skills fire there with `$step`.
 **Decision:** Add `wave/release/` as the owner for daily verification, weekly publishing, self-hosted cron infrastructure, local updater freshness, and product-release parity. Root gardens it alongside desktop, mobile, and workflows.
 
 **Implications:** Release work is no longer incidental workflow plumbing. Changes to schedules, deploy shape, Doppler assumptions, or cross-repo parity should update the release wave metadata and include a Mitchell Hashimoto simulated review when they ship.
+
+## 2026-06-29 — Mac Mini is the first maintained Loopflow host
+
+**Context:** The release automation goal needs one real self-hosted `lfd` server, not a generic cloud abstraction. The Mac Mini already sits on the tailnet and is the cheapest useful cron host once it is online.
+
+**Decision:** Target `mini-heart` at `100.96.227.95` as the first maintained Loopflow `lfd` cron host. Local clients use Tailscale HTTP on `http://100.96.227.95:2486` with bearer-token auth first; Caddy/TLS remains available for later public or polished access. Concerto, `lfq`, Codex, and Claude sessions should point at that host rather than a studio control plane.
+
+**Implications:** Setup scripts and docs optimize for Mac Mini + Tailscale. Secrets stay in Doppler or host-local env, agent credentials are made available to the Mini executor, and remote repo paths are paths on the Mini. Cadenza remains cheap and product-specific: one prod server, regular/hotfix releases, and local/TestFlight clients pointed at prod unless a deliberate staging need appears.


### PR DESCRIPTION
## Usage

```bash
# On the Mini: bootstrap lfd
export LFD_AUTH_TOKEN=$(openssl rand -hex 32)
export LFD_EXECUTOR_CREDENTIALS_MOUNTS=claude,codex,ssh
deploy/bootstrap-cron-host.sh --host mac

# On this Mac: point clients at the Mini
deploy/setup-mini-client.sh --token "$LFD_AUTH_TOKEN"
source ~/.lf/mini.env
lfq status
```

## Summary

Makes the Mac Mini (`mini-heart` at `100.96.227.95`) the first maintained self-hosted `lfd` cron host. Clients reach it over Tailscale HTTP with bearer-token auth—skipping Caddy/TLS setup for the first cut while leaving it available for later public access. Adds an end-to-end runbook plus a client setup script that wires up `lfq`, SSH, and Concerto remote connection in one step.

## Changes

- New `deploy/MAC_MINI.md` runbook: bring the Mini online, bootstrap `lfd`, configure this Mac as a client, run remote sessions, verify, and repair.
- New `deploy/setup-mini-client.sh`: writes `~/.lf/mini.env` (`MINI`, `LFD_URL`, `LFD_TOKEN`, `mini` SSH alias) and seeds Concerto's remote connection UserDefaults + Keychain token. Env file is written `0600`.
- `deploy/README.md` points to the Mac Mini path as the first maintained host and adds `codex` to the executor credential mounts.
- Extends the release-automation test to assert the new script's `--help`, the runbook contents, and updated mount docs.
- Records the decision in `release/unreleased/DECISIONS.md`.