### PR TITLE
wave: codify release infra operating goal

### DIFF
--- a/release/unreleased/DECISIONS.md
+++ b/release/unreleased/DECISIONS.md
@@ -227,3 +227,11 @@ built-in commands — skills fire there with `$step`.
 **Decision:** Continue autonomous release-infra iteration until actual or projected automation spend would exceed $100/month. Card/bank transactions are the source of truth; AWS, Fly.io, Claude/Anthropic, OpenAI/Codex, OpenCode, Doppler, and release-host services should use the company card when the vendor supports card billing.
 
 **Implications:** Cost tracking is part of release infrastructure, not bookkeeping after the fact. Provider dashboards can warn early, but the monthly budget gate is enforced from transaction exports/API data. Spending above the threshold requires human approval before proceeding.
+
+## 2026-06-30 — Release infra is measured by cadence, host health, and budget
+
+**Context:** The release-infra work had become several intertwined threads: nightly package checks, weekly releases, local `lf` refresh, a self-hosted `lfd` cron host, Cadenza production deployment, and cost controls. Without a written operating contract, progress was easy to mistake for whichever deployment task happened most recently.
+
+**Decision:** Treat the goal as one release system with explicit measures: nightly package verification green, weekly release gated by that verification, local refresh as one command, self-hosted cron host reachable and observable, and automation/runtime spend under $100/month. Loopflow owns the primitives and cron host; Cadenza mirrors the cadence and proves the product-repo deployment shape. Secrets stay in Doppler or host-local env; private host details stay out of public repos.
+
+**Implications:** The next Loopflow work should prioritize local `lf`/`lfd` refresh and the self-hosted cron host before adding more product-specific deployment features. Any attempt to introduce a global studio-hosted default server is out of scope unless explicitly re-decided. Cost above $100/month is the next true human blocker.

--- a/wave/root/README.md
+++ b/wave/root/README.md
@@ -25,8 +25,8 @@ wave: root
 
 ## Current priorities
 
-1. **`review-open-work-and-garden-parity`** — manual and automated status passes should read as one system
-2. **Release automation spine** — daily verification, weekly publishing, and self-hosted cron hosting should stay visible as one operating rhythm
+1. **Release infra and cron host** — nightly/weekly release cadence, local updater, maintained self-hosted `lfd`, and budget guardrails
+2. **`review-open-work-and-garden-parity`** — manual and automated status passes should read as one system
 3. **Calendar rhythm that earns trust** — scheduled scans need to be current enough to matter and quiet enough not to create noise
 4. **Mutation review that stays human-sized** — root should propose reviewable adjustments, not dump a strategy deck into a PR
 
@@ -47,4 +47,4 @@ wave: root
 
 ## What success looks like
 
-Open Concerto in the morning and get the full picture in one pass: shipped work, blocked work, mutation proposals, calibration checkpoints, and anything that needs a human. Root is doing its job when that ritual feels obvious and the next action is clear.
+Open Concerto in the morning and get the full picture in one pass: shipped work, blocked work, release health, cron-host health, mutation proposals, calibration checkpoints, and anything that needs a human. Root is doing its job when that ritual feels obvious and the next action is clear.

--- a/wave/workflows/0-release-infra-and-cron-host.md
+++ b/wave/workflows/0-release-infra-and-cron-host.md
@@ -1,0 +1,65 @@
+# Release infra and cron host
+
+**Finish line:** Loopflow and Cadenza share one boring release system: nightly package verification, weekly release, hotfix release, local binary refresh, and a maintained self-hosted Loopflow cron host. The cadence is identical across repos; only repo-specific commands differ.
+
+## Goal
+
+Make releases routine enough that the system can ship without a human reconstructing state from chat history.
+
+Loopflow owns the primitives and the cron host. Cadenza proves the product-repo shape: Fly app runtime, Neon Postgres, Doppler secrets, cheap production, and explicit admin/debug tooling. The two repos should feel carbon-copy where cadence and operations matter, even when build matrices differ.
+
+## Measures
+
+- **Nightly package verification is green** — official artifacts build, install/extract, and pass smoke commands without deploying anywhere.
+- **Weekly release is gated** — publishing only happens after the same package verification passes in that workflow run and commits exist since the last tag.
+- **Local refresh is one command** — a developer can pull the latest default-branch `lf`/`lfd` into a local bin path without remembering build internals.
+- **Cron host is reachable and observable** — a self-hosted `lfd` runs scheduled flows, exposes health/log/admin checks, and can be updated predictably.
+- **Cost stays under the standing budget** — automation/runtime spend remains under $100/month; crossing that line is the human blocker.
+- **Secrets stay out of source** — committed infra describes topology and mechanics; Doppler or host-local env carries credentials.
+
+## Process and cadence
+
+| Cadence | What runs | Publishes? | Evidence |
+|---------|-----------|------------|----------|
+| Nightly | Build official packages and run smoke checks | No | workflow run + artifact smoke log |
+| Weekly | Nightly-style verification, then release/tag when there are commits | Yes | release notes + tag + package checks |
+| Hotfix | Manual release path with the same verification gate | Yes | PR/incident note + tag |
+| Local refresh | Pull default branch, build, atomically replace local binaries/apps | Local only | script output |
+| Cron host refresh | Pull default branch, restart host services, run health checks | No | admin log |
+
+Run a Mitchell Hashimoto-style simulated review for each unit of work before calling it done. Findings either get fixed immediately or recorded in PR notes.
+
+## Roadmap
+
+1. **Codify the operating contract** — keep `release/SCHEDULE.md`, wave metadata, and PR notes aligned with the shared cadence.
+2. **Get local Loopflow current** — make `scripts/pull-local-bin.sh` the single path for refreshing local `lf`/`lfd` from default branch.
+3. **Bring up the self-hosted cron host** — run `lfd` on a maintained private host, keep it awake/reachable, and expose health/log/admin commands without committing private host details.
+4. **Schedule verification** — wire nightly package verification and weekly release workflows for Loopflow and Cadenza with matching cron semantics.
+5. **Budget reporting** — produce a simple monthly spend view across Fly, AWS, and agent/tooling providers where APIs allow it; stop before exceeding $100/month.
+6. **Remote execution** — support secure remote Loopflow execution against the self-hosted host, scoped to self-hosting rather than a global studio server.
+
+## Boundaries
+
+### In scope
+
+- Loopflow `lfd` self-hosting primitives
+- GitHub Actions release cadence
+- Local binary/app updater scripts
+- Doppler-backed deploy/admin scripts
+- Cost guardrails and budget reporting
+- Cadenza parity where it proves the shared release shape
+
+### Out of scope
+
+- A studio-operated default global server
+- Publicly committed private hostnames, Tailscale IPs, service tokens, or personal machine details
+- Provider abstractions that do not serve an immediate deployed path
+- Replacing vendor IDE/chat surfaces
+
+## Done when
+
+- Loopflow and Cadenza both carry the shared nightly/weekly release workflow shape.
+- Local `lf`/`lfd` refresh is one command and used by default.
+- A self-hosted `lfd` runs scheduled flows from a maintained host with documented admin/debug commands.
+- Release status and scheduled automation show up in the same wave/run vocabulary as garden/govern work.
+- Cost reporting is boring enough to run monthly without spelunking dashboards.

--- a/wave/workflows/README.md
+++ b/wave/workflows/README.md
@@ -5,6 +5,7 @@ surfaces that expose all of that coherently.
 
 ## Tasks
 
+0. **`release-infra-and-cron-host`** (p0) — shared Loopflow/Cadenza release cadence, local updater, self-hosted `lfd` cron host, and budget guardrails
 1. **`daily-garden-cycle`** (p1) — root runs a scheduled garden pass and
    produces reviewable mutation PRs
 2. **`continuous-build-loop`** (p1) — loop-mode waves ingest from PM, ship work,
@@ -38,3 +39,4 @@ surfaces that expose all of that coherently.
   primary path. `npx/*` and `rams/*` stay on the assembled-prompt fallback until
   external skill namespace semantics are designed.
 - Scheduled automation is only useful if the outputs stay reviewable and calm
+- Release infrastructure spans Loopflow and Cadenza; shared cadence belongs here, while repo-specific deploy mechanics stay in each repo


### PR DESCRIPTION
## Summary

This branch promotes release infrastructure to a first-class, written operating contract for the wave. Previously the release work was several intertwined threads — nightly package checks, weekly releases, local `lf`/`lfd` refresh, a self-hosted `lfd` cron host, Cadenza deployment, and cost controls — with no single document defining what "done" or "healthy" means. This adds that contract so progress is measured by cadence, host health, and budget rather than by whichever deploy task happened most recently.

## Changes

- **New workflow goal** `wave/workflows/0-release-infra-and-cron-host.md` (p0) — defines the finish line, measures (nightly verification green, gated weekly release, one-command local refresh, reachable/observable cron host, sub-$100/month spend, secrets out of source), a cadence table, roadmap, in/out-of-scope boundaries, and done-when criteria. Loopflow owns the primitives and cron host; Cadenza mirrors the cadence to prove the product-repo shape.
- **Decision logged** in `release/unreleased/DECISIONS.md` (2026-06-30) — treat release infra as one system with explicit measures; prioritize local refresh and the self-hosted cron host before more product-specific deploy features; a global studio-hosted default server is explicitly out of scope.
- **Root priorities reordered** in `wave/root/README.md` — "Release infra and cron host" becomes priority 1, and the morning Concerto status pass now includes release health and cron-host health.
- **Workflows index** updated to list the new p0 task and note that shared release cadence belongs at the wave level while repo-specific deploy mechanics stay in each repo.