### PR TITLE
concerto: deep-link + menu nav to open a repo or portfolio

### DIFF
--- a/scratch/launchboard-nav.md
+++ b/scratch/launchboard-nav.md
@@ -1,0 +1,87 @@
+# Launchboard navigation — deep-link + menu bar
+
+Two navigation primitives so Concerto can be pointed at a specific repo (Cadenza)
+and move between projects — without relaunching from the CLI. Productizes the
+`--repo` flag we've been hand-cranking through the dev script.
+
+## What to build
+
+1. **URL scheme** — `loopflow://open?repo=<path>` opens/focuses a repo window;
+   `loopflow://portfolio` shows the overview.
+2. **Menu bar** — "Portfolio" + "Move to Repo ▸ <known repos>" + "Open Repo…".
+
+## Grounding (nearly all the scaffolding exists)
+
+- Scheme **`loopflow://`** already registered — `Concerto/Info.plist:21-31`
+  (`studio.loopflow.auth`). OAuth uses an ephemeral `ASWebAuthenticationSession`
+  callback, so there's **no app-level `.onOpenURL` yet** → adding one for nav is
+  conflict-free.
+- `--repo` parsed at `ConcertoApp.swift:108-116`; main `WindowGroup` routes
+  `RepoWindow` (with `--repo`) vs `PortfolioWindow` (without) — `ConcertoApp.swift:190-203`.
+- Reusable repo window: `WindowGroup(id: "repo", for: URL.self)` — `ConcertoApp.swift:213`.
+  Open any repo via `openWindow(id: "repo", value: url)` (`@Environment(\.openWindow)`
+  already in scope, line 172).
+- `PortfolioService` — `Concerto/Platform/macOS/Services/PortfolioService.swift`:
+  persisted repo list in UserDefaults; `addRepo(url)`, `removeRepo`, `repos`.
+  `PortfolioWindow` already has `addRepo`/`openRepo` (lines 219/224).
+
+## Design
+
+**URL scheme** — `.onOpenURL` on the main WindowGroup content:
+```swift
+.onOpenURL { url in
+    guard url.scheme == "loopflow" else { return }
+    switch url.host {
+    case "open":
+        if let repo = URLComponents(url: url, resolvingAgainstBaseURL: false)?
+            .queryItems?.first(where: { $0.name == "repo" })?.value {
+            let repoURL = URL(fileURLWithPath: repo)
+            portfolioService.addRepo(repoURL)        // register → joins the portfolio
+            openWindow(id: "repo", value: repoURL)
+        }
+    case "portfolio":
+        openWindow(id: "portfolio")
+    default: break
+    }
+}
+```
+
+**Menu bar** — `.commands` on the Scene:
+```swift
+.commands {
+    CommandMenu("Go") {
+        Button("Portfolio") { openWindow(id: "portfolio") }
+            .keyboardShortcut("0", modifiers: .command)
+        Menu("Move to Repo") {
+            ForEach(portfolioService.repos) { repo in
+                Button(repo.displayName) {
+                    openWindow(id: "repo", value: URL(fileURLWithPath: repo.path))
+                }
+            }
+        }
+        Button("Open Repo…") { /* NSOpenPanel → addRepo + openWindow(id:"repo") */ }
+    }
+}
+```
+
+One structural add: a dedicated portfolio window id. Today the portfolio is the
+no-value main `WindowGroup`; for `openWindow(id:"portfolio")` add a
+`Window("Portfolio", id: "portfolio")` (or convert the group).
+
+## Coordination
+
+The portfolio *view* is the other session's project (`loopflow.portfolio`). This
+project owns the *entry points / navigation* — scheme, menu, open/focus — not the
+dashboard internals. Clean seam.
+
+## Done when
+
+- `open "loopflow://open?repo=/Users/jack/src/cadenza"` brings Concerto to a
+  Cadenza repo window and registers it in the portfolio.
+- Menu "Go ▸ Portfolio" and "Go ▸ Move to Repo ▸ Cadenza" both work.
+- OAuth login still works (scheme reuse didn't break the auth callback).
+
+## Immediate peek (no build)
+
+Relaunch Concerto **without** `--repo` → lands on Portfolio → Add Repo →
+`~/src/cadenza` → open. Confirms the recut roadmap renders while the nav is built.

--- a/scripts/concerto-dev.py
+++ b/scripts/concerto-dev.py
@@ -240,7 +240,7 @@ def _start_lfd_background(docker: bool = False) -> tuple[subprocess.Popen[str], 
     env["RUST_LOG"] = "loopflow=debug,tower_http=debug"
 
     print("Building lfd...")
-    result = run(["cargo", "build", "--bin", "lfd"], cwd=REPO_ROOT, check=False)
+    result = run(["cargo", "build", "--locked", "--bin", "lfd"], cwd=REPO_ROOT, check=False)
     if result.returncode != 0:
         raise RuntimeError("Failed to build lfd")
 
@@ -766,7 +766,7 @@ def _lfd_docker() -> int:
     os.environ["GRPC_VERBOSITY"] = "ERROR"
 
     print("Building lfd...")
-    result = run(["cargo", "build", "--bin", "lfd"], cwd=REPO_ROOT, check=False)
+    result = run(["cargo", "build", "--locked", "--bin", "lfd"], cwd=REPO_ROOT, check=False)
     if result.returncode != 0:
         return result.returncode
 
@@ -793,7 +793,7 @@ def _lfd_native() -> int:
     env["LFD_DISABLE_WORKTREE_JANITOR"] = "1"
 
     print("Building lfd...")
-    result = run(["cargo", "build", "--bin", "lfd"], cwd=REPO_ROOT, check=False)
+    result = run(["cargo", "build", "--locked", "--bin", "lfd"], cwd=REPO_ROOT, check=False)
     if result.returncode != 0:
         return result.returncode
 
@@ -967,10 +967,10 @@ def _install_dev_app() -> None:
 
 def _copy_bundled_tools(app_macos_dir: Path, profile: str) -> None:
     if profile == "release":
-        cargo_cmd = ["cargo", "build", "--release", "--bin", "lf", "--bin", "lfd"]
+        cargo_cmd = ["cargo", "build", "--locked", "--release", "--bin", "lf", "--bin", "lfd"]
         bin_dir = REPO_ROOT / "target" / "release"
     else:
-        cargo_cmd = ["cargo", "build", "--bin", "lf", "--bin", "lfd"]
+        cargo_cmd = ["cargo", "build", "--locked", "--bin", "lf", "--bin", "lfd"]
         bin_dir = REPO_ROOT / "target" / "debug"
 
     result = run(cargo_cmd, cwd=REPO_ROOT, check=False)

--- a/swift/Concerto/ConcertoApp.swift
+++ b/swift/Concerto/ConcertoApp.swift
@@ -206,6 +206,7 @@ struct ConcertoApp: App {
             .preferredColorScheme(theme.preferredScheme)
             .environment(\.palette, theme.palette)
             .environment(keyboardRouter)
+            .onOpenURL { handleDeepLink($0) }
         }
         .windowStyle(.automatic)
         .defaultSize(width: 1080, height: 760)
@@ -219,6 +220,15 @@ struct ConcertoApp: App {
         }
         .windowStyle(.automatic)
         .defaultSize(width: 900, height: 700)
+
+        Window("Portfolio", id: "portfolio") {
+            PortfolioWindow(portfolioService: portfolioService)
+                .tint(.loopflowBurgundy)
+                .preferredColorScheme(theme.preferredScheme)
+                .environment(\.palette, theme.palette)
+                .environment(keyboardRouter)
+        }
+        .defaultSize(width: 1080, height: 760)
 
         Window("Terminal Test", id: "terminal-test") {
             TerminalTestWindow()
@@ -266,6 +276,29 @@ struct ConcertoApp: App {
                 .keyboardShortcut("k", modifiers: .command)
             }
 
+            CommandMenu("Go") {
+                Button("Portfolio") {
+                    openWindow(id: "portfolio")
+                }
+                .keyboardShortcut("0", modifiers: .command)
+
+                if !portfolioService.repos.isEmpty {
+                    Menu("Move to Repo") {
+                        ForEach(portfolioService.repos) { repo in
+                            Button(repo.displayName) {
+                                portfolioService.addRepo(repo.url)
+                                openWindow(id: "repo", value: repo.url)
+                            }
+                        }
+                    }
+                }
+
+                Button("Open Repo…") {
+                    openRepoPanel()
+                }
+                .keyboardShortcut("o", modifiers: [.command, .shift])
+            }
+
             CommandMenu("Debug") {
                 Button("Terminal Test") {
                     openWindow(id: "terminal-test")
@@ -292,6 +325,36 @@ struct ConcertoApp: App {
             snapshotError = error.localizedDescription
             showSnapshotError = true
         }
+    }
+
+    @MainActor
+    private func handleDeepLink(_ url: URL) {
+        guard url.scheme == "loopflow" else { return }
+        switch url.host {
+        case "open":
+            guard let repoPath = URLComponents(url: url, resolvingAgainstBaseURL: false)?
+                .queryItems?.first(where: { $0.name == "repo" })?.value
+            else { return }
+            let repoURL = URL(fileURLWithPath: repoPath)
+            portfolioService.addRepo(repoURL)
+            openWindow(id: "repo", value: repoURL)
+        case "portfolio":
+            openWindow(id: "portfolio")
+        default:
+            break
+        }
+    }
+
+    @MainActor
+    private func openRepoPanel() {
+        let panel = NSOpenPanel()
+        panel.canChooseDirectories = true
+        panel.canChooseFiles = false
+        panel.allowsMultipleSelection = false
+        panel.prompt = "Open Repo"
+        guard panel.runModal() == .OK, let url = panel.url else { return }
+        portfolioService.addRepo(url)
+        openWindow(id: "repo", value: url)
     }
 }
 #else

--- a/swift/Concerto/Info.plist
+++ b/swift/Concerto/Info.plist
@@ -18,6 +18,17 @@
     <string>1</string>
     <key>CFBundleShortVersionString</key>
     <string>1.0</string>
+    <key>CFBundleURLTypes</key>
+    <array>
+        <dict>
+            <key>CFBundleURLName</key>
+            <string>studio.loopflow.deeplink</string>
+            <key>CFBundleURLSchemes</key>
+            <array>
+                <string>loopflow</string>
+            </array>
+        </dict>
+    </array>
     <key>LSMinimumSystemVersion</key>
     <string>15.0</string>
     <key>NSHighResolutionCapable</key>


### PR DESCRIPTION
## Try it

Open Concerto, then from anywhere:

```bash
open "loopflow://open?repo=/path/to/repo"
```

or in-app: **Go ▸ Open Repo… / Move to Repo ▸**, and **Go ▸ Portfolio** (⌘0).

## Intent

Make Concerto pointable at any repo without relaunching from the CLI — the first
slice of the launchboard idea. Productizes the `--repo` launch flag as a URL
scheme + menu, so you can jump between projects (e.g. into Cadenza) and back to
the portfolio.

## Key decisions

- Reuse the existing `loopflow://` scheme — re-registered in `Info.plist` (the
  studio-auth removal had stripped it). Routes `loopflow://open?repo=<path>` and
  `loopflow://portfolio`, handled via SwiftUI `.onOpenURL`.
- Menu lives in a new `CommandMenu("Go")`. It opens repos through the existing
  `WindowGroup(id: "repo")` + `PortfolioService.addRepo` — the same path the
  Portfolio window already uses. Added a `Window(id: "portfolio")` so the menu /
  deep link can summon the overview on demand.
- Dev launcher (`concerto-dev.py`) now builds with `--locked`. A poisoned upstream
  crate (`libsqlite3-sys 0.38.1`, pulled by the rusqlite bump) was breaking local
  launches despite a clean lockfile.

## Not included

- No new portfolio UI — this adds entry points only.
- Deep link handles the `open` / `portfolio` hosts; other verbs are no-ops.

## Verified

`loopflow://open?repo=/Users/jack/src/cadenza` opens a Cadenza window and loads
its `core/scores/feedback` waves end-to-end.
