### PR TITLE
install: make refresh the shared local update path

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,11 +307,11 @@ Default install location is `~/.local/bin`. Override with `LF_INSTALL_DIR=/path`
 From a dev checkout, build everything locally with one entry:
 
 ```bash
-uv run python scripts/install.py local --use   # build lf, lfd, Loopflow.app -> local-bin/, make active
-scripts/pull-local-bin.sh                       # lf/lfd only → ~/.local/bin
+uv run python scripts/install.py local --use   # full build: lf, lfd, Loopflow.app -> local-bin/, make active
+uv run python scripts/install.py refresh       # CLI refresh: pull default branch, rebuild/install lf+lfd
 ```
 
-`install.py local` builds this worktree's `lf`, `lfd`, and `Loopflow.app` into `<worktree>/local-bin/`. `--use` symlinks `lf`/`lfd` onto `PATH` and installs `Loopflow.app` into `/Applications`—each worktree builds in isolation, `--use` picks the active one.
+`install.py` is the local entry point. `local --use` builds this worktree's `lf`, `lfd`, and `Loopflow.app` into `<worktree>/local-bin/`, then promotes that build. `refresh` is the fast CLI-only path: pull the default branch, rebuild `lf`/`lfd`, and install them into the local bin dir.
 
 Built-in steps and flows included. `lf init` sets up your coding agent and preferences.
 

--- a/deploy/PRIVATE_HOST.md
+++ b/deploy/PRIVATE_HOST.md
@@ -58,7 +58,7 @@ doppler secrets set LFD_AUTH_TOKEN="$LFD_AUTH_TOKEN"
 doppler secrets set LFD_EXECUTOR_CREDENTIALS_MOUNTS=claude,codex,ssh
 ```
 
-The launch agent keeps native `lfd` up. A second `com.loopflow.lfd.update` launch agent runs `deploy/native-lfd-host.sh update` at 04:30 host-local time. Both plists read the token from `~/.lf/lfd-token` through `LFD_AUTH_TOKEN_FILE`; the bearer token is not embedded in launchd config. Docker Desktop is not required for the native service. Use `deploy/bootstrap-cron-host.sh` only when you explicitly want the Docker Compose stack.
+The launch agent keeps native `lfd` up. A second `com.loopflow.lfd.update` launch agent runs `deploy/native-lfd-host.sh update` at 04:30 host-local time; that update path uses `scripts/install.py refresh` for the CLI rebuild. Both plists read the token from `~/.lf/lfd-token` through `LFD_AUTH_TOKEN_FILE`; the bearer token is not embedded in launchd config. Docker Desktop is not required for the native service. Use `deploy/bootstrap-cron-host.sh` only when you explicitly want the Docker Compose stack.
 
 ## Configure this Mac as a client
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -72,7 +72,7 @@ deploy/bootstrap-cron-host.sh --host linux
 
 Use Doppler for maintained hosts. On Linux the bootstrap writes `/etc/loopflow-server.env` with `0600` permissions so systemd can reach either `DOPPLER_TOKEN` or host-local fallback secrets. On macOS it writes the same launch environment into `~/Library/LaunchAgents/loopflow.server.plist`; prefer a Doppler service token over embedding long-lived provider credentials there.
 
-The Linux update timer refreshes container hosts nightly. The native macOS private-host path installs `com.loopflow.lfd.update`, which refreshes the repo, rebuilds local binaries, and restarts `lfd` at 04:30 host-local time. Keep local dev binaries fresh with `scripts/pull-local-bin.sh`; server restarts should be predictable.
+The Linux update timer refreshes container hosts nightly. The native macOS private-host path installs `com.loopflow.lfd.update`, which refreshes the repo, rebuilds local binaries, and restarts `lfd` at 04:30 host-local time. Keep local dev binaries fresh with `uv run python scripts/install.py refresh`; server restarts should be predictable.
 
 ## Manual Linux service install
 

--- a/deploy/native-lfd-host.sh
+++ b/deploy/native-lfd-host.sh
@@ -120,7 +120,7 @@ update_target() {
 }
 
 install_bins() {
-    "$repo/scripts/pull-local-bin.sh" --repo "$repo" --install-dir "$install_dir" "$@"
+    uv run --with typer python "$repo/scripts/install.py" refresh --install-dir "$install_dir" "$@"
 }
 
 wait_for_health() {

--- a/python/tests/test_release_automation.py
+++ b/python/tests/test_release_automation.py
@@ -74,7 +74,12 @@ def test_bump_patch_version_groups_long_commit_lists_without_dropping_commits(tm
     subprocess.run(["git", "config", "user.name", "Test"], cwd=repo, check=True)
     subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=repo, check=True)
     subprocess.run(["git", "add", "."], cwd=repo, check=True)
-    subprocess.run(["git", "commit", "-m", "release: v1.2.3"], cwd=repo, check=True, stdout=subprocess.DEVNULL)
+    subprocess.run(
+        ["git", "commit", "-m", "release: v1.2.3"],
+        cwd=repo,
+        check=True,
+        stdout=subprocess.DEVNULL,
+    )
     subprocess.run(["git", "tag", "v1.2.3"], cwd=repo, check=True)
 
     subjects = [
@@ -89,7 +94,12 @@ def test_bump_patch_version_groups_long_commit_lists_without_dropping_commits(tm
     for index, subject in enumerate(subjects):
         (repo / "change.txt").write_text(f"{index}\n")
         subprocess.run(["git", "add", "change.txt"], cwd=repo, check=True)
-        subprocess.run(["git", "commit", "-m", subject], cwd=repo, check=True, stdout=subprocess.DEVNULL)
+        subprocess.run(
+            ["git", "commit", "-m", subject],
+            cwd=repo,
+            check=True,
+            stdout=subprocess.DEVNULL,
+        )
 
     result = subprocess.run(
         [str(script), "v1.2.3", str(len(subjects))],
@@ -120,6 +130,10 @@ def test_pull_local_bin_builds_and_installs_binaries(tmp_path: Path):
     repo = tmp_path / "repo"
     repo.mkdir()
     (repo / "Cargo.toml").write_text("[workspace]\nmembers = []\n")
+    scripts = repo / "scripts"
+    scripts.mkdir()
+    (scripts / "install.py").write_text((ROOT / "scripts/install.py").read_text())
+    (scripts / "bundle_version.py").write_text((ROOT / "scripts/bundle_version.py").read_text())
     subprocess.run(["git", "init"], cwd=repo, check=True, stdout=subprocess.DEVNULL)
 
     fake_bin = tmp_path / "fake-bin"
@@ -130,18 +144,7 @@ def test_pull_local_bin_builds_and_installs_binaries(tmp_path: Path):
         f"""#!/usr/bin/env bash
 set -euo pipefail
 printf '%s\n' "$*" > {cargo_log}
-repo=''
-while [[ $# -gt 0 ]]; do
-    case "$1" in
-        --manifest-path)
-            repo="$(dirname "$2")"
-            shift 2
-            ;;
-        *)
-            shift
-            ;;
-    esac
-done
+repo="$PWD"
 mkdir -p "$repo/target/release"
 printf '#!/usr/bin/env bash\necho lf fake\n' > "$repo/target/release/lf"
 printf '#!/usr/bin/env bash\necho lfd fake\n' > "$repo/target/release/lfd"
@@ -175,16 +178,20 @@ chmod +x "$repo/target/release/lf" "$repo/target/release/lfd"
     assert (install_dir / "lf").read_text().startswith("#!/usr/bin/env bash")
     assert (install_dir / "lfd").read_text().startswith("#!/usr/bin/env bash")
     assert "build --release -p loopflow --bin lf --bin lfd" in cargo_log.read_text()
+    assert "scripts/install.py refresh" in (ROOT / "scripts/pull-local-bin.sh").read_text()
 
 
-def test_pull_local_bin_fetches_then_merges_without_user_pull_config():
-    script = (ROOT / "scripts/pull-local-bin.sh").read_text()
+def test_install_refresh_fetches_then_merges_without_user_pull_config():
+    install = (ROOT / "scripts/install.py").read_text()
+    wrapper = (ROOT / "scripts/pull-local-bin.sh").read_text()
 
-    assert 'git -C "$repo" fetch origin "$default_branch"' in script
-    assert 'git -C "$repo" merge --ff-only "origin/$default_branch"' in script
-    assert 'git -C "$repo" fetch' in script
-    assert 'git -C "$repo" merge --ff-only "@{upstream}"' in script
-    assert 'git -C "$repo" pull --ff-only' not in script
+    assert '["git", "fetch", "origin", default_branch]' in install
+    assert '["git", "merge", "--ff-only", f"origin/{default_branch}"]' in install
+    assert '["git", "fetch"]' in install
+    assert '["git", "merge", "--ff-only", "@{upstream}"]' in install
+    assert "pull --ff-only" not in install
+    assert "scripts/install.py" in wrapper
+    assert "cargo build" not in wrapper
 
 
 def test_self_hosted_server_primitives_are_documented_and_runnable():
@@ -223,7 +230,10 @@ def test_self_hosted_server_primitives_are_documented_and_runnable():
     assert "--token-file PATH" in private_client_help.stderr
     assert "--no-concerto" in private_client_help.stderr
     assert "native-lfd-host.sh" in native_host_help.stderr
-    assert "install|install-update-agent|update|restart|status|logs|health|serve" in native_host_help.stderr
+    assert (
+        "install|install-update-agent|update|restart|status|logs|health|serve"
+        in native_host_help.stderr
+    )
     assert "LFD_HTTP_ADDR=0.0.0.0:2486" in native_host_help.stderr
     assert "LFD_AUTH_TOKEN_FILE=~/.lf/lfd-token" in native_host_help.stderr
 
@@ -285,7 +295,8 @@ def test_self_hosted_server_primitives_are_documented_and_runnable():
     assert "install -m 0600" in bootstrap
 
     native_host = (ROOT / "deploy/native-lfd-host.sh").read_text()
-    assert "scripts/pull-local-bin.sh" in native_host
+    assert "scripts/install.py" in native_host
+    assert "scripts/pull-local-bin.sh" not in native_host
     assert '"Label": "com.loopflow.lfd"' in native_host
     assert '"serve"' in native_host
     assert 'exec "$lfd_bin" serve' in native_host
@@ -297,7 +308,10 @@ def test_self_hosted_server_primitives_are_documented_and_runnable():
     assert '"LFD_AUTH_TOKEN_FILE": token_file' in native_host
     assert 'printf \'%s\\n\' "$LFD_AUTH_TOKEN" > "$token_file"' in native_host
     assert 'chmod 0600 "$token_file"' in native_host
-    assert "LFD_AUTH_TOKEN or readable LFD_AUTH_TOKEN_FILE is required for native private lfd host management" in native_host
+    assert (
+        "LFD_AUTH_TOKEN or readable LFD_AUTH_TOKEN_FILE is required "
+        "for native private lfd host management"
+    ) in native_host
 
     private_client = (ROOT / "deploy/setup-private-client.sh").read_text()
     assert "Host is required. Pass --host or set LFD_HOST." in private_client

--- a/release/README.md
+++ b/release/README.md
@@ -8,15 +8,15 @@ find release -maxdepth 2 -type f | sort
 ```
 
 ```bash
-uv run python scripts/install.py local --use   # build lf, lfd, Loopflow.app -> local-bin/, make active
-scripts/pull-local-bin.sh    # lf/lfd only: pull default branch, build, install to ~/.local/bin
+uv run python scripts/install.py local --use   # full build: lf, lfd, Loopflow.app -> local-bin/, make active
+uv run python scripts/install.py refresh       # CLI refresh: pull default branch, rebuild/install lf+lfd
 cat release/SCHEDULE.md      # shared loopflow + cadenza release cadence
 ```
 
-`install.py local` builds this worktree's `lf`, `lfd`, and `Loopflow.app` into
-`<worktree>/local-bin/`. `--use` promotes that build: symlinks `lf`/`lfd` onto
-`PATH` and installs `Loopflow.app` into `/Applications`. Each worktree builds in
-isolation; `--use` picks which one is active.
+`install.py` is the local entry point. `local --use` builds this worktree's
+`lf`, `lfd`, and `Loopflow.app` into `<worktree>/local-bin/`, then promotes that
+build. `refresh` is the fast CLI-only path: pull the default branch, rebuild
+`lf`/`lfd`, and install them into the local bin dir.
 
 Use `release/` to keep the rationale and notes for each shipped version close to the code.
 
@@ -51,7 +51,7 @@ version as `lf --version` — no separate manifest to bump or drift.
 | Weekly | `Regression (weekly auto-release)` | Runs nightly package verification, bumps patch when commits landed since the last tag, tags, and dispatches `Release` | Yes |
 | Release | `Release` (on tag) | Builds the native tarballs **and** the signed, notarized `Loopflow.dmg`; uploads the DMG to R2 and attaches it to the GitHub Release alongside `lf`/`lfd` | Yes |
 | Local | `scripts/install.py local --use` | Build this worktree's `lf`, `lfd`, and `Loopflow.app` into `local-bin/`, then promote it active | Local only |
-| Local | `scripts/pull-local-bin.sh` | `lf`/`lfd` only: pull, release-build, atomically copy into the local bin dir | Local only |
+| Local | `scripts/install.py refresh` | `lf`/`lfd` only: pull, release-build, atomically copy into the local bin dir | Local only |
 
 Nightly packages prove release artifacts while keeping deployment out of the loop. Weekly release reuses that package gate before publishing.
 

--- a/release/SCHEDULE.md
+++ b/release/SCHEDULE.md
@@ -17,7 +17,7 @@ Each repo should carry these files with carbon-copy cadence:
 .github/workflows/nightly-packages.yml   # same schedule; repo-specific package test body
 .github/workflows/weekly-release.yml     # same schedule; calls nightly package verification before publishing
 scripts/install.py                       # single local build entry: lf + lfd + desktop app -> per-worktree local-bin/
-scripts/pull-local-bin.sh                # or repo-equivalent CLI-only local updater
+uv run python scripts/install.py refresh # or repo-equivalent CLI-only local updater
 deploy/loopflow-server.sh                # or repo-equivalent self-hosted cron runner
 deploy/systemd/* / deploy/launchd/*      # host keep-alive/update units
 ```

--- a/release/unreleased/DECISIONS.md
+++ b/release/unreleased/DECISIONS.md
@@ -1,0 +1,9 @@
+# Decisions
+
+## 2026-06-30 — Local refresh and native deploy share one implementation
+
+**Context:** Local development and the native Mac host had two implementations of the same operation: pull the default branch, rebuild `lf`/`lfd`, and install them into a local bin directory. The split made docs harder to explain and risked the Mac host drifting from the developer path.
+
+**Decision:** `scripts/install.py` owns local installation. `install.py local --use` remains the full build-and-promote path for `lf`, `lfd`, and `Loopflow.app`; `install.py refresh` is the fast CLI-only update path. `scripts/pull-local-bin.sh` stays only as a compatibility wrapper, and native host updates call `install.py refresh` directly.
+
+**Implications:** There is one implementation to test and one command family to document. Existing callers of `pull-local-bin.sh` continue working, but new docs point users and deploy scripts at `scripts/install.py`.

--- a/scripts/install.py
+++ b/scripts/install.py
@@ -6,6 +6,7 @@
     install.py local --service  # also install/restart lfd as a launchd service
     install.py local --skip swift
     install.py local -n         # dry run
+    install.py refresh          # pull default branch, rebuild lf/lfd, install to PATH
 
 Remote releases happen via `lf release patch` -> merge -> auto-tag -> CI.
 """
@@ -108,6 +109,44 @@ def _run_or_raise(cmd: list[str], label: str, cwd: Path | None = None) -> None:
         raise StageError(f"{label} exited {code}")
 
 
+# --- Git refresh ---
+
+
+def _git_stdout(args: list[str], repo: Path = ROOT, check: bool = True) -> str:
+    result = subprocess.run(
+        ["git", "-C", str(repo), *args],
+        capture_output=True,
+        text=True,
+        check=check,
+    )
+    if check:
+        result.check_returncode()
+    if result.returncode != 0:
+        return ""
+    return result.stdout.strip()
+
+
+def _refresh_default_branch(repo: Path = ROOT) -> None:
+    default_branch = _git_stdout(
+        ["symbolic-ref", "--quiet", "--short", "refs/remotes/origin/HEAD"],
+        repo=repo,
+        check=False,
+    ).removeprefix("origin/")
+    current_branch = _git_stdout(["branch", "--show-current"], repo=repo)
+    if default_branch and current_branch != default_branch:
+        raise StageError(
+            f"refusing to pull {current_branch}; checkout {default_branch} or pass --no-pull"
+        )
+
+    typer.echo(f"Pulling {repo}...")
+    if default_branch:
+        _run_or_raise(["git", "fetch", "origin", default_branch], "git", cwd=repo)
+        _run_or_raise(["git", "merge", "--ff-only", f"origin/{default_branch}"], "git", cwd=repo)
+    else:
+        _run_or_raise(["git", "fetch"], "git", cwd=repo)
+        _run_or_raise(["git", "merge", "--ff-only", "@{upstream}"], "git", cwd=repo)
+
+
 # --- Builds ---
 
 
@@ -119,6 +158,15 @@ def _build_wheel() -> None:
 def _build_binaries() -> None:
     typer.echo("Building lf/lfd (cargo release)...")
     _run_or_raise(["cargo", "build", "-p", "loopflow", "--release"], "cargo", cwd=ROOT)
+
+
+def _build_cli_binaries() -> None:
+    typer.echo("Building lf/lfd (cargo release)...")
+    _run_or_raise(
+        ["cargo", "build", "--release", "-p", "loopflow", "--bin", "lf", "--bin", "lfd"],
+        "cargo",
+        cwd=ROOT,
+    )
 
 
 def _build_concerto() -> None:
@@ -241,10 +289,15 @@ def _install_wheel() -> None:
 
 def _stage_binaries(local_bin: Path) -> None:
     """Copy freshly built lf/lfd into this worktree's local-bin/."""
-    local_bin.mkdir(parents=True, exist_ok=True)
+    _install_cli_binaries(local_bin)
+
+
+def _install_cli_binaries(install_dir: Path) -> None:
+    """Atomically copy freshly built lf/lfd into install_dir."""
+    install_dir.mkdir(parents=True, exist_ok=True)
     built = ROOT / "target" / "release"
     for name in ("lf", "lfd"):
-        _atomic_install(built / name, local_bin / name)
+        _atomic_install(built / name, install_dir / name)
 
 
 def _promote(local_bin: Path, install_dir: Path, applications_dir: Path = APPLICATIONS_DIR) -> None:
@@ -417,6 +470,34 @@ app = typer.Typer(help="Build and install loopflow locally.", add_completion=Fal
 @app.callback()
 def _root() -> None:
     """Build and install loopflow locally."""
+
+
+@app.command()
+def refresh(
+    no_pull: bool = typer.Option(
+        False, "--no-pull", help="Build the current checkout without pulling"
+    ),
+    install_dir: Path | None = typer.Option(
+        None, "--install-dir", help="Install lf/lfd here instead of the resolved local bin dir"
+    ),
+) -> None:
+    """Pull the default branch, rebuild lf/lfd, and install them locally."""
+    resolved_install_dir = install_dir.expanduser() if install_dir else _resolve_install_dir()
+
+    try:
+        if not no_pull:
+            _refresh_default_branch(ROOT)
+        _build_cli_binaries()
+        _install_cli_binaries(resolved_install_dir)
+    except (subprocess.CalledProcessError, StageError) as exc:
+        typer.echo(f"refresh failed: {exc}", err=True)
+        raise typer.Exit(code=1) from exc
+
+    typer.echo(f"installed: {resolved_install_dir / 'lf'}")
+    for name in ("lf", "lfd"):
+        result = subprocess.run([str(resolved_install_dir / name), "--version"], text=True)
+        if result.returncode != 0:
+            raise typer.Exit(code=result.returncode)
 
 
 @app.command()

--- a/scripts/pull-local-bin.sh
+++ b/scripts/pull-local-bin.sh
@@ -1,10 +1,6 @@
 #!/usr/bin/env bash
-# Pull the default branch, build lf/lfd, and install them into a local bin directory.
-#
-# Usage:
-#   scripts/pull-local-bin.sh
-#   scripts/pull-local-bin.sh --no-pull
-#   scripts/pull-local-bin.sh --repo ~/src/loopflow --install-dir ~/.local/bin
+# Compatibility wrapper for the CLI-only local refresh path.
+# Prefer: uv run python scripts/install.py refresh
 
 set -euo pipefail
 
@@ -12,15 +8,14 @@ usage() {
     cat >&2 <<'USAGE'
 Usage: pull-local-bin.sh [--repo PATH] [--install-dir PATH] [--no-pull]
 
-Builds release lf/lfd from the repo and atomically copies them into the install
-bin directory. Defaults: current script's repo and $LF_INSTALL_DIR or ~/.local/bin.
+Compatibility wrapper around scripts/install.py refresh. Pulls the default branch,
+builds release lf/lfd, and installs them into the local bin directory.
 USAGE
 }
 
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 repo="$(cd "$script_dir/.." && pwd)"
-install_dir="${LF_INSTALL_DIR:-$HOME/.local/bin}"
-pull=true
+args=()
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -43,15 +38,15 @@ while [[ $# -gt 0 ]]; do
                 usage
                 exit 1
             fi
-            install_dir="$2"
+            args+=("--install-dir" "$2")
             shift 2
             ;;
         --install-dir=*)
-            install_dir="${1#--install-dir=}"
+            args+=("--install-dir" "${1#--install-dir=}")
             shift
             ;;
         --no-pull)
-            pull=false
+            args+=("--no-pull")
             shift
             ;;
         -h|--help)
@@ -67,42 +62,4 @@ while [[ $# -gt 0 ]]; do
 done
 
 repo="$(git -C "$repo" rev-parse --show-toplevel)"
-install_dir="$(mkdir -p "$install_dir" && cd "$install_dir" && pwd)"
-
-if [[ "$pull" == true ]]; then
-    default_branch="$(git -C "$repo" symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null | sed 's#^origin/##')"
-    current_branch="$(git -C "$repo" branch --show-current)"
-    if [[ -n "$default_branch" && "$current_branch" != "$default_branch" ]]; then
-        echo "refusing to pull $current_branch; checkout $default_branch or pass --no-pull" >&2
-        exit 1
-    fi
-
-    echo "pulling $repo"
-    if [[ -n "$default_branch" ]]; then
-        git -C "$repo" fetch origin "$default_branch"
-        git -C "$repo" merge --ff-only "origin/$default_branch"
-    else
-        git -C "$repo" fetch
-        git -C "$repo" merge --ff-only "@{upstream}"
-    fi
-fi
-
-echo "building lf/lfd"
-cargo build --release -p loopflow --bin lf --bin lfd --manifest-path "$repo/Cargo.toml"
-
-for bin in lf lfd; do
-    src="$repo/target/release/$bin"
-    dst="$install_dir/$bin"
-    tmp="$install_dir/.${bin}.tmp.$$"
-    if [[ ! -x "$src" ]]; then
-        echo "missing built binary: $src" >&2
-        exit 1
-    fi
-    cp "$src" "$tmp"
-    chmod +x "$tmp"
-    mv -f "$tmp" "$dst"
-done
-
-echo "installed: $install_dir/lf"
-"$install_dir/lf" --version
-"$install_dir/lfd" --version
+exec uv run --with typer python "$repo/scripts/install.py" refresh "${args[@]}"


### PR DESCRIPTION
## Usage

```bash
uv run python scripts/install.py local --use   # full build: lf, lfd, Loopflow.app -> local-bin/, make active
uv run python scripts/install.py refresh        # CLI refresh: pull default branch, rebuild/install lf+lfd
```

## Summary

Local development and the native Mac `lfd` host previously had two implementations of the same operation—pull the default branch, rebuild `lf`/`lfd`, and install them into a local bin dir. This collapses them onto one path: `scripts/install.py` now owns local installation, with a new `refresh` command as the fast CLI-only update. `scripts/pull-local-bin.sh` becomes a thin compatibility wrapper, and the native host update agent calls `install.py refresh` directly. The result is one implementation to test and one command family to document, with no risk of the Mac host drifting from the developer path.

## Changes

- New `install.py refresh` command: refuses to pull a non-default branch, fast-forward merges the default branch (with `--no-pull` and `--install-dir` options), rebuilds `lf`/`lfd`, and atomically installs them.
- Factored binary staging into a shared `_install_cli_binaries` used by both `local` and `refresh`.
- `deploy/native-lfd-host.sh` now invokes `install.py refresh` for its update path instead of `pull-local-bin.sh`.
- `scripts/pull-local-bin.sh` reduced to a compatibility wrapper that delegates to `install.py refresh`.
- Docs (README, release/, deploy/) and release automation tests updated to point at the new entry point; added a DECISIONS.md ledger entry recording the consolidation.