### PR TITLE
lfd: persist native service environment

### DIFF
--- a/docs/lfd.md
+++ b/docs/lfd.md
@@ -55,6 +55,16 @@ lfd serve
 
 The default listen address is `127.0.0.1:2486`. Override it with `LFD_HTTP_ADDR`.
 
+For a self-hosted native remote daemon, set the remote bind address and bearer token when installing. `lfd install` persists selected `LFD_*` environment variables into the service file, so the daemon survives restarts without hand-editing launchd or systemd units.
+
+```bash
+export LFD_HTTP_ADDR=0.0.0.0:2486
+export LFD_AUTH_TOKEN=$(openssl rand -hex 32)
+lfd install --force
+```
+
+Service files that contain token-like values are written with owner-only permissions.
+
 ## Install
 
 ```bash

--- a/rust/loopflow/src/lfd/service/linux.rs
+++ b/rust/loopflow/src/lfd/service/linux.rs
@@ -4,7 +4,7 @@ use std::process::Command;
 
 use crate::lfd::config::{LfdConfig, RuntimeBackend};
 
-use super::compose;
+use super::{compose, contains_sensitive_service_env, service_environment, write_service_file};
 
 // Linux systemd user service management.
 //
@@ -42,6 +42,7 @@ pub fn install(config: &LfdConfig, force: bool) -> Result<()> {
         .to_string_lossy()
         .to_string();
     let path_env = std::env::var("PATH").unwrap_or_default();
+    let env_vars = service_environment(&path_env);
     let exec_start = build_exec_start(config.runtime_backend, &lfd_path)?;
 
     let unit_path = unit_path()?;
@@ -49,24 +50,13 @@ pub fn install(config: &LfdConfig, force: bool) -> Result<()> {
         std::fs::create_dir_all(parent)?;
     }
 
-    let content = format!(
-        r#"[Unit]
-Description=Loopflow Daemon
-After=network.target
+    let content = render_unit(&exec_start, &env_vars);
 
-[Service]
-Type=simple
-ExecStart={exec_start}
-Restart=on-failure
-RestartSec=5
-Environment=PATH={path_env}
-
-[Install]
-WantedBy=default.target
-"#
-    );
-
-    std::fs::write(&unit_path, &content)?;
+    write_service_file(
+        &unit_path,
+        &content,
+        contains_sensitive_service_env(&env_vars),
+    )?;
     println!("Installed {}", unit_path.display());
 
     let _ = Command::new("systemctl")
@@ -206,6 +196,34 @@ pub fn status(config: &LfdConfig) -> Result<()> {
     Ok(())
 }
 
+fn render_unit(exec_start: &str, env_vars: &[(String, String)]) -> String {
+    let env_lines = env_vars
+        .iter()
+        .map(|(name, value)| format!("Environment=\"{}={}\"", name, systemd_escape(value)))
+        .collect::<Vec<_>>()
+        .join("\n");
+    format!(
+        r#"[Unit]
+Description=Loopflow Daemon
+After=network.target
+
+[Service]
+Type=simple
+ExecStart={exec_start}
+Restart=on-failure
+RestartSec=5
+{env_lines}
+
+[Install]
+WantedBy=default.target
+"#
+    )
+}
+
+fn systemd_escape(value: &str) -> String {
+    value.replace('\\', "\\\\").replace('"', "\\\"")
+}
+
 fn build_exec_start(backend: RuntimeBackend, lfd_path: &str) -> Result<String> {
     match backend {
         RuntimeBackend::Native => Ok(format!("{lfd_path} serve")),
@@ -244,7 +262,7 @@ fn teardown_backend(backend: RuntimeBackend) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use super::{detect_backend_from_unit, RuntimeBackend};
+    use super::{detect_backend_from_unit, render_unit, RuntimeBackend};
 
     #[test]
     fn detects_compose_backend_from_unit_content() {
@@ -256,5 +274,18 @@ mod tests {
     fn detects_native_backend_from_unit_content() {
         let content = "ExecStart=/usr/local/bin/lfd serve";
         assert_eq!(detect_backend_from_unit(content), RuntimeBackend::Native);
+    }
+
+    #[test]
+    fn render_unit_persists_remote_native_environment() {
+        let env_vars = vec![
+            ("PATH".to_string(), "/usr/bin:/bin".to_string()),
+            ("LFD_HTTP_ADDR".to_string(), "0.0.0.0:2486".to_string()),
+            ("LFD_AUTH_TOKEN".to_string(), "token\"value".to_string()),
+        ];
+        let content = render_unit("/usr/local/bin/lfd serve", &env_vars);
+
+        assert!(content.contains("Environment=\"LFD_HTTP_ADDR=0.0.0.0:2486\""));
+        assert!(content.contains("Environment=\"LFD_AUTH_TOKEN=token\\\"value\""));
     }
 }

--- a/rust/loopflow/src/lfd/service/macos.rs
+++ b/rust/loopflow/src/lfd/service/macos.rs
@@ -4,7 +4,7 @@ use std::process::Command;
 
 use crate::lfd::config::{LfdConfig, RuntimeBackend};
 
-use super::compose;
+use super::{compose, contains_sensitive_service_env, service_environment, write_service_file};
 
 /// macOS launchd service management.
 ///
@@ -41,6 +41,7 @@ pub fn install(config: &LfdConfig, force: bool) -> Result<()> {
         .to_string_lossy()
         .to_string();
     let path_env = std::env::var("PATH").unwrap_or_default();
+    let env_vars = service_environment(&path_env);
     let log_dir = log_dir()?;
     std::fs::create_dir_all(&log_dir)?;
 
@@ -57,14 +58,18 @@ pub fn install(config: &LfdConfig, force: bool) -> Result<()> {
         std::fs::create_dir_all(parent)?;
     }
 
-    let content = render_plist(&program_args, &path_env, &log_dir)?;
+    let content = render_plist(&program_args, &env_vars, &log_dir)?;
 
     let plist_str = plist_path.to_string_lossy().to_string();
     let _ = Command::new("launchctl")
         .args(["unload", &plist_str])
         .output();
 
-    std::fs::write(&plist_path, &content)?;
+    write_service_file(
+        &plist_path,
+        &content,
+        contains_sensitive_service_env(&env_vars),
+    )?;
     println!("Installed {}", plist_path.display());
 
     let status = Command::new("launchctl")
@@ -199,12 +204,23 @@ pub fn status(config: &LfdConfig) -> Result<()> {
 
 fn render_plist(
     program_args: &[String],
-    path_env: &str,
+    env_vars: &[(String, String)],
     log_dir: &std::path::Path,
 ) -> Result<String> {
     let program_args_xml = program_args
         .iter()
-        .map(|arg| format!("        <string>{arg}</string>"))
+        .map(|arg| format!("        <string>{}</string>", xml_escape(arg)))
+        .collect::<Vec<_>>()
+        .join("\n");
+    let env_xml = env_vars
+        .iter()
+        .map(|(name, value)| {
+            format!(
+                "        <key>{}</key>\n        <string>{}</string>",
+                xml_escape(name),
+                xml_escape(value)
+            )
+        })
         .collect::<Vec<_>>()
         .join("\n");
 
@@ -233,14 +249,23 @@ fn render_plist(
     <string>{log_dir}/lfd.log</string>
     <key>EnvironmentVariables</key>
     <dict>
-        <key>PATH</key>
-        <string>{path_env}</string>
+{env_xml}
     </dict>
 </dict>
 </plist>
 "#,
         log_dir = log_dir.display(),
+        env_xml = env_xml,
     ))
+}
+
+fn xml_escape(value: &str) -> String {
+    value
+        .replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+        .replace('\'', "&apos;")
 }
 
 fn build_program_arguments(backend: RuntimeBackend, lfd_path: &str) -> Result<Vec<String>> {
@@ -281,7 +306,8 @@ fn teardown_backend(backend: RuntimeBackend) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use super::{detect_backend_from_plist, RuntimeBackend};
+    use super::{detect_backend_from_plist, render_plist, RuntimeBackend};
+    use std::path::Path;
 
     #[test]
     fn detects_compose_backend_from_plist_content() {
@@ -304,5 +330,25 @@ mod tests {
 </array>
 "#;
         assert_eq!(detect_backend_from_plist(content), RuntimeBackend::Native);
+    }
+
+    #[test]
+    fn render_plist_persists_remote_native_environment() {
+        let env_vars = vec![
+            ("PATH".to_string(), "/usr/bin:/bin".to_string()),
+            ("LFD_HTTP_ADDR".to_string(), "0.0.0.0:2486".to_string()),
+            ("LFD_AUTH_TOKEN".to_string(), "token<&>\"".to_string()),
+        ];
+        let content = render_plist(
+            &["/usr/local/bin/lfd".to_string(), "serve".to_string()],
+            &env_vars,
+            Path::new("/tmp"),
+        )
+        .expect("render plist");
+
+        assert!(content.contains("<key>LFD_HTTP_ADDR</key>"));
+        assert!(content.contains("<string>0.0.0.0:2486</string>"));
+        assert!(content.contains("<key>LFD_AUTH_TOKEN</key>"));
+        assert!(content.contains("token&lt;&amp;&gt;&quot;"));
     }
 }

--- a/rust/loopflow/src/lfd/service/mod.rs
+++ b/rust/loopflow/src/lfd/service/mod.rs
@@ -5,7 +5,74 @@ mod linux;
 mod macos;
 mod onboarding;
 
+use std::path::Path;
+
+use anyhow::Result;
+
 use crate::lfd::config::{LfdConfig, ServiceManager};
+
+const SERVICE_ENV_KEYS: &[&str] = &[
+    "LFD_HTTP_ADDR",
+    "LFD_AUTH_TOKEN",
+    "LFD_MODE",
+    "LFD_DB_PATH",
+    "LFD_DATABASE_URL",
+    "LFD_MAX_SLOTS",
+    "LFD_GITHUB_WEBHOOK_SECRET",
+    "LFD_GITHUB_TOKEN",
+    "LFD_EXECUTOR_CREDENTIALS_ENV",
+    "LFD_EXECUTOR_CREDENTIALS_MOUNTS",
+    "LFD_EXECUTOR_IMAGE",
+    "LFD_EXECUTOR_AGENT_TIMEOUT",
+    "LFD_EXECUTOR_LIMITS_MEMORY",
+    "LFD_EXECUTOR_LIMITS_MEMORY_SWAP",
+    "LFD_EXECUTOR_LIMITS_CPU_QUOTA",
+    "LFD_EXECUTOR_LIMITS_PIDS_LIMIT",
+    "LFD_HTTP_MAX_JSON_BODY_BYTES",
+    "LFD_HTTP_MAX_HOOK_BODY_BYTES",
+    "LFD_HTTP_MAX_WS_FRAME_BYTES",
+    "LFD_HTTP_MAX_WS_MESSAGE_BYTES",
+    "LFD_HTTP_MAX_WS_QUEUE",
+    "LFD_HTTP_MAX_WS_MALFORMED",
+    "LFD_HTTP_AUTH_FAILURES_PER_MINUTE",
+    "LFD_HTTP_TRUSTED_PROXY_CIDRS",
+];
+
+pub(super) fn service_environment(path_env: &str) -> Vec<(String, String)> {
+    let mut values = vec![("PATH".to_string(), path_env.to_string())];
+    for name in SERVICE_ENV_KEYS {
+        let Ok(value) = std::env::var(name) else {
+            continue;
+        };
+        let trimmed = value.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        values.push((name.to_string(), trimmed.to_string()));
+    }
+    values
+}
+
+pub(super) fn contains_sensitive_service_env(values: &[(String, String)]) -> bool {
+    values.iter().any(|(name, _)| {
+        let name = name.to_ascii_uppercase();
+        name.contains("TOKEN") || name.contains("SECRET") || name.contains("KEY")
+    })
+}
+
+pub(super) fn write_service_file(path: &Path, content: &str, sensitive: bool) -> Result<()> {
+    std::fs::write(path, content)?;
+    if sensitive {
+        let mut permissions = std::fs::metadata(path)?.permissions();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            permissions.set_mode(0o600);
+        }
+        std::fs::set_permissions(path, permissions)?;
+    }
+    Ok(())
+}
 
 pub fn install(force: bool, no_interactive: bool) -> Result<(), Box<dyn std::error::Error>> {
     let config = LfdConfig::load()?;


### PR DESCRIPTION
## Usage

```bash
export LFD_HTTP_ADDR=0.0.0.0:2486
export LFD_AUTH_TOKEN=$(openssl rand -hex 32)
lfd install --force
```

## Summary

`lfd install` now persists selected `LFD_*` environment variables into the generated launchd (macOS) and systemd (Linux) service files, so a self-hosted native remote daemon keeps its remote bind address, auth token, and other settings across restarts without hand-editing the unit. Service files containing token-like values are written with owner-only (`0600`) permissions.

## Changes

- New shared helpers in `service/mod.rs`: `service_environment` collects a curated allowlist of `LFD_*` keys (plus `PATH`) from the environment, `contains_sensitive_service_env` flags token/secret/key values, and `write_service_file` applies `0600` permissions when sensitive.
- macOS: `render_plist` emits all collected env vars into `EnvironmentVariables`, with XML escaping for keys and values.
- Linux: new `render_unit` emits one `Environment="NAME=value"` line per var, with systemd quote/backslash escaping.
- Tests cover environment persistence and escaping for both plist and unit rendering.
- `docs/lfd.md` documents configuring a native remote daemon via `LFD_*` env vars and the owner-only permissions behavior.