### PR TITLE
deploy: keep native lfd tokens out of launchd plists

### DIFF
--- a/deploy/PRIVATE_HOST.md
+++ b/deploy/PRIVATE_HOST.md
@@ -58,7 +58,7 @@ doppler secrets set LFD_AUTH_TOKEN="$LFD_AUTH_TOKEN"
 doppler secrets set LFD_EXECUTOR_CREDENTIALS_MOUNTS=claude,codex,ssh
 ```
 
-The launch agent keeps native `lfd` up. A second `com.loopflow.lfd.update` launch agent runs `deploy/native-lfd-host.sh update` at 04:30 host-local time and reads the token from `~/.lf/lfd-token` through `LFD_AUTH_TOKEN_FILE`; the bearer token is not embedded in the plist. Docker Desktop is not required for the native service. Use `deploy/bootstrap-cron-host.sh` only when you explicitly want the Docker Compose stack.
+The launch agent keeps native `lfd` up. A second `com.loopflow.lfd.update` launch agent runs `deploy/native-lfd-host.sh update` at 04:30 host-local time. Both plists read the token from `~/.lf/lfd-token` through `LFD_AUTH_TOKEN_FILE`; the bearer token is not embedded in launchd config. Docker Desktop is not required for the native service. Use `deploy/bootstrap-cron-host.sh` only when you explicitly want the Docker Compose stack.
 
 ## Configure this Mac as a client
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -98,7 +98,7 @@ chmod 600 ~/.lf/lfd-token
 deploy/native-lfd-host.sh install
 ```
 
-The native install does not require Docker Desktop. It installs the `com.loopflow.lfd` service and `com.loopflow.lfd.update` nightly update agent.
+The native install does not require Docker Desktop. It installs the `com.loopflow.lfd` service and `com.loopflow.lfd.update` nightly update agent. Both launchd jobs read the bearer token from `~/.lf/lfd-token` instead of embedding it in the plist.
 
 Use the Docker Compose launchd path only when you explicitly want the container stack:
 

--- a/deploy/native-lfd-host.sh
+++ b/deploy/native-lfd-host.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 
 usage() {
     cat >&2 <<'USAGE'
-Usage: native-lfd-host.sh [--repo PATH] [--install-dir PATH] <install|install-update-agent|update|restart|status|logs|health>
+Usage: native-lfd-host.sh [--repo PATH] [--install-dir PATH] <install|install-update-agent|update|restart|status|logs|health|serve>
 
 Commands:
   install              Build/install lf+lfd, install launchd service/update agent, and wait for health
@@ -16,6 +16,7 @@ Commands:
   status               Show launchd service/update-agent state and local daemon status
   logs                 Tail native lfd launchd logs
   health               Check local daemon health and authenticated status when token is available
+  serve                Internal launchd entrypoint; load token file and exec lfd serve
 
 Environment:
   LFD_HTTP_ADDR=0.0.0.0:2486      listen address for remote/private clients
@@ -53,7 +54,7 @@ while [[ $# -gt 0 ]]; do
             install_dir="${1#--install-dir=}"
             shift
             ;;
-        install|install-update-agent|update|restart|status|logs|health)
+        install|install-update-agent|update|restart|status|logs|health|serve)
             command="$1"
             shift
             ;;
@@ -136,12 +137,48 @@ wait_for_health() {
 }
 
 install_service() {
-    require_token
+    ensure_token_file
     if [[ ! -x "$lfd_bin" ]]; then
         echo "missing lfd binary: $lfd_bin" >&2
         exit 1
     fi
-    LFD_HTTP_ADDR="$http_addr" LFD_AUTH_TOKEN="$LFD_AUTH_TOKEN" "$lfd_bin" install --force
+    mkdir -p "$(dirname "$plist")" "$log_dir"
+    chmod 700 "$HOME/.lf" "$log_dir" 2>/dev/null || true
+    python3 - "$plist" "$script_path" "$repo" "$install_dir" "$http_addr" "$token_file" "$log_out" <<'PY'
+import os
+import plistlib
+import sys
+from pathlib import Path
+
+plist_path, script_path, repo, install_dir, http_addr, token_file, log_path = sys.argv[1:]
+data = {
+    "Label": "com.loopflow.lfd",
+    "ProgramArguments": [
+        script_path,
+        "--repo",
+        repo,
+        "--install-dir",
+        install_dir,
+        "serve",
+    ],
+    "RunAtLoad": True,
+    "KeepAlive": True,
+    "ThrottleInterval": 10,
+    "ExitTimeOut": 30,
+    "StandardOutPath": log_path,
+    "StandardErrorPath": log_path,
+    "EnvironmentVariables": {
+        "PATH": os.environ.get("PATH", ""),
+        "LFD_HTTP_ADDR": http_addr,
+        "LFD_AUTH_TOKEN_FILE": token_file,
+    },
+}
+Path(plist_path).write_bytes(plistlib.dumps(data))
+PY
+    chmod 0600 "$plist"
+    launchctl bootout "$(service_target)" >/dev/null 2>&1 || true
+    launchctl bootstrap "gui/$(id -u)" "$plist"
+    echo "installed: $plist"
 }
 
 install_update_agent() {
@@ -234,5 +271,9 @@ case "$command" in
         ;;
     health)
         health
+        ;;
+    serve)
+        require_token
+        exec "$lfd_bin" serve
         ;;
 esac

--- a/python/tests/test_release_automation.py
+++ b/python/tests/test_release_automation.py
@@ -151,7 +151,7 @@ def test_self_hosted_server_primitives_are_documented_and_runnable():
     assert "--token-file PATH" in private_client_help.stderr
     assert "--no-concerto" in private_client_help.stderr
     assert "native-lfd-host.sh" in native_host_help.stderr
-    assert "install|install-update-agent|update|restart|status|logs|health" in native_host_help.stderr
+    assert "install|install-update-agent|update|restart|status|logs|health|serve" in native_host_help.stderr
     assert "LFD_HTTP_ADDR=0.0.0.0:2486" in native_host_help.stderr
     assert "LFD_AUTH_TOKEN_FILE=~/.lf/lfd-token" in native_host_help.stderr
 
@@ -214,7 +214,10 @@ def test_self_hosted_server_primitives_are_documented_and_runnable():
 
     native_host = (ROOT / "deploy/native-lfd-host.sh").read_text()
     assert "scripts/pull-local-bin.sh" in native_host
-    assert "install --force" in native_host
+    assert '"Label": "com.loopflow.lfd"' in native_host
+    assert '"serve"' in native_host
+    assert 'exec "$lfd_bin" serve' in native_host
+    assert "install --force" not in native_host
     assert "launchctl kickstart -k" in native_host
     assert "StartCalendarInterval" in native_host
     assert '"Hour": 4' in native_host


### PR DESCRIPTION
## Usage

```bash
deploy/native-lfd-host.sh install
```

## Summary

The native `lfd` launchd service no longer embeds the bearer token in its plist. `install` now writes the `com.loopflow.lfd` plist directly (via a small inline Python `plistlib` step) so the daemon launches through a new `serve` subcommand and reads the token from `~/.lf/lfd-token` via `LFD_AUTH_TOKEN_FILE` at runtime. This matches the nightly update agent, which already reads the token from a file, so neither launchd job stores the secret on disk in cleartext.

## Changes

- Add a `serve` command to `native-lfd-host.sh` that loads the token file and execs `lfd serve`; used as the launchd entrypoint.
- `install` builds and bootstraps the `com.loopflow.lfd` plist itself instead of calling `lfd install --force`, setting `LFD_AUTH_TOKEN_FILE` and `LFD_HTTP_ADDR` in the environment and chmod 0600 on the plist.
- Update `deploy/PRIVATE_HOST.md` and `deploy/README.md` to note both launchd jobs read the token from `~/.lf/lfd-token` rather than embedding it.
- Update release-automation tests to assert the new `serve` command and plist shape.
