### PR TITLE
token-compress: add compression step and group release-note commits

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ Side-channel utilities — wrappers around git, PR, release, and wave state.
 | `release` | Run the full release workflow (notes, PR, tag, status) |
 | `release-notes` | Write narrative `RELEASE_NOTES.md` from release context, preferring release decisions when present |
 | `synthesize` | Combine multiple perspectives into one |
+| `token-compress` | Compress text into a target token budget without silently dropping important information |
 | `validate` | Validate flows, steps, and directions |
 
 ## Flows

--- a/docs/index.md
+++ b/docs/index.md
@@ -147,6 +147,18 @@ Steps run to completion. Built-ins: `debug`, `design`, `implement`, `gate`, `qa`
 ln -s ../.lf/steps .claude/commands
 ```
 
+### Token compression
+
+Use `token-compress` when a workflow needs to fit more context into a smaller budget without losing the important shape.
+
+```bash
+lf token-compress: Compress this release context to 1200 tokens
+```
+
+Compression is not truncation. A good compression pass preserves decisions, rationale, risks, open questions, names, dates, versions, paths, commands, URLs, and identifiers. It groups repetition before cutting. If the budget forces meaningful omissions, it says what was omitted.
+
+Release systems, long-running waves, and handoffs should compress source material before summarizing it. Do not take the first N commits, first N lines, or latest N messages as a substitute for understanding the whole input.
+
 ---
 
 ## Flow

--- a/python/tests/test_release_automation.py
+++ b/python/tests/test_release_automation.py
@@ -44,6 +44,78 @@ def test_nightly_packages_workflow_builds_and_smokes_without_deploying():
     assert not any(term in commands for term in forbidden)
 
 
+def test_token_compress_step_is_documented_as_preserving_information():
+    step = (ROOT / "rust/loopflow/src/engine/builtins/ops/step/token-compress.md").read_text()
+    docs = (ROOT / "docs/index.md").read_text()
+    readme = (ROOT / "README.md").read_text()
+
+    assert "Compress text into a target token budget" in step
+    assert "Compression is not truncation" in step
+    assert "Do not summarize a list by taking the first items" in step
+    assert "Omitted" in step
+    assert "lf token-compress" in docs
+    assert "Do not take the first N commits" in docs
+    assert "| `token-compress` |" in readme
+
+
+def test_bump_patch_version_groups_long_commit_lists_without_dropping_commits(tmp_path: Path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "Cargo.toml").write_text('[package]\nname = "loopflow"\nversion = "1.2.3"\n')
+    (repo / "pyproject.toml").write_text('[project]\nname = "loopflow"\nversion = "1.2.3"\n')
+    (repo / "RELEASE_NOTES.md").write_text("# v1.2.3\n\nPrevious release.\n")
+    scripts = repo / "scripts"
+    scripts.mkdir()
+    script = scripts / "bump_patch_version.sh"
+    script.write_text((ROOT / "scripts/bump_patch_version.sh").read_text())
+    script.chmod(script.stat().st_mode | stat.S_IXUSR)
+
+    subprocess.run(["git", "init"], cwd=repo, check=True, stdout=subprocess.DEVNULL)
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=repo, check=True)
+    subprocess.run(["git", "add", "."], cwd=repo, check=True)
+    subprocess.run(["git", "commit", "-m", "release: v1.2.3"], cwd=repo, check=True, stdout=subprocess.DEVNULL)
+    subprocess.run(["git", "tag", "v1.2.3"], cwd=repo, check=True)
+
+    subjects = [
+        "deploy: add native host updater",
+        "lfd: persist remote token file",
+        "concerto: improve portfolio status",
+        "lf: hand off steps through vendor skills",
+        "build(deps): bump serde from 1.0.0 to 1.0.1 (#1)",
+    ]
+    subjects.extend(f"workflow: generated change {index}" for index in range(55))
+
+    for index, subject in enumerate(subjects):
+        (repo / "change.txt").write_text(f"{index}\n")
+        subprocess.run(["git", "add", "change.txt"], cwd=repo, check=True)
+        subprocess.run(["git", "commit", "-m", subject], cwd=repo, check=True, stdout=subprocess.DEVNULL)
+
+    result = subprocess.run(
+        [str(script), "v1.2.3", str(len(subjects))],
+        cwd=repo,
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+
+    notes = (repo / "RELEASE_NOTES.md").read_text()
+    assert "next=1.2.4" in result.stdout
+    assert "# v1.2.4" in notes
+    assert f"Weekly auto-release with {len(subjects)} commits since `v1.2.3`." in notes
+    assert "Commits are grouped by theme instead of truncated" in notes
+    assert "## Release and self-hosting infrastructure" in notes
+    assert "## Authentication and remote execution" in notes
+    assert "## Concerto and user surfaces" in notes
+    assert "## Agent workflows and developer tooling" in notes
+    assert "## Dependency updates" in notes
+    assert "serde 1.0.0 → 1.0.1" in notes
+    for subject in subjects:
+        if subject.startswith("build(deps)"):
+            continue
+        assert subject in notes
+
+
 def test_pull_local_bin_builds_and_installs_binaries(tmp_path: Path):
     repo = tmp_path / "repo"
     repo.mkdir()

--- a/release/SCHEDULE.md
+++ b/release/SCHEDULE.md
@@ -27,6 +27,7 @@ Loopflow and Cadenza both carry the scheduled release workflow pair. Each repo r
 
 - Nightly jobs prove release artifacts without deploying them.
 - Weekly publishing never runs unless nightly-style package verification passed in the same workflow run.
+- Release-note generation uses token compression: read the full release context, group repetition, preserve decisions and unique facts, and never substitute first-N commits or lines for summarization.
 - Secrets stay in Doppler or host-local env files, never Terraform state or committed config.
 - The cron server is self-hosted per repo. Studio discovery/auth is not supported.
 - Local updater scripts refuse to pull a non-default branch unless explicitly told not to pull.

--- a/rust/loopflow/src/engine/builtins/ops/step/token-compress.md
+++ b/rust/loopflow/src/engine/builtins/ops/step/token-compress.md
@@ -1,0 +1,47 @@
+---
+requires: text input and target token budget
+produces: compressed text
+---
+Compress text into a target token budget without silently dropping important information.
+
+## Goal
+
+Produce a smaller artifact that preserves the decisions, facts, risks, names, dates, and structure a downstream agent or human needs. Compression is not truncation. Shape the information so it fits.
+
+## Workflow
+
+1. Identify the target budget. Use the user's requested `N` tokens when provided. If no budget is provided, ask for one in interactive mode; in headless mode choose a practical budget and state it.
+2. Read the source text fully before writing the compressed version.
+3. Extract the durable content:
+   - decisions and rationale
+   - constraints and requirements
+   - risks, blockers, and open questions
+   - names, dates, versions, paths, commands, URLs, and identifiers
+   - evidence that would be expensive to rediscover
+4. Group related details before cutting. Replace repetition with structure.
+5. Write the compressed version under the target budget.
+6. If the budget forces meaningful omissions, add an `Omitted` line naming the categories omitted. Do not hide loss.
+
+## Compression rules
+
+- Preserve causality: keep why something happened, not just what happened.
+- Preserve interfaces: commands, API names, file paths, config keys, environment variables, and external contracts usually matter.
+- Preserve uncertainty: open questions and weak assumptions are first-class information.
+- Merge duplicates; do not delete unique facts just because they appear late.
+- Prefer dense bullets over vague prose.
+- Do not use placeholders like "various fixes" when concrete categories fit.
+- Do not summarize a list by taking the first items. Recency, impact, and risk matter more than order.
+
+## Output
+
+Return only the compressed text unless the user asked for commentary.
+
+When useful, use this shape:
+
+```markdown
+Budget: <N> tokens
+
+<compressed text>
+
+Omitted: <only if meaningful information was intentionally left out>
+```

--- a/scripts/bump_patch_version.sh
+++ b/scripts/bump_patch_version.sh
@@ -52,10 +52,105 @@ tmp=$(mktemp)
 {
     printf '# v%s\n\n' "$next"
     if [ -n "$last_tag" ]; then
-        printf 'Weekly auto-release with %s commits since `%s`.\n\n' "$commit_count" "$last_tag"
-        printf '## Commits\n\n'
-        git log "$last_tag..HEAD" --pretty=format:'- %s' | head -50
-        printf '\n\n'
+        commits_tmp=$(mktemp)
+        git log "$last_tag..HEAD" --pretty=format:'%s' > "$commits_tmp"
+        python3 - "$last_tag" "$commit_count" "$commits_tmp" <<'PY'
+import collections
+import re
+import sys
+
+last_tag = sys.argv[1]
+commit_count = sys.argv[2]
+subjects_path = sys.argv[3]
+with open(subjects_path, encoding="utf-8") as handle:
+    subjects = [line.strip() for line in handle if line.strip()]
+
+sections = [
+    (
+        "Release and self-hosting infrastructure",
+        lambda subject: any(
+            marker in subject.lower()
+            for marker in ("release", "deploy", "cron", "host", "budget", "local binary")
+        ),
+    ),
+    (
+        "Authentication and remote execution",
+        lambda subject: any(
+            marker in subject.lower()
+            for marker in ("auth", "token", "credential", "remote", "lfd")
+        ),
+    ),
+    (
+        "Concerto and user surfaces",
+        lambda subject: any(
+            marker in subject.lower()
+            for marker in ("concerto", "desktop", "mobile", "portfolio", "website")
+        ),
+    ),
+    (
+        "Agent workflows and developer tooling",
+        lambda subject: any(
+            marker in subject.lower()
+            for marker in ("lf:", "engine", "installer", "skill", "workflow", "wave")
+        ),
+    ),
+    (
+        "Dependency updates",
+        lambda subject: subject.startswith("build(deps"),
+    ),
+]
+
+grouped: dict[str, list[str]] = collections.defaultdict(list)
+for subject in subjects:
+    if subject.startswith("build(deps"):
+        grouped["Dependency updates"].append(subject)
+        continue
+    for name, predicate in sections:
+        if predicate(subject):
+            grouped[name].append(subject)
+            break
+    else:
+        grouped["Other changes"].append(subject)
+
+print(f"Weekly auto-release with {commit_count} commits since `{last_tag}`.")
+print()
+print(
+    "Commits are grouped by theme instead of truncated. "
+    "This is a deterministic token-compression pass for CI: preserve every unique commit subject, merge repetition into structure, and avoid first-N summaries."
+)
+print()
+
+for name, _ in sections:
+    items = grouped.get(name, [])
+    if not items:
+        continue
+    print(f"## {name}")
+    print()
+    if name == "Dependency updates":
+        packages = []
+        pattern = re.compile(r"bump ([^ ]+) from ([^ ]+) to ([^ ]+)")
+        for item in items:
+            match = pattern.search(item)
+            if match:
+                package, old, new = match.groups()
+                packages.append(f"{package} {old} → {new}")
+            else:
+                packages.append(item)
+        print(f"- {len(items)} dependency update(s): {', '.join(packages)}")
+    else:
+        for item in items:
+            print(f"- {item}")
+    print()
+
+other = grouped.get("Other changes", [])
+if other:
+    print("## Other changes")
+    print()
+    for item in other:
+        print(f"- {item}")
+    print()
+PY
+        rm -f "$commits_tmp"
     else
         printf 'Weekly auto-release.\n\n'
     fi


### PR DESCRIPTION
## Usage

```bash
lf token-compress: Compress this release context to 1200 tokens
```

## Summary

This PR introduces a `token-compress` builtin step and applies its philosophy to weekly auto-releases so release notes stop silently dropping commits. The step formalizes the principle that compression is not truncation: read the whole input, preserve decisions, rationale, risks, names, dates, versions, paths, commands, and identifiers, group repetition into structure, and declare any meaningful omissions instead of hiding them.

The weekly release-note generator previously did `git log ... | head -50`, truncating commit history once a release exceeded 50 commits. It now runs a deterministic Python compression pass in `bump_patch_version.sh` that groups every commit subject by theme (infrastructure, auth/remote, Concerto/surfaces, agent tooling, dependency updates, other) without dropping any unique subject, and collapses dependency bumps into a single `pkg old → new` summary line.

## Changes

- New builtin step `rust/loopflow/src/engine/builtins/ops/step/token-compress.md` with goal, workflow, compression rules, and output shape
- `bump_patch_version.sh` groups commits by theme instead of `head -50`, preserving every commit subject and summarizing dependency bumps
- Docs: README ops table, `docs/index.md` token-compression section, and `release/SCHEDULE.md` note that release-note generation uses token compression
- Tests verify the step is documented as information-preserving and that the bump script groups long commit lists without dropping commits