### PR TITLE
deploy: add monthly spend guardrails

### DIFF
--- a/deploy/COSTS.md
+++ b/deploy/COSTS.md
@@ -1,0 +1,69 @@
+# Cost guardrails
+
+Track automation spend before it surprises the release host.
+
+```bash
+scripts/check_monthly_spend.py --csv ~/.lf/costs/mercury-2026-06.csv
+scripts/check_monthly_spend.py --json ~/.lf/costs/mercury-transactions-2026-06.json
+```
+
+The monthly automation budget is **$100**. If actual or projected spend crosses that line, stop and get human approval before adding spend.
+
+## Source of truth
+
+Use the company card/bank feed as the source of truth. Provider dashboards are useful early warnings, but card transactions are what decide the budget gate.
+
+Keep exports outside the repo:
+
+```bash
+mkdir -p ~/.lf/costs
+# Save Mercury CSV/API exports here, not under the checkout.
+scripts/check_monthly_spend.py --csv ~/.lf/costs/mercury-$(date +%Y-%m).csv
+```
+
+## Vendors covered
+
+`deploy/budget.yaml` categorizes charges for:
+
+- AWS
+- Fly.io
+- Claude / Anthropic
+- Codex / OpenAI
+- OpenCode
+- Doppler
+
+Add a match term when a statement line uses a new merchant spelling. Do not add card numbers, account IDs, tokens, or private billing details.
+
+## Payment policy
+
+Use the company card for AWS, Fly.io, Claude/Anthropic, OpenAI/Codex, OpenCode, Doppler, and release-host services whenever the vendor supports card billing. If a service needs invoice or bank transfer billing, record the transaction export the same way and keep credentials outside the repo.
+
+## Gate behavior
+
+```bash
+scripts/check_monthly_spend.py --csv ~/.lf/costs/mercury-2026-06.csv --month 2026-06
+```
+
+The script exits:
+
+| Exit | Meaning |
+|------|---------|
+| `0` | Actual/projected spend is within budget |
+| `2` | Actual/projected spend exceeds budget; stop for approval |
+
+Projection is on by default for the current month. Disable it for closed months:
+
+```bash
+scripts/check_monthly_spend.py --csv ~/.lf/costs/mercury-2026-05.csv --month 2026-05 --no-projection
+```
+
+## Mercury path
+
+Use either CSV exports or transaction JSON from Mercury. The script accepts both because live bank credentials should not be required for local validation.
+
+```bash
+scripts/check_monthly_spend.py --csv ~/.lf/costs/mercury.csv
+scripts/check_monthly_spend.py --json ~/.lf/costs/mercury-transactions.json
+```
+
+Later adapters can fetch Mercury, AWS Cost Explorer, Fly usage, or provider API usage directly. Keep the card transaction check as the final gate.

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -15,6 +15,8 @@ deploy/loopflow-server.sh up
 
 Container mode and self-hosted bearer-token auth are the default. Keep secrets in Doppler; `.env` is the local fallback.
 
+Cost guardrails live in `deploy/COSTS.md`. The maintained automation budget is $100/month; if actual or projected spend crosses it, stop before adding spend.
+
 ## Loopflow and Cadenza
 
 Use the same server shape for both repos. The Terraform module and `loopflow-server.sh --repo PATH` are repo-parameterized; each repo should carry its own Docker/deploy files and Doppler project/config. Keep the cadence from `release/SCHEDULE.md` identical, then vary only product-specific build, smoke-test, signing, and publish commands.

--- a/deploy/budget.yaml
+++ b/deploy/budget.yaml
@@ -1,0 +1,37 @@
+# Monthly automation spend guardrail.
+# Card/bank transactions are the source of truth; provider APIs are advisory.
+monthly_budget_usd: "100.00"
+currency: USD
+source_of_truth: mercury_company_card
+projection: true
+vendors:
+  - name: aws
+    label: AWS
+    match:
+      - amazon web services
+      - aws
+  - name: fly
+    label: Fly.io
+    match:
+      - fly.io
+      - flyio
+      - fly io
+  - name: claude
+    label: Claude / Anthropic
+    match:
+      - anthropic
+      - claude
+  - name: codex
+    label: Codex / OpenAI
+    match:
+      - openai
+      - chatgpt
+      - codex
+  - name: opencode
+    label: OpenCode
+    match:
+      - opencode
+  - name: doppler
+    label: Doppler
+    match:
+      - doppler

--- a/python/tests/test_budget_guardrails.py
+++ b/python/tests/test_budget_guardrails.py
@@ -1,0 +1,103 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "scripts/check_monthly_spend.py"
+CONFIG = ROOT / "deploy/budget.yaml"
+
+
+def run_budget(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), "--config", str(CONFIG), *args],
+        text=True,
+        capture_output=True,
+    )
+
+
+def test_budget_guardrail_allows_spend_under_projected_budget(tmp_path: Path):
+    export = tmp_path / "mercury.csv"
+    export.write_text(
+        "Date,Description,Amount\n"
+        "2026-06-01,Amazon Web Services,10.00\n"
+        "2026-06-02,Fly.io,5.00\n"
+        "2026-06-03,Unrelated coffee,7.00\n"
+    )
+
+    result = run_budget("--csv", str(export), "--month", "2026-06", "--today", "2026-06-30")
+
+    assert result.returncode == 0
+    assert "budget: $100.00" in result.stdout
+    assert "actual tracked spend: $15.00" in result.stdout
+    assert "verdict: OK" in result.stdout
+    assert "Unrelated coffee" not in result.stdout
+
+
+def test_budget_guardrail_blocks_projected_spend_over_budget(tmp_path: Path):
+    export = tmp_path / "mercury.csv"
+    export.write_text("Date,Description,Amount\n2026-06-15,Anthropic Claude,55.00\n")
+
+    result = run_budget("--csv", str(export), "--month", "2026-06", "--today", "2026-06-15")
+
+    assert result.returncode == 2
+    assert "actual tracked spend: $55.00" in result.stdout
+    assert "projected spend: $110.00" in result.stdout
+    assert "verdict: BLOCK" in result.stdout
+    assert "stop and get human approval" in result.stderr
+
+
+def test_budget_guardrail_supports_debit_credit_exports(tmp_path: Path):
+    export = tmp_path / "mercury.csv"
+    export.write_text(
+        "Date,Description,Debit,Credit\n"
+        "2026-06-01,OpenAI Codex,30.00,\n"
+        "2026-06-03,OpenAI refund,,5.00\n"
+    )
+
+    result = run_budget(
+        "--csv",
+        str(export),
+        "--month",
+        "2026-06",
+        "--today",
+        "2026-06-30",
+        "--json-output",
+    )
+
+    assert result.returncode == 0
+    payload = json.loads(result.stdout)
+    assert payload["actual"] == "25.00"
+    assert payload["over_budget"] is False
+
+
+def test_budget_guardrail_supports_transaction_json(tmp_path: Path):
+    export = tmp_path / "transactions.json"
+    export.write_text(
+        json.dumps(
+            {
+                "transactions": [
+                    {
+                        "postedAt": "2026-06-04T12:00:00Z",
+                        "merchantName": "Fly.io",
+                        "amount": {"amount": "12.34"},
+                    }
+                ]
+            }
+        )
+    )
+
+    result = run_budget(
+        "--json",
+        str(export),
+        "--month",
+        "2026-06",
+        "--today",
+        "2026-06-30",
+        "--json-output",
+    )
+
+    assert result.returncode == 0
+    payload = json.loads(result.stdout)
+    assert payload["actual"] == "12.34"
+    assert payload["matched"][0]["vendor"] == "fly"

--- a/python/tests/test_release_automation.py
+++ b/python/tests/test_release_automation.py
@@ -137,6 +137,8 @@ def test_self_hosted_server_primitives_are_documented_and_runnable():
 
     readme = (ROOT / "deploy/README.md").read_text()
     assert "doppler secrets set LFD_AUTH_TOKEN" in readme
+    assert "deploy/COSTS.md" in readme
+    assert "$100/month" in readme
     assert "openssl rand -hex 32" in readme
     assert "leave `LF_TLS_MODE` empty" in readme
     assert "Mac mini + Tailscale" in readme
@@ -198,6 +200,17 @@ def test_self_hosted_server_primitives_are_documented_and_runnable():
     assert "loopflow.server" in plist
     assert "studio.loopflow.server" not in plist
     assert "loopflow-server.sh" in plist
+
+    cost_docs = (ROOT / "deploy/COSTS.md").read_text()
+    budget_config = yaml.safe_load((ROOT / "deploy/budget.yaml").read_text())
+    assert budget_config["monthly_budget_usd"] == "100.00"
+    assert budget_config["source_of_truth"] == "mercury_company_card"
+    assert "scripts/check_monthly_spend.py" in cost_docs
+    assert "company card" in cost_docs
+    assert "AWS" in cost_docs
+    assert "Fly.io" in cost_docs
+    assert "Claude / Anthropic" in cost_docs
+    assert "Codex / OpenAI" in cost_docs
 
 
 def test_aws_self_hosted_topology_keeps_secrets_out_of_terraform():

--- a/release/SCHEDULE.md
+++ b/release/SCHEDULE.md
@@ -30,3 +30,4 @@ Loopflow and Cadenza both carry the scheduled release workflow pair. Each repo r
 - Secrets stay in Doppler or host-local env files, never Terraform state or committed config.
 - The cron server is self-hosted per repo. Studio discovery/auth is not supported.
 - Local updater scripts refuse to pull a non-default branch unless explicitly told not to pull.
+- Automation spend uses the company card feed as source of truth and stops for approval above $100/month.

--- a/release/unreleased/DECISIONS.md
+++ b/release/unreleased/DECISIONS.md
@@ -219,3 +219,11 @@ built-in commands — skills fire there with `$step`.
 **Decision:** Target a private Tailscale-connected host as the first maintained Loopflow `lfd` cron host. Local clients use Tailscale HTTP with bearer-token auth first; Caddy/TLS remains available for later public or polished access. Concerto, `lfq`, Codex, and Claude sessions should point at that host rather than a studio control plane. Host-specific names, addresses, users, and tokens stay in local env, Doppler, or private machine config.
 
 **Implications:** Setup scripts and docs optimize for a private Tailscale host without committing personal topology. Secrets stay in Doppler or host-local env, agent credentials are made available to the private executor, and remote repo paths are paths on that host. Cadenza remains cheap and product-specific: one prod server, regular/hotfix releases, and local/TestFlight clients pointed at prod unless a deliberate staging need appears.
+
+## 2026-06-30 — Spend over $100/month is the next human blocker
+
+**Context:** Release automation needs to keep moving without checking in for every reversible step, but cloud hosts and agent providers can create open-ended spend.
+
+**Decision:** Continue autonomous release-infra iteration until actual or projected automation spend would exceed $100/month. Card/bank transactions are the source of truth; AWS, Fly.io, Claude/Anthropic, OpenAI/Codex, OpenCode, Doppler, and release-host services should use the company card when the vendor supports card billing.
+
+**Implications:** Cost tracking is part of release infrastructure, not bookkeeping after the fact. Provider dashboards can warn early, but the monthly budget gate is enforced from transaction exports/API data. Spending above the threshold requires human approval before proceeding.

--- a/scripts/check_monthly_spend.py
+++ b/scripts/check_monthly_spend.py
@@ -1,0 +1,396 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import calendar
+import csv
+import json
+import re
+import sys
+from dataclasses import dataclass
+from datetime import date, datetime
+from decimal import ROUND_HALF_UP, Decimal, InvalidOperation
+from pathlib import Path
+from typing import Any, Iterable, Optional
+
+import yaml
+
+MONEY_QUANT = Decimal("0.01")
+DATE_FIELDS = ["date", "posted_at", "postedat", "created_at", "createdat", "timestamp"]
+TEXT_FIELDS = [
+    "description",
+    "merchant",
+    "merchant_name",
+    "merchantname",
+    "counterparty",
+    "counterparty_name",
+    "counterpartyname",
+    "name",
+    "memo",
+    "note",
+]
+DEBIT_FIELDS = ["debit", "withdrawal", "withdrawals", "charge", "charges", "spent", "expense"]
+CREDIT_FIELDS = ["credit", "deposit", "deposits", "refund", "payment"]
+AMOUNT_FIELDS = ["amount", "transaction_amount", "transactionamount", "net_amount", "netamount"]
+
+
+@dataclass(frozen=True)
+class Vendor:
+    name: str
+    label: str
+    match: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class Config:
+    monthly_budget: Decimal
+    currency: str
+    projection: bool
+    vendors: tuple[Vendor, ...]
+
+
+@dataclass(frozen=True)
+class Transaction:
+    occurred_on: date
+    description: str
+    amount: Decimal
+    source: str
+
+
+@dataclass(frozen=True)
+class MatchedSpend:
+    vendor: Vendor
+    transaction: Transaction
+
+
+@dataclass(frozen=True)
+class Report:
+    month: str
+    budget: Decimal
+    actual: Decimal
+    projected: Decimal
+    projection_enabled: bool
+    matched: tuple[MatchedSpend, ...]
+    uncategorized: tuple[Transaction, ...]
+
+    @property
+    def gate_amount(self) -> Decimal:
+        if self.projection_enabled:
+            return max(self.actual, self.projected)
+        return self.actual
+
+    @property
+    def over_budget(self) -> bool:
+        return self.gate_amount > self.budget
+
+
+def _money(value: Decimal) -> str:
+    return f"${value.quantize(MONEY_QUANT, rounding=ROUND_HALF_UP)}"
+
+
+def _normalize_key(value: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "_", value.strip().lower()).strip("_")
+
+
+def _normalize_row(row: dict[str, Any]) -> dict[str, Any]:
+    return {_normalize_key(str(key)): value for key, value in row.items()}
+
+
+def _parse_decimal(value: Any) -> Optional[Decimal]:
+    if value is None:
+        return None
+    if isinstance(value, dict):
+        for key in ("amount", "value", "cents"):
+            parsed = _parse_decimal(value.get(key))
+            if parsed is not None:
+                if key == "cents":
+                    return parsed / Decimal(100)
+                return parsed
+        return None
+    raw = str(value).strip()
+    if not raw:
+        return None
+    negative = raw.startswith("(") and raw.endswith(")")
+    cleaned = raw.strip("()")
+    cleaned = cleaned.replace("$", "").replace(",", "")
+    cleaned = re.sub(r"[^0-9+\-.]", "", cleaned)
+    if cleaned in {"", "+", "-", "."}:
+        return None
+    try:
+        amount = Decimal(cleaned)
+    except InvalidOperation:
+        return None
+    if negative:
+        amount = -amount
+    return amount
+
+
+def _parse_date(value: Any) -> Optional[date]:
+    if value is None:
+        return None
+    raw = str(value).strip()
+    if not raw:
+        return None
+    raw = raw[:10]
+    for fmt in ("%Y-%m-%d", "%m/%d/%Y", "%m/%d/%y"):
+        try:
+            return datetime.strptime(raw, fmt).date()
+        except ValueError:
+            continue
+    return None
+
+
+def _first(row: dict[str, Any], keys: Iterable[str]) -> Optional[Any]:
+    for key in keys:
+        if key in row and str(row[key]).strip():
+            return row[key]
+    return None
+
+
+def _description(row: dict[str, Any]) -> str:
+    parts = [str(row[key]).strip() for key in TEXT_FIELDS if key in row and str(row[key]).strip()]
+    if parts:
+        return " | ".join(parts)
+    values = [str(value).strip() for value in row.values() if str(value).strip()]
+    return " | ".join(values)
+
+
+def _spend_amount(row: dict[str, Any]) -> Optional[Decimal]:
+    debit = _parse_decimal(_first(row, DEBIT_FIELDS))
+    credit = _parse_decimal(_first(row, CREDIT_FIELDS))
+    if debit is not None:
+        return abs(debit)
+    if credit is not None:
+        return -abs(credit)
+
+    amount = _parse_decimal(_first(row, AMOUNT_FIELDS))
+    if amount is None:
+        return None
+    return abs(amount)
+
+
+def _load_config(path: Path) -> Config:
+    data = yaml.safe_load(path.read_text()) or {}
+    raw_budget = data.get("monthly_budget_usd")
+    budget = _parse_decimal(raw_budget)
+    if budget is None or budget <= 0:
+        raise ValueError(f"invalid monthly_budget_usd in {path}")
+
+    vendors = []
+    for raw_vendor in data.get("vendors", []):
+        name = str(raw_vendor["name"])
+        label = str(raw_vendor.get("label", name))
+        match = tuple(str(term).lower() for term in raw_vendor.get("match", []))
+        if not match:
+            raise ValueError(f"vendor {name} has no match terms")
+        vendors.append(Vendor(name=name, label=label, match=match))
+
+    if not vendors:
+        raise ValueError(f"no vendors configured in {path}")
+
+    return Config(
+        monthly_budget=budget,
+        currency=str(data.get("currency", "USD")),
+        projection=bool(data.get("projection", True)),
+        vendors=tuple(vendors),
+    )
+
+
+def _load_csv(path: Path) -> list[Transaction]:
+    transactions = []
+    with path.open(newline="") as handle:
+        reader = csv.DictReader(handle)
+        for raw_row in reader:
+            row = _normalize_row(raw_row)
+            occurred_on = _parse_date(_first(row, DATE_FIELDS))
+            amount = _spend_amount(row)
+            if occurred_on is None or amount is None or amount == 0:
+                continue
+            transactions.append(
+                Transaction(
+                    occurred_on=occurred_on,
+                    description=_description(row),
+                    amount=amount,
+                    source=str(path),
+                )
+            )
+    return transactions
+
+
+def _json_items(data: Any) -> list[dict[str, Any]]:
+    if isinstance(data, list):
+        return [item for item in data if isinstance(item, dict)]
+    if isinstance(data, dict):
+        for key in ("transactions", "data", "items", "results"):
+            value = data.get(key)
+            if isinstance(value, list):
+                return [item for item in value if isinstance(item, dict)]
+    return []
+
+
+def _load_json(path: Path) -> list[Transaction]:
+    transactions = []
+    for raw_row in _json_items(json.loads(path.read_text())):
+        row = _normalize_row(raw_row)
+        occurred_on = _parse_date(_first(row, DATE_FIELDS))
+        amount = _spend_amount(row)
+        if occurred_on is None or amount is None or amount == 0:
+            continue
+        transactions.append(
+            Transaction(
+                occurred_on=occurred_on,
+                description=_description(row),
+                amount=amount,
+                source=str(path),
+            )
+        )
+    return transactions
+
+
+def _month_for_today(today: date) -> str:
+    return today.strftime("%Y-%m")
+
+
+def _in_month(value: date, month: str) -> bool:
+    return value.strftime("%Y-%m") == month
+
+
+def _project(actual: Decimal, month: str, today: date) -> Decimal:
+    year, month_num = [int(part) for part in month.split("-", maxsplit=1)]
+    days = calendar.monthrange(year, month_num)[1]
+    if today.strftime("%Y-%m") != month:
+        return actual
+    elapsed = max(today.day, 1)
+    return (actual * Decimal(days) / Decimal(elapsed)).quantize(MONEY_QUANT)
+
+
+def _classify(config: Config, transaction: Transaction) -> Optional[Vendor]:
+    text = transaction.description.lower()
+    for vendor in config.vendors:
+        if any(term in text for term in vendor.match):
+            return vendor
+    return None
+
+
+def build_report(
+    config: Config,
+    transactions: Iterable[Transaction],
+    month: str,
+    today: date,
+    projection: bool,
+) -> Report:
+    matched = []
+    uncategorized = []
+    for transaction in transactions:
+        if not _in_month(transaction.occurred_on, month):
+            continue
+        vendor = _classify(config, transaction)
+        if vendor is None:
+            uncategorized.append(transaction)
+            continue
+        matched.append(MatchedSpend(vendor=vendor, transaction=transaction))
+
+    actual = sum((item.transaction.amount for item in matched), Decimal("0.00"))
+    projected = _project(actual, month, today) if projection else actual
+    return Report(
+        month=month,
+        budget=config.monthly_budget,
+        actual=actual,
+        projected=projected,
+        projection_enabled=projection,
+        matched=tuple(matched),
+        uncategorized=tuple(uncategorized),
+    )
+
+
+def _render_text(report: Report) -> str:
+    lines = [
+        f"month: {report.month}",
+        f"budget: {_money(report.budget)}",
+        f"actual tracked spend: {_money(report.actual)}",
+    ]
+    if report.projection_enabled:
+        lines.append(f"projected spend: {_money(report.projected)}")
+    lines.append(f"gate amount: {_money(report.gate_amount)}")
+    lines.append(f"verdict: {'BLOCK' if report.over_budget else 'OK'}")
+
+    totals: dict[str, Decimal] = {}
+    labels: dict[str, str] = {}
+    for item in report.matched:
+        totals[item.vendor.name] = (
+            totals.get(item.vendor.name, Decimal("0.00")) + item.transaction.amount
+        )
+        labels[item.vendor.name] = item.vendor.label
+    if totals:
+        lines.append("")
+        lines.append("by vendor:")
+        for name, total in sorted(totals.items()):
+            lines.append(f"  {labels[name]}: {_money(total)}")
+    return "\n".join(lines)
+
+
+def _render_json(report: Report) -> str:
+    payload = {
+        "month": report.month,
+        "budget": str(report.budget.quantize(MONEY_QUANT)),
+        "actual": str(report.actual.quantize(MONEY_QUANT)),
+        "projected": str(report.projected.quantize(MONEY_QUANT)),
+        "gate_amount": str(report.gate_amount.quantize(MONEY_QUANT)),
+        "over_budget": report.over_budget,
+        "matched": [
+            {
+                "vendor": item.vendor.name,
+                "label": item.vendor.label,
+                "date": item.transaction.occurred_on.isoformat(),
+                "amount": str(item.transaction.amount.quantize(MONEY_QUANT)),
+                "description": item.transaction.description,
+                "source": item.transaction.source,
+            }
+            for item in report.matched
+        ],
+    }
+    return json.dumps(payload, indent=2, sort_keys=True)
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Check monthly automation spend against budget.")
+    parser.add_argument("--config", type=Path, default=Path("deploy/budget.yaml"))
+    parser.add_argument("--csv", type=Path, action="append", default=[])
+    parser.add_argument("--json", type=Path, action="append", default=[])
+    parser.add_argument("--month", help="Month to check, YYYY-MM. Defaults to current month.")
+    parser.add_argument("--today", help="Override today's date for projection tests, YYYY-MM-DD.")
+    parser.add_argument("--no-projection", action="store_true")
+    parser.add_argument("--json-output", action="store_true")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = _parse_args()
+    today = _parse_date(args.today) if args.today else date.today()
+    if today is None:
+        raise ValueError("--today must be YYYY-MM-DD")
+
+    config = _load_config(args.config)
+    month = args.month or _month_for_today(today)
+    projection = config.projection and not args.no_projection
+
+    transactions = []
+    for path in args.csv:
+        transactions.extend(_load_csv(path))
+    for path in args.json:
+        transactions.extend(_load_json(path))
+
+    report = build_report(config, transactions, month, today, projection)
+    print(_render_json(report) if args.json_output else _render_text(report))
+    if report.over_budget:
+        print(
+            "monthly automation spend exceeds "
+            f"{_money(report.budget)}; stop and get human approval",
+            file=sys.stderr,
+        )
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Usage

```bash
scripts/check_monthly_spend.py --csv ~/.lf/costs/mercury-2026-06.csv
scripts/check_monthly_spend.py --json ~/.lf/costs/mercury-transactions-2026-06.json
scripts/check_monthly_spend.py --csv ~/.lf/costs/mercury-2026-05.csv --month 2026-05 --no-projection
```

## Summary

Release automation can quietly rack up open-ended cloud and agent-provider spend. This adds a $100/month budget gate so autonomous release-infra work keeps moving on reversible steps but stops for human approval before crossing the line. The company card/bank feed (Mercury) is the source of truth; provider dashboards are advisory early warnings only. `scripts/check_monthly_spend.py` reads a Mercury CSV or transaction JSON export, categorizes charges by vendor, computes actual and projected month spend, and exits `2` (with a stop-for-approval message) when actual or projected spend exceeds budget, `0` otherwise.

## Changes

- `scripts/check_monthly_spend.py` — parses CSV/JSON exports (debit/credit or signed-amount columns), classifies vendor charges, projects current-month spend, and gates on the budget via exit code
- `deploy/budget.yaml` — $100 monthly budget plus vendor match terms for AWS, Fly.io, Claude/Anthropic, OpenAI/Codex, OpenCode, and Doppler
- `deploy/COSTS.md` — cost-guardrail docs: source of truth, payment policy, gate behavior, and keeping exports outside the repo
- `deploy/README.md` and `release/SCHEDULE.md` — point at the guardrails and record the $100/month stop line
- `release/unreleased/DECISIONS.md` — records that spend over $100/month is the next human blocker
- Tests in `test_budget_guardrails.py` (allow/block/projection, debit-credit and transaction-JSON exports) and additions to `test_release_automation.py`