### PR TITLE
pm: close roadmap tasks with a PR link via lf op pm update --pr

### DIFF
--- a/rust/loopflow/src/engine/builtins/LOOPFLOW.md
+++ b/rust/loopflow/src/engine/builtins/LOOPFLOW.md
@@ -53,11 +53,15 @@ only way to read or change it. There is no local roadmap file to edit and no
 sync step; Asana is the source of truth.
 
 ```bash
-lf op pm show                                  # the wave's live roadmap
-lf op pm update --title "..." --notes "..."    # file a new task
-lf op pm update --id <task-id> --status done   # close a shipped task
-lf op pm update --id <task-id> --title "..."   # edit an existing task
+lf op pm show                                          # the wave's live roadmap
+lf op pm update --title "..." --notes "..."            # file a new task
+lf op pm update --id <task-id> --status done --pr <url> # close a shipped task with its PR link
+lf op pm update --id <task-id> --title "..."           # edit an existing task
 ```
+
+Close a shipped task with `--status done --pr <url>` so the roadmap carries a
+pointer back to the work. The PR link posts as a comment; it never clobbers the
+task's description.
 
 Add `--wave <name>` when the wave is ambiguous. Never write `wave/<name>/N-*.md`
 roadmap files or a roadmap table in `GOAL.md` — that mirror is gone.

--- a/rust/loopflow/src/lf/commands/ops/mod.rs
+++ b/rust/loopflow/src/lf/commands/ops/mod.rs
@@ -407,6 +407,7 @@ fn pm_cmd(cmd: &PmCommand, progress: &impl Progress) -> Result<()> {
             title,
             notes,
             status,
+            pr,
         } => {
             let result = crate::ops::pm::pm_update(
                 &repo_root,
@@ -416,12 +417,17 @@ fn pm_cmd(cmd: &PmCommand, progress: &impl Progress) -> Result<()> {
                     title: title.clone(),
                     notes: notes.clone(),
                     status: status.clone(),
+                    pr: pr.clone(),
                 },
                 progress,
             )?;
             let verb = if result.created { "created" } else { "updated" };
             let closed = if result.completed { ", closed" } else { "" };
-            println!("{}: {verb} task {}{closed}", result.wave, result.id);
+            let linked = match result.linked_pr {
+                Some(pr) => format!(", linked {pr}"),
+                None => String::new(),
+            };
+            println!("{}: {verb} task {}{closed}{linked}", result.wave, result.id);
         }
         PmCommand::Status { wave } => {
             let result = crate::ops::pm::pm_status(

--- a/rust/loopflow/src/lf/mod.rs
+++ b/rust/loopflow/src/lf/mod.rs
@@ -348,6 +348,9 @@ pub enum PmCommand {
         /// Set to `done` to close the task
         #[arg(long = "status")]
         status: Option<String>,
+        /// PR URL to attach as a comment (the loop's write-back link)
+        #[arg(long = "pr")]
+        pr: Option<String>,
     },
     /// Show roadmap status for linked waves
     Status {
@@ -579,6 +582,7 @@ mod tests {
                             title,
                             notes,
                             status,
+                            pr,
                         },
                 },
         }) = cli.command
@@ -590,15 +594,17 @@ mod tests {
         assert_eq!(title, "Ship it");
         assert_eq!(notes.as_deref(), Some("details"));
         assert_eq!(status, None);
+        assert_eq!(pr, None);
 
         let cli = Cli::try_parse_from([
             "lf", "op", "pm", "update", "--id", "123", "--title", "Ship it", "--status", "done",
+            "--pr", "https://github.com/acme/repo/pull/7",
         ])
         .expect("parse");
         let Some(Commands::Op {
             op:
                 OpsCommand::Pm {
-                    cmd: PmCommand::Update { id, status, .. },
+                    cmd: PmCommand::Update { id, status, pr, .. },
                 },
         }) = cli.command
         else {
@@ -606,6 +612,7 @@ mod tests {
         };
         assert_eq!(id.as_deref(), Some("123"));
         assert_eq!(status.as_deref(), Some("done"));
+        assert_eq!(pr.as_deref(), Some("https://github.com/acme/repo/pull/7"));
     }
 
     #[test]

--- a/rust/loopflow/src/lf/mod.rs
+++ b/rust/loopflow/src/lf/mod.rs
@@ -597,8 +597,18 @@ mod tests {
         assert_eq!(pr, None);
 
         let cli = Cli::try_parse_from([
-            "lf", "op", "pm", "update", "--id", "123", "--title", "Ship it", "--status", "done",
-            "--pr", "https://github.com/acme/repo/pull/7",
+            "lf",
+            "op",
+            "pm",
+            "update",
+            "--id",
+            "123",
+            "--title",
+            "Ship it",
+            "--status",
+            "done",
+            "--pr",
+            "https://github.com/acme/repo/pull/7",
         ])
         .expect("parse");
         let Some(Commands::Op {

--- a/rust/loopflow/src/ops/pm.rs
+++ b/rust/loopflow/src/ops/pm.rs
@@ -50,6 +50,8 @@ pub struct PmUpdateOptions {
     pub title: String,
     pub notes: Option<String>,
     pub status: Option<String>,
+    /// PR URL to attach as a comment on the task (the loop's write-back link).
+    pub pr: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -58,6 +60,7 @@ pub struct PmUpdateResult {
     pub id: String,
     pub created: bool,
     pub completed: bool,
+    pub linked_pr: Option<String>,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -344,6 +347,27 @@ async fn apply_update(
         }
     };
 
+    // Attach the PR link as a comment before closing so the task carries a
+    // durable pointer to the work without clobbering its description.
+    let linked_pr = match options
+        .pr
+        .as_deref()
+        .map(str::trim)
+        .filter(|pr| !pr.is_empty())
+    {
+        Some(pr) => {
+            progress.status(&format!("commenting PR link on asana task {id}"));
+            let body = if mark_done {
+                format!("Shipped: {pr}")
+            } else {
+                format!("PR: {pr}")
+            };
+            ctx.client.comment(&id, &body).await.map_err(pm_to_ops)?;
+            Some(pr.to_string())
+        }
+        None => None,
+    };
+
     if mark_done {
         ctx.client.complete_item(&id).await.map_err(pm_to_ops)?;
     }
@@ -353,6 +377,7 @@ async fn apply_update(
         id,
         created,
         completed: mark_done,
+        linked_pr,
     })
 }
 
@@ -588,6 +613,7 @@ mod tests {
             title: "New task".to_string(),
             notes: Some("details".to_string()),
             status: None,
+            pr: None,
         };
 
         let result = apply_update("goals", &ctx, &options, &NullProgress)
@@ -596,6 +622,7 @@ mod tests {
         assert!(result.created);
         assert_eq!(result.id, "new-task");
         assert!(!result.completed);
+        assert!(result.linked_pr.is_none());
         assert_eq!(requests.lock().await.len(), 2);
     }
 
@@ -615,6 +642,7 @@ mod tests {
             title: "Existing".to_string(),
             notes: None,
             status: Some("done".to_string()),
+            pr: None,
         };
 
         let result = apply_update("goals", &ctx, &options, &NullProgress)
@@ -623,5 +651,44 @@ mod tests {
         assert!(!result.created);
         assert_eq!(result.id, "task-9");
         assert!(result.completed);
+    }
+
+    #[tokio::test]
+    async fn apply_update_comments_pr_link_then_closes() {
+        let (base_url, requests) = test_server::spawn(vec![
+            // update_item PUT
+            json_response(StatusCode::OK, json!({ "data": {} })),
+            // comment POST (PR link)
+            json_response(StatusCode::CREATED, json!({ "data": { "gid": "story-1" } })),
+            // complete_item PUT
+            json_response(StatusCode::OK, json!({ "data": {} })),
+        ])
+        .await;
+        let ctx = test_ctx(base_url, "proj-1");
+        let options = PmUpdateOptions {
+            wave: None,
+            id: Some("task-9".to_string()),
+            title: "Existing".to_string(),
+            notes: None,
+            status: Some("done".to_string()),
+            pr: Some("https://github.com/acme/repo/pull/42".to_string()),
+        };
+
+        let result = apply_update("goals", &ctx, &options, &NullProgress)
+            .await
+            .expect("update succeeds");
+        assert!(result.completed);
+        assert_eq!(
+            result.linked_pr.as_deref(),
+            Some("https://github.com/acme/repo/pull/42")
+        );
+
+        let requests = requests.lock().await;
+        let comment = requests
+            .iter()
+            .find(|req| req.path.ends_with("/stories"))
+            .expect("PR link is posted as a comment");
+        assert!(comment.body.contains("Shipped:"));
+        assert!(comment.body.contains("pull/42"));
     }
 }

--- a/tests/goldens/basic.md
+++ b/tests/goldens/basic.md
@@ -54,11 +54,15 @@ only way to read or change it. There is no local roadmap file to edit and no
 sync step; Asana is the source of truth.
 
 ```bash
-lf op pm show                                  # the wave's live roadmap
-lf op pm update --title "..." --notes "..."    # file a new task
-lf op pm update --id <task-id> --status done   # close a shipped task
-lf op pm update --id <task-id> --title "..."   # edit an existing task
+lf op pm show                                          # the wave's live roadmap
+lf op pm update --title "..." --notes "..."            # file a new task
+lf op pm update --id <task-id> --status done --pr <url> # close a shipped task with its PR link
+lf op pm update --id <task-id> --title "..."           # edit an existing task
 ```
+
+Close a shipped task with `--status done --pr <url>` so the roadmap carries a
+pointer back to the work. The PR link posts as a comment; it never clobbers the
+task's description.
 
 Add `--wave <name>` when the wave is ambiguous. Never write `wave/<name>/N-*.md`
 roadmap files or a roadmap table in `GOAL.md` — that mirror is gone.

--- a/tests/goldens/builtin_code_review.md
+++ b/tests/goldens/builtin_code_review.md
@@ -54,11 +54,15 @@ only way to read or change it. There is no local roadmap file to edit and no
 sync step; Asana is the source of truth.
 
 ```bash
-lf op pm show                                  # the wave's live roadmap
-lf op pm update --title "..." --notes "..."    # file a new task
-lf op pm update --id <task-id> --status done   # close a shipped task
-lf op pm update --id <task-id> --title "..."   # edit an existing task
+lf op pm show                                          # the wave's live roadmap
+lf op pm update --title "..." --notes "..."            # file a new task
+lf op pm update --id <task-id> --status done --pr <url> # close a shipped task with its PR link
+lf op pm update --id <task-id> --title "..."           # edit an existing task
 ```
+
+Close a shipped task with `--status done --pr <url>` so the roadmap carries a
+pointer back to the work. The PR link posts as a comment; it never clobbers the
+task's description.
 
 Add `--wave <name>` when the wave is ambiguous. Never write `wave/<name>/N-*.md`
 roadmap files or a roadmap table in `GOAL.md` — that mirror is gone.

--- a/tests/goldens/builtin_debug.md
+++ b/tests/goldens/builtin_debug.md
@@ -54,11 +54,15 @@ only way to read or change it. There is no local roadmap file to edit and no
 sync step; Asana is the source of truth.
 
 ```bash
-lf op pm show                                  # the wave's live roadmap
-lf op pm update --title "..." --notes "..."    # file a new task
-lf op pm update --id <task-id> --status done   # close a shipped task
-lf op pm update --id <task-id> --title "..."   # edit an existing task
+lf op pm show                                          # the wave's live roadmap
+lf op pm update --title "..." --notes "..."            # file a new task
+lf op pm update --id <task-id> --status done --pr <url> # close a shipped task with its PR link
+lf op pm update --id <task-id> --title "..."           # edit an existing task
 ```
+
+Close a shipped task with `--status done --pr <url>` so the roadmap carries a
+pointer back to the work. The PR link posts as a comment; it never clobbers the
+task's description.
 
 Add `--wave <name>` when the wave is ambiguous. Never write `wave/<name>/N-*.md`
 roadmap files or a roadmap table in `GOAL.md` — that mirror is gone.

--- a/tests/goldens/builtin_demo.md
+++ b/tests/goldens/builtin_demo.md
@@ -54,11 +54,15 @@ only way to read or change it. There is no local roadmap file to edit and no
 sync step; Asana is the source of truth.
 
 ```bash
-lf op pm show                                  # the wave's live roadmap
-lf op pm update --title "..." --notes "..."    # file a new task
-lf op pm update --id <task-id> --status done   # close a shipped task
-lf op pm update --id <task-id> --title "..."   # edit an existing task
+lf op pm show                                          # the wave's live roadmap
+lf op pm update --title "..." --notes "..."            # file a new task
+lf op pm update --id <task-id> --status done --pr <url> # close a shipped task with its PR link
+lf op pm update --id <task-id> --title "..."           # edit an existing task
 ```
+
+Close a shipped task with `--status done --pr <url>` so the roadmap carries a
+pointer back to the work. The PR link posts as a comment; it never clobbers the
+task's description.
 
 Add `--wave <name>` when the wave is ambiguous. Never write `wave/<name>/N-*.md`
 roadmap files or a roadmap table in `GOAL.md` — that mirror is gone.

--- a/tests/goldens/builtin_implement.md
+++ b/tests/goldens/builtin_implement.md
@@ -54,11 +54,15 @@ only way to read or change it. There is no local roadmap file to edit and no
 sync step; Asana is the source of truth.
 
 ```bash
-lf op pm show                                  # the wave's live roadmap
-lf op pm update --title "..." --notes "..."    # file a new task
-lf op pm update --id <task-id> --status done   # close a shipped task
-lf op pm update --id <task-id> --title "..."   # edit an existing task
+lf op pm show                                          # the wave's live roadmap
+lf op pm update --title "..." --notes "..."            # file a new task
+lf op pm update --id <task-id> --status done --pr <url> # close a shipped task with its PR link
+lf op pm update --id <task-id> --title "..."           # edit an existing task
 ```
+
+Close a shipped task with `--status done --pr <url>` so the roadmap carries a
+pointer back to the work. The PR link posts as a comment; it never clobbers the
+task's description.
 
 Add `--wave <name>` when the wave is ambiguous. Never write `wave/<name>/N-*.md`
 roadmap files or a roadmap table in `GOAL.md` — that mirror is gone.

--- a/tests/goldens/with_direction.md
+++ b/tests/goldens/with_direction.md
@@ -54,11 +54,15 @@ only way to read or change it. There is no local roadmap file to edit and no
 sync step; Asana is the source of truth.
 
 ```bash
-lf op pm show                                  # the wave's live roadmap
-lf op pm update --title "..." --notes "..."    # file a new task
-lf op pm update --id <task-id> --status done   # close a shipped task
-lf op pm update --id <task-id> --title "..."   # edit an existing task
+lf op pm show                                          # the wave's live roadmap
+lf op pm update --title "..." --notes "..."            # file a new task
+lf op pm update --id <task-id> --status done --pr <url> # close a shipped task with its PR link
+lf op pm update --id <task-id> --title "..."           # edit an existing task
 ```
+
+Close a shipped task with `--status done --pr <url>` so the roadmap carries a
+pointer back to the work. The PR link posts as a comment; it never clobbers the
+task's description.
 
 Add `--wave <name>` when the wave is ambiguous. Never write `wave/<name>/N-*.md`
 roadmap files or a roadmap table in `GOAL.md` — that mirror is gone.

--- a/tests/goldens/with_direction_group.md
+++ b/tests/goldens/with_direction_group.md
@@ -54,11 +54,15 @@ only way to read or change it. There is no local roadmap file to edit and no
 sync step; Asana is the source of truth.
 
 ```bash
-lf op pm show                                  # the wave's live roadmap
-lf op pm update --title "..." --notes "..."    # file a new task
-lf op pm update --id <task-id> --status done   # close a shipped task
-lf op pm update --id <task-id> --title "..."   # edit an existing task
+lf op pm show                                          # the wave's live roadmap
+lf op pm update --title "..." --notes "..."            # file a new task
+lf op pm update --id <task-id> --status done --pr <url> # close a shipped task with its PR link
+lf op pm update --id <task-id> --title "..."           # edit an existing task
 ```
+
+Close a shipped task with `--status done --pr <url>` so the roadmap carries a
+pointer back to the work. The PR link posts as a comment; it never clobbers the
+task's description.
 
 Add `--wave <name>` when the wave is ambiguous. Never write `wave/<name>/N-*.md`
 roadmap files or a roadmap table in `GOAL.md` — that mirror is gone.

--- a/tests/goldens/with_docs.md
+++ b/tests/goldens/with_docs.md
@@ -54,11 +54,15 @@ only way to read or change it. There is no local roadmap file to edit and no
 sync step; Asana is the source of truth.
 
 ```bash
-lf op pm show                                  # the wave's live roadmap
-lf op pm update --title "..." --notes "..."    # file a new task
-lf op pm update --id <task-id> --status done   # close a shipped task
-lf op pm update --id <task-id> --title "..."   # edit an existing task
+lf op pm show                                          # the wave's live roadmap
+lf op pm update --title "..." --notes "..."            # file a new task
+lf op pm update --id <task-id> --status done --pr <url> # close a shipped task with its PR link
+lf op pm update --id <task-id> --title "..."           # edit an existing task
 ```
+
+Close a shipped task with `--status done --pr <url>` so the roadmap carries a
+pointer back to the work. The PR link posts as a comment; it never clobbers the
+task's description.
 
 Add `--wave <name>` when the wave is ambiguous. Never write `wave/<name>/N-*.md`
 roadmap files or a roadmap table in `GOAL.md` — that mirror is gone.


### PR DESCRIPTION
## What

Adds `--pr <url>` to `lf op pm update`. The flag posts the PR link as an Asana **comment** on the task and, combined with `--status done`, closes the task in a single call:

```bash
lf op pm update --id <task-id> --status done --pr <url>
```

`LOOPFLOW.md` (the wave's operating prompt) documents the flag so the Looping Agent uses it when a dispatched task's PR lands. The in-flight context the loop already sees carries each dispatch's `pr_url`, so the agent has the link to pass.

## Why

The Goals roadmap item *"Asana as the live roadmap"* (`wave/goals/2-asana-roadmap.md`) is **Done when**:

> A Goal completes a real Asana task end-to-end: reads it, does the work, moves it to Done with a PR link, with no local mirror in the path.

Everything but the **PR link** was already shipped: the local mirror is gone (commit `c113ef04b`), the loop reads live via `lf op pm show`, dispatches work, and closes tasks with `--status done`. But the write-back could only mark done — there was no clean way to attach the shipped PR. `--notes` overwrites the task's description; the purpose-built `AsanaClient::comment` existed only inside `claim_item` and was never exposed to the loop.

This wires that existing seam through, closing the last clause of the Done-when. Kept minimal per the item's "keep the surface minimal — don't build the full service" guidance: one flag, reusing the existing `comment()` client method.

## Maps to Done-when

| Clause | Mechanism |
| --- | --- |
| reads it | `lf op pm show` → Asana `list_items` (already shipped) |
| does the work | `lfq worker run` dispatch (already shipped) |
| moves it to Done | `--status done` → `complete_item` (already shipped) |
| **with a PR link** | **`--pr <url>` → `comment` (this PR)** |
| no local mirror | mirror removed in `c113ef04b` (already shipped) |

## Tests

`cargo fmt`, `cargo clippy -p loopflow --lib -- -D warnings`, and `cargo test -p loopflow --lib` all pass. New/updated tests:
- `apply_update_comments_pr_link_then_closes` — asserts the PR link posts to `/stories` and the task closes.
- `pm_update_parses_create_and_close` — asserts `--pr` parses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)