### PR TITLE
lf pm: connect reduce to asana

### DIFF
--- a/scratch/questions.md
+++ b/scratch/questions.md
@@ -1,0 +1,20 @@
+# Open Questions / Blockers
+
+## BLOCKER: Wave has no roadmap or metrics — no safe move exists (2026-07-02, re-confirmed 2026-07-03)
+
+The looping Goal agent ran one iteration and found nothing to act on:
+
+- **Roadmap handle:** empty — no Asana backlog to read or pick from.
+- **Metrics:** none configured — no way to measure whether a move advances the goal.
+- **Wave memory / in-flight:** empty — no prior context or work to continue.
+
+The goal contract forbids inventing work. With no roadmap task to dispatch and no
+metric to drive, any move would be local optimization dressed as progress. Halted
+per "record the blocker and stop."
+
+**To unblock, wire one of:**
+1. A roadmap handle (Asana project/section) holding at least one scoped task.
+2. Metrics for the goal, so the loop has a target to measure against and can
+   propose moves that provably advance the whole.
+
+Until then the loop has nothing to advance.

--- a/wave/reduce/GOAL.md
+++ b/wave/reduce/GOAL.md
@@ -2,10 +2,12 @@
 primary_flow: ship-roadmap
 mode: manual
 metrics:
-  - net concept count (steps, flows, DTO types, public types) flat-or-falling while feature waves ship
-  - duplicated abstractions known vs. resolved, incl. cross-wave convergence
-  - analysis coverage %, and max staleness in commits behind HEAD
-  - proposal funnel — drafted → agreed → executed — and arc cycle time
+- net concept count (steps, flows, DTO types, public types) flat-or-falling while feature waves ship
+- duplicated abstractions known vs. resolved, incl. cross-wave convergence
+- analysis coverage %, and max staleness in commits behind HEAD
+- proposal funnel — drafted → agreed → executed — and arc cycle time
+pm:
+  asana_project: '1216271408546327'
 ---
 
 # Goal: loopflow grows more capable while getting smaller.


### PR DESCRIPTION
Connect the reduce wave's roadmap to Asana: `lf op pm init -w reduce` created project 1216271408546327 and wrote `pm.asana_project` into wave/reduce/GOAL.md. Populates reduce's Asana roadmap (proposal spine, execution engine, steady state) plus items re-homed from the retired workflows wave.

🤖 Generated with [Claude Code](https://claude.com/claude-code)