### PR TITLE
release: cap weekly notes commit list at 50 with git --max-count

### DIFF
--- a/python/tests/test_release_automation.py
+++ b/python/tests/test_release_automation.py
@@ -44,6 +44,50 @@ def test_nightly_packages_workflow_builds_and_smokes_without_deploying():
     assert not any(term in commands for term in forbidden)
 
 
+def test_bump_patch_version_handles_more_than_fifty_commits(tmp_path: Path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "Cargo.toml").write_text('[package]\nname = "loopflow"\nversion = "1.2.3"\n')
+    (repo / "pyproject.toml").write_text('[project]\nname = "loopflow"\nversion = "1.2.3"\n')
+    (repo / "RELEASE_NOTES.md").write_text("# v1.2.3\n\nPrevious release.\n")
+    scripts = repo / "scripts"
+    scripts.mkdir()
+    script = scripts / "bump_patch_version.sh"
+    script.write_text((ROOT / "scripts/bump_patch_version.sh").read_text())
+    script.chmod(script.stat().st_mode | stat.S_IXUSR)
+
+    subprocess.run(["git", "init"], cwd=repo, check=True, stdout=subprocess.DEVNULL)
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=repo, check=True)
+    subprocess.run(["git", "add", "."], cwd=repo, check=True)
+    subprocess.run(["git", "commit", "-m", "release: v1.2.3"], cwd=repo, check=True, stdout=subprocess.DEVNULL)
+    subprocess.run(["git", "tag", "v1.2.3"], cwd=repo, check=True)
+
+    for index in range(55):
+        (repo / "change.txt").write_text(f"{index}\n")
+        subprocess.run(["git", "add", "change.txt"], cwd=repo, check=True)
+        subprocess.run(
+            ["git", "commit", "-m", f"change {index}"],
+            cwd=repo,
+            check=True,
+            stdout=subprocess.DEVNULL,
+        )
+
+    result = subprocess.run(
+        [str(script), "v1.2.3", "55"],
+        cwd=repo,
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+
+    notes = (repo / "RELEASE_NOTES.md").read_text()
+    assert "next=1.2.4" in result.stdout
+    assert '# v1.2.4' in notes
+    assert "Weekly auto-release with 55 commits since `v1.2.3`." in notes
+    assert notes.count("- change ") == 50
+
+
 def test_pull_local_bin_builds_and_installs_binaries(tmp_path: Path):
     repo = tmp_path / "repo"
     repo.mkdir()

--- a/scripts/bump_patch_version.sh
+++ b/scripts/bump_patch_version.sh
@@ -54,7 +54,7 @@ tmp=$(mktemp)
     if [ -n "$last_tag" ]; then
         printf 'Weekly auto-release with %s commits since `%s`.\n\n' "$commit_count" "$last_tag"
         printf '## Commits\n\n'
-        git log "$last_tag..HEAD" --pretty=format:'- %s' | head -50
+        git log "$last_tag..HEAD" --max-count=50 --pretty=format:'- %s'
         printf '\n\n'
     else
         printf 'Weekly auto-release.\n\n'


### PR DESCRIPTION
## Usage

```bash
scripts/bump_patch_version.sh v1.2.3 55
```

Generates the next patch version and writes `RELEASE_NOTES.md` with at most 50 commits listed, even when the range since the last tag contains more.

## Summary

The weekly auto-release notes truncated the commit list with `git log ... | head -50`. Piping `git log` into `head` makes git write to a closed pipe once `head` has taken its 50 lines, which can surface as a broken-pipe error and make the script flaky on long commit ranges. This switches to `git log --max-count=50`, so git itself stops after 50 commits and exits cleanly.

## Changes

- `bump_patch_version.sh`: replace `| head -50` with `--max-count=50` when listing commits in the release notes
- Add a regression test that runs the script against a repo with 55 commits since the last tag and asserts the notes cap the commit list at 50 entries