### PR TITLE
deploy: schedule native lfd host updates

### DIFF
--- a/deploy/PRIVATE_HOST.md
+++ b/deploy/PRIVATE_HOST.md
@@ -43,6 +43,9 @@ cd ~/src/loopflow
 
 export LFD_HTTP_ADDR=0.0.0.0:2486
 export LFD_AUTH_TOKEN=$(openssl rand -hex 32)
+mkdir -p ~/.lf
+printf '%s\n' "$LFD_AUTH_TOKEN" > ~/.lf/lfd-token
+chmod 600 ~/.lf/lfd-token
 
 deploy/native-lfd-host.sh install
 ```
@@ -55,7 +58,7 @@ doppler secrets set LFD_AUTH_TOKEN="$LFD_AUTH_TOKEN"
 doppler secrets set LFD_EXECUTOR_CREDENTIALS_MOUNTS=claude,codex,ssh
 ```
 
-The launch agent keeps native `lfd` up. Docker Desktop is not required for the native service. Use `deploy/bootstrap-cron-host.sh` only when you explicitly want the Docker Compose stack.
+The launch agent keeps native `lfd` up. A second `com.loopflow.lfd.update` launch agent runs `deploy/native-lfd-host.sh update` at 04:30 host-local time and reads the token from `~/.lf/lfd-token` through `LFD_AUTH_TOKEN_FILE`; the bearer token is not embedded in the plist. Docker Desktop is not required for the native service. Use `deploy/bootstrap-cron-host.sh` only when you explicitly want the Docker Compose stack.
 
 ## Configure this Mac as a client
 
@@ -116,7 +119,9 @@ cd ~/src/loopflow
 deploy/native-lfd-host.sh status
 deploy/native-lfd-host.sh logs
 deploy/native-lfd-host.sh update
+deploy/native-lfd-host.sh install-update-agent
 launchctl print gui/$(id -u)/com.loopflow.lfd
+launchctl print gui/$(id -u)/com.loopflow.lfd.update
 ```
 
 From this Mac:

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -72,7 +72,7 @@ deploy/bootstrap-cron-host.sh --host linux
 
 Use Doppler for maintained hosts. On Linux the bootstrap writes `/etc/loopflow-server.env` with `0600` permissions so systemd can reach either `DOPPLER_TOKEN` or host-local fallback secrets. On macOS it writes the same launch environment into `~/Library/LaunchAgents/loopflow.server.plist`; prefer a Doppler service token over embedding long-lived provider credentials there.
 
-The update timer refreshes Linux hosts nightly. The macOS launch agent checks the stack every five minutes. Keep local dev binaries fresh with `scripts/pull-local-bin.sh`; server restarts should be predictable.
+The Linux update timer refreshes container hosts nightly. The native macOS private-host path installs `com.loopflow.lfd.update`, which refreshes the repo, rebuilds local binaries, and restarts `lfd` at 04:30 host-local time. Keep local dev binaries fresh with `scripts/pull-local-bin.sh`; server restarts should be predictable.
 
 ## Manual Linux service install
 
@@ -88,6 +88,19 @@ sudo systemctl enable --now loopflow-server-update.timer
 ```
 
 ## Manual Mac mini + Tailscale install
+
+```bash
+export LFD_HTTP_ADDR=0.0.0.0:2486
+export LFD_AUTH_TOKEN=$(openssl rand -hex 32)
+mkdir -p ~/.lf
+printf '%s\n' "$LFD_AUTH_TOKEN" > ~/.lf/lfd-token
+chmod 600 ~/.lf/lfd-token
+deploy/native-lfd-host.sh install
+```
+
+The native install does not require Docker Desktop. It installs the `com.loopflow.lfd` service and `com.loopflow.lfd.update` nightly update agent.
+
+Use the Docker Compose launchd path only when you explicitly want the container stack:
 
 ```bash
 mkdir -p ~/Library/LaunchAgents

--- a/deploy/native-lfd-host.sh
+++ b/deploy/native-lfd-host.sh
@@ -6,19 +6,21 @@ set -euo pipefail
 
 usage() {
     cat >&2 <<'USAGE'
-Usage: native-lfd-host.sh [--repo PATH] [--install-dir PATH] <install|update|restart|status|logs|health>
+Usage: native-lfd-host.sh [--repo PATH] [--install-dir PATH] <install|install-update-agent|update|restart|status|logs|health>
 
 Commands:
-  install   Build/install lf+lfd, install launchd service, and wait for health
-  update    Pull default branch, rebuild/install lf+lfd, restart service, and wait for health
-  restart   Restart the launchd lfd service and wait for health
-  status    Show launchd service state and local daemon status
-  logs      Tail native lfd launchd logs
-  health    Check local daemon health and authenticated status when token is available
+  install              Build/install lf+lfd, install launchd service/update agent, and wait for health
+  install-update-agent Install the nightly launchd update agent
+  update               Pull default branch, rebuild/install lf+lfd, restart service, and wait for health
+  restart              Restart the launchd lfd service and wait for health
+  status               Show launchd service/update-agent state and local daemon status
+  logs                 Tail native lfd launchd logs
+  health               Check local daemon health and authenticated status when token is available
 
 Environment:
   LFD_HTTP_ADDR=0.0.0.0:2486      listen address for remote/private clients
   LFD_AUTH_TOKEN=...              required for install/update/restart on non-loopback hosts
+  LFD_AUTH_TOKEN_FILE=~/.lf/lfd-token token file used when LFD_AUTH_TOKEN is unset
   LFD_PORT=2486                   health-check port derived from LFD_HTTP_ADDR when unset
 USAGE
 }
@@ -28,7 +30,10 @@ repo="$(cd "$script_dir/.." && pwd)"
 install_dir="${LF_INSTALL_DIR:-$HOME/.local/bin}"
 command=""
 label="com.loopflow.lfd"
+update_label="com.loopflow.lfd.update"
 plist="$HOME/Library/LaunchAgents/$label.plist"
+update_plist="$HOME/Library/LaunchAgents/$update_label.plist"
+token_file="${LFD_AUTH_TOKEN_FILE:-$HOME/.lf/lfd-token}"
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -48,7 +53,7 @@ while [[ $# -gt 0 ]]; do
             install_dir="${1#--install-dir=}"
             shift
             ;;
-        install|update|restart|status|logs|health)
+        install|install-update-agent|update|restart|status|logs|health)
             command="$1"
             shift
             ;;
@@ -72,20 +77,45 @@ fi
 repo="$(git -C "$repo" rev-parse --show-toplevel)"
 install_dir="$(mkdir -p "$install_dir" && cd "$install_dir" && pwd)"
 lfd_bin="$install_dir/lfd"
+script_path="$repo/deploy/native-lfd-host.sh"
 http_addr="${LFD_HTTP_ADDR:-0.0.0.0:${LFD_PORT:-2486}}"
 port="${LFD_PORT:-${http_addr##*:}}"
-log_out="/tmp/lfd.out.log"
-log_err="/tmp/lfd.err.log"
+log_dir="$HOME/.lf/logs"
+log_out="$log_dir/lfd.log"
+update_log="$log_dir/lfd-update.log"
+
+load_token() {
+    if [[ -z "${LFD_AUTH_TOKEN:-}" && -r "$token_file" ]]; then
+        LFD_AUTH_TOKEN="$(tr -d '\r\n' < "$token_file")"
+        export LFD_AUTH_TOKEN
+    fi
+}
 
 require_token() {
+    load_token
     if [[ -z "${LFD_AUTH_TOKEN:-}" ]]; then
-        echo "LFD_AUTH_TOKEN is required for native private lfd host management" >&2
+        echo "LFD_AUTH_TOKEN or readable LFD_AUTH_TOKEN_FILE is required for native private lfd host management" >&2
         exit 1
+    fi
+}
+
+ensure_token_file() {
+    require_token
+    if [[ ! -r "$token_file" ]]; then
+        mkdir -p "$(dirname "$token_file")"
+        chmod 700 "$(dirname "$token_file")" 2>/dev/null || true
+        umask 077
+        printf '%s\n' "$LFD_AUTH_TOKEN" > "$token_file"
+        chmod 0600 "$token_file"
     fi
 }
 
 service_target() {
     echo "gui/$(id -u)/$label"
+}
+
+update_target() {
+    echo "gui/$(id -u)/$update_label"
 }
 
 install_bins() {
@@ -114,6 +144,47 @@ install_service() {
     LFD_HTTP_ADDR="$http_addr" LFD_AUTH_TOKEN="$LFD_AUTH_TOKEN" "$lfd_bin" install --force
 }
 
+install_update_agent() {
+    ensure_token_file
+    mkdir -p "$(dirname "$update_plist")" "$log_dir"
+    chmod 700 "$HOME/.lf" "$log_dir" 2>/dev/null || true
+    python3 - "$update_plist" "$script_path" "$repo" "$install_dir" "$http_addr" "$token_file" "$update_log" <<'PY'
+import os
+import plistlib
+import sys
+from pathlib import Path
+
+plist_path, script_path, repo, install_dir, http_addr, token_file, log_path = sys.argv[1:]
+data = {
+    "Label": "com.loopflow.lfd.update",
+    "ProgramArguments": [
+        script_path,
+        "--repo",
+        repo,
+        "--install-dir",
+        install_dir,
+        "update",
+    ],
+    "StartCalendarInterval": {
+        "Hour": 4,
+        "Minute": 30,
+    },
+    "StandardOutPath": log_path,
+    "StandardErrorPath": log_path,
+    "EnvironmentVariables": {
+        "PATH": os.environ.get("PATH", ""),
+        "LFD_HTTP_ADDR": http_addr,
+        "LFD_AUTH_TOKEN_FILE": token_file,
+    },
+}
+Path(plist_path).write_bytes(plistlib.dumps(data))
+PY
+    chmod 0600 "$update_plist"
+    launchctl bootout "$(update_target)" >/dev/null 2>&1 || true
+    launchctl bootstrap "gui/$(id -u)" "$update_plist"
+    echo "installed: $update_plist"
+}
+
 restart_service() {
     require_token
     launchctl kickstart -k "$(service_target)" >/dev/null 2>&1 || {
@@ -126,6 +197,7 @@ restart_service() {
 health() {
     curl -fsS "http://127.0.0.1:$port/health"
     echo
+    load_token
     if [[ -n "${LFD_AUTH_TOKEN:-}" ]]; then
         curl -fsS -H "Authorization: Bearer $LFD_AUTH_TOKEN" "http://127.0.0.1:$port/status"
         echo
@@ -136,8 +208,12 @@ case "$command" in
     install)
         install_bins
         install_service
+        install_update_agent
         wait_for_health
         health
+        ;;
+    install-update-agent)
+        install_update_agent
         ;;
     update)
         install_bins
@@ -150,10 +226,11 @@ case "$command" in
         ;;
     status)
         launchctl print "$(service_target)" 2>/dev/null || true
+        launchctl print "$(update_target)" 2>/dev/null || true
         health || true
         ;;
     logs)
-        tail -f "$log_out" "$log_err"
+        tail -f "$log_out" "$update_log"
         ;;
     health)
         health

--- a/python/tests/test_release_automation.py
+++ b/python/tests/test_release_automation.py
@@ -151,14 +151,16 @@ def test_self_hosted_server_primitives_are_documented_and_runnable():
     assert "--token-file PATH" in private_client_help.stderr
     assert "--no-concerto" in private_client_help.stderr
     assert "native-lfd-host.sh" in native_host_help.stderr
-    assert "install|update|restart|status|logs|health" in native_host_help.stderr
+    assert "install|install-update-agent|update|restart|status|logs|health" in native_host_help.stderr
     assert "LFD_HTTP_ADDR=0.0.0.0:2486" in native_host_help.stderr
+    assert "LFD_AUTH_TOKEN_FILE=~/.lf/lfd-token" in native_host_help.stderr
 
     readme = (ROOT / "deploy/README.md").read_text()
     assert "doppler secrets set LFD_AUTH_TOKEN" in readme
     assert "deploy/COSTS.md" in readme
     assert "$100/month" in readme
     assert "openssl rand -hex 32" in readme
+    assert "com.loopflow.lfd.update" in readme
     assert "leave `LF_TLS_MODE` empty" in readme
     assert "Mac mini + Tailscale" in readme
     assert "bootstrap-cron-host.sh" in readme
@@ -174,6 +176,8 @@ def test_self_hosted_server_primitives_are_documented_and_runnable():
     assert "http://<tailscale-host-or-ip>:2486" in private_readme
     assert "deploy/setup-private-client.sh --host" in private_readme
     assert "deploy/native-lfd-host.sh install" in private_readme
+    assert "deploy/native-lfd-host.sh install-update-agent" in private_readme
+    assert "com.loopflow.lfd.update" in private_readme
     assert "Docker Desktop is not required for the native service" in private_readme
     assert "ssh-remote+$LFD_SSH_USER@$LFD_HOST" in private_readme
     assert "LFD_EXECUTOR_CREDENTIALS_MOUNTS=claude,codex,ssh" in private_readme
@@ -212,7 +216,13 @@ def test_self_hosted_server_primitives_are_documented_and_runnable():
     assert "scripts/pull-local-bin.sh" in native_host
     assert "install --force" in native_host
     assert "launchctl kickstart -k" in native_host
-    assert "LFD_AUTH_TOKEN is required for native private lfd host management" in native_host
+    assert "StartCalendarInterval" in native_host
+    assert '"Hour": 4' in native_host
+    assert '"Minute": 30' in native_host
+    assert '"LFD_AUTH_TOKEN_FILE": token_file' in native_host
+    assert 'printf \'%s\\n\' "$LFD_AUTH_TOKEN" > "$token_file"' in native_host
+    assert 'chmod 0600 "$token_file"' in native_host
+    assert "LFD_AUTH_TOKEN or readable LFD_AUTH_TOKEN_FILE is required for native private lfd host management" in native_host
 
     private_client = (ROOT / "deploy/setup-private-client.sh").read_text()
     assert "Host is required. Pass --host or set LFD_HOST." in private_client


### PR DESCRIPTION
## Usage

```bash
export LFD_HTTP_ADDR=0.0.0.0:2486
export LFD_AUTH_TOKEN=$(openssl rand -hex 32)
mkdir -p ~/.lf
printf '%s\n' "$LFD_AUTH_TOKEN" > ~/.lf/lfd-token
chmod 600 ~/.lf/lfd-token

deploy/native-lfd-host.sh install              # installs service + nightly update agent
deploy/native-lfd-host.sh install-update-agent # install just the update agent
```

## Summary

The native macOS private-host path now keeps itself fresh automatically. `deploy/native-lfd-host.sh install` installs a second launch agent, `com.loopflow.lfd.update`, that runs `native-lfd-host.sh update` at 04:30 host-local time — refreshing the repo, rebuilding local binaries, and restarting `lfd`. This brings the native Mac host in line with the nightly refresh the Linux container hosts already get, without requiring Docker Desktop.

The bearer token is no longer embedded in the plist. Both the service and update agent read it from `~/.lf/lfd-token` via `LFD_AUTH_TOKEN_FILE`, with `LFD_AUTH_TOKEN` still honored when set. Logs move to `~/.lf/logs/`.

## Changes

- New `install-update-agent` command and a `StartCalendarInterval` launchd plist generated for the nightly update at 04:30.
- Token loading via `LFD_AUTH_TOKEN_FILE` (default `~/.lf/lfd-token`); `install` writes the token file with `0600` perms and the update agent references it instead of inlining the secret.
- `status` now prints the update agent's launchd state; `logs` tails the new `~/.lf/logs/` paths.
- Docs (`deploy/README.md`, `deploy/PRIVATE_HOST.md`) document the update agent, token file, and native install path; release-automation tests assert the new help text, plist, and docs.
