### PR TITLE
release: use canonical release flow for weekly publishing

### DIFF
--- a/.github/workflows/weekly-release.yml
+++ b/.github/workflows/weekly-release.yml
@@ -52,10 +52,11 @@ jobs:
     needs: [tag-check, package-test]
     if: needs.tag-check.outputs.skip != 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 90
     permissions:
       contents: write
       actions: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v7
         with:
@@ -63,34 +64,20 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
-      - name: Bump patch version and append release notes
-        id: bump
+      - uses: astral-sh/setup-uv@v7
+      - name: Fetch release secrets
+        uses: dopplerhq/secrets-fetch-action@v2.0.0
+        with:
+          doppler-token: ${{ secrets.DOPPLER_TOKEN_PRD }}
+          inject-env-vars: true
+          doppler-project: loopflow
+          doppler-config: prd
+      - name: Install lf
         run: |
           set -euo pipefail
-          ./scripts/bump_patch_version.sh \
-            "${{ needs.tag-check.outputs.last_tag }}" \
-            "${{ needs.tag-check.outputs.commit_count }}" \
-            | tee bump.out
-          # bump_patch_version.sh prints `next=<version>` on its last line.
-          next=$(grep '^next=' bump.out | cut -d= -f2)
-          echo "next=$next" >> "$GITHUB_OUTPUT"
-      - name: Refresh Cargo.lock
-        run: cargo update -p loopflow
-      - name: Commit, tag, and dispatch release
+          cargo build --release -p loopflow --bin lf
+          echo "$PWD/target/release" >> "$GITHUB_PATH"
+      - name: Run canonical release flow
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-          version="v${{ steps.bump.outputs.next }}"
-          git config user.name "loopflow-bot"
-          git config user.email "bot@loopflow.studio"
-          git add Cargo.toml Cargo.lock pyproject.toml RELEASE_NOTES.md
-          git commit -m "release: ${version} (weekly auto-release)"
-          git push origin HEAD:main
-
-          # Pushes made with GITHUB_TOKEN don't trigger other workflows, so
-          # cut the tag and dispatch release.yml explicitly — mirrors what
-          # auto-tag.yml would have done for a human-driven release.
-          git tag "$version"
-          git push origin "$version"
-          gh workflow run release.yml --ref "$version" -f tag="$version"
+        run: lf op release run patch

--- a/python/tests/test_release_automation.py
+++ b/python/tests/test_release_automation.py
@@ -361,6 +361,8 @@ def test_release_schedule_contract_covers_loopflow_and_cadenza():
     assert (
         "Weekly publishing never runs unless nightly-style package verification passed" in schedule
     )
+    assert "lf op release run patch" in schedule
+    assert "release/unreleased/DECISIONS.md" in schedule
 
     weekly = yaml.load(
         (ROOT / ".github/workflows/weekly-release.yml").read_text(), Loader=yaml.BaseLoader
@@ -368,3 +370,18 @@ def test_release_schedule_contract_covers_loopflow_and_cadenza():
     assert weekly["jobs"]["package-test"]["uses"] == "./.github/workflows/nightly-packages.yml"
     assert weekly["jobs"]["release"]["needs"] == ["tag-check", "package-test"]
     assert weekly["jobs"]["release"]["permissions"]["actions"] == "write"
+    assert weekly["jobs"]["release"]["permissions"]["pull-requests"] == "write"
+
+    commands = "\n".join(
+        step.get("run", "") for step in weekly["jobs"]["release"]["steps"]
+    )
+    release_steps = weekly["jobs"]["release"]["steps"]
+    assert any(
+        step.get("uses") == "dopplerhq/secrets-fetch-action@v2.0.0"
+        for step in release_steps
+    )
+    assert "cargo build --release -p loopflow --bin lf" in commands
+    assert "lf op release run patch" in commands
+    assert "bump_patch_version.sh" not in commands
+    assert "git push origin HEAD:main" not in commands
+    assert "gh workflow run release.yml" not in commands

--- a/release/SCHEDULE.md
+++ b/release/SCHEDULE.md
@@ -34,6 +34,7 @@ Loopflow and Cadenza both carry the scheduled release workflow pair. Each repo r
 
 - Nightly jobs prove release artifacts without deploying them.
 - Weekly publishing never runs unless nightly-style package verification passed in the same workflow run.
+- Weekly publishing uses the canonical `lf op release run patch` path, including the `release-notes` step and `release/unreleased/DECISIONS.md` narrative context. Do not duplicate release-note generation in workflow YAML.
 - Release-note generation uses token compression: read the full release context, group repetition, preserve decisions and unique facts, and never substitute first-N commits or lines for summarization.
 - Secrets stay in Doppler or host-local env files, never Terraform state or committed config.
 - The cron server is self-hosted per repo. Studio discovery/auth is not supported.


### PR DESCRIPTION
## Usage

```bash
lf op release run patch
```

The weekly release workflow now publishes through the canonical `lf op release run patch` path instead of a bespoke chain of shell steps (`bump_patch_version.sh`, manual commit/push to `main`, hand-cut tag, explicit `gh workflow run release.yml`). This routes weekly auto-releases through the same release flow humans use — including the `release-notes` step and `release/unreleased/DECISIONS.md` narrative context — so release-note generation lives in one place rather than being duplicated in workflow YAML.

## Changes

- `weekly-release.yml`: replace the version-bump/commit/tag/dispatch steps with a single `lf op release run patch` invocation. Build and install `lf` from source first, fetch release secrets from Doppler, raise the job timeout to 90 minutes, and grant `pull-requests: write`.
- `release/SCHEDULE.md`: document that weekly publishing uses the canonical path and that release-note generation must not be duplicated in workflow YAML.
- `test_release_automation.py`: assert the workflow uses Doppler + the canonical `lf op release run patch` command, and no longer references the old bump script, direct `main` push, or `gh workflow run release.yml`.