### PR TITLE
scripts: make local binary refresh ignore pull config

### DIFF
--- a/python/tests/test_release_automation.py
+++ b/python/tests/test_release_automation.py
@@ -105,6 +105,16 @@ chmod +x "$repo/target/release/lf" "$repo/target/release/lfd"
     assert "build --release -p loopflow --bin lf --bin lfd" in cargo_log.read_text()
 
 
+def test_pull_local_bin_fetches_then_merges_without_user_pull_config():
+    script = (ROOT / "scripts/pull-local-bin.sh").read_text()
+
+    assert 'git -C "$repo" fetch origin "$default_branch"' in script
+    assert 'git -C "$repo" merge --ff-only "origin/$default_branch"' in script
+    assert 'git -C "$repo" fetch' in script
+    assert 'git -C "$repo" merge --ff-only "@{upstream}"' in script
+    assert 'git -C "$repo" pull --ff-only' not in script
+
+
 def test_self_hosted_server_primitives_are_documented_and_runnable():
     help_result = subprocess.run(
         [str(ROOT / "deploy/loopflow-server.sh"), "--help"],

--- a/scripts/pull-local-bin.sh
+++ b/scripts/pull-local-bin.sh
@@ -79,9 +79,11 @@ if [[ "$pull" == true ]]; then
 
     echo "pulling $repo"
     if [[ -n "$default_branch" ]]; then
-        git -C "$repo" pull --ff-only origin "$default_branch"
+        git -C "$repo" fetch origin "$default_branch"
+        git -C "$repo" merge --ff-only "origin/$default_branch"
     else
-        git -C "$repo" pull --ff-only
+        git -C "$repo" fetch
+        git -C "$repo" merge --ff-only "@{upstream}"
     fi
 fi
 


### PR DESCRIPTION
## Usage

```bash
scripts/pull-local-bin.sh
```

## Summary

The local binary refresh script used `git pull --ff-only`, which honors a user's `pull.rebase`/`pull.ff` config and can fail or rebase unexpectedly depending on local settings. This splits the pull into an explicit `fetch` followed by `merge --ff-only`, so the refresh behaves the same regardless of the user's git pull configuration.

## Changes

- `scripts/pull-local-bin.sh`: replace `git pull --ff-only` with `git fetch` + `git merge --ff-only` for both the named-default-branch and upstream-tracking paths.
- Add a test asserting the script fetches then fast-forward merges and no longer calls `git pull --ff-only`.