### PR TITLE
concerto: scope the connected wave snapshot to the window's repo

### DIFF
--- a/swift/ConcertoTests/RepoStateSnapshotScopeTests.swift
+++ b/swift/ConcertoTests/RepoStateSnapshotScopeTests.swift
@@ -1,0 +1,41 @@
+import Foundation
+import Testing
+@testable import LoopflowCore
+
+@MainActor
+@Suite("RepoState snapshot scope")
+struct RepoStateSnapshotScopeTests {
+    @Test("connected snapshot keeps only the window's repo waves")
+    func snapshotScopedToRepo() {
+        let repoURL = URL(fileURLWithPath: "/tmp/repo-a")
+        let state = RepoState()
+        state.repoTarget = .local(repoURL)
+
+        let mine = makeWave(id: "mine", repoPath: repoURL.normalizedFilePath)
+        let other = makeWave(
+            id: "other",
+            repoPath: URL(fileURLWithPath: "/tmp/repo-b").normalizedFilePath
+        )
+
+        // The bundled daemon hands back both repos' waves; only this repo's survive.
+        state.applyConnectedSnapshot([mine, other])
+
+        #expect(state.waves.count == 1)
+        #expect(state.waves.first?.id == "mine")
+    }
+
+    private func makeWave(id: String, repoPath: String) -> Wave {
+        Wave(
+            id: id,
+            name: id,
+            repo: repoPath,
+            flow: "build",
+            direction: [],
+            area: ["."],
+            triggers: [],
+            status: .running,
+            iteration: 0,
+            diffStat: nil
+        )
+    }
+}

--- a/swift/LoopflowCore/State/RepoState.swift
+++ b/swift/LoopflowCore/State/RepoState.swift
@@ -513,7 +513,7 @@ public final class RepoState {
                         switch event {
                         case .connected(let connected):
                             self.updateConnectionState(.connected)
-                            self.waveStore.setAll(connected.waves.map(self.makeWaveViewModel))
+                            self.applyConnectedSnapshot(connected.waves)
                             self.preloadWaveContent(for: self.waves)
                             await self.refreshAttention()
                             await self.refreshTerminalSessions()
@@ -1579,6 +1579,16 @@ public final class RepoState {
         groupBy: UsageGroupBy
     ) async throws -> UsageTimeseries {
         try await waveService.usageTimeseries(filters: filters, bucket: bucket, groupBy: groupBy)
+    }
+
+    /// Apply the daemon's initial wave snapshot, scoped to this window's repo.
+    /// The bundled daemon may serve several repos at once; without this filter a
+    /// window would swallow every repo's waves. Per-event updates (`handleWaveEvent`)
+    /// are already repo-scoped — this closes the same gap on the bulk snapshot.
+    func applyConnectedSnapshot(_ waves: [Wave]) {
+        let currentRepoPath = repoTarget?.path.normalizedFilePath
+        let scoped = waves.filter { $0.repo.normalizedFilePath == currentRepoPath }
+        waveStore.setAll(scoped.map(makeWaveViewModel))
     }
 
     private func makeWaveViewModel(api wave: Wave) -> WaveViewModel {


### PR DESCRIPTION
## What

Pointing Concerto at a second repo — e.g. opening Cadenza from the loopflow
window via the new `loopflow://open?repo=` deep link — showed **both** repos'
waves jumbled together: Cadenza's `core/scores/feedback` plus loopflow's
`desktop/mobile/root/workflows`, with duplicates.

## Cause

The bundled lfd serves several repos at once. macOS `RepoState` filters per-wave
**events** by `repoTarget` (`handleWaveEvent`), but the initial `.connected`
snapshot called `waveStore.setAll(connected.waves...)` **unfiltered** — so a
window swallowed every repo's waves the moment it connected.

## Fix

Scope the connected snapshot to the window's repo, exactly as the event path
already does. Extracted into `applyConnectedSnapshot(_:)` so it's covered by a
unit test (`RepoStateSnapshotScopeTests`).

## Verify

Open repo A, deep-link to repo B → B's window shows only B's waves. In the repro
that means Cadenza shows `core / scores / feedback` (+ `release`) and nothing
from loopflow.
