### PR TITLE
deploy: add native mac lfd host manager

### DIFF
--- a/deploy/PRIVATE_HOST.md
+++ b/deploy/PRIVATE_HOST.md
@@ -32,7 +32,7 @@ ssh "$LFD_SSH_USER@$LFD_HOST"
 
 If the CLI shim is stale, call the app binary directly. Local machines may have stale Tailscale shims after app renames or reinstalls.
 
-## Bootstrap lfd on the host
+## Bootstrap native lfd on the host
 
 On the host:
 
@@ -41,12 +41,10 @@ mkdir -p ~/src
 git clone https://github.com/loopflowstudio/loopflow.git ~/src/loopflow
 cd ~/src/loopflow
 
-export LF_DOMAIN="$LFD_HOST"
-export LF_TLS_MODE=internal
+export LFD_HTTP_ADDR=0.0.0.0:2486
 export LFD_AUTH_TOKEN=$(openssl rand -hex 32)
-export LFD_EXECUTOR_CREDENTIALS_MOUNTS=claude,codex,ssh
 
-deploy/bootstrap-cron-host.sh --host mac
+deploy/native-lfd-host.sh install
 ```
 
 Use Doppler for maintained secrets once the host is reachable:
@@ -57,7 +55,7 @@ doppler secrets set LFD_AUTH_TOKEN="$LFD_AUTH_TOKEN"
 doppler secrets set LFD_EXECUTOR_CREDENTIALS_MOUNTS=claude,codex,ssh
 ```
 
-The launch agent keeps the stack up. Docker Desktop must be running.
+The launch agent keeps native `lfd` up. Docker Desktop is not required for the native service. Use `deploy/bootstrap-cron-host.sh` only when you explicitly want the Docker Compose stack.
 
 ## Configure this Mac as a client
 
@@ -115,10 +113,10 @@ On the host:
 
 ```bash
 cd ~/src/loopflow
-deploy/loopflow-server.sh status
-deploy/loopflow-server.sh logs
-deploy/loopflow-server.sh update
-launchctl print gui/$(id -u)/loopflow.server
+deploy/native-lfd-host.sh status
+deploy/native-lfd-host.sh logs
+deploy/native-lfd-host.sh update
+launchctl print gui/$(id -u)/com.loopflow.lfd
 ```
 
 From this Mac:
@@ -126,5 +124,5 @@ From this Mac:
 ```bash
 source ~/.lf/private-host.env
 lfq list
-ssh "$LFD_SSH_USER@$LFD_HOST" 'cd ~/src/loopflow && deploy/loopflow-server.sh status'
+ssh "$LFD_SSH_USER@$LFD_HOST" 'cd ~/src/loopflow && deploy/native-lfd-host.sh status'
 ```

--- a/deploy/native-lfd-host.sh
+++ b/deploy/native-lfd-host.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+# Manage a native macOS self-hosted lfd service.
+# Use this for private Mac/Tailscale hosts where Docker Compose is not the desired runtime.
+
+set -euo pipefail
+
+usage() {
+    cat >&2 <<'USAGE'
+Usage: native-lfd-host.sh [--repo PATH] [--install-dir PATH] <install|update|restart|status|logs|health>
+
+Commands:
+  install   Build/install lf+lfd, install launchd service, and wait for health
+  update    Pull default branch, rebuild/install lf+lfd, restart service, and wait for health
+  restart   Restart the launchd lfd service and wait for health
+  status    Show launchd service state and local daemon status
+  logs      Tail native lfd launchd logs
+  health    Check local daemon health and authenticated status when token is available
+
+Environment:
+  LFD_HTTP_ADDR=0.0.0.0:2486      listen address for remote/private clients
+  LFD_AUTH_TOKEN=...              required for install/update/restart on non-loopback hosts
+  LFD_PORT=2486                   health-check port derived from LFD_HTTP_ADDR when unset
+USAGE
+}
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo="$(cd "$script_dir/.." && pwd)"
+install_dir="${LF_INSTALL_DIR:-$HOME/.local/bin}"
+command=""
+label="com.loopflow.lfd"
+plist="$HOME/Library/LaunchAgents/$label.plist"
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --repo)
+            repo="$2"
+            shift 2
+            ;;
+        --repo=*)
+            repo="${1#--repo=}"
+            shift
+            ;;
+        --install-dir)
+            install_dir="$2"
+            shift 2
+            ;;
+        --install-dir=*)
+            install_dir="${1#--install-dir=}"
+            shift
+            ;;
+        install|update|restart|status|logs|health)
+            command="$1"
+            shift
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "unknown argument: $1" >&2
+            usage
+            exit 1
+            ;;
+    esac
+done
+
+if [[ -z "$command" ]]; then
+    usage
+    exit 1
+fi
+
+repo="$(git -C "$repo" rev-parse --show-toplevel)"
+install_dir="$(mkdir -p "$install_dir" && cd "$install_dir" && pwd)"
+lfd_bin="$install_dir/lfd"
+http_addr="${LFD_HTTP_ADDR:-0.0.0.0:${LFD_PORT:-2486}}"
+port="${LFD_PORT:-${http_addr##*:}}"
+log_out="/tmp/lfd.out.log"
+log_err="/tmp/lfd.err.log"
+
+require_token() {
+    if [[ -z "${LFD_AUTH_TOKEN:-}" ]]; then
+        echo "LFD_AUTH_TOKEN is required for native private lfd host management" >&2
+        exit 1
+    fi
+}
+
+service_target() {
+    echo "gui/$(id -u)/$label"
+}
+
+install_bins() {
+    "$repo/scripts/pull-local-bin.sh" --repo "$repo" --install-dir "$install_dir" "$@"
+}
+
+wait_for_health() {
+    local attempts=60
+    until curl -fsS "http://127.0.0.1:$port/health" >/dev/null 2>&1; do
+        attempts=$((attempts - 1))
+        if [[ "$attempts" -le 0 ]]; then
+            echo "native lfd did not become healthy" >&2
+            echo "Run: $0 logs" >&2
+            exit 1
+        fi
+        sleep 1
+    done
+}
+
+install_service() {
+    require_token
+    if [[ ! -x "$lfd_bin" ]]; then
+        echo "missing lfd binary: $lfd_bin" >&2
+        exit 1
+    fi
+    LFD_HTTP_ADDR="$http_addr" LFD_AUTH_TOKEN="$LFD_AUTH_TOKEN" "$lfd_bin" install --force
+}
+
+restart_service() {
+    require_token
+    launchctl kickstart -k "$(service_target)" >/dev/null 2>&1 || {
+        echo "failed to restart $label; run install first" >&2
+        exit 1
+    }
+    wait_for_health
+}
+
+health() {
+    curl -fsS "http://127.0.0.1:$port/health"
+    echo
+    if [[ -n "${LFD_AUTH_TOKEN:-}" ]]; then
+        curl -fsS -H "Authorization: Bearer $LFD_AUTH_TOKEN" "http://127.0.0.1:$port/status"
+        echo
+    fi
+}
+
+case "$command" in
+    install)
+        install_bins
+        install_service
+        wait_for_health
+        health
+        ;;
+    update)
+        install_bins
+        restart_service
+        health
+        ;;
+    restart)
+        restart_service
+        health
+        ;;
+    status)
+        launchctl print "$(service_target)" 2>/dev/null || true
+        health || true
+        ;;
+    logs)
+        tail -f "$log_out" "$log_err"
+        ;;
+    health)
+        health
+        ;;
+esac

--- a/python/tests/test_release_automation.py
+++ b/python/tests/test_release_automation.py
@@ -124,6 +124,12 @@ def test_self_hosted_server_primitives_are_documented_and_runnable():
         text=True,
         capture_output=True,
     )
+    native_host_help = subprocess.run(
+        [str(ROOT / "deploy/native-lfd-host.sh"), "--help"],
+        check=True,
+        text=True,
+        capture_output=True,
+    )
 
     assert "up|update|down|status|logs|health" in help_result.stderr
     assert "LOOPFLOW_SECRETS=auto|doppler|env" in help_result.stderr
@@ -134,6 +140,9 @@ def test_self_hosted_server_primitives_are_documented_and_runnable():
     assert "setup-private-client.sh" in private_client_help.stderr
     assert "--token-file PATH" in private_client_help.stderr
     assert "--no-concerto" in private_client_help.stderr
+    assert "native-lfd-host.sh" in native_host_help.stderr
+    assert "install|update|restart|status|logs|health" in native_host_help.stderr
+    assert "LFD_HTTP_ADDR=0.0.0.0:2486" in native_host_help.stderr
 
     readme = (ROOT / "deploy/README.md").read_text()
     assert "doppler secrets set LFD_AUTH_TOKEN" in readme
@@ -154,6 +163,8 @@ def test_self_hosted_server_primitives_are_documented_and_runnable():
     assert "<tailscale-host-or-ip>" in private_readme
     assert "http://<tailscale-host-or-ip>:2486" in private_readme
     assert "deploy/setup-private-client.sh --host" in private_readme
+    assert "deploy/native-lfd-host.sh install" in private_readme
+    assert "Docker Desktop is not required for the native service" in private_readme
     assert "ssh-remote+$LFD_SSH_USER@$LFD_HOST" in private_readme
     assert "LFD_EXECUTOR_CREDENTIALS_MOUNTS=claude,codex,ssh" in private_readme
 
@@ -186,6 +197,12 @@ def test_self_hosted_server_primitives_are_documented_and_runnable():
     assert '"DOCKER_HOST"' in bootstrap
     assert "lfq create root" in bootstrap
     assert "install -m 0600" in bootstrap
+
+    native_host = (ROOT / "deploy/native-lfd-host.sh").read_text()
+    assert "scripts/pull-local-bin.sh" in native_host
+    assert "install --force" in native_host
+    assert "launchctl kickstart -k" in native_host
+    assert "LFD_AUTH_TOKEN is required for native private lfd host management" in native_host
 
     private_client = (ROOT / "deploy/setup-private-client.sh").read_text()
     assert "Host is required. Pass --host or set LFD_HOST." in private_client

--- a/release/unreleased/DECISIONS.md
+++ b/release/unreleased/DECISIONS.md
@@ -235,3 +235,11 @@ built-in commands — skills fire there with `$step`.
 **Decision:** Treat the goal as one release system with explicit measures: nightly package verification green, weekly release gated by that verification, local refresh as one command, self-hosted cron host reachable and observable, and automation/runtime spend under $100/month. Loopflow owns the primitives and cron host; Cadenza mirrors the cadence and proves the product-repo deployment shape. Secrets stay in Doppler or host-local env; private host details stay out of public repos.
 
 **Implications:** The next Loopflow work should prioritize local `lf`/`lfd` refresh and the self-hosted cron host before adding more product-specific deployment features. Any attempt to introduce a global studio-hosted default server is out of scope unless explicitly re-decided. Cost above $100/month is the next true human blocker.
+
+## 2026-06-30 — Mac private cron hosts use native lfd first
+
+**Context:** Bringing up the private Mac host exposed Docker Desktop assumptions that make the container stack a poor first step on macOS: launchd PATH, Docker Desktop context, credential helper behavior, and slow first-run image builds. Native `lfd` already supports launchd, remote bind, and bearer-token auth, and it became healthy with fewer moving parts.
+
+**Decision:** Use native launchd `lfd` as the default Mac private cron-host path. Keep Docker Compose as an explicit self-hosted/container option, especially for Linux or hosts that need container isolation, but do not block the Mac private host on it.
+
+**Implications:** The Mac host runbook centers on `deploy/native-lfd-host.sh`. Secure remote execution still needs a containerized executor story, but daemon availability, wave scheduling, and remote API access should not wait for Docker Compose first-run polish.


### PR DESCRIPTION
## Usage

On the private Mac host:

```bash
cd ~/src/loopflow
export LFD_HTTP_ADDR=0.0.0.0:2486
export LFD_AUTH_TOKEN=$(openssl rand -hex 32)
deploy/native-lfd-host.sh install
```

Manage it later:

```bash
deploy/native-lfd-host.sh status
deploy/native-lfd-host.sh logs
deploy/native-lfd-host.sh update
```

## Summary

Adds `deploy/native-lfd-host.sh` to run a self-hosted `lfd` as a native launchd service on macOS, making it the default path for private Mac/Tailscale cron hosts. Bringing up the Mac host surfaced Docker Desktop friction (launchd PATH, Docker context, credential helpers, slow first-run builds), while native `lfd` already supports launchd, remote bind, and bearer-token auth and becomes healthy with fewer moving parts. Docker Compose remains an explicit option for Linux or container-isolation needs, but the Mac host no longer waits on it.

## Changes

- New `deploy/native-lfd-host.sh` wrapping `install`/`update`/`restart`/`status`/`logs`/`health`, building lf+lfd via `scripts/pull-local-bin.sh`, installing the `com.loopflow.lfd` launchd agent, and polling `/health`
- `deploy/PRIVATE_HOST.md` bootstrap and ops sections rewritten around the native service (Docker Desktop no longer required)
- Release `DECISIONS.md` records the native-first choice for Mac private cron hosts
- Release automation test asserts the new script's help text, runbook references, and key behaviors