### PR TITLE
deploy: harden private lfd host bootstrap

### DIFF
--- a/deploy/PRIVATE_HOST.md
+++ b/deploy/PRIVATE_HOST.md
@@ -66,7 +66,7 @@ After `LFD_AUTH_TOKEN` exists on the host, run locally:
 ```bash
 deploy/setup-private-client.sh --host "$LFD_HOST" --ssh-user "$LFD_SSH_USER" --token "$LFD_AUTH_TOKEN"
 source ~/.lf/private-host.env
-lfq status
+lfq list
 ```
 
 The setup script writes:
@@ -103,7 +103,7 @@ Claude and Codex sessions run inside `lfd` executor containers when waves or ses
 source ~/.lf/private-host.env
 curl -f "$LFD_URL/health"
 curl -H "Authorization: Bearer $LFD_TOKEN" "$LFD_URL/status"
-lfq status
+lfq list
 uv run python scripts/test_remote_smoke.py --url "$LFD_URL" --token "$LFD_TOKEN" --repo /Users/jack/src/loopflow --insecure
 ```
 
@@ -125,6 +125,6 @@ From this Mac:
 
 ```bash
 source ~/.lf/private-host.env
-lfq status
+lfq list
 ssh "$LFD_SSH_USER@$LFD_HOST" 'cd ~/src/loopflow && deploy/loopflow-server.sh status'
 ```

--- a/deploy/bootstrap-cron-host.sh
+++ b/deploy/bootstrap-cron-host.sh
@@ -143,19 +143,28 @@ install_mac_launch_agent() {
     local dest="$HOME/Library/LaunchAgents/loopflow.server.plist"
     mkdir -p "$(dirname "$dest")"
     cp "$repo/deploy/launchd/loopflow.server.plist" "$dest"
-    plutil -replace ProgramArguments.0 -string "$repo/deploy/loopflow-server.sh" "$dest"
-    python3 - "$dest" <<'PY_PLIST'
+    python3 - "$dest" "$repo/deploy/loopflow-server.sh" <<'PY_PLIST'
 import os
 import plistlib
 import sys
 from pathlib import Path
 
 path = Path(sys.argv[1])
+server_script = sys.argv[2]
 with path.open("rb") as handle:
     data = plistlib.load(handle)
 
+data["ProgramArguments"] = [server_script, "up"]
+
 env = data.setdefault("EnvironmentVariables", {})
-for name in ["DOPPLER_TOKEN", "LOOPFLOW_SECRETS", "LF_DOMAIN", "LF_TLS_MODE", "LFD_AUTH_TOKEN", "LFD_PORT"]:
+env.setdefault(
+    "PATH",
+    os.environ.get(
+        "PATH",
+        "/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin",
+    ),
+)
+for name in ["DOPPLER_TOKEN", "DOCKER_CONFIG", "DOCKER_HOST", "LOOPFLOW_SECRETS", "LF_DOMAIN", "LF_TLS_MODE", "LFD_AUTH_TOKEN", "LFD_PORT"]:
     value = os.environ.get(name)
     if value:
         env[name] = value

--- a/deploy/setup-private-client.sh
+++ b/deploy/setup-private-client.sh
@@ -18,7 +18,7 @@ Options:
   --token-file PATH  Read bearer token from PATH.
   --env-file PATH    Write shell exports here (default: ~/.lf/private-host.env)
   --no-concerto      Do not seed Concerto UserDefaults/Keychain.
-  --verify           Run lfq status after writing local config.
+  --verify           Run lfq list after writing local config.
   -h, --help         Show this help.
 
 The env file contains secrets and is written with 0600 permissions.
@@ -189,5 +189,7 @@ fi
 if [[ "$verify" -eq 1 ]]; then
     # shellcheck disable=SC1090
     source "$env_file"
-    lfq status
+    lfq list >/dev/null
+    curl -fsS -H "Authorization: Bearer $LFD_TOKEN" "$LFD_URL/status" >/dev/null
+    echo "verified private lfd connection"
 fi

--- a/python/tests/test_release_automation.py
+++ b/python/tests/test_release_automation.py
@@ -180,6 +180,10 @@ def test_self_hosted_server_primitives_are_documented_and_runnable():
     assert "is required for cron-host bootstrap" in bootstrap
     assert "systemctl enable --now loopflow-server.service" in bootstrap
     assert "launchctl bootstrap" in bootstrap
+    assert 'data["ProgramArguments"] = [server_script, "up"]' in bootstrap
+    assert '"PATH"' in bootstrap
+    assert '"DOCKER_CONFIG"' in bootstrap
+    assert '"DOCKER_HOST"' in bootstrap
     assert "lfq create root" in bootstrap
     assert "install -m 0600" in bootstrap
 
@@ -189,6 +193,9 @@ def test_self_hosted_server_primitives_are_documented_and_runnable():
     assert "loopflow.connection.token" in private_client
     assert "concerto.connectionSettings.v2" in private_client
     assert "alias lfdhost='ssh" in private_client
+    assert "lfq list >/dev/null" in private_client
+    assert 'curl -fsS -H "Authorization: Bearer $LFD_TOKEN" "$LFD_URL/status"' in private_client
+    assert "lfq status" not in private_client
 
     service = (ROOT / "deploy/systemd/loopflow-server.service").read_text()
     assert "ExecStart=/opt/loopflow/deploy/loopflow-server.sh up" in service

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -48,9 +48,9 @@ loopflow_detect_container_mode() {
     local timeout_s
     timeout_s="$(awk "BEGIN {printf \"%.1f\", $(loopflow_status_timeout_ms) / 1000}")"
     if loopflow_has_cmd timeout; then
-        timeout "$timeout_s" lfq status >/dev/null 2>&1
+        timeout "$timeout_s" lfq list >/dev/null 2>&1
     else
-        lfq status >/dev/null 2>&1
+        lfq list >/dev/null 2>&1
     fi
 }
 

--- a/scripts/lfd-up.sh
+++ b/scripts/lfd-up.sh
@@ -28,14 +28,14 @@ _lf_up_msg() {
 _lf_up_health_gate() {
     local attempts=0 max_attempts=60  # 60 * 250ms = 15s
     while (( attempts < max_attempts )); do
-        if lfq status >/dev/null 2>&1; then
+        if lfq list >/dev/null 2>&1; then
             _lf_up_msg "ready"
             return 0
         fi
         (( attempts++ ))
         sleep 0.25
     done
-    _lf_up_msg "timeout waiting for lfd health -- check: lfd status"
+    _lf_up_msg "timeout waiting for lfd health -- check: lfq list or lfd status"
     return 1
 }
 
@@ -60,7 +60,7 @@ main() {
     fi
 
     # Step 3: Start daemon if not running
-    if ! lfq status >/dev/null 2>&1; then
+    if ! lfq list >/dev/null 2>&1; then
         _lf_up_msg "starting lfd..."
         lfd start
     fi

--- a/scripts/loopflow-status.sh
+++ b/scripts/loopflow-status.sh
@@ -75,9 +75,9 @@ generate_container_status() {
     # Check daemon health first
     local lfq_ok=false
     if loopflow_has_cmd timeout; then
-        timeout "$timeout_s" lfq status >/dev/null 2>&1 && lfq_ok=true
+        timeout "$timeout_s" lfq list >/dev/null 2>&1 && lfq_ok=true
     else
-        lfq status >/dev/null 2>&1 && lfq_ok=true
+        lfq list >/dev/null 2>&1 && lfq_ok=true
     fi
 
     if [[ "$lfq_ok" != true ]]; then


### PR DESCRIPTION
## Usage

```bash
# On the cron host
deploy/bootstrap-cron-host.sh

# Locally, point a client at the private host
deploy/setup-private-client.sh --host "$LFD_HOST" --ssh-user "$LFD_SSH_USER" --token "$LFD_AUTH_TOKEN" --verify
source ~/.lf/private-host.env
lfq list
```

## Summary

Tightens the self-hosted private `lfd` deployment path so the launch agent starts reliably and client setup actually proves the connection works. The macOS launch agent now gets an explicit `ProgramArguments` of `[server_script, "up"]` plus a sane `PATH` and Docker env (`DOCKER_CONFIG`, `DOCKER_HOST`) so it can find Homebrew tooling and reach the Docker daemon when launched outside an interactive shell. Client setup's `--verify` now does a real health check instead of a bare status call. Throughout, the deprecated `lfq status` invocation is replaced with `lfq list`.

## Changes

- `bootstrap-cron-host.sh`: build the launch agent plist in one Python step that sets `ProgramArguments` to run `loopflow-server.sh up`, seeds `PATH`, and forwards `DOCKER_CONFIG`/`DOCKER_HOST` alongside the existing secret env vars.
- `setup-private-client.sh`: `--verify` now runs `lfq list` and curls the authenticated `/status` endpoint, printing a confirmation on success.
- Replace `lfq status` with `lfq list` across `helpers.sh`, `lfd-up.sh`, `loopflow-status.sh`, docs, and help text.
- Extend `test_release_automation.py` to assert the new bootstrap and client-verify primitives are present.
