### PR TITLE
lfd: fix sqlite health checks

### DIFF
--- a/rust/loopflow/src/lfd/store/mod.rs
+++ b/rust/loopflow/src/lfd/store/mod.rs
@@ -2772,6 +2772,15 @@ mod tests {
         run_store_basic_suite(&store).await;
     }
 
+    #[tokio::test]
+    async fn sqlite_health_check_succeeds() {
+        let db_path = env::temp_dir().join(format!("lfd-test-{}.db", LfdId::new()));
+        let config = StorageConfig::sqlite(db_path);
+        let store = super::open_store(&config).await.expect("store should open");
+
+        store.health_check().await.expect("sqlite health check");
+    }
+
     // When lfd restarts, `fail_orphaned_runs` marks in-flight runs as Failed.
     // Without also resetting the wave's own status, the wave stays visually
     // "running" — the Concerto sidebar and buttons stay disabled forever even

--- a/rust/loopflow/src/lfd/store/sqlite.rs
+++ b/rust/loopflow/src/lfd/store/sqlite.rs
@@ -298,7 +298,7 @@ impl SqliteStore {
 impl SqliteStore {
     pub fn health_check(&self) -> StoreResult<()> {
         let conn = self.conn.lock().expect("store mutex poisoned");
-        conn.execute(Self::sql(Query::HealthCheck), [])?;
+        conn.query_row(Self::sql(Query::HealthCheck), [], |_| Ok(()))?;
         Ok(())
     }
 


### PR DESCRIPTION
## Usage

```bash
cargo test -p loopflow sqlite_health_check_succeeds
```

## Summary

The SQLite store's `health_check` ran its probe query via `conn.execute`, which rusqlite reserves for statements that don't return rows. The health-check query is a `SELECT`, so `execute` would error on a perfectly healthy database, making the check report failure when nothing was wrong. Switching to `conn.query_row` runs the same query through the row-returning path and treats any successful row as a pass.

## Changes

- `sqlite.rs`: run the health-check query with `query_row` instead of `execute`
- `store/mod.rs`: add a test that opens a SQLite store and asserts `health_check` succeeds