### PR TITLE
lf op cloud: scaffold a wave's Goal as a vendor-cloud loop (A2)

### DIFF
--- a/python/loopflow/models.py
+++ b/python/loopflow/models.py
@@ -115,6 +115,7 @@ class Wave(BaseModel):
     flow_steps: list[FlowStep]
     parent_wave_id: Optional[str]
     created_at: Optional[datetime] = None
+    cloud_session_url: Optional[str] = None
 
     @field_validator("flow_steps", mode="before")
     @classmethod

--- a/python/tests/test_contract.py
+++ b/python/tests/test_contract.py
@@ -28,6 +28,7 @@ def test_wave_fixture_parses():
     assert wave.direction == ["ux", "clarity"]
     assert wave.area == ["src/"]
     assert wave.parent_wave_id == "wave_parent999"
+    assert wave.cloud_session_url == "https://claude.ai/session/engbot"
     assert len(wave.crons) == 1
     assert wave.crons[0].flow == "wave-polish"
 

--- a/rust/loopflow/src/lf/commands/ops/mod.rs
+++ b/rust/loopflow/src/lf/commands/ops/mod.rs
@@ -102,6 +102,11 @@ pub fn run(op: &OpsCommand, cli_model: Option<&str>) -> Result<()> {
         },
         OpsCommand::Pm { cmd } => pm_cmd(cmd, &progress),
         OpsCommand::Auth { cmd } => crate::lf::commands::auth::run(cmd),
+        OpsCommand::Cloud {
+            vendor,
+            wave,
+            session_url,
+        } => cloud_cmd(vendor, wave.clone(), session_url.clone(), &progress),
     }
 }
 
@@ -439,6 +444,56 @@ fn pm_cmd(cmd: &PmCommand, progress: &impl Progress) -> Result<()> {
                     );
                 }
             }
+        }
+    }
+    Ok(())
+}
+
+fn cloud_cmd(
+    vendor: &str,
+    wave: Option<String>,
+    session_url: Option<String>,
+    progress: &impl Progress,
+) -> Result<()> {
+    let repo_root = find_repo_root()?;
+    let result = crate::ops::cloud_launch(
+        &repo_root,
+        &crate::ops::CloudLaunchOptions {
+            vendor: vendor.to_string(),
+            wave,
+            session_url,
+        },
+        progress,
+    )?;
+
+    match result.mode {
+        crate::ops::CloudMode::Record => {
+            println!(
+                "{}: recorded {} cloud session {}",
+                result.wave,
+                result.vendor,
+                result.session_url.as_deref().unwrap_or("")
+            );
+        }
+        crate::ops::CloudMode::Scaffold => {
+            println!("{}: scaffolded {} cloud loop", result.wave, result.vendor);
+            if let Some(path) = &result.prompt_path {
+                println!("  prompt: {}", path.display());
+            }
+            if let Some(path) = &result.mcp_path {
+                println!("  mcp:    {}", path.display());
+            }
+            println!("  skills: {} written", result.skills_written);
+            if let Some(link) = &result.deep_link {
+                println!("  launch: {link}");
+            }
+            println!(
+                "\nOpen the launch link, attach this repo, paste the prompt, and set a recurring schedule."
+            );
+            println!(
+                "Then run `lf op cloud {} {} --session-url <url>` to deep-link Concerto back to it.",
+                result.vendor, result.wave
+            );
         }
     }
     Ok(())

--- a/rust/loopflow/src/lf/mod.rs
+++ b/rust/loopflow/src/lf/mod.rs
@@ -268,6 +268,16 @@ pub enum OpsCommand {
         #[command(subcommand)]
         cmd: AuthCommand,
     },
+    /// Scaffold a vendor-cloud looping session for a wave (claude)
+    Cloud {
+        /// Vendor to scaffold for (claude)
+        vendor: String,
+        /// Wave name (auto-detected if omitted)
+        wave: Option<String>,
+        /// Record an already-launched vendor session URL onto the wave
+        #[arg(long = "session-url")]
+        session_url: Option<String>,
+    },
 }
 
 #[derive(Subcommand, Debug)]

--- a/rust/loopflow/src/lfd/http/dto.rs
+++ b/rust/loopflow/src/lfd/http/dto.rs
@@ -101,6 +101,10 @@ pub struct WaveDto {
     /// Parent wave in the chord tree. `null` for a root wave. Always emitted
     /// (no `skip_serializing_if`) so the Python/Swift mirrors stay in lockstep.
     pub parent_wave_id: Option<String>,
+    /// Vendor-cloud session/routine URL (`lf op cloud`), for Concerto to
+    /// deep-link back out to the running cloud loop. Absent until launched.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cloud_session_url: Option<String>,
 }
 
 /// Per-repo execution surface for a wave: status/iteration plus the live git
@@ -611,6 +615,7 @@ mod contract_tests {
             has_stale_pr_state: false,
             repos: Vec::new(),
             parent_wave_id: None,
+            cloud_session_url: None,
         };
 
         let json = serde_json::to_value(&wave).unwrap();

--- a/rust/loopflow/src/lfd/http/routes/mod.rs
+++ b/rust/loopflow/src/lfd/http/routes/mod.rs
@@ -168,6 +168,9 @@ pub async fn build_wave_dto(
     let crons_list = store.list_wave_crons(wave.id()).await.unwrap_or_default();
     let crons = crons_list.into_iter().map(wave_cron_dto).collect();
     let wave_config = wave_config::read_wave_config(std::path::Path::new(wave.repo()), wave.name());
+    let cloud_session_url = wave_config
+        .as_ref()
+        .and_then(|config| config.cloud_session_url.clone());
 
     Ok(WaveDto {
         id: wave.id().to_string(),
@@ -190,6 +193,7 @@ pub async fn build_wave_dto(
         crons,
         repos,
         parent_wave_id: wave.parent_wave_id().map(|id| id.to_string()),
+        cloud_session_url,
     })
 }
 

--- a/rust/loopflow/src/lfd/http/routes/wave_config.rs
+++ b/rust/loopflow/src/lfd/http/routes/wave_config.rs
@@ -43,6 +43,9 @@ pub(crate) struct WaveConfig {
     pub agent: Option<String>,
     pub step_agents: Option<HashMap<String, String>>,
     pub pm: Option<WavePmConfig>,
+    /// Vendor-cloud session/routine URL, set by `lf op cloud <vendor> --session-url`.
+    /// Surfaced on `WaveDto` so Concerto can deep-link back out to the session.
+    pub cloud_session_url: Option<String>,
 }
 
 /// Read wave intent from `wave/<name>/GOAL.md` frontmatter.
@@ -183,6 +186,19 @@ pub(crate) fn update_wave_goal_config(
     Ok(())
 }
 
+/// Record (or clear) the vendor-cloud session URL in `wave/<name>/GOAL.md`.
+/// Pass an empty string to clear the key.
+pub(crate) fn update_wave_cloud_session_url(
+    repo: &Path,
+    name: &str,
+    url: Option<String>,
+) -> Result<(), String> {
+    update_wave_goal_config(repo, name, |map| {
+        remove_or_set_string(map, "cloud_session_url", url);
+        Ok(())
+    })
+}
+
 /// Update agent fields in `wave/<name>/GOAL.md`, preserving existing frontmatter.
 pub(crate) fn update_wave_agent_config(
     repo: &Path,
@@ -294,6 +310,36 @@ mod tests {
                 "claude:sonnet".to_string(),
             )]))
         );
+    }
+
+    #[test]
+    fn update_wave_cloud_session_url_round_trips() {
+        let temp = tempdir().expect("temp dir");
+        let dir = temp.path().join("wave").join("scan");
+        fs::create_dir_all(&dir).expect("create dir");
+        fs::write(
+            dir.join("GOAL.md"),
+            "---\nprimary_flow: build\n---\nDrive the work.\n",
+        )
+        .expect("write");
+
+        update_wave_cloud_session_url(
+            temp.path(),
+            "scan",
+            Some("https://claude.ai/session/abc".to_string()),
+        )
+        .expect("set url");
+        let config = read_wave_config(temp.path(), "scan").expect("config");
+        assert_eq!(
+            config.cloud_session_url.as_deref(),
+            Some("https://claude.ai/session/abc")
+        );
+
+        // Empty string clears the key.
+        update_wave_cloud_session_url(temp.path(), "scan", Some(String::new())).expect("clear url");
+        let config = read_wave_config(temp.path(), "scan").expect("config");
+        assert!(config.cloud_session_url.is_none());
+        assert_eq!(config.primary_flow.as_deref(), Some("build"));
     }
 
     #[test]

--- a/rust/loopflow/src/ops/cloud.rs
+++ b/rust/loopflow/src/ops/cloud.rs
@@ -1,0 +1,367 @@
+//! `lf op cloud <vendor>` — scaffold a per-repo looping session in a vendor's
+//! cloud (claude, codex) that re-runs a wave's Goal prompt on the vendor's own
+//! recurring schedule.
+//!
+//! This is the **A2** shape: lfd assembles the launch scaffold — the rendered
+//! Goal prompt, the flows-as-Skills, a loop instruction, and an Asana `.mcp.json`
+//! — and the human presses go in the vendor UI. lfd does not drive the vendor
+//! API or own the runtime; we rent the vendor's persistence and recurrence.
+//!
+//! Once launched, `--session-url` records the vendor session URL back onto the
+//! wave (`cloud_session_url` in `wave/<name>/GOAL.md`) so Concerto can deep-link
+//! out to it with `NSWorkspace.open`.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use crate::engine::{
+    available_flow_names, load_goal, render_goal, sync_skills, GoalRenderContext, SkillSyncOptions,
+};
+use crate::lfd::http::routes::wave_config::{read_wave_config, update_wave_cloud_session_url};
+use crate::ops::error::{OpsError, OpsResult};
+use crate::ops::progress::Progress;
+use crate::ops::util::resolve_wave_name;
+
+/// Asana's hosted remote MCP server (OAuth via bearer token). A fresh cloud
+/// clone has no `lf` binary and no local Asana OAuth, so the cloud session
+/// reaches the roadmap over MCP instead of `lf op pm`.
+const ASANA_MCP_URL: &str = "https://mcp.asana.com/sse";
+
+/// Where the human creates the recurring routine. There is no create-routine
+/// API today (A1), so we deep-link to the vendor UI and let the human press go.
+const CLAUDE_CLOUD_URL: &str = "https://claude.ai/new";
+
+/// Appended to the rendered Goal prompt: tells the vendor session it is a loop
+/// and how to reach the roadmap over MCP on each scheduled run.
+const CLOUD_LOOP_INSTRUCTION: &str = "\n\n<lf:cloud-loop>\n\
+This prompt is a recurring loop. Register it as a scheduled routine in your \
+vendor's cloud so it re-runs on a cadence. On each scheduled run:\n\
+1. Read this wave's roadmap from Asana via the `asana` MCP server.\n\
+2. Pick the next open roadmap item.\n\
+3. Do the work in this repo, open a PR, and record progress on the roadmap.\n\
+Then stop until the next scheduled run.\n\
+</lf:cloud-loop>\n";
+
+/// The cloud vendors a wave can be scaffolded for.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Vendor {
+    Claude,
+}
+
+impl Vendor {
+    fn parse(raw: &str) -> OpsResult<Self> {
+        match raw.trim().to_lowercase().as_str() {
+            "claude" => Ok(Vendor::Claude),
+            "codex" => Err(OpsError::Message(
+                "codex cloud scaffolding is a follow-on increment; start with `lf op cloud claude`"
+                    .to_string(),
+            )),
+            other => Err(OpsError::Message(format!(
+                "unknown cloud vendor '{other}' (expected: claude)"
+            ))),
+        }
+    }
+
+    fn as_str(self) -> &'static str {
+        match self {
+            Vendor::Claude => "claude",
+        }
+    }
+
+    fn deep_link(self) -> &'static str {
+        match self {
+            Vendor::Claude => CLAUDE_CLOUD_URL,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct CloudLaunchOptions {
+    pub vendor: String,
+    pub wave: Option<String>,
+    /// When set, record this already-launched vendor session URL onto the wave
+    /// instead of scaffolding.
+    pub session_url: Option<String>,
+}
+
+/// What `cloud_launch` did — scaffold a launch, or record a session URL.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CloudMode {
+    Scaffold,
+    Record,
+}
+
+#[derive(Debug, Clone)]
+pub struct CloudLaunchResult {
+    pub wave: String,
+    pub vendor: String,
+    pub mode: CloudMode,
+    pub prompt_path: Option<PathBuf>,
+    pub mcp_path: Option<PathBuf>,
+    pub skills_written: usize,
+    pub deep_link: Option<String>,
+    pub session_url: Option<String>,
+}
+
+/// Scaffold (or record) a vendor-cloud looping session for a wave.
+pub fn cloud_launch(
+    repo: &Path,
+    options: &CloudLaunchOptions,
+    progress: &impl Progress,
+) -> OpsResult<CloudLaunchResult> {
+    let vendor = Vendor::parse(&options.vendor)?;
+    let wave = resolve_wave_name(repo, options.wave.as_deref())
+        .ok_or_else(|| OpsError::Message("cannot determine wave name".to_string()))?;
+    let wave_dir = repo.join("wave").join(&wave);
+    if !wave_dir.is_dir() {
+        return Err(OpsError::Message(format!(
+            "wave directory not found: wave/{wave}/"
+        )));
+    }
+
+    // Record mode: persist a launched session URL so Concerto can reopen it.
+    if let Some(url) = options.session_url.as_deref() {
+        let url = url.trim();
+        if url.is_empty() {
+            return Err(OpsError::Message(
+                "--session-url must not be empty".to_string(),
+            ));
+        }
+        update_wave_cloud_session_url(repo, &wave, Some(url.to_string()))
+            .map_err(OpsError::Message)?;
+        progress.status(&format!(
+            "recorded {} cloud session for wave/{wave}",
+            vendor.as_str()
+        ));
+        return Ok(CloudLaunchResult {
+            wave,
+            vendor: vendor.as_str().to_string(),
+            mode: CloudMode::Record,
+            prompt_path: None,
+            mcp_path: None,
+            skills_written: 0,
+            deep_link: None,
+            session_url: Some(url.to_string()),
+        });
+    }
+
+    // Scaffold mode: rendered Goal prompt + flows-as-Skills + Asana MCP.
+    progress.status(&format!(
+        "scaffolding {} cloud loop for wave/{wave}",
+        vendor.as_str()
+    ));
+
+    let prompt = render_cloud_prompt(repo, &wave)?;
+    let prompt_path = repo.join(".lf").join("cloud").join(&wave).join("PROMPT.md");
+    write_file(&prompt_path, &prompt)?;
+
+    let report = sync_skills(repo, &SkillSyncOptions::default())
+        .map_err(|err| OpsError::Message(format!("failed to sync skills: {err}")))?;
+
+    let token = crate::ops::pm::asana_access_token()?;
+    let mcp = build_asana_mcp_json(&token)?;
+    let mcp_path = repo.join(".mcp.json");
+    write_file(&mcp_path, &mcp)?;
+
+    // The prompt scaffold and the token-bearing .mcp.json are generated, local,
+    // and secret — keep them out of git the same way skill sync does.
+    ensure_git_excluded(repo, &[".mcp.json", ".lf/cloud/"])?;
+
+    Ok(CloudLaunchResult {
+        wave,
+        vendor: vendor.as_str().to_string(),
+        mode: CloudMode::Scaffold,
+        prompt_path: Some(prompt_path),
+        mcp_path: Some(mcp_path),
+        skills_written: report.written.len(),
+        deep_link: Some(vendor.deep_link().to_string()),
+        session_url: None,
+    })
+}
+
+/// Render the wave's Goal into a vendor-launchable loop prompt: the same
+/// context `lf goal` assembles, plus a loop instruction. In-flight dispatches
+/// are omitted — a cloud clone has no local `lfd` to query.
+fn render_cloud_prompt(repo: &Path, wave: &str) -> OpsResult<String> {
+    let goal = load_goal(wave, repo).map_err(|err| {
+        OpsError::Message(format!("failed to load goal for wave '{wave}': {err}"))
+    })?;
+    let wave_config = read_wave_config(repo, wave).unwrap_or_default();
+    let memory =
+        fs::read_to_string(repo.join("wave").join(wave).join("MEMORY.md")).unwrap_or_default();
+
+    let ctx = GoalRenderContext {
+        flows: available_flow_names(repo),
+        roadmap: wave_config.roadmap.unwrap_or_default(),
+        memory,
+        metrics: wave_config.metrics.unwrap_or_default(),
+        in_flight: Vec::new(),
+    };
+
+    let mut message = render_goal(&goal, &ctx);
+    message.push_str(CLOUD_LOOP_INSTRUCTION);
+    Ok(message)
+}
+
+/// Wire Asana over MCP: the hosted remote server authenticated with the wave's
+/// stored OAuth token. The token grants the cloud session read/write on the
+/// workspace; the roadmap project GID travels in the Goal prompt.
+fn build_asana_mcp_json(token: &str) -> OpsResult<String> {
+    let value = serde_json::json!({
+        "mcpServers": {
+            "asana": {
+                "type": "sse",
+                "url": ASANA_MCP_URL,
+                "headers": {
+                    "Authorization": format!("Bearer {token}"),
+                },
+            },
+        },
+    });
+    serde_json::to_string_pretty(&value)
+        .map(|mut s| {
+            s.push('\n');
+            s
+        })
+        .map_err(|err| OpsError::Message(format!("failed to render .mcp.json: {err}")))
+}
+
+fn write_file(path: &Path, contents: &str) -> OpsResult<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(|err| {
+            OpsError::Message(format!("failed to create {}: {err}", parent.display()))
+        })?;
+    }
+    fs::write(path, contents)
+        .map_err(|err| OpsError::Message(format!("failed to write {}: {err}", path.display())))
+}
+
+/// Append paths to `.git/info/exclude` if not already present. No-op when the
+/// file is absent (e.g. a bare or freshly-initialized clone).
+fn ensure_git_excluded(repo: &Path, paths: &[&str]) -> OpsResult<()> {
+    let exclude_path = repo.join(".git/info/exclude");
+    if !exclude_path.exists() {
+        return Ok(());
+    }
+    let mut content = fs::read_to_string(&exclude_path)
+        .map_err(|err| OpsError::Message(format!("failed to read git exclude: {err}")))?;
+    let mut changed = false;
+    for line in paths {
+        if !content.lines().any(|existing| existing.trim() == *line) {
+            if !content.is_empty() && !content.ends_with('\n') {
+                content.push('\n');
+            }
+            content.push_str(line);
+            content.push('\n');
+            changed = true;
+        }
+    }
+    if changed {
+        fs::write(&exclude_path, content)
+            .map_err(|err| OpsError::Message(format!("failed to write git exclude: {err}")))?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn wave_fixture() -> TempDir {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let wave_dir = tmp.path().join("wave/ship");
+        std::fs::create_dir_all(&wave_dir).expect("wave dir");
+        std::fs::write(
+            wave_dir.join("GOAL.md"),
+            "---\nroadmap: wave/ship\nmetrics:\n  - tests pass\n---\nDrive the ship wave.",
+        )
+        .expect("write goal");
+        std::fs::write(wave_dir.join("MEMORY.md"), "Last loop shipped auth.")
+            .expect("write memory");
+        tmp
+    }
+
+    #[test]
+    fn vendor_parse_accepts_claude_rejects_others() {
+        assert_eq!(Vendor::parse("claude").unwrap(), Vendor::Claude);
+        assert_eq!(Vendor::parse("Claude").unwrap(), Vendor::Claude);
+        assert!(Vendor::parse("codex").is_err());
+        assert!(Vendor::parse("gemini").is_err());
+    }
+
+    #[test]
+    fn asana_mcp_json_carries_bearer_token_and_url() {
+        let json = build_asana_mcp_json("tok_123").expect("render mcp json");
+        let value: serde_json::Value = serde_json::from_str(&json).expect("valid json");
+        let asana = &value["mcpServers"]["asana"];
+        assert_eq!(asana["url"], ASANA_MCP_URL);
+        assert_eq!(asana["headers"]["Authorization"], "Bearer tok_123");
+    }
+
+    #[test]
+    fn cloud_prompt_renders_goal_context_and_loop_instruction() {
+        let tmp = wave_fixture();
+        let prompt = render_cloud_prompt(tmp.path(), "ship").expect("render prompt");
+        assert!(prompt.contains("Drive the ship wave."));
+        assert!(prompt.contains("<lf:goal-context>"));
+        assert!(prompt.contains("wave/ship"));
+        assert!(prompt.contains("- tests pass"));
+        assert!(prompt.contains("<lf:cloud-loop>"));
+        assert!(prompt.contains("asana` MCP server"));
+    }
+
+    #[test]
+    fn git_exclude_appends_paths_idempotently() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let info = tmp.path().join(".git/info");
+        std::fs::create_dir_all(&info).expect("git info dir");
+        std::fs::write(info.join("exclude"), "existing\n").expect("seed exclude");
+
+        ensure_git_excluded(tmp.path(), &[".mcp.json", ".lf/cloud/"]).expect("exclude once");
+        ensure_git_excluded(tmp.path(), &[".mcp.json", ".lf/cloud/"]).expect("exclude twice");
+
+        let content = std::fs::read_to_string(info.join("exclude")).expect("read exclude");
+        assert_eq!(content.matches(".mcp.json").count(), 1);
+        assert_eq!(content.matches(".lf/cloud/").count(), 1);
+        assert!(content.contains("existing"));
+    }
+
+    #[test]
+    fn record_mode_requires_wave_directory() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let err = cloud_launch(
+            tmp.path(),
+            &CloudLaunchOptions {
+                vendor: "claude".to_string(),
+                wave: Some("ghost".to_string()),
+                session_url: Some("https://claude.ai/session/abc".to_string()),
+            },
+            &crate::ops::progress::NullProgress,
+        )
+        .expect_err("missing wave should fail");
+        assert!(err.to_string().contains("wave directory not found"));
+    }
+
+    #[test]
+    fn record_mode_persists_session_url_onto_wave() {
+        let tmp = wave_fixture();
+        let result = cloud_launch(
+            tmp.path(),
+            &CloudLaunchOptions {
+                vendor: "claude".to_string(),
+                wave: Some("ship".to_string()),
+                session_url: Some("https://claude.ai/session/abc".to_string()),
+            },
+            &crate::ops::progress::NullProgress,
+        )
+        .expect("record session url");
+
+        assert_eq!(result.mode, CloudMode::Record);
+        let config = read_wave_config(tmp.path(), "ship").expect("config");
+        assert_eq!(
+            config.cloud_session_url.as_deref(),
+            Some("https://claude.ai/session/abc")
+        );
+    }
+}

--- a/rust/loopflow/src/ops/flow.rs
+++ b/rust/loopflow/src/ops/flow.rs
@@ -207,8 +207,10 @@ fn execute_parsed_ops(repo: &Path, op: &OpsCommand, progress: &impl Progress) ->
         | OpsCommand::Branches { .. }
         | OpsCommand::Wt { .. }
         | OpsCommand::Shell { .. }
-        | OpsCommand::Auth { .. } => Err(OpsError::Message(
-            "ops item does not support cp/doctor/pm/branches/wt/shell/auth commands".to_string(),
+        | OpsCommand::Auth { .. }
+        | OpsCommand::Cloud { .. } => Err(OpsError::Message(
+            "ops item does not support cp/doctor/pm/branches/wt/shell/auth/cloud commands"
+                .to_string(),
         )),
     }
 }

--- a/rust/loopflow/src/ops/mod.rs
+++ b/rust/loopflow/src/ops/mod.rs
@@ -1,5 +1,6 @@
 mod abandon;
 mod branches;
+mod cloud;
 mod combine;
 mod commit;
 mod error;
@@ -19,6 +20,7 @@ pub use branches::{
     list_branch_candidates, prune_branches, BranchCandidate, BranchFilterOptions,
     BranchListOptions, BranchPruneOptions,
 };
+pub use cloud::{cloud_launch, CloudLaunchOptions, CloudLaunchResult, CloudMode};
 pub use combine::{combine_prs, CombineOptions, CombineResult};
 pub use commit::{commit_workflow, commit_workflow_traced, CommitOptions};
 pub use error::{OpsError, OpsResult};

--- a/rust/loopflow/src/ops/pm.rs
+++ b/rust/loopflow/src/ops/pm.rs
@@ -111,6 +111,12 @@ async fn resolve_context(repo: &Path, wave: &str) -> OpsResult<PmContext> {
     Ok(PmContext { client, project })
 }
 
+/// Resolve the stored Asana OAuth access token for embedding in cloud scaffolds
+/// (`lf op cloud`), refreshing it in place if it has expired.
+pub(crate) fn asana_access_token() -> OpsResult<String> {
+    block_on_pm(resolve_asana_token())
+}
+
 async fn resolve_asana_token() -> OpsResult<String> {
     let store = open_store(&storage_config_from_env()?)
         .await

--- a/rust/loopflow/tests/dto_fixtures.rs
+++ b/rust/loopflow/tests/dto_fixtures.rs
@@ -38,6 +38,10 @@ fn wave_fixture_nests_repo_work() {
     assert_eq!(wave.primary_flow, "build");
     assert_eq!(wave.status, "running");
     assert_eq!(wave.parent_wave_id.as_deref(), Some("wave_parent999"));
+    assert_eq!(
+        wave.cloud_session_url.as_deref(),
+        Some("https://claude.ai/session/engbot")
+    );
 
     assert_eq!(wave.repos.len(), 1);
     let repo = &wave.repos[0];

--- a/scratch/questions.md
+++ b/scratch/questions.md
@@ -1,0 +1,23 @@
+# `lf op cloud` — open questions (A2 increment 1)
+
+No detailed design doc existed for the `.mcp.json` shape or deep-link, so I made
+executive calls. Flag for review:
+
+- **Asana MCP shape.** Emitting a hosted remote MCP entry (`type: sse`,
+  `https://mcp.asana.com/sse`) with the wave's stored OAuth token as a
+  `Bearer` header. The token is a live secret, so `.mcp.json` is added to
+  `.git/info/exclude`. Open: is the hosted SSE server the right transport, or
+  do we want a token-scoped stdio server? Workspace/project GIDs currently
+  travel in the Goal prompt (the roadmap handle), not in the MCP config — the
+  token grants workspace access and the agent uses the project GID from the
+  prompt.
+
+- **Deep-link target.** Claude has no create-routine API/deep-link, so the
+  scaffold prints `https://claude.ai/new` and instructs the human to attach the
+  repo, paste the prompt, and set a schedule. If there's a better prefill URL,
+  swap `CLAUDE_CLOUD_URL` in `ops/cloud.rs`.
+
+- **Codex is deferred.** `lf op cloud codex` returns a clear "follow-on"
+  error. Codex reads MCP from `~/.codex/config.toml` (not `.mcp.json`) and has
+  no server-side schedule, so its scaffold differs enough to be its own
+  increment.

--- a/swift/ConcertoTests/ContractTests.swift
+++ b/swift/ConcertoTests/ContractTests.swift
@@ -38,6 +38,7 @@ struct ContractTests {
         #expect(wave.direction == ["ux", "clarity"])
         #expect(wave.area == ["src/"])
         #expect(wave.parentWaveId == "wave_parent999")
+        #expect(wave.cloudSessionURL == "https://claude.ai/session/engbot")
 
         #expect(wave.repos.count == 1)
         #expect(wave.repos.first?.repo == "/home/user/project")

--- a/swift/LoopflowCore/Models/Wave.swift
+++ b/swift/LoopflowCore/Models/Wave.swift
@@ -255,6 +255,9 @@ public struct Wave: Sendable, Identifiable, Hashable {
     public var createdAt: Date?
     /// Parent wave in the chord tree. `nil` for a root wave.
     public var parentWaveId: String?
+    /// Vendor-cloud session/routine URL (`lf op cloud`); `NSWorkspace.open` target
+    /// for deep-linking out to the running cloud loop. Nil until launched.
+    public var cloudSessionURL: String?
 
     public init(
         id: String,
@@ -272,7 +275,8 @@ public struct Wave: Sendable, Identifiable, Hashable {
         status: WaveStatus = .idle,
         flowSteps: [String] = [],
         createdAt: Date? = nil,
-        parentWaveId: String? = nil
+        parentWaveId: String? = nil,
+        cloudSessionURL: String? = nil
     ) {
         self.id = id
         self.name = name
@@ -290,6 +294,7 @@ public struct Wave: Sendable, Identifiable, Hashable {
         self.flowSteps = flowSteps
         self.createdAt = createdAt
         self.parentWaveId = parentWaveId
+        self.cloudSessionURL = cloudSessionURL
     }
 
     /// Single-repo convenience mirroring the old flat shape: packs the per-repo
@@ -317,7 +322,8 @@ public struct Wave: Sendable, Identifiable, Hashable {
         flowSteps: [String] = [],
         openPRCount: Int = 0,
         activeRun: Run? = nil,
-        createdAt: Date? = nil
+        createdAt: Date? = nil,
+        cloudSessionURL: String? = nil
     ) {
         self.init(
             id: id,
@@ -347,7 +353,8 @@ public struct Wave: Sendable, Identifiable, Hashable {
             status: status,
             flowSteps: flowSteps,
             createdAt: createdAt,
-            parentWaveId: nil
+            parentWaveId: nil,
+            cloudSessionURL: cloudSessionURL
         )
     }
 }

--- a/swift/LoopflowCore/Services/LocalWaveService.swift
+++ b/swift/LoopflowCore/Services/LocalWaveService.swift
@@ -1010,7 +1010,8 @@ public struct WaveService: WaveServiceProtocol, @unchecked Sendable {
             status: status,
             flowSteps: flowSteps,
             createdAt: createdAt,
-            parentWaveId: json["parent_wave_id"] as? String
+            parentWaveId: json["parent_wave_id"] as? String,
+            cloudSessionURL: json["cloud_session_url"] as? String
         )
     }
 

--- a/tests/fixtures/wave.json
+++ b/tests/fixtures/wave.json
@@ -14,6 +14,7 @@
   "has_stale_pr_state": false,
   "workers": 1,
   "parent_wave_id": "wave_parent999",
+  "cloud_session_url": "https://claude.ai/session/engbot",
   "crons": [
     {
       "id": "cron_001",


### PR DESCRIPTION
## What

Adds `lf op cloud claude <wave>` — the **A2** increment of roadmap item 02, *Looping Agent — codex/claude cloud backend (a)*. lfd assembles the launch scaffold and the human presses go in the vendor UI; lfd does not drive the vendor API or own the runtime.

Reuses existing seams:
- **Rendered Goal prompt** via `render_goal` + `GoalRenderContext` (same context `lf goal` assembles, minus in-flight dispatches — a cloud clone has no local `lfd`), plus a `<lf:cloud-loop>` instruction telling the vendor session it's a recurring loop.
- **Flows-as-Skills** via `sync_skills` (`.claude/skills` / `.agents/skills`).
- **`.mcp.json` Asana emitter**: a fresh cloud clone has no `lf` binary or local OAuth, so we wire Asana over MCP (hosted SSE server `https://mcp.asana.com/sse` + the wave's stored OAuth token as a `Bearer` header). Written to repo root and git-excluded because it carries a live secret.
- **Deep-link out**: prints `https://claude.ai/new` (Claude has no create-routine deep-link/API today).

**Deep-link back**: `--session-url <url>` records the launched vendor session URL onto the wave as `cloud_session_url` in `GOAL.md`. Surfaced on `WaveDto` so Concerto can reopen it via `NSWorkspace.open` (no new URL scheme — `loopflow://` is inbound-only).

## Done-when mapping

> One repo's Goal runs as a recurring vendor-cloud loop, reads its Asana roadmap, and is reachable via a Concerto deep-link.

- **Goal → launchable loop**: yes — renders Goal prompt + loop instruction + skills.
- **reads its Asana roadmap**: yes — `.mcp.json` wires Asana over MCP.
- **reachable via Concerto deep-link**: yes — `cloud_session_url` persisted on the wave and carried on `WaveDto` (Rust/Python/Swift mirrors + fixture).
- **recurring**: depends on the **human registering a Routine** in the Claude UI. A1 (lfd registering the trigger via API) isn't possible uniformly today — no create-routine API for Claude, no server-side schedule for Codex. This is the deliberate A2 boundary.

## Wire change

New `cloud_session_url: Option<String>` on `WaveDto`, mirrored in Python `Wave`, Swift `Wave` (+ `parseWaveFromJSON`), persisted in `GOAL.md` frontmatter, added to `tests/fixtures/wave.json` with Rust/Python/Swift round-trip assertions. Scoped to this one field; branched off current `origin/main` so it composes with the merged `parent_wave_id` (#781).

## What remains (follow-on)

- `lf op cloud codex` (MCP config lives in `~/.codex/config.toml`, not `.mcp.json`; returns a clear "follow-on" error for now).
- A1 vendor-API driving, if/when create-routine APIs exist.
- Open executive calls (Asana MCP transport, deep-link target) noted in `scratch/questions.md`.

## Tests

- `cargo fmt --all`, `cargo clippy -p loopflow -- -D warnings`, `cargo test -p loopflow` — green (7 new tests).
- `pytest` contract + model + dto fixtures — green.
- Swift `ContractTests` — green.
- Verified record mode end-to-end: `lf op cloud claude ship --session-url ...` writes `cloud_session_url` into `GOAL.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)