### PR TITLE
Reintroduce wave ancestry so chords surface their children

### DIFF
--- a/python/loopflow/models.py
+++ b/python/loopflow/models.py
@@ -113,6 +113,7 @@ class Wave(BaseModel):
     status: str
     repos: list[RepoWork]
     flow_steps: list[FlowStep]
+    parent_wave_id: Optional[str]
     created_at: Optional[datetime] = None
 
     @field_validator("flow_steps", mode="before")

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -16,6 +16,7 @@ WAVE_MINIMAL = {
     "triggers": [],
     "crons": [],
     "flow_steps": [],
+    "parent_wave_id": None,
     "repos": [
         {
             "repo": "/tmp/repo",

--- a/python/tests/test_contract.py
+++ b/python/tests/test_contract.py
@@ -27,6 +27,7 @@ def test_wave_fixture_parses():
     assert wave.status == "running"
     assert wave.direction == ["ux", "clarity"]
     assert wave.area == ["src/"]
+    assert wave.parent_wave_id == "wave_parent999"
     assert len(wave.crons) == 1
     assert wave.crons[0].flow == "wave-polish"
 

--- a/rust/loopflow/src/lfd/executor/docker/tests.rs
+++ b/rust/loopflow/src/lfd/executor/docker/tests.rs
@@ -353,6 +353,7 @@ async fn create_running_wave_and_run(store: &SharedStore, repo: &Path, name: &st
         paused: false,
         created_at: Some(OffsetDateTime::now_utc()),
         workers: 1,
+        parent_wave_id: None,
     };
     store
         .create_wave(&wave)
@@ -605,6 +606,7 @@ async fn docker_startup_lost_agent_does_not_flip_terminal_run_wave_status() {
         paused: false,
         created_at: Some(OffsetDateTime::now_utc()),
         workers: 1,
+        parent_wave_id: None,
     };
     store
         .create_wave(&wave)

--- a/rust/loopflow/src/lfd/executor/wave/mod.rs
+++ b/rust/loopflow/src/lfd/executor/wave/mod.rs
@@ -1471,6 +1471,7 @@ mod tests {
             paused: false,
             created_at: Some(OffsetDateTime::now_utc()),
             workers: 1,
+            parent_wave_id: None,
         };
         store
             .create_wave(&wave)
@@ -1536,6 +1537,7 @@ mod tests {
             paused: false,
             created_at: Some(OffsetDateTime::now_utc()),
             workers: 1,
+            parent_wave_id: None,
         }
     }
 
@@ -1733,6 +1735,7 @@ mod tests {
             paused: false,
             created_at: Some(OffsetDateTime::now_utc()),
             workers: 1,
+            parent_wave_id: None,
         };
         store
             .create_wave(&target_wave)

--- a/rust/loopflow/src/lfd/http/dto.rs
+++ b/rust/loopflow/src/lfd/http/dto.rs
@@ -98,6 +98,9 @@ pub struct WaveDto {
     pub crons: Vec<WaveCronDto>,
     /// Per-repo execution state, one entry per repo the wave runs in.
     pub repos: Vec<RepoWorkDto>,
+    /// Parent wave in the chord tree. `null` for a root wave. Always emitted
+    /// (no `skip_serializing_if`) so the Python/Swift mirrors stay in lockstep.
+    pub parent_wave_id: Option<String>,
 }
 
 /// Per-repo execution surface for a wave: status/iteration plus the live git
@@ -607,6 +610,7 @@ mod contract_tests {
             flow_steps: Vec::new(),
             has_stale_pr_state: false,
             repos: Vec::new(),
+            parent_wave_id: None,
         };
 
         let json = serde_json::to_value(&wave).unwrap();

--- a/rust/loopflow/src/lfd/http/routes/hooks.rs
+++ b/rust/loopflow/src/lfd/http/routes/hooks.rs
@@ -805,6 +805,7 @@ mod tests {
             paused: false,
             created_at: Some(OffsetDateTime::now_utc()),
             workers: 1,
+            parent_wave_id: None,
         };
         state.store.create_wave(&wave).await.expect("create wave");
         let trigger = Trigger {

--- a/rust/loopflow/src/lfd/http/routes/mod.rs
+++ b/rust/loopflow/src/lfd/http/routes/mod.rs
@@ -189,6 +189,7 @@ pub async fn build_wave_dto(
         triggers,
         crons,
         repos,
+        parent_wave_id: wave.parent_wave_id().map(|id| id.to_string()),
     })
 }
 
@@ -519,6 +520,7 @@ mod tests {
             paused: false,
             created_at: Some(OffsetDateTime::now_utc()),
             workers: 1,
+            parent_wave_id: None,
         }
     }
 

--- a/rust/loopflow/src/lfd/http/routes/repos.rs
+++ b/rust/loopflow/src/lfd/http/routes/repos.rs
@@ -486,6 +486,7 @@ mod tests {
             paused: false,
             created_at: Some(OffsetDateTime::now_utc()),
             workers: 1,
+            parent_wave_id: None,
         }
     }
 

--- a/rust/loopflow/src/lfd/http/routes/session_controls.rs
+++ b/rust/loopflow/src/lfd/http/routes/session_controls.rs
@@ -363,6 +363,7 @@ mod tests {
             paused: false,
             created_at: Some(OffsetDateTime::now_utc()),
             workers: 1,
+            parent_wave_id: None,
         }
     }
 

--- a/rust/loopflow/src/lfd/http/routes/waves.rs
+++ b/rust/loopflow/src/lfd/http/routes/waves.rs
@@ -290,6 +290,7 @@ pub async fn create_wave_handler(
         paused: false,
         created_at: Some(OffsetDateTime::now_utc()),
         workers,
+        parent_wave_id: None,
     };
     if let Some(status) = status {
         let parsed = WaveStatus::from_str(&status)
@@ -809,6 +810,15 @@ pub async fn get_wave_agent_tree_handler(
     let root_wave = build_wave_dto(&state.store, &state.github, wave, false)
         .await
         .map_err(map_store_error)?;
+    let children = state
+        .store
+        .list_child_waves(&wave_id)
+        .await
+        .map_err(map_store_error)?;
+    let child_waves =
+        crate::lfd::http::routes::build_wave_dtos(&state.store, &state.github, children, false)
+            .await
+            .map_err(map_store_error)?;
     let statuses = query
         .active_only
         .unwrap_or(true)
@@ -834,7 +844,7 @@ pub async fn get_wave_agent_tree_handler(
         object: "wave_agent_tree".to_string(),
         id: format!("tree-{wave_id}"),
         wave: root_wave,
-        child_waves: Vec::new(),
+        child_waves,
         sessions,
     }))
 }
@@ -1950,6 +1960,7 @@ mod tests {
             paused: false,
             created_at: Some(OffsetDateTime::now_utc()),
             workers: 1,
+            parent_wave_id: None,
         }
     }
 
@@ -2416,6 +2427,7 @@ mod tests {
 
         assert_eq!(response.object, "wave_agent_tree");
         assert_eq!(response.wave.id, wave.id().to_string());
+        // This wave is a leaf (no child waves), so the chord tree is empty here.
         assert_eq!(response.child_waves.len(), 0);
         let child_node = response
             .sessions
@@ -2434,6 +2446,57 @@ mod tests {
             Some("lf-worker")
         );
     }
+
+    // A chord's WaveAgentTree exposes its children: one leaf child wave per
+    // repo, each with its own repo. This is the two-repo chord shape — the
+    // ancestry query drives which children a chord would loop.
+    #[tokio::test]
+    async fn get_wave_agent_tree_returns_child_waves_for_chord() {
+        let state = test_http_state_with_runner().await;
+        let repo_a = tempdir().expect("tempdir a");
+        let repo_b = tempdir().expect("tempdir b");
+        init_git_repo(repo_a.path());
+        init_git_repo(repo_b.path());
+
+        let chord = make_wave(&repo_a.path().to_string_lossy(), "chord-root");
+        state.store.create_wave(&chord).await.expect("seed chord");
+
+        let child_a = make_wave(&repo_a.path().to_string_lossy(), "chord-child-a")
+            .with_parent(chord.id().clone());
+        let child_b = make_wave(&repo_b.path().to_string_lossy(), "chord-child-b")
+            .with_parent(chord.id().clone());
+        state
+            .store
+            .create_wave(&child_a)
+            .await
+            .expect("seed child a");
+        state
+            .store
+            .create_wave(&child_b)
+            .await
+            .expect("seed child b");
+
+        let Json(response) = get_wave_agent_tree_handler(
+            State(state.clone()),
+            HeaderMap::new(),
+            Path(chord.id().to_string()),
+            Query(GetWaveAgentTreeQuery {
+                active_only: Some(true),
+            }),
+        )
+        .await
+        .expect("get wave agent tree");
+
+        assert_eq!(response.child_waves.len(), 2);
+        let repos: Vec<&str> = response
+            .child_waves
+            .iter()
+            .flat_map(|w| w.repos.iter().map(|r| r.repo.as_str()))
+            .collect();
+        assert!(repos.contains(&repo_a.path().to_string_lossy().as_ref()));
+        assert!(repos.contains(&repo_b.path().to_string_lossy().as_ref()));
+    }
+
     // Reproduces the "Ingest & build" empty-reply bug: when a wave has PM
     // configured, POST /waves/{id}/run with a roadmap_item aborts the HTTP
     // connection without a response, because the ingest code path calls

--- a/rust/loopflow/src/lfd/queue.rs
+++ b/rust/loopflow/src/lfd/queue.rs
@@ -736,6 +736,7 @@ mod tests {
             paused: false,
             created_at: Some(OffsetDateTime::now_utc()),
             workers: 1,
+            parent_wave_id: None,
         }
     }
 

--- a/rust/loopflow/src/lfd/store/catalog.rs
+++ b/rust/loopflow/src/lfd/store/catalog.rs
@@ -80,6 +80,7 @@ pub(crate) enum Query {
     DeleteWaveReposByWave,
     GetPendingActivationForWave,
     ResetStaleActiveRepos,
+    ListChildWaves,
 }
 
 impl Query {
@@ -155,10 +156,11 @@ impl Query {
         Self::DeleteWaveReposByWave,
         Self::GetPendingActivationForWave,
         Self::ResetStaleActiveRepos,
+        Self::ListChildWaves,
     ];
 }
 
-const QUERY_COUNT: usize = Query::ResetStaleActiveRepos as usize + 1;
+const QUERY_COUNT: usize = Query::ListChildWaves as usize + 1;
 
 #[derive(Debug, Clone, Copy)]
 struct QueryDef {
@@ -174,27 +176,27 @@ const QUERY_DEFS: [QueryDef; QUERY_COUNT] = [
         postgres_override: None,
     },
     QueryDef {
-        template: "SELECT id, name, direction, area, paused, created_at, workers, mode,\n                    primary_flow, goal, metrics\n             FROM waves\n             ORDER BY created_at DESC",
+        template: "SELECT id, name, direction, area, paused, created_at, workers, mode,\n                    primary_flow, goal, metrics, parent_wave_id\n             FROM waves\n             ORDER BY created_at DESC",
         sqlite_override: None,
         postgres_override: None,
     },
     QueryDef {
-        template: "SELECT id, name, direction, area, paused, created_at, workers, mode,\n                    primary_flow, goal, metrics\n             FROM waves\n             WHERE EXISTS (SELECT 1 FROM wave_repos wr WHERE wr.wave_id = waves.id AND wr.repo = {p1})\n             ORDER BY created_at DESC",
+        template: "SELECT id, name, direction, area, paused, created_at, workers, mode,\n                    primary_flow, goal, metrics, parent_wave_id\n             FROM waves\n             WHERE EXISTS (SELECT 1 FROM wave_repos wr WHERE wr.wave_id = waves.id AND wr.repo = {p1})\n             ORDER BY created_at DESC",
         sqlite_override: None,
         postgres_override: None,
     },
     QueryDef {
-        template: "INSERT INTO waves (\n                id, name, direction, area, paused, created_at, workers, mode, primary_flow, goal, metrics\n            ) VALUES ({p1}, {p2}, {p3}, {p4}, {p5}, {p6}, {p7}, {p8}, {p9}, {p10}, {p11})\n            ON CONFLICT(id) DO UPDATE SET\n                name = excluded.name,\n                direction = excluded.direction,\n                area = excluded.area,\n                paused = excluded.paused,\n                created_at = excluded.created_at,\n                workers = excluded.workers,\n                mode = excluded.mode,\n                primary_flow = excluded.primary_flow,\n                goal = excluded.goal,\n                metrics = excluded.metrics",
+        template: "INSERT INTO waves (\n                id, name, direction, area, paused, created_at, workers, mode, primary_flow, goal, metrics, parent_wave_id\n            ) VALUES ({p1}, {p2}, {p3}, {p4}, {p5}, {p6}, {p7}, {p8}, {p9}, {p10}, {p11}, {p12})\n            ON CONFLICT(id) DO UPDATE SET\n                name = excluded.name,\n                direction = excluded.direction,\n                area = excluded.area,\n                paused = excluded.paused,\n                created_at = excluded.created_at,\n                workers = excluded.workers,\n                mode = excluded.mode,\n                primary_flow = excluded.primary_flow,\n                goal = excluded.goal,\n                metrics = excluded.metrics,\n                parent_wave_id = excluded.parent_wave_id",
         sqlite_override: None,
         postgres_override: None,
     },
     QueryDef {
-        template: "SELECT id, name, direction, area, paused, created_at, workers, mode,\n                    primary_flow, goal, metrics\n             FROM waves WHERE id = {p1}",
+        template: "SELECT id, name, direction, area, paused, created_at, workers, mode,\n                    primary_flow, goal, metrics, parent_wave_id\n             FROM waves WHERE id = {p1}",
         sqlite_override: None,
         postgres_override: None,
     },
     QueryDef {
-        template: "SELECT id, name, direction, area, paused, created_at, workers, mode,\n                    primary_flow, goal, metrics\n             FROM waves\n             WHERE name = {p1}",
+        template: "SELECT id, name, direction, area, paused, created_at, workers, mode,\n                    primary_flow, goal, metrics, parent_wave_id\n             FROM waves\n             WHERE name = {p1}",
         sqlite_override: None,
         postgres_override: None,
     },
@@ -477,7 +479,7 @@ const QUERY_DEFS: [QueryDef; QUERY_COUNT] = [
     },
     // ListLoopableWaves
     QueryDef {
-        template: "SELECT id, name, direction, area, paused, created_at, workers, mode,\n                    primary_flow, goal, metrics\n             FROM waves\n             WHERE mode = 'loop' AND paused = 0\n             ORDER BY created_at DESC",
+        template: "SELECT id, name, direction, area, paused, created_at, workers, mode,\n                    primary_flow, goal, metrics, parent_wave_id\n             FROM waves\n             WHERE mode = 'loop' AND paused = 0\n             ORDER BY created_at DESC",
         sqlite_override: None,
         postgres_override: None,
     },
@@ -543,6 +545,12 @@ const QUERY_DEFS: [QueryDef; QUERY_COUNT] = [
         postgres_override: Some(
             "UPDATE wave_repos SET status = {p1}\n             WHERE status = ANY({p2})",
         ),
+    },
+    // ListChildWaves — a chord's contents are its children, ordered by creation.
+    QueryDef {
+        template: "SELECT id, name, direction, area, paused, created_at, workers, mode,\n                    primary_flow, goal, metrics, parent_wave_id\n             FROM waves\n             WHERE parent_wave_id = {p1}\n             ORDER BY created_at ASC",
+        sqlite_override: None,
+        postgres_override: None,
     },
 ];
 

--- a/rust/loopflow/src/lfd/store/migrations.rs
+++ b/rust/loopflow/src/lfd/store/migrations.rs
@@ -186,6 +186,10 @@ const ALL_MIGRATIONS: &[Migration] = &[
         version: "043_drop_legacy_wave_columns",
         sql: include_str!("migrations/043_drop_legacy_wave_columns.sql"),
     },
+    Migration {
+        version: "044_wave_parent",
+        sql: include_str!("migrations/044_wave_parent.sql"),
+    },
 ];
 
 /// Migrations applicable to a backend. Currently returns all migrations

--- a/rust/loopflow/src/lfd/store/migrations/044_wave_parent.sql
+++ b/rust/loopflow/src/lfd/store/migrations/044_wave_parent.sql
@@ -1,0 +1,16 @@
+-- Reintroduce wave ancestry on the durable model. The chord tree was folded
+-- into `waves` via `parent_wave_id` in migration 011, then dropped again in 013
+-- (and the standalone chord tables in 028). The Wave/Run/Session reduction left
+-- no ancestry column at all, so `WaveAgentTree.child_waves` could never be
+-- populated.
+--
+-- A chord is simply a wave that has children — there is no `wave_type` or
+-- `position` column. Chord-ness is derived from `children_of(id)` being
+-- non-empty; siblings order by `created_at`.
+--
+-- Nullable (a root wave has no parent) with no default, so ADD COLUMN with a
+-- self-referential REFERENCES clause is legal in SQLite. ON DELETE CASCADE
+-- mirrors the original 011 semantics: deleting a chord deletes its children.
+ALTER TABLE waves ADD COLUMN parent_wave_id TEXT
+    REFERENCES waves(id) ON DELETE CASCADE;
+CREATE INDEX idx_waves_parent ON waves(parent_wave_id);

--- a/rust/loopflow/src/lfd/store/mod.rs
+++ b/rust/loopflow/src/lfd/store/mod.rs
@@ -205,6 +205,12 @@ impl Store {
         self.replace_wave_repos(wave.id(), &wave.repos).await
     }
 
+    /// A chord's contents: the waves whose `parent_wave_id` is `parent`,
+    /// ordered by creation, each stitched with its `repos`.
+    pub async fn list_child_waves(&self, parent: &LfdId) -> StoreResult<Vec<Wave>> {
+        WaveStateStore::children_of(self, parent).await
+    }
+
     pub async fn get_wave(&self, wave_id: &LfdId) -> StoreResult<Option<Wave>> {
         WaveStateStore::get_wave(self, wave_id).await
     }
@@ -635,6 +641,7 @@ pub trait WaveStateStore: Send + Sync {
     async fn list_loopable_waves(&self) -> StoreResult<Vec<Wave>>;
     async fn list_wave_crons(&self, wave_id: &LfdId) -> StoreResult<Vec<WaveCron>>;
     async fn list_all_active_crons(&self) -> StoreResult<Vec<WaveCron>>;
+    async fn children_of(&self, parent: &LfdId) -> StoreResult<Vec<Wave>>;
     async fn get_wave(&self, wave_id: &LfdId) -> StoreResult<Option<Wave>>;
     async fn get_wave_by_name(&self, name: &str) -> StoreResult<Option<Wave>>;
     async fn create_wave(&self, wave: &Wave) -> StoreResult<()>;
@@ -910,6 +917,17 @@ impl WaveStateStore for Store {
             }
             StoreBackend::Postgres(store) => store.list_all_active_crons().await,
         }
+    }
+
+    async fn children_of(&self, parent: &LfdId) -> StoreResult<Vec<Wave>> {
+        let waves = match &self.backend {
+            StoreBackend::Sqlite(store) => {
+                let parent = parent.clone();
+                run_sqlite(store, move |store| store.list_child_waves(&parent)).await
+            }
+            StoreBackend::Postgres(store) => store.list_child_waves(parent).await,
+        }?;
+        self.attach_repos_vec(waves).await
     }
 
     async fn get_wave(&self, wave_id: &LfdId) -> StoreResult<Option<Wave>> {
@@ -2085,6 +2103,7 @@ mod tests {
             paused: false,
             created_at: Some(OffsetDateTime::now_utc()),
             workers: 1,
+            parent_wave_id: None,
         }
     }
 
@@ -2473,6 +2492,57 @@ mod tests {
         let config = StorageConfig::sqlite(db_path);
         let store = super::open_store(&config).await.expect("store should open");
         run_store_basic_suite(&store).await;
+    }
+
+    // A chord is a wave whose children point back at it via `parent_wave_id`.
+    // `list_child_waves` returns those children (ordered, repos stitched); a
+    // leaf wave returns none. This is the ancestry the WaveAgentTree needs.
+    #[tokio::test]
+    async fn sqlite_wave_ancestry_and_children() {
+        let db_path = env::temp_dir().join(format!("lfd-test-{}.db", LfdId::new()));
+        let config = StorageConfig::sqlite(db_path);
+        let store = super::open_store(&config).await.expect("store should open");
+
+        let parent = make_wave("/chord");
+        store.create_wave(&parent).await.expect("create parent");
+
+        let child_a = make_wave("/repo-a").with_parent(parent.id().clone());
+        let child_b = make_wave("/repo-b").with_parent(parent.id().clone());
+        store.create_wave(&child_a).await.expect("create child a");
+        store.create_wave(&child_b).await.expect("create child b");
+
+        // Wave exposes its parent relation after a round-trip.
+        let reloaded = store
+            .get_wave(child_a.id())
+            .await
+            .expect("get child")
+            .expect("child exists");
+        assert_eq!(reloaded.parent_wave_id(), Some(parent.id()));
+
+        // Chord contents = children where parent_wave_id = id, one per repo.
+        let children = store
+            .list_child_waves(parent.id())
+            .await
+            .expect("list children");
+        assert_eq!(children.len(), 2);
+        let repos: Vec<&str> = children.iter().map(|w| w.repo()).collect();
+        assert!(repos.contains(&"/repo-a"));
+        assert!(repos.contains(&"/repo-b"));
+
+        // A leaf wave has no children.
+        assert!(store
+            .list_child_waves(child_a.id())
+            .await
+            .expect("leaf children")
+            .is_empty());
+
+        // The root wave itself has no parent.
+        let root = store
+            .get_wave(parent.id())
+            .await
+            .expect("get parent")
+            .expect("parent exists");
+        assert_eq!(root.parent_wave_id(), None);
     }
 
     #[tokio::test]

--- a/rust/loopflow/src/lfd/store/postgres.rs
+++ b/rust/loopflow/src/lfd/store/postgres.rs
@@ -227,6 +227,7 @@ impl PostgresStore {
             let primary_flow = wave.primary_flow();
             let goal = wave.goal();
             let metrics = metrics_json.as_str();
+            let parent_wave_id = wave.parent_wave_id().map(|id| id.as_str());
             client
                 .execute(
                     Self::sql(Query::UpsertWave),
@@ -242,6 +243,7 @@ impl PostgresStore {
                         &primary_flow.as_str(),
                         &goal,
                         &metrics,
+                        &parent_wave_id,
                     ],
                 )
                 .await?;
@@ -728,6 +730,16 @@ impl PostgresStore {
         self.with_client(|client| async move {
             let rows = client
                 .query(Self::sql(Query::ListLoopableWaves), &[])
+                .await?;
+            rows.iter().map(map_wave_row).collect()
+        })
+        .await
+    }
+
+    pub async fn list_child_waves(&self, parent: &LfdId) -> StoreResult<Vec<Wave>> {
+        self.with_client(|client| async move {
+            let rows = client
+                .query(Self::sql(Query::ListChildWaves), &[&parent])
                 .await?;
             rows.iter().map(map_wave_row).collect()
         })

--- a/rust/loopflow/src/lfd/store/rows.rs
+++ b/rust/loopflow/src/lfd/store/rows.rs
@@ -99,7 +99,7 @@ pub fn parse_pr(value: Option<String>) -> StoreResult<Option<PullRequest>> {
 // -- Shared row mappers ------------------------------------------------------
 
 /// SELECT id, name, direction, area, paused, created_at, workers, mode,
-///        primary_flow, goal, metrics
+///        primary_flow, goal, metrics, parent_wave_id
 pub fn map_wave_row(row: &impl StoreRow) -> StoreResult<Wave> {
     let direction = parse_json_vec(&row.text(2)?)?;
     let area = parse_json_vec(&row.text(3)?)?;
@@ -111,6 +111,7 @@ pub fn map_wave_row(row: &impl StoreRow) -> StoreResult<Wave> {
     let primary_flow = row.text(8)?;
     let goal = row.text(9)?;
     let metrics = parse_json_vec(&row.text(10)?)?;
+    let parent_wave_id = row.opt_text(11)?.map(LfdId::from_raw);
 
     Ok(Wave {
         id: LfdId::from_raw(row.text(0)?),
@@ -126,6 +127,7 @@ pub fn map_wave_row(row: &impl StoreRow) -> StoreResult<Wave> {
         paused,
         created_at: Some(created_at),
         workers,
+        parent_wave_id,
     })
 }
 

--- a/rust/loopflow/src/lfd/store/sqlite.rs
+++ b/rust/loopflow/src/lfd/store/sqlite.rs
@@ -242,6 +242,7 @@ impl SqliteStore {
                 wave.primary_flow(),
                 wave.goal(),
                 metrics_json,
+                wave.parent_wave_id(),
             ],
         )?;
         Ok(())
@@ -726,6 +727,17 @@ impl SqliteStore {
         let conn = self.conn.lock().expect("store mutex poisoned");
         let mut stmt = conn.prepare(Self::sql(Query::ListLoopableWaves))?;
         let rows = stmt.query_map([], |row| Ok(map_wave_row(row)))?;
+        let mut waves = Vec::new();
+        for wave in rows {
+            waves.push(wave??);
+        }
+        Ok(waves)
+    }
+
+    pub fn list_child_waves(&self, parent: &LfdId) -> StoreResult<Vec<Wave>> {
+        let conn = self.conn.lock().expect("store mutex poisoned");
+        let mut stmt = conn.prepare(Self::sql(Query::ListChildWaves))?;
+        let rows = stmt.query_map(params![parent], |row| Ok(map_wave_row(row)))?;
         let mut waves = Vec::new();
         for wave in rows {
             waves.push(wave??);

--- a/rust/loopflow/src/lfd/triggers/activation.rs
+++ b/rust/loopflow/src/lfd/triggers/activation.rs
@@ -575,6 +575,7 @@ mod tests {
             paused: false,
             created_at: Some(OffsetDateTime::now_utc()),
             workers: 1,
+            parent_wave_id: None,
         };
         store.create_wave(&wave).await.expect("create wave");
         wave

--- a/rust/loopflow/src/lfd/triggers/ci_failure.rs
+++ b/rust/loopflow/src/lfd/triggers/ci_failure.rs
@@ -210,6 +210,7 @@ mod tests {
             paused: false,
             created_at: Some(OffsetDateTime::now_utc()),
             workers: 1,
+            parent_wave_id: None,
         };
         store.create_wave(&wave).await.expect("create wave");
         wave
@@ -290,6 +291,7 @@ mod tests {
             paused: false,
             created_at: Some(OffsetDateTime::now_utc()),
             workers: 1,
+            parent_wave_id: None,
         };
         store.create_wave(&wave).await.expect("create wave");
         wave

--- a/rust/loopflow/src/lfd/triggers/common.rs
+++ b/rust/loopflow/src/lfd/triggers/common.rs
@@ -266,6 +266,7 @@ mod tests {
             paused: false,
             created_at: Some(OffsetDateTime::now_utc()),
             workers: 1,
+            parent_wave_id: None,
         }
     }
 

--- a/rust/loopflow/src/lfd/triggers/cron.rs
+++ b/rust/loopflow/src/lfd/triggers/cron.rs
@@ -197,6 +197,7 @@ mod tests {
             paused: false,
             created_at: Some(OffsetDateTime::now_utc()),
             workers: 0,
+            parent_wave_id: None,
         };
         state.store.create_wave(&wave).await.expect("create wave");
 

--- a/rust/loopflow/src/lfd/triggers/loop_ticker.rs
+++ b/rust/loopflow/src/lfd/triggers/loop_ticker.rs
@@ -188,6 +188,7 @@ mod tests {
             paused: false,
             created_at: Some(OffsetDateTime::now_utc()),
             workers: 1,
+            parent_wave_id: None,
         }
     }
 

--- a/rust/loopflow/src/lfd/types/wave.rs
+++ b/rust/loopflow/src/lfd/types/wave.rs
@@ -251,6 +251,11 @@ pub struct Wave {
     /// Maximum number of active runs this wave can have at once.
     #[serde(default = "default_workers")]
     pub workers: u32,
+    /// Parent wave in the chord tree. `None` for a root wave. A chord is simply
+    /// a wave that has children (`children_of(id)` non-empty) — there is no
+    /// `wave_type` discriminator.
+    #[serde(default)]
+    pub parent_wave_id: Option<LfdId>,
 }
 
 impl Wave {
@@ -277,11 +282,23 @@ impl Wave {
             paused: false,
             created_at: Some(OffsetDateTime::now_utc()),
             workers: default_workers(),
+            parent_wave_id: None,
         }
+    }
+
+    /// Attach this wave to a parent, making it a child in the chord tree.
+    pub fn with_parent(mut self, parent: LfdId) -> Self {
+        self.parent_wave_id = Some(parent);
+        self
     }
 
     pub fn id(&self) -> &LfdId {
         &self.id
+    }
+
+    /// Parent wave in the chord tree, `None` for a root wave.
+    pub fn parent_wave_id(&self) -> Option<&LfdId> {
+        self.parent_wave_id.as_ref()
     }
 
     pub fn name(&self) -> &String {

--- a/rust/loopflow/tests/dto_fixtures.rs
+++ b/rust/loopflow/tests/dto_fixtures.rs
@@ -37,6 +37,7 @@ fn wave_fixture_nests_repo_work() {
     assert_eq!(wave.name, "engbot");
     assert_eq!(wave.primary_flow, "build");
     assert_eq!(wave.status, "running");
+    assert_eq!(wave.parent_wave_id.as_deref(), Some("wave_parent999"));
 
     assert_eq!(wave.repos.len(), 1);
     let repo = &wave.repos[0];

--- a/rust/loopflow/tests/wave_worktree_tests.rs
+++ b/rust/loopflow/tests/wave_worktree_tests.rs
@@ -47,6 +47,7 @@ fn make_wave(repo: &str, name: &str) -> Wave {
         paused: false,
         created_at: None,
         workers: 1,
+        parent_wave_id: None,
     }
 }
 

--- a/swift/ConcertoTests/ContractTests.swift
+++ b/swift/ConcertoTests/ContractTests.swift
@@ -37,6 +37,7 @@ struct ContractTests {
         #expect(wave.status == .running)
         #expect(wave.direction == ["ux", "clarity"])
         #expect(wave.area == ["src/"])
+        #expect(wave.parentWaveId == "wave_parent999")
 
         #expect(wave.repos.count == 1)
         #expect(wave.repos.first?.repo == "/home/user/project")

--- a/swift/LoopflowCore/Models/Wave.swift
+++ b/swift/LoopflowCore/Models/Wave.swift
@@ -253,6 +253,8 @@ public struct Wave: Sendable, Identifiable, Hashable {
     public var repos: [RepoWork]
     public var flowSteps: [String]
     public var createdAt: Date?
+    /// Parent wave in the chord tree. `nil` for a root wave.
+    public var parentWaveId: String?
 
     public init(
         id: String,
@@ -269,7 +271,8 @@ public struct Wave: Sendable, Identifiable, Hashable {
         crons: [WaveCron] = [],
         status: WaveStatus = .idle,
         flowSteps: [String] = [],
-        createdAt: Date? = nil
+        createdAt: Date? = nil,
+        parentWaveId: String? = nil
     ) {
         self.id = id
         self.name = name
@@ -286,6 +289,7 @@ public struct Wave: Sendable, Identifiable, Hashable {
         self.status = status
         self.flowSteps = flowSteps
         self.createdAt = createdAt
+        self.parentWaveId = parentWaveId
     }
 
     /// Single-repo convenience mirroring the old flat shape: packs the per-repo
@@ -342,7 +346,8 @@ public struct Wave: Sendable, Identifiable, Hashable {
             crons: crons,
             status: status,
             flowSteps: flowSteps,
-            createdAt: createdAt
+            createdAt: createdAt,
+            parentWaveId: nil
         )
     }
 }

--- a/swift/LoopflowCore/Services/LocalWaveService.swift
+++ b/swift/LoopflowCore/Services/LocalWaveService.swift
@@ -1009,7 +1009,8 @@ public struct WaveService: WaveServiceProtocol, @unchecked Sendable {
             crons: crons,
             status: status,
             flowSteps: flowSteps,
-            createdAt: createdAt
+            createdAt: createdAt,
+            parentWaveId: json["parent_wave_id"] as? String
         )
     }
 

--- a/tests/fixtures/wave.json
+++ b/tests/fixtures/wave.json
@@ -13,6 +13,7 @@
   "flow_steps": ["implement", "compress", "gate"],
   "has_stale_pr_state": false,
   "workers": 1,
+  "parent_wave_id": "wave_parent999",
   "crons": [
     {
       "id": "cron_001",


### PR DESCRIPTION
## What

The Wave/Run/Session runtime reduction collapsed the durable model to three nouns but dropped the parent-wave field off `Wave` in the process, so `WaveAgentTree.child_waves` was hardcoded `Vec::new()` and a chord's contents (a wave whose members are waves) could never be observed.

**Corrected premise:** the roadmap item and MEMORY.md claim "the store already has the `parent_wave_id` column." It does not — migration `013_remove_chord_tree.sql` dropped `parent_wave_id`/`wave_type`/`position`, and `028_drop_chords_tables.sql` dropped the fallback tables. So this **adds a new migration (`044_wave_parent.sql`)** reintroducing the column, rather than surfacing an existing one.

## Maps to the item's Done-when

- **`Wave` exposes its parent relation; chord contents = children where `parent_wave_id = id`.** `Wave` now carries `parent_wave_id: Option<LfdId>` (with a `with_parent` builder). `Store::list_child_waves` runs `SELECT ... WHERE parent_wave_id = ? ORDER BY created_at ASC`, repos stitched. Covered by `sqlite_wave_ancestry_and_children`.
- **`WaveAgentTree` returns child waves (not an empty list) for a chord.** `get_wave_agent_tree_handler` populates `child_waves` via `build_wave_dtos(list_child_waves(...))`. Covered by the new `get_wave_agent_tree_returns_child_waves_for_chord` test (parent + two leaf children in different repos → both surface); the existing leaf-wave test still asserts an empty tree.
- **No "member" in the wave-structure code.** Vocabulary stays parent/child/sibling; the `migrations.rs` guard that the chord tables are absent is kept. Grep is clean.
- **Two-repo chord runs with a child Looping Agent per repo.** The ancestry query supplies which children a chord would loop; the executor already launches one wave-agent Session per wave. The tree/store tests cover the two-repo chord *shape* (one leaf child per repo). The end-to-end "loop the chord, assert one live `WaveAgent` session per repo" path is not exercised by a new test here — see Follow-on.
- **`cargo test` passes.**

## Design choices (per `scratch/2-wave-ancestry.md`)

- Chord-ness is **derived from having children** — no `wave_type` discriminator or `position` column revived; siblings order by `created_at`.
- `parent_wave_id` crosses the lfd HTTP boundary, so it is mirrored on `WaveDto` (Rust), `Wave` (Python), and `Wave` (Swift) as an explicit `Option`/`str | None`/`String?` — **no `#[serde(default)]`, no `Default`, always emitted (no `skip_serializing_if`)** so the three mirrors stay in lockstep. `tests/fixtures/wave.json` pins a concrete parent value, asserted in the Rust, Python, and Swift fixture tests.

## Tests run

- `cargo fmt --all`, `cargo clippy -p loopflow -- -D warnings` — clean.
- `cargo test -p loopflow` — 833 lib + all integration suites pass (incl. `sqlite_wave_ancestry_and_children`, `get_wave_agent_tree_returns_child_waves_for_chord`, `wave_fixture_nests_repo_work`, `migrations::*`).
- `uv run pytest` (contract/models/client/cli) — 95 passed.
- `swift test --filter ContractTests` — 3 passed (`wave.json` parses `parentWaveId`); full `swift build` clean.

## Follow-on

The Done-when clause "a two-repo chord runs with a child Looping Agent per repo" is covered here at the data/tree layer (the chord shape and the ancestry query that drives which children to loop). A full executor/integration test that loops a chord and asserts one live `WaveAgent` session per repo exceeds this unit PR and remains as a follow-on, alongside chord-creation wiring (nothing constructs chords with `with_parent` in production yet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)