### PR TITLE
release: fuse decisions and shipped behavior in release notes

### DIFF
--- a/docs/lfop.md
+++ b/docs/lfop.md
@@ -93,13 +93,13 @@ Mechanical release subcommands. Use `lf release` or `lf op release run` for the 
 ```bash
 lf op release run patch          # full release workflow
 lf op release check              # PRs merged since last tag?
-lf op release notes 1.2.3        # generate RELEASE_NOTES.md
+lf op release notes 1.2.3        # generate narrative RELEASE_NOTES.md from decisions + PRs
 lf op release bump 1.2.3         # bump manifests
 lf op release tag 1.2.3          # create + push git tag
 lf op release status             # workflow + GitHub Release status
 ```
 
-Keep release-cycle rationale in `release/unreleased/DECISIONS.md` when you want narrative-first notes. If that directory exists, the full release workflow promotes it to `release/v<version>/`, uses `DECISIONS.md` as the primary narrative source, and archives the generated root `RELEASE_NOTES.md` to `release/v<version>/NOTES.md`. If it does not exist, Loopflow falls back to merged PR history.
+Keep release-cycle rationale in `release/unreleased/DECISIONS.md` when you want narrative-first notes. `lf op release notes` and the full release workflow promote it to `release/v<version>/`, use `DECISIONS.md` as the intent source, use merged PRs/diffs as the shipped-behavior source, and archive the generated root `RELEASE_NOTES.md` to `release/v<version>/NOTES.md`. If the ledger is absent, Loopflow falls back to merged PR history.
 
 ---
 

--- a/release/unreleased/DECISIONS.md
+++ b/release/unreleased/DECISIONS.md
@@ -7,3 +7,11 @@
 **Decision:** `scripts/install.py` owns local installation. `install.py local --use` remains the full build-and-promote path for `lf`, `lfd`, and `Loopflow.app`; `install.py refresh` is the fast CLI-only update path. `scripts/pull-local-bin.sh` stays only as a compatibility wrapper, and native host updates call `install.py refresh` directly.
 
 **Implications:** There is one implementation to test and one command family to document. Existing callers of `pull-local-bin.sh` continue working, but new docs point users and deploy scripts at `scripts/install.py`.
+
+## 2026-06-30 — Release notes fuse decisions and shipped behavior
+
+**Context:** Cadenza's first release showed the useful half of the decisions ledger — it captured intent — and the weak half of a raw ledger dump: it was too long and not interpreted. Loopflow's older PR-based notes had the opposite problem: concrete changes without enough narrative intent.
+
+**Decision:** The shared `release-notes` step now treats `DECISIONS.md` as the intent ledger and merged PRs/diffs as the behavior ledger. `lf op release notes` uses the same agent-backed release-note step as `lf op release run`, so standalone notes, weekly releases, and repo consumers share one prompt contract.
+
+**Implications:** Release notes should read as an interpreted story grounded in shipped behavior, while the raw decision ledger remains archived under `release/v<version>/DECISIONS.md`. Repos like Cadenza can call Loopflow's release-note command instead of embedding their own note writer.

--- a/rust/loopflow/src/engine/builtins/ops/prompt/release_notes.md
+++ b/rust/loopflow/src/engine/builtins/ops/prompt/release_notes.md
@@ -4,10 +4,10 @@ Do not ask questions. Make best-effort assumptions and proceed.
 
 ## Workflow
 
-1. Read the PR list below. Note diff stats — PRs with 100+ additions are major changes.
-2. Find connections between PRs. Which ones are part of the same story?
-3. For major changes (100+ lines added), run `git diff <prev_tag>..HEAD -- <relevant paths>` to understand what actually changed. The PR title and body are a summary — the diff is ground truth.
-4. Write the release notes.
+1. Read the structured release context. Use release decisions as the intent ledger and PRs/diffs as the behavior ledger.
+2. Find the through-line: which decisions explain why these changes belong in one release?
+3. For major changes or unclear PRs, run `git diff <prev_tag>..HEAD -- <relevant paths>` to verify what actually shipped.
+4. Write the release notes as an interpreted story grounded in shipped behavior.
 
 ## Output format
 
@@ -16,25 +16,26 @@ Raw markdown only. No JSON, no code fences wrapping the output.
 First line must be exactly: `# v{version}`
 
 Structure:
-1. **Opening** — 2-3 sentences answering "why upgrade?" Not a list. Not "This release includes..." Tell the story.
-2. **Thematic sections** — named after what actually changed in this release. Not "Improvements" or "Bug fixes" — names like "Sandbox execution", "Release workflow", "CLI ergonomics". Each section has a prose paragraph connecting the changes, followed by detail bullets for scanners.
-3. **Small changes** — group minor fixes and tweaks at the end under a single section.
+1. **Opening** — 2-4 sentences answering “why upgrade?” Tell the release story.
+2. **Thematic sections** — named after user/operator outcomes, not implementation buckets. Each section has a prose paragraph connecting intent to behavior, followed by detail bullets for scanners.
+3. **Operational notes** — only when relevant: deployment, release process, migration, billing, TestFlight, compatibility, or manual steps.
+4. **Small changes** — group minor fixes and tweaks at the end.
 
 ## Theming
 
-Theme names come from the changes, not a template. Read the PRs and find what they're about.
+Theme names come from the release, not a template. Read decisions first, then PRs and diffs. Use decisions to understand intent; use commits and diffs to prove what shipped.
 
 When target context is provided (target name, tag prefix, area scope), include only changes relevant to that scope.
 
 ## Style
 
-Lead with outcomes, not mechanisms. What can users do now? What got better?
+Lead with outcomes, not mechanisms.
 
-Good: "`lf op next` now starts fresh from main after merged PRs — no manual cleanup"
-Bad: "Refactored release.rs to extract helper functions"
+Good: “`lf op release run` now turns release decisions into versioned notes and archives the ledger for audit.”
+Bad: “Updated release.rs and release_notes.md.”
 
-Skip internal refactors unless they affect what users experience.
+Do not paste `DECISIONS.md` wholesale. Do not dump PR titles verbatim. The release notes are the synthesis; the ledger remains archived separately.
 
-Each thematic section: prose paragraph first (what's the story?), then bullets (what specifically changed?). The prose connects related PRs into a narrative. The bullets give scanners the detail.
+Skip internal refactors unless they affect what users experience or how operators run the system.
 
-If previous release notes are provided below, match their voice and density.
+If previous release notes are provided below, match their voice and density while keeping this release concise.

--- a/rust/loopflow/src/engine/builtins/ops/step/release-notes.md
+++ b/rust/loopflow/src/engine/builtins/ops/step/release-notes.md
@@ -3,24 +3,51 @@ requires: LF_RELEASE_NOTES_CONTEXT env var pointing to JSON release context
 produces: RELEASE_NOTES.md
 diff_files: false
 ---
-Write narrative release notes from structured release context.
+Write release notes that fuse release intent with shipped behavior.
 
 ## Workflow
 
 1. Read `LF_RELEASE_NOTES_CONTEXT` and parse the JSON.
-2. If `decisions` is present, treat it as primary source — the agent-authored ledger of intent decisions made during this cycle. Use its themes, voice, and framing. PRs in `merged_prs` are supplementary: use them to fill gaps and surface mechanical changes that weren't logged as decisions.
-3. If `decisions` is absent or empty, fall back to `merged_prs` as the primary source.
-4. Keep the previous release-note voice if `previous_release_notes` exists.
-5. Write `RELEASE_NOTES.md` with:
-   - `# v<version>` header
-   - "Changes since `<prev_tag>`" section
-   - themed sections grouping by what users feel, not what code changed
-   - concise bullets with concrete impact
+2. Treat `decisions` as the intent ledger: what changed in product direction, release policy, operations, and user experience during this cycle.
+3. Treat `merged_prs` and, when needed, `git diff <prev_tag>..HEAD`, as the behavior ledger: what actually shipped.
+4. Fuse them. The release notes should explain what users, operators, and contributors can do differently now. Use commits/PRs to ground every claim.
+5. Keep the previous release-note voice if `previous_release_notes` exists, but improve structure when the previous notes were too raw.
+6. Write `RELEASE_NOTES.md`.
 
-## Guardrails
+## Output
 
-- Decisions describe intent; PRs describe diffs. Lead with intent.
-- Don't dump PR titles verbatim — rephrase for users.
-- Prefer clear themes over chronological lists.
-- Keep language specific and factual; no marketing filler.
-- Always overwrite `RELEASE_NOTES.md` with the new version's notes.
+Raw markdown only. No JSON. No code fence wrapping the output.
+
+First line must be exactly:
+
+```markdown
+# v<version>
+```
+
+Structure:
+
+1. **Opening story** — 2-4 sentences. Answer “why upgrade?” and name the through-line of the release. This is narrative, not a list.
+2. **Thematic sections** — sections named after user/operator outcomes, not implementation buckets. Each section starts with a short paragraph connecting the decisions to the shipped behavior, followed by concise bullets for scanners.
+3. **Operational notes** — include only when relevant: release process, deployment, migration, billing, TestFlight, compatibility, or known manual steps.
+4. **Small changes** — minor fixes and polish that do not deserve a full theme.
+
+## Source handling
+
+- Decisions are source material, not release notes. Do not paste the ledger wholesale.
+- PR titles are source material, not release notes. Do not dump them chronologically.
+- If decisions and commits disagree, trust the commits for what shipped and use decisions to explain why.
+- If decisions mention future work that did not ship, either omit it or mark it clearly as “not included.”
+- If there are no decisions, build the narrative from merged PRs and diffs.
+- If there are decisions but no matching shipped behavior, keep the note cautious: describe the policy/intent change, not an implementation that is absent.
+
+## Style
+
+- Lead with outcomes, not mechanisms.
+- Be specific and factual. No marketing filler.
+- Prefer a few strong themes over many headings.
+- Write for the person deciding whether to upgrade and the operator debugging the release six weeks later.
+- Keep the decision ledger archived under `release/v<version>/DECISIONS.md`; `RELEASE_NOTES.md` should be the interpreted story.
+
+## Quality bar
+
+A good release note could not be generated from PR titles alone. It carries the intent from `DECISIONS.md`, proves it against shipped changes, and leaves a concise operational record.

--- a/rust/loopflow/src/ops/release.rs
+++ b/rust/loopflow/src/ops/release.rs
@@ -252,12 +252,10 @@ pub fn release_notes(
     progress.status("Collecting merged PRs...");
     let prs = merged_prs_since(&main_repo, &resolved_prev_tag, &target)?;
 
-    progress.status("Generating release notes...");
-    let notes = generate_release_notes(&prs, &version, &resolved_prev_tag, &target)?;
+    progress.status("Generating narrative release notes...");
+    run_release_notes_step(&main_repo, &version, &resolved_prev_tag, &prs, &target)?;
 
-    progress.status("Writing RELEASE_NOTES.md...");
-    write_release_notes(&main_repo, &notes, &version)?;
-
+    let notes = fs::read_to_string(main_repo.join("RELEASE_NOTES.md"))?;
     Ok(notes)
 }
 


### PR DESCRIPTION
## Usage

```bash
lf op release notes 1.2.3        # narrative RELEASE_NOTES.md from decisions + PRs
lf op release run patch          # full workflow, same release-note step
```

## Summary

Release notes now fuse two ledgers: `DECISIONS.md` as the source of *intent* and merged PRs/diffs as the source of *shipped behavior*. Cadenza's first release exposed the failure modes on both sides — a raw decisions dump reads long and uninterpreted, while PR-only notes carry concrete changes with no narrative. The `release-notes` step now interprets decisions against what actually shipped, producing an outcome-oriented story while the raw ledger stays archived under `release/v<version>/DECISIONS.md`.

Crucially, `lf op release notes` and `lf op release run` now share the same agent-backed release-note step, so standalone notes, weekly releases, and repo consumers (like Cadenza) all use one prompt contract instead of embedding their own note writers.

## Changes

- `release.rs`: `release_notes` calls the shared `run_release_notes_step` instead of the standalone generator, then reads back the written `RELEASE_NOTES.md`.
- Rewrote the `release-notes` step and `release_notes` prompt around the intent-ledger / behavior-ledger split, with explicit output structure (opening story → thematic sections → operational notes → small changes) and source-handling rules (trust commits for what shipped, decisions for why).
- Added a DECISIONS.md entry recording the fusion decision, and updated `docs/lfop.md` to describe the shared promote/archive flow.
