### PR TITLE
Wave spend budget (first-class)

### DIFF
--- a/python/loopflow/models.py
+++ b/python/loopflow/models.py
@@ -94,6 +94,13 @@ class RepoWork(BaseModel):
     pr: Optional[PullRequest] = None
 
 
+class SpendCap(BaseModel):
+    """Wave spend ceiling, in cents. Mirrors Rust's `SpendCap`."""
+
+    rate: int
+    per_iteration: int
+
+
 class Wave(BaseModel):
     """Wave wire type. No field defaults — every field the server always emits
     is required, mirroring Rust's `WaveDto` (absent → parse error). Optional
@@ -106,6 +113,8 @@ class Wave(BaseModel):
     goal: str
     metrics: list[str]
     workers: int
+    spend_cap: Optional[SpendCap]
+    spent: int
     direction: list[str]
     area: list[str]
     triggers: list[Trigger]

--- a/python/tests/test_contract.py
+++ b/python/tests/test_contract.py
@@ -27,6 +27,10 @@ def test_wave_fixture_parses():
     assert wave.status == "running"
     assert wave.direction == ["ux", "clarity"]
     assert wave.area == ["src/"]
+    assert wave.spend_cap is not None
+    assert wave.spend_cap.rate == 5000
+    assert wave.spend_cap.per_iteration == 1000
+    assert wave.spent == 1234
     assert len(wave.crons) == 1
     assert wave.crons[0].flow == "wave-polish"
 

--- a/rust/loopflow/src/engine/agent.rs
+++ b/rust/loopflow/src/engine/agent.rs
@@ -14,7 +14,7 @@ use std::time::{Duration, Instant};
 use crate::engine::config::parse_agent;
 use crate::engine::error::CoreError;
 use crate::engine::platform::kill_process;
-use crate::engine::stream::{format_event, ParseResult, StreamFormat, StreamParser};
+use crate::engine::stream::{format_event, ParseResult, StreamEvent, StreamFormat, StreamParser};
 use crate::engine::structured_reply::{render_structured_reply_guidance, StructuredReply};
 
 /// PID of the current child agent process. The Ctrl+C handler sends SIGTERM
@@ -51,6 +51,10 @@ pub struct LaunchResult {
     pub exit_code: i32,
     pub stdout: String,
     pub stderr: String,
+    /// Total agent cost in USD, summed across the run's `Result` events. `None`
+    /// when the harness reported no cost (e.g. batch/interactive mode, or a
+    /// harness that never emits cost). Only the streaming path populates this.
+    pub cost_usd: Option<f64>,
 }
 
 /// Configuration for launching an agent.
@@ -626,6 +630,7 @@ fn launch_batch(cmd: &mut Command, timeout: Option<Duration>) -> Result<LaunchRe
         exit_code: status.code().unwrap_or(1),
         stdout: String::from_utf8_lossy(&stdout_bytes).to_string(),
         stderr: String::from_utf8_lossy(&stderr_bytes).to_string(),
+        cost_usd: None,
     })
 }
 
@@ -655,6 +660,7 @@ fn launch_interactive(
         exit_code: status.code().unwrap_or(1),
         stdout: String::new(),
         stderr: String::new(),
+        cost_usd: None,
     })
 }
 
@@ -710,6 +716,7 @@ fn launch_streaming(
     let mut stderr_content = String::new();
     let mut logged_first_output = false;
     let mut parser = StreamParser::new();
+    let mut total_cost_usd: Option<f64> = None;
 
     let use_color = match stream_format {
         StreamFormat::Human(c) => Some(c),
@@ -730,18 +737,18 @@ fn launch_streaming(
                 }
                 match stream {
                     StreamKind::Stdout => {
-                        if let Some(color) = use_color {
-                            match parser.feed_line(&line) {
-                                ParseResult::Events(events) => {
-                                    for event in &events {
-                                        format_event(event, color);
-                                    }
+                        // Always parse to accrue cost; display depends on format.
+                        let parsed = parser.feed_line(&line);
+                        accrue_cost(&parsed, &mut total_cost_usd);
+                        match (use_color, parsed) {
+                            (Some(color), ParseResult::Events(events)) => {
+                                for event in &events {
+                                    format_event(event, color);
                                 }
-                                ParseResult::Skipped => {}
-                                ParseResult::Passthrough => println!("{line}"),
                             }
-                        } else {
-                            println!("{line}");
+                            (Some(_), ParseResult::Skipped) => {}
+                            (Some(_), ParseResult::Passthrough) => println!("{line}"),
+                            (None, _) => println!("{line}"),
                         }
                         stdout_content.push_str(&line);
                         stdout_content.push('\n');
@@ -789,11 +796,53 @@ fn launch_streaming(
         )));
     }
 
+    write_cost_sidecar(total_cost_usd);
+
     Ok(LaunchResult {
         exit_code: status.code().unwrap_or(1),
         stdout: stdout_content,
         stderr: stderr_content,
+        cost_usd: total_cost_usd,
     })
+}
+
+/// Sum cost from any `Result` events into the running total.
+fn accrue_cost(parsed: &ParseResult, total: &mut Option<f64>) {
+    let ParseResult::Events(events) = parsed else {
+        return;
+    };
+    for event in events {
+        if let StreamEvent::Result {
+            cost_usd: Some(cost),
+            ..
+        } = event
+        {
+            *total = Some(total.unwrap_or(0.0) + cost);
+        }
+    }
+}
+
+/// Append the run's accrued cost (USD) to `LOOPFLOW_COST_FILE` when set, so a
+/// parent lfd process running this agent in a tmux pane can read spend back.
+/// Mirrors the tmux exit-file handshake — the only channel lfd has into a pane.
+fn write_cost_sidecar(total_cost_usd: Option<f64>) {
+    let Some(cost) = total_cost_usd else {
+        return;
+    };
+    let Ok(path) = std::env::var("LOOPFLOW_COST_FILE") else {
+        return;
+    };
+    if path.is_empty() {
+        return;
+    }
+    // Accumulate across multiple agent launches within one session.
+    let prior: f64 = std::fs::read_to_string(&path)
+        .ok()
+        .and_then(|text| text.trim().parse().ok())
+        .unwrap_or(0.0);
+    if let Err(err) = std::fs::write(&path, format!("{}", prior + cost)) {
+        tracing::warn!(path, error = %err, "failed to write agent cost sidecar");
+    }
 }
 
 fn wait_for_exit(

--- a/rust/loopflow/src/engine/flow.rs
+++ b/rust/loopflow/src/engine/flow.rs
@@ -144,6 +144,19 @@ pub struct GoalRenderContext {
     pub memory: String,
     pub metrics: Vec<String>,
     pub in_flight: Vec<InFlightDispatch>,
+    /// Wave spend-to-date and headroom, when the wave carries a spend cap. Lets
+    /// the Goal economize below the ceiling. `None` when uncapped.
+    pub spend: Option<SpendSummary>,
+}
+
+/// Spend signal handed to the Goal: what the wave has spent and how much room
+/// remains under its cap. Amounts in cents (kept integer so the context stays
+/// `Eq`); rendered as dollars.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SpendSummary {
+    pub spent_cents: i64,
+    pub rate_cap_cents: i64,
+    pub per_iteration_cap_cents: i64,
 }
 
 /// A wave run that is still dispatched — not yet completed, failed, or landed.
@@ -361,16 +374,44 @@ pub fn render_goal(goal: &Goal, ctx: &GoalRenderContext) -> String {
             .join("\n")
     };
 
+    let spend = render_spend(ctx.spend.as_ref());
+
     format!(
-        "<lf:loopflow-operating-prompt>\n{}\n</lf:loopflow-operating-prompt>\n\n{}\n\n<lf:wave-memory>\n{}\n</lf:wave-memory>\n\n<lf:in-flight>\n{}\n</lf:in-flight>\n\n<lf:goal-context>\nAvailable flows:\n{}\n\nRoadmap handle:\n{}\n\nMetrics:\n{}\n</lf:goal-context>",
+        "<lf:loopflow-operating-prompt>\n{}\n</lf:loopflow-operating-prompt>\n\n{}\n\n<lf:wave-memory>\n{}\n</lf:wave-memory>\n\n<lf:in-flight>\n{}\n</lf:in-flight>\n{}\n<lf:goal-context>\nAvailable flows:\n{}\n\nRoadmap handle:\n{}\n\nMetrics:\n{}\n</lf:goal-context>",
         LOOPFLOW_OPERATING_PROMPT,
         goal.prompt.trim(),
         memory,
         in_flight,
+        spend,
         flows,
         ctx.roadmap,
         metrics
     )
+}
+
+/// Render the spend signal block. Empty string when the wave is uncapped, so
+/// uncapped goals see no budget noise.
+fn render_spend(spend: Option<&SpendSummary>) -> String {
+    let Some(spend) = spend else {
+        return String::new();
+    };
+    let usd = |cents: i64| format!("${:.2}", cents as f64 / 100.0);
+    let mut lines = vec![format!("Spent so far: {}", usd(spend.spent_cents))];
+    if spend.rate_cap_cents > 0 {
+        let headroom = (spend.rate_cap_cents - spend.spent_cents).max(0);
+        lines.push(format!("Spend cap: {}", usd(spend.rate_cap_cents)));
+        lines.push(format!("Headroom remaining: {}", usd(headroom)));
+    }
+    if spend.per_iteration_cap_cents > 0 {
+        lines.push(format!(
+            "Per-iteration cap: {}",
+            usd(spend.per_iteration_cap_cents)
+        ));
+    }
+    lines.push(
+        "Economize below the cap; crossing it pauses the wave and blocks to a human.".to_string(),
+    );
+    format!("\n<lf:spend>\n{}\n</lf:spend>\n", lines.join("\n"))
 }
 
 /// Like `load_flow`, but resolves only exact-name matches in the builtin
@@ -1699,6 +1740,7 @@ mod tests {
                 memory: "Last loop found the docs drift.".to_string(),
                 metrics: vec!["tests pass".to_string(), "docs updated".to_string()],
                 in_flight: Vec::new(),
+                spend: None,
             },
         );
 
@@ -1731,6 +1773,7 @@ mod tests {
                 memory: String::new(),
                 metrics: Vec::new(),
                 in_flight: Vec::new(),
+                spend: None,
             },
         );
 
@@ -1759,6 +1802,7 @@ mod tests {
                     pr_url: Some("https://github.com/example/repo/pull/42".to_string()),
                     pr_state: Some("open".to_string()),
                 }],
+                spend: None,
             },
         );
 

--- a/rust/loopflow/src/engine/mod.rs
+++ b/rust/loopflow/src/engine/mod.rs
@@ -39,7 +39,7 @@ pub use flow::{
     available_flow_names, expand_flow, load_direction, load_flow, load_goal, load_step,
     next_action, render_goal, ConcreteAnd, ConcreteAndBranch, ConcreteItem, ConcreteLoop,
     ConcreteOp, ConcreteOr, ConcreteStep, ConcreteXor, Direction, Flow, FlowAction, FlowItem, Goal,
-    GoalRenderContext, InFlightDispatch, Op, OrDef, Step, XorDef, XorPath,
+    GoalRenderContext, InFlightDispatch, Op, OrDef, SpendSummary, Step, XorDef, XorPath,
 };
 pub use launch::{
     prepare_goal_launch, prepare_launch_prompt, ContextSourceOverrides, LaunchPromptInput,

--- a/rust/loopflow/src/engine/stream.rs
+++ b/rust/loopflow/src/engine/stream.rs
@@ -274,19 +274,37 @@ fn parse_codex_item(v: &serde_json::Value) -> Vec<StreamEvent> {
 }
 
 fn parse_codex_turn_completed(v: &serde_json::Value) -> Vec<StreamEvent> {
-    // Codex doesn't report cost or duration in the JSON output
-    let usage = v.get("usage");
-    let _ = usage; // available for future use
+    // Codex reports token usage but no dollars. Estimate cost from usage via
+    // the Codex rate table so a Codex wave still accrues a spend proxy.
+    let cost_usd = v.get("usage").and_then(estimate_codex_cost);
     let mut events = Vec::new();
     if let Some(text) = extract_codex_turn_text(v) {
         events.push(StreamEvent::Text(text));
     }
     events.push(StreamEvent::Result {
         subtype: ResultSubtype::Success,
-        cost_usd: None,
+        cost_usd,
         duration_secs: None,
     });
     events
+}
+
+/// Estimate Codex run cost (USD) from a `usage` object using the estimated
+/// Codex rate table. Returns `None` when usage carries no token counts.
+fn estimate_codex_cost(usage: &serde_json::Value) -> Option<f64> {
+    let rates = crate::lfd::providers::lookup_cost_rates("codex", "codex")?;
+    let field = |name: &str| usage.get(name).and_then(|v| v.as_f64()).unwrap_or(0.0);
+    let input = field("input_tokens");
+    let output = field("output_tokens");
+    let cached = field("cached_input_tokens");
+    if input == 0.0 && output == 0.0 && cached == 0.0 {
+        return None;
+    }
+    let cost = (input * rates.input_per_mtok
+        + output * rates.output_per_mtok
+        + cached * rates.cache_read_per_mtok)
+        / 1_000_000.0;
+    Some(cost)
 }
 
 // ── Gemini parsing ──────────────────────────────────────────────────────────
@@ -765,9 +783,24 @@ mod tests {
     }
 
     #[test]
-    fn codex_turn_completed() {
+    fn codex_turn_completed_estimates_cost_from_usage() {
         let mut parser = StreamParser::new();
         let line = r#"{"type":"turn.completed","usage":{"input_tokens":100,"output_tokens":50}}"#;
+        let expected = (100.0 * 1.25 + 50.0 * 10.0) / 1_000_000.0;
+        assert_eq!(
+            parser.feed_line(line),
+            ParseResult::Events(vec![StreamEvent::Result {
+                subtype: ResultSubtype::Success,
+                cost_usd: Some(expected),
+                duration_secs: None,
+            }])
+        );
+    }
+
+    #[test]
+    fn codex_turn_completed_without_usage_has_no_cost() {
+        let mut parser = StreamParser::new();
+        let line = r#"{"type":"turn.completed"}"#;
         assert_eq!(
             parser.feed_line(line),
             ParseResult::Events(vec![StreamEvent::Result {

--- a/rust/loopflow/src/lf/commands/goal.rs
+++ b/rust/loopflow/src/lf/commands/goal.rs
@@ -226,6 +226,9 @@ fn build_goal_message(
         memory,
         metrics: wave_config.metrics.unwrap_or_default(),
         in_flight,
+        // The CLI preview has no live wave to read spend from; the running
+        // wave loop populates this from the store.
+        spend: None,
     };
 
     let mut message = render_goal(&goal, &ctx);

--- a/rust/loopflow/src/lfd/attention.rs
+++ b/rust/loopflow/src/lfd/attention.rs
@@ -2,7 +2,7 @@ use crate::lfd::id::LfdId;
 use crate::lfd::store::SharedStore;
 use crate::lfd::types::{
     AttentionItem, AttentionKind, AttentionStatus, QueueBlock, QueueBlockReason, Run, RunStatus,
-    Wave,
+    SpendPause, Wave,
 };
 use serde_json::json;
 use time::OffsetDateTime;
@@ -10,6 +10,42 @@ use time::OffsetDateTime;
 /// Stable ID for queue-block attention items: reuse the run_id so upserts converge.
 pub fn attention_id_for_queue_block(run_id: &LfdId) -> LfdId {
     run_id.clone()
+}
+
+/// Stable ID for a wave's spend-cap block: reuse the wave_id so repeated
+/// crossings converge onto one item rather than piling up.
+pub fn attention_id_for_spend_cap(wave_id: &LfdId) -> LfdId {
+    wave_id.clone()
+}
+
+/// Algedonic block raised when a wave crosses its spend cap. Pauses belong to
+/// the wave (not a run), so the item keys on `wave_id`.
+pub async fn create_spend_cap_attention(
+    store: &SharedStore,
+    wave: &Wave,
+    pause: SpendPause,
+) -> Result<AttentionItem, String> {
+    let item = AttentionItem {
+        id: attention_id_for_spend_cap(wave.id()),
+        wave_id: wave.id().clone(),
+        run_id: None,
+        kind: AttentionKind::Algedonic,
+        status: AttentionStatus::Surfaced,
+        title: "Spend cap reached".to_string(),
+        summary: pause.summary(),
+        context: json!({
+            "spend_cap": true,
+            "spent_cents": wave.spent().cents(),
+        }),
+        surfaced_at: OffsetDateTime::now_utc(),
+        viewed_at: None,
+        resolved_at: None,
+    };
+    store
+        .upsert_attention_item(&item)
+        .await
+        .map_err(|err| format!("upsert spend cap attention failed: {err}"))?;
+    Ok(item)
 }
 
 /// Daemon-created algedonic attention: repair chain exhausted.

--- a/rust/loopflow/src/lfd/executor/docker/tests.rs
+++ b/rust/loopflow/src/lfd/executor/docker/tests.rs
@@ -353,6 +353,8 @@ async fn create_running_wave_and_run(store: &SharedStore, repo: &Path, name: &st
         paused: false,
         created_at: Some(OffsetDateTime::now_utc()),
         workers: 1,
+        spend_cap: None,
+        spent: crate::lfd::types::Money::ZERO,
     };
     store
         .create_wave(&wave)
@@ -605,6 +607,8 @@ async fn docker_startup_lost_agent_does_not_flip_terminal_run_wave_status() {
         paused: false,
         created_at: Some(OffsetDateTime::now_utc()),
         workers: 1,
+        spend_cap: None,
+        spent: crate::lfd::types::Money::ZERO,
     };
     store
         .create_wave(&wave)

--- a/rust/loopflow/src/lfd/executor/wave/mod.rs
+++ b/rust/loopflow/src/lfd/executor/wave/mod.rs
@@ -32,7 +32,7 @@ use crate::lfd::triggers::{
     ActivationEnvelope, EnqueueOutcome, ImmediateActivation,
 };
 use crate::lfd::types::{
-    tmux_session_name, Event, LivePrState, LivePullRequestState, Run, RunStatus, Session,
+    tmux_session_name, Event, LivePrState, LivePullRequestState, Money, Run, RunStatus, Session,
     SessionStatus, SessionUse, Signal, Wave, WaveMode, WaveStatus, CI_FIX_FLOW,
     LIVE_SESSION_STATUSES, PALETTE_TERMINAL_SOURCE, TMUX_TERMINAL_SOURCE,
 };
@@ -84,6 +84,31 @@ fn shell_escape(value: &str) -> String {
 fn tmux_exit_file(cwd: &Path, session_id: &LfdId) -> PathBuf {
     cwd.join(".lf/tmp/sessions")
         .join(format!("{session_id}.exit"))
+}
+
+/// Sidecar file a run's agent writes its accrued cost (USD) into. The child
+/// `lf`/agent process is handed this path via `LOOPFLOW_COST_FILE`; lfd reads
+/// it back when the run finishes. Keyed on run id so it survives across the
+/// tmux/direct launch split.
+fn run_cost_file(cwd: &Path, run_id: &LfdId) -> PathBuf {
+    cwd.join(".lf/tmp/sessions").join(format!("{run_id}.cost"))
+}
+
+/// Read and consume a run's cost sidecar, returning accrued spend (zero when
+/// absent or unparseable). Removes the file so a reused worktree doesn't
+/// double-count.
+async fn read_run_cost(cwd: String, run_id: LfdId) -> crate::lfd::types::Money {
+    let path = run_cost_file(Path::new(&cwd), &run_id);
+    tokio::task::spawn_blocking(move || {
+        let usd = std::fs::read_to_string(&path)
+            .ok()
+            .and_then(|text| text.trim().parse::<f64>().ok())
+            .unwrap_or(0.0);
+        let _ = std::fs::remove_file(&path);
+        crate::lfd::types::Money::from_usd(usd)
+    })
+    .await
+    .unwrap_or(crate::lfd::types::Money::ZERO)
 }
 
 fn tmux_available() -> bool {
@@ -155,6 +180,11 @@ fn build_wave_agent_command(
     let repo = Path::new(worktree);
     let goal = crate::engine::load_goal(wave.goal(), repo)?;
     let memory = read_wave_memory(repo, wave.name())?;
+    let spend = wave.spend_cap().map(|cap| crate::engine::SpendSummary {
+        spent_cents: wave.spent().cents(),
+        rate_cap_cents: cap.rate.cents(),
+        per_iteration_cap_cents: cap.per_iteration.cents(),
+    });
     let prompt = crate::engine::render_goal(
         &goal,
         &crate::engine::GoalRenderContext {
@@ -163,6 +193,7 @@ fn build_wave_agent_command(
             memory,
             metrics: wave.metrics().clone(),
             in_flight,
+            spend,
         },
     );
     let cmd = build_lf_inline_command(&prompt, true, direction, area, wave.name());
@@ -575,6 +606,14 @@ impl WaveExecutor {
             "LFD_AGENT_ROLE".to_string(),
             session_use.as_str().to_string(),
         ));
+        // Hand the agent a sidecar path to write its accrued cost into, so the
+        // wave can account spend even when the run executes in a tmux pane.
+        env.push((
+            "LOOPFLOW_COST_FILE".to_string(),
+            run_cost_file(Path::new(&run.worktree), &run.id)
+                .display()
+                .to_string(),
+        ));
         let tmux_managed = !self.disable_tmux && tmux_available();
         let session = Session {
             id: session_id.clone(),
@@ -697,6 +736,36 @@ impl WaveExecutor {
         }
     }
 
+    /// Roll a finished run's cost onto the wave and enforce the spend cap.
+    /// Loads the wave fresh so concurrent runs don't clobber each other's
+    /// accrual, pauses + raises an algedonic block when the cap is crossed.
+    async fn accrue_run_spend(&self, wave_id: &LfdId, run_cost: Money) -> Result<()> {
+        let Some(mut wave) = self.store.get_wave(wave_id).await? else {
+            return Ok(());
+        };
+        wave.accrue_spend(run_cost);
+        let pause = wave.spend_pause_reason(run_cost);
+        if pause.is_some() {
+            wave.set_status(WaveStatus::Paused);
+        }
+        self.store.update_wave(&wave).await?;
+        if let Some(pause) = pause {
+            warn!(
+                wave_id = %wave_id,
+                spent = %wave.spent(),
+                "wave crossed spend cap, pausing and blocking to human"
+            );
+            match crate::lfd::attention::create_spend_cap_attention(&self.store, &wave, pause).await
+            {
+                Ok(item) => self.event_hub.send(Event::attention_created(item)),
+                Err(err) => {
+                    warn!(wave_id = %wave_id, error = %err, "failed to raise spend cap block")
+                }
+            }
+        }
+        Ok(())
+    }
+
     async fn finish_completed_run(&self, wave: &Wave, run: &mut Run) -> Result<()> {
         run.status = RunStatus::Completed;
         run.ended_at = Some(OffsetDateTime::now_utc());
@@ -770,6 +839,8 @@ impl WaveExecutor {
         }
 
         self.store.update_run(run).await?;
+        // Read the run's cost sidecar before the worktree is cleaned up below.
+        let run_cost = read_run_cost(run.worktree.clone(), run.id.clone()).await;
         self.output.close_writer(&run.id.to_string());
         self.trigger_listeners_on_completion(wave.id(), &run.branch)
             .await;
@@ -802,6 +873,8 @@ impl WaveExecutor {
         if !other_active {
             self.set_wave_status(wave.id(), WaveStatus::Idle).await;
         }
+        // Accrue after the idle reset so a cap crossing's Paused status wins.
+        self.accrue_run_spend(wave.id(), run_cost).await?;
         self.event_hub.send(Event::wave_updated(wave.id().clone()));
         Ok(())
     }
@@ -930,9 +1003,13 @@ impl WaveExecutor {
         // execute_run_inner (triggers/common.rs), which checks the full
         // repair chain depth and applies backoff.
 
+        let run_cost = read_run_cost(run.worktree.clone(), run.id.clone()).await;
         self.output.close_writer(&run.id.to_string());
 
         self.set_wave_status(wave.id(), WaveStatus::Failed).await;
+        // A failed run still burned tokens; accrue and enforce the cap (a
+        // crossing's Paused status supersedes Failed).
+        self.accrue_run_spend(wave.id(), run_cost).await?;
         self.event_hub.send(Event::wave_updated(wave.id().clone()));
         Ok(())
     }
@@ -1471,6 +1548,8 @@ mod tests {
             paused: false,
             created_at: Some(OffsetDateTime::now_utc()),
             workers: 1,
+            spend_cap: None,
+            spent: crate::lfd::types::Money::ZERO,
         };
         store
             .create_wave(&wave)
@@ -1536,6 +1615,8 @@ mod tests {
             paused: false,
             created_at: Some(OffsetDateTime::now_utc()),
             workers: 1,
+            spend_cap: None,
+            spent: crate::lfd::types::Money::ZERO,
         }
     }
 
@@ -1733,6 +1814,8 @@ mod tests {
             paused: false,
             created_at: Some(OffsetDateTime::now_utc()),
             workers: 1,
+            spend_cap: None,
+            spent: crate::lfd::types::Money::ZERO,
         };
         store
             .create_wave(&target_wave)

--- a/rust/loopflow/src/lfd/http/dto.rs
+++ b/rust/loopflow/src/lfd/http/dto.rs
@@ -5,7 +5,7 @@ use time::OffsetDateTime;
 use crate::lfd::queue::QueueRunView;
 use crate::lfd::types::{
     ActivationLog, AttentionItem, ChatMemoryBlock, ChatMessage, LivePullRequestState, Run,
-    RunStatus, Session, Trigger, WaveCron,
+    RunStatus, Session, SpendCap, Trigger, WaveCron,
 };
 
 #[derive(Debug, Serialize)]
@@ -94,6 +94,10 @@ pub struct WaveDto {
     pub flow_steps: Vec<String>,
     pub has_stale_pr_state: bool,
     pub workers: u32,
+    /// Hard spend ceiling, or `null` when uncapped. Cents-based `SpendCap`.
+    pub spend_cap: Option<SpendCap>,
+    /// Cumulative agent spend to date, in cents.
+    pub spent: i64,
     pub triggers: Vec<TriggerDto>,
     pub crons: Vec<WaveCronDto>,
     /// Per-repo execution state, one entry per repo the wave runs in.
@@ -607,6 +611,8 @@ mod contract_tests {
             flow_steps: Vec::new(),
             has_stale_pr_state: false,
             repos: Vec::new(),
+            spend_cap: None,
+            spent: 0,
         };
 
         let json = serde_json::to_value(&wave).unwrap();

--- a/rust/loopflow/src/lfd/http/routes/hooks.rs
+++ b/rust/loopflow/src/lfd/http/routes/hooks.rs
@@ -805,6 +805,8 @@ mod tests {
             paused: false,
             created_at: Some(OffsetDateTime::now_utc()),
             workers: 1,
+            spend_cap: None,
+            spent: crate::lfd::types::Money::ZERO,
         };
         state.store.create_wave(&wave).await.expect("create wave");
         let trigger = Trigger {

--- a/rust/loopflow/src/lfd/http/routes/mod.rs
+++ b/rust/loopflow/src/lfd/http/routes/mod.rs
@@ -186,6 +186,8 @@ pub async fn build_wave_dto(
         flow_steps,
         has_stale_pr_state,
         workers: wave.workers(),
+        spend_cap: wave.spend_cap(),
+        spent: wave.spent().cents(),
         triggers,
         crons,
         repos,
@@ -519,6 +521,8 @@ mod tests {
             paused: false,
             created_at: Some(OffsetDateTime::now_utc()),
             workers: 1,
+            spend_cap: None,
+            spent: crate::lfd::types::Money::ZERO,
         }
     }
 

--- a/rust/loopflow/src/lfd/http/routes/repos.rs
+++ b/rust/loopflow/src/lfd/http/routes/repos.rs
@@ -486,6 +486,8 @@ mod tests {
             paused: false,
             created_at: Some(OffsetDateTime::now_utc()),
             workers: 1,
+            spend_cap: None,
+            spent: crate::lfd::types::Money::ZERO,
         }
     }
 

--- a/rust/loopflow/src/lfd/http/routes/session_controls.rs
+++ b/rust/loopflow/src/lfd/http/routes/session_controls.rs
@@ -363,6 +363,8 @@ mod tests {
             paused: false,
             created_at: Some(OffsetDateTime::now_utc()),
             workers: 1,
+            spend_cap: None,
+            spent: crate::lfd::types::Money::ZERO,
         }
     }
 

--- a/rust/loopflow/src/lfd/http/routes/wave_config.rs
+++ b/rust/loopflow/src/lfd/http/routes/wave_config.rs
@@ -4,6 +4,8 @@ use std::collections::HashMap;
 use std::path::Path;
 use tracing::warn;
 
+use crate::lfd::types::Money;
+
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub(crate) struct TriggerDef {
     pub signal: String,
@@ -43,6 +45,32 @@ pub(crate) struct WaveConfig {
     pub agent: Option<String>,
     pub step_agents: Option<HashMap<String, String>>,
     pub pm: Option<WavePmConfig>,
+    pub spend_cap: Option<SpendCapConfig>,
+}
+
+/// Spend cap declared in GOAL.md frontmatter, in dollars for human legibility.
+/// Converted to the cents-based `SpendCap` at wave creation.
+#[derive(Debug, Clone, Deserialize, Serialize, Default)]
+pub(crate) struct SpendCapConfig {
+    pub rate_usd: Option<f64>,
+    pub per_iteration_usd: Option<f64>,
+}
+
+impl SpendCapConfig {
+    pub fn to_spend_cap(&self) -> Option<crate::lfd::types::SpendCap> {
+        let rate = self.rate_usd.map(Money::from_usd).unwrap_or(Money::ZERO);
+        let per_iteration = self
+            .per_iteration_usd
+            .map(Money::from_usd)
+            .unwrap_or(Money::ZERO);
+        if rate.is_zero() && per_iteration.is_zero() {
+            return None;
+        }
+        Some(crate::lfd::types::SpendCap {
+            rate,
+            per_iteration,
+        })
+    }
 }
 
 /// Read wave intent from `wave/<name>/GOAL.md` frontmatter.

--- a/rust/loopflow/src/lfd/http/routes/waves.rs
+++ b/rust/loopflow/src/lfd/http/routes/waves.rs
@@ -38,8 +38,8 @@ use crate::lfd::triggers::{
     ActivationEnvelope, ImmediateActivation,
 };
 use crate::lfd::types::{
-    Event, ExecutionProcessStatus, RepoWork, Run, RunStatus, Session, SessionUse, Signal, Trigger,
-    Wave, WaveCron, WaveMode, WaveStatus, LIVE_SESSION_STATUSES,
+    Event, ExecutionProcessStatus, Money, RepoWork, Run, RunStatus, Session, SessionUse, Signal,
+    Trigger, Wave, WaveCron, WaveMode, WaveStatus, LIVE_SESSION_STATUSES,
 };
 
 #[derive(Debug, Deserialize)]
@@ -267,6 +267,10 @@ pub async fn create_wave_handler(
         .unwrap_or_default();
     let cron_defs = requested_crons.unwrap_or_default();
     let crons = build_wave_crons(&id, &cron_defs)?;
+    let spend_cap = wave_config
+        .as_ref()
+        .and_then(|config| config.spend_cap.as_ref())
+        .and_then(|cap| cap.to_spend_cap());
 
     let mut wave = Wave {
         id: id.clone(),
@@ -290,6 +294,8 @@ pub async fn create_wave_handler(
         paused: false,
         created_at: Some(OffsetDateTime::now_utc()),
         workers,
+        spend_cap,
+        spent: Money::ZERO,
     };
     if let Some(status) = status {
         let parsed = WaveStatus::from_str(&status)
@@ -1950,6 +1956,8 @@ mod tests {
             paused: false,
             created_at: Some(OffsetDateTime::now_utc()),
             workers: 1,
+            spend_cap: None,
+            spent: crate::lfd::types::Money::ZERO,
         }
     }
 

--- a/rust/loopflow/src/lfd/providers.rs
+++ b/rust/loopflow/src/lfd/providers.rs
@@ -80,7 +80,7 @@ pub static PROVIDER_CATALOG: &[ProviderInfo] = &[
         models: CODEX_MODELS,
         is_default: false,
         auth_provider: Some(Provider::Codex),
-        model_rates: &[],
+        model_rates: CODEX_MODEL_RATES,
     },
     ProviderInfo {
         id: "opencode",
@@ -102,6 +102,20 @@ pub struct ModelRate {
     pub model_prefix: &'static str,
     pub rates: CostRates,
 }
+
+// Codex runs on a ChatGPT subscription with no per-token billing to the user.
+// These rates are an ESTIMATE (GPT-5-class pricing) so a Codex wave accrues a
+// spend proxy instead of dropping usage entirely — the weak spot called out in
+// the wave-budget design. Treat resulting cost as approximate, not billed.
+const CODEX_MODEL_RATES: &[ModelRate] = &[ModelRate {
+    model_prefix: "codex",
+    rates: CostRates {
+        input_per_mtok: 1.25,
+        output_per_mtok: 10.0,
+        cache_read_per_mtok: 0.125,
+        cache_write_per_mtok: 1.25,
+    },
+}];
 
 const OPENCODE_MODEL_RATES: &[ModelRate] = &[
     // Moonshot — Kimi K2
@@ -267,9 +281,16 @@ mod tests {
     }
 
     #[test]
-    fn subscription_harnesses_have_no_rates() {
+    fn claude_subscription_has_no_rates() {
+        // Claude reports total_cost_usd directly, so needs no rate table.
         assert!(lookup_cost_rates("claude", "anything").is_none());
-        assert!(lookup_cost_rates("codex", "anything").is_none());
+    }
+
+    #[test]
+    fn codex_has_estimated_rate() {
+        // Codex reports usage but no dollars; an estimated rate lets a Codex
+        // wave still accrue a spend proxy.
+        assert!(lookup_cost_rates("codex", "codex").is_some());
     }
 
     #[test]

--- a/rust/loopflow/src/lfd/queue.rs
+++ b/rust/loopflow/src/lfd/queue.rs
@@ -736,6 +736,8 @@ mod tests {
             paused: false,
             created_at: Some(OffsetDateTime::now_utc()),
             workers: 1,
+            spend_cap: None,
+            spent: crate::lfd::types::Money::ZERO,
         }
     }
 

--- a/rust/loopflow/src/lfd/store/catalog.rs
+++ b/rust/loopflow/src/lfd/store/catalog.rs
@@ -174,27 +174,27 @@ const QUERY_DEFS: [QueryDef; QUERY_COUNT] = [
         postgres_override: None,
     },
     QueryDef {
-        template: "SELECT id, name, direction, area, paused, created_at, workers, mode,\n                    primary_flow, goal, metrics\n             FROM waves\n             ORDER BY created_at DESC",
+        template: "SELECT id, name, direction, area, paused, created_at, workers, mode,\n                    primary_flow, goal, metrics, spend_cap, spent\n             FROM waves\n             ORDER BY created_at DESC",
         sqlite_override: None,
         postgres_override: None,
     },
     QueryDef {
-        template: "SELECT id, name, direction, area, paused, created_at, workers, mode,\n                    primary_flow, goal, metrics\n             FROM waves\n             WHERE EXISTS (SELECT 1 FROM wave_repos wr WHERE wr.wave_id = waves.id AND wr.repo = {p1})\n             ORDER BY created_at DESC",
+        template: "SELECT id, name, direction, area, paused, created_at, workers, mode,\n                    primary_flow, goal, metrics, spend_cap, spent\n             FROM waves\n             WHERE EXISTS (SELECT 1 FROM wave_repos wr WHERE wr.wave_id = waves.id AND wr.repo = {p1})\n             ORDER BY created_at DESC",
         sqlite_override: None,
         postgres_override: None,
     },
     QueryDef {
-        template: "INSERT INTO waves (\n                id, name, direction, area, paused, created_at, workers, mode, primary_flow, goal, metrics\n            ) VALUES ({p1}, {p2}, {p3}, {p4}, {p5}, {p6}, {p7}, {p8}, {p9}, {p10}, {p11})\n            ON CONFLICT(id) DO UPDATE SET\n                name = excluded.name,\n                direction = excluded.direction,\n                area = excluded.area,\n                paused = excluded.paused,\n                created_at = excluded.created_at,\n                workers = excluded.workers,\n                mode = excluded.mode,\n                primary_flow = excluded.primary_flow,\n                goal = excluded.goal,\n                metrics = excluded.metrics",
+        template: "INSERT INTO waves (\n                id, name, direction, area, paused, created_at, workers, mode, primary_flow, goal, metrics, spend_cap, spent\n            ) VALUES ({p1}, {p2}, {p3}, {p4}, {p5}, {p6}, {p7}, {p8}, {p9}, {p10}, {p11}, {p12}, {p13})\n            ON CONFLICT(id) DO UPDATE SET\n                name = excluded.name,\n                direction = excluded.direction,\n                area = excluded.area,\n                paused = excluded.paused,\n                created_at = excluded.created_at,\n                workers = excluded.workers,\n                mode = excluded.mode,\n                primary_flow = excluded.primary_flow,\n                goal = excluded.goal,\n                metrics = excluded.metrics,\n                spend_cap = excluded.spend_cap,\n                spent = excluded.spent",
         sqlite_override: None,
         postgres_override: None,
     },
     QueryDef {
-        template: "SELECT id, name, direction, area, paused, created_at, workers, mode,\n                    primary_flow, goal, metrics\n             FROM waves WHERE id = {p1}",
+        template: "SELECT id, name, direction, area, paused, created_at, workers, mode,\n                    primary_flow, goal, metrics, spend_cap, spent\n             FROM waves WHERE id = {p1}",
         sqlite_override: None,
         postgres_override: None,
     },
     QueryDef {
-        template: "SELECT id, name, direction, area, paused, created_at, workers, mode,\n                    primary_flow, goal, metrics\n             FROM waves\n             WHERE name = {p1}",
+        template: "SELECT id, name, direction, area, paused, created_at, workers, mode,\n                    primary_flow, goal, metrics, spend_cap, spent\n             FROM waves\n             WHERE name = {p1}",
         sqlite_override: None,
         postgres_override: None,
     },
@@ -477,7 +477,7 @@ const QUERY_DEFS: [QueryDef; QUERY_COUNT] = [
     },
     // ListLoopableWaves
     QueryDef {
-        template: "SELECT id, name, direction, area, paused, created_at, workers, mode,\n                    primary_flow, goal, metrics\n             FROM waves\n             WHERE mode = 'loop' AND paused = 0\n             ORDER BY created_at DESC",
+        template: "SELECT id, name, direction, area, paused, created_at, workers, mode,\n                    primary_flow, goal, metrics, spend_cap, spent\n             FROM waves\n             WHERE mode = 'loop' AND paused = 0\n             ORDER BY created_at DESC",
         sqlite_override: None,
         postgres_override: None,
     },

--- a/rust/loopflow/src/lfd/store/migrations.rs
+++ b/rust/loopflow/src/lfd/store/migrations.rs
@@ -186,6 +186,10 @@ const ALL_MIGRATIONS: &[Migration] = &[
         version: "043_drop_legacy_wave_columns",
         sql: include_str!("migrations/043_drop_legacy_wave_columns.sql"),
     },
+    Migration {
+        version: "044_wave_spend_cap",
+        sql: include_str!("migrations/044_wave_spend_cap.sql"),
+    },
 ];
 
 /// Migrations applicable to a backend. Currently returns all migrations

--- a/rust/loopflow/src/lfd/store/migrations/044_wave_spend_cap.sql
+++ b/rust/loopflow/src/lfd/store/migrations/044_wave_spend_cap.sql
@@ -1,0 +1,5 @@
+-- Wave spend budget: a hard spend ceiling plus the running accrued total.
+-- spend_cap is a JSON object {"rate": cents, "per_iteration": cents} or NULL
+-- (uncapped). spent is cumulative agent cost in cents.
+ALTER TABLE waves ADD COLUMN spend_cap TEXT;
+ALTER TABLE waves ADD COLUMN spent BIGINT NOT NULL DEFAULT 0;

--- a/rust/loopflow/src/lfd/store/mod.rs
+++ b/rust/loopflow/src/lfd/store/mod.rs
@@ -2085,6 +2085,8 @@ mod tests {
             paused: false,
             created_at: Some(OffsetDateTime::now_utc()),
             workers: 1,
+            spend_cap: None,
+            spent: crate::lfd::types::Money::ZERO,
         }
     }
 

--- a/rust/loopflow/src/lfd/store/postgres.rs
+++ b/rust/loopflow/src/lfd/store/postgres.rs
@@ -14,7 +14,7 @@ use crate::lfd::store::rows::{
     map_activation_log_row, map_agent_row, map_chat_memory_block_row, map_chat_message_row,
     map_fork_run_row, map_live_pr_state_row, map_pending_activation_row, map_repo_edge_row,
     map_repo_row, map_run_row, map_summary_row, map_trigger_row, map_wave_cron_row,
-    map_wave_repo_row, map_wave_row, now_unix, serialize_pr,
+    map_wave_repo_row, map_wave_row, now_unix, serialize_pr, serialize_spend_cap,
 };
 use crate::lfd::store::token_crypto;
 use crate::lfd::store::{ForkRun, ForkRunStatus, StoreError, StoreResult};
@@ -215,6 +215,7 @@ impl PostgresStore {
             let direction_json = serde_json::to_string(wave.direction())?;
             let area_json = serde_json::to_string(wave.area())?;
             let metrics_json = serde_json::to_string(wave.metrics())?;
+            let spend_cap_json = serialize_spend_cap(&wave.spend_cap())?;
             let paused: i32 = if wave.status() == WaveStatus::Paused {
                 1
             } else {
@@ -227,6 +228,7 @@ impl PostgresStore {
             let primary_flow = wave.primary_flow();
             let goal = wave.goal();
             let metrics = metrics_json.as_str();
+            let spent = wave.spent().cents();
             client
                 .execute(
                     Self::sql(Query::UpsertWave),
@@ -242,6 +244,8 @@ impl PostgresStore {
                         &primary_flow.as_str(),
                         &goal,
                         &metrics,
+                        &spend_cap_json,
+                        &spent,
                     ],
                 )
                 .await?;

--- a/rust/loopflow/src/lfd/store/rows.rs
+++ b/rust/loopflow/src/lfd/store/rows.rs
@@ -2,9 +2,9 @@ use crate::lfd::id::LfdId;
 use crate::lfd::store::{ForkRun, ForkRunStatus, StoreError, StoreResult};
 use crate::lfd::types::{
     ActivationLog, ActivationOutcome, ChatMemoryBlock, ChatMessage, ExecutionProcess,
-    ExecutionProcessStatus, LivePrState, LivePullRequestState, PendingActivation, PullRequest,
-    Repo, RepoEdge, RepoId, RepoWork, Run, RunStackStatus, RunStatus, Signal, Summary, Trigger,
-    Wave, WaveCron, WaveMode, WaveStatus,
+    ExecutionProcessStatus, LivePrState, LivePullRequestState, Money, PendingActivation,
+    PullRequest, Repo, RepoEdge, RepoId, RepoWork, Run, RunStackStatus, RunStatus, Signal,
+    SpendCap, Summary, Trigger, Wave, WaveCron, WaveMode, WaveStatus,
 };
 
 // -- Row adapter trait -------------------------------------------------------
@@ -99,7 +99,7 @@ pub fn parse_pr(value: Option<String>) -> StoreResult<Option<PullRequest>> {
 // -- Shared row mappers ------------------------------------------------------
 
 /// SELECT id, name, direction, area, paused, created_at, workers, mode,
-///        primary_flow, goal, metrics
+///        primary_flow, goal, metrics, spend_cap, spent
 pub fn map_wave_row(row: &impl StoreRow) -> StoreResult<Wave> {
     let direction = parse_json_vec(&row.text(2)?)?;
     let area = parse_json_vec(&row.text(3)?)?;
@@ -111,6 +111,8 @@ pub fn map_wave_row(row: &impl StoreRow) -> StoreResult<Wave> {
     let primary_flow = row.text(8)?;
     let goal = row.text(9)?;
     let metrics = parse_json_vec(&row.text(10)?)?;
+    let spend_cap = parse_spend_cap(row.opt_text(11)?)?;
+    let spent = Money::from_cents(row.bigint(12)?);
 
     Ok(Wave {
         id: LfdId::from_raw(row.text(0)?),
@@ -126,7 +128,25 @@ pub fn map_wave_row(row: &impl StoreRow) -> StoreResult<Wave> {
         paused,
         created_at: Some(created_at),
         workers,
+        spend_cap,
+        spent,
     })
+}
+
+pub fn parse_spend_cap(value: Option<String>) -> StoreResult<Option<SpendCap>> {
+    match value {
+        Some(raw) if !raw.trim().is_empty() => serde_json::from_str::<SpendCap>(&raw)
+            .map(Some)
+            .map_err(StoreError::Serde),
+        _ => Ok(None),
+    }
+}
+
+pub fn serialize_spend_cap(value: &Option<SpendCap>) -> StoreResult<Option<String>> {
+    match value {
+        Some(cap) => Ok(Some(serde_json::to_string(cap)?)),
+        None => Ok(None),
+    }
 }
 
 /// SELECT id, wave_id, flow, schedule, last_triggered_at, created_at

--- a/rust/loopflow/src/lfd/store/sqlite.rs
+++ b/rust/loopflow/src/lfd/store/sqlite.rs
@@ -13,7 +13,7 @@ use crate::lfd::store::rows::{
     map_activation_log_row, map_agent_row, map_chat_memory_block_row, map_chat_message_row,
     map_fork_run_row, map_live_pr_state_row, map_pending_activation_row, map_repo_edge_row,
     map_repo_row, map_run_row, map_summary_row, map_trigger_row, map_wave_cron_row,
-    map_wave_repo_row, map_wave_row, now_unix, serialize_pr,
+    map_wave_repo_row, map_wave_row, now_unix, serialize_pr, serialize_spend_cap,
 };
 use crate::lfd::store::token_crypto;
 use crate::lfd::store::{ForkRun, ForkRunStatus, StoreError, StoreResult};
@@ -219,6 +219,7 @@ impl SqliteStore {
         let direction_json = serde_json::to_string(wave.direction())?;
         let area_json = serde_json::to_string(wave.area())?;
         let metrics_json = serde_json::to_string(wave.metrics())?;
+        let spend_cap_json = serialize_spend_cap(&wave.spend_cap())?;
         let created_at = wave
             .created_at()
             .map(|dt| dt.unix_timestamp())
@@ -242,6 +243,8 @@ impl SqliteStore {
                 wave.primary_flow(),
                 wave.goal(),
                 metrics_json,
+                spend_cap_json,
+                wave.spent().cents(),
             ],
         )?;
         Ok(())

--- a/rust/loopflow/src/lfd/triggers/activation.rs
+++ b/rust/loopflow/src/lfd/triggers/activation.rs
@@ -575,6 +575,8 @@ mod tests {
             paused: false,
             created_at: Some(OffsetDateTime::now_utc()),
             workers: 1,
+            spend_cap: None,
+            spent: crate::lfd::types::Money::ZERO,
         };
         store.create_wave(&wave).await.expect("create wave");
         wave

--- a/rust/loopflow/src/lfd/triggers/ci_failure.rs
+++ b/rust/loopflow/src/lfd/triggers/ci_failure.rs
@@ -210,6 +210,8 @@ mod tests {
             paused: false,
             created_at: Some(OffsetDateTime::now_utc()),
             workers: 1,
+            spend_cap: None,
+            spent: crate::lfd::types::Money::ZERO,
         };
         store.create_wave(&wave).await.expect("create wave");
         wave
@@ -290,6 +292,8 @@ mod tests {
             paused: false,
             created_at: Some(OffsetDateTime::now_utc()),
             workers: 1,
+            spend_cap: None,
+            spent: crate::lfd::types::Money::ZERO,
         };
         store.create_wave(&wave).await.expect("create wave");
         wave

--- a/rust/loopflow/src/lfd/triggers/common.rs
+++ b/rust/loopflow/src/lfd/triggers/common.rs
@@ -266,6 +266,8 @@ mod tests {
             paused: false,
             created_at: Some(OffsetDateTime::now_utc()),
             workers: 1,
+            spend_cap: None,
+            spent: crate::lfd::types::Money::ZERO,
         }
     }
 

--- a/rust/loopflow/src/lfd/triggers/cron.rs
+++ b/rust/loopflow/src/lfd/triggers/cron.rs
@@ -197,6 +197,8 @@ mod tests {
             paused: false,
             created_at: Some(OffsetDateTime::now_utc()),
             workers: 0,
+            spend_cap: None,
+            spent: crate::lfd::types::Money::ZERO,
         };
         state.store.create_wave(&wave).await.expect("create wave");
 

--- a/rust/loopflow/src/lfd/triggers/loop_ticker.rs
+++ b/rust/loopflow/src/lfd/triggers/loop_ticker.rs
@@ -87,6 +87,35 @@ async fn tick_loop_waves(
             continue;
         }
 
+        // Safety valve: never dispatch another iteration once the wave has
+        // reached its cumulative spend cap. Pause + block to a human, mirroring
+        // the max-iterations valve below.
+        if let Some(pause) = wave.spend_pause_reason(crate::lfd::types::Money::ZERO) {
+            tracing::warn!(
+                wave = %wave.name(),
+                spent = %wave.spent(),
+                "spend cap reached, pausing wave"
+            );
+            let mut paused_wave = wave.clone();
+            paused_wave.set_status(WaveStatus::Paused);
+            if let Err(err) = store.update_wave(&paused_wave).await {
+                tracing::error!(
+                    wave_id = %paused_wave.id,
+                    error = %err,
+                    "failed to pause wave after spend cap"
+                );
+            }
+            match crate::lfd::attention::create_spend_cap_attention(store, &paused_wave, pause)
+                .await
+            {
+                Ok(item) => event_hub.send(crate::lfd::types::Event::attention_created(item)),
+                Err(err) => {
+                    tracing::error!(wave = %wave.name(), error = %err, "failed to raise spend cap block")
+                }
+            }
+            continue;
+        }
+
         // Safety valve: check max_iterations on any trigger for this wave.
         if let Ok(triggers) = store.list_triggers(Some(wave.id())).await {
             if let Some(trigger) = triggers.iter().find(|t| t.max_iterations.is_some()) {
@@ -188,6 +217,8 @@ mod tests {
             paused: false,
             created_at: Some(OffsetDateTime::now_utc()),
             workers: 1,
+            spend_cap: None,
+            spent: crate::lfd::types::Money::ZERO,
         }
     }
 

--- a/rust/loopflow/src/lfd/types/mod.rs
+++ b/rust/loopflow/src/lfd/types/mod.rs
@@ -8,6 +8,7 @@ mod chat_memory;
 mod chat_message;
 mod event;
 mod execution;
+mod money;
 mod repo;
 mod session;
 mod summary;
@@ -19,6 +20,7 @@ pub use chat_memory::ChatMemoryBlock;
 pub use chat_message::ChatMessage;
 pub use event::Event;
 pub use execution::{ExecutionProcess, ExecutionProcessStatus};
+pub use money::{Money, SpendCap};
 pub use repo::{Repo, RepoEdge, RepoId};
 pub use session::{
     tmux_session_name, Session, SessionStatus, SessionUse, LIVE_SESSION_STATUSES,
@@ -30,5 +32,5 @@ pub use trigger::{
 };
 pub use wave::{
     LivePrState, LivePullRequestState, PullRequest, QueueBlock, QueueBlockReason, QueueMergeEvent,
-    RepoWork, Run, RunStackStatus, RunStatus, Wave, WaveCron, WaveMode, WaveStatus,
+    RepoWork, Run, RunStackStatus, RunStatus, SpendPause, Wave, WaveCron, WaveMode, WaveStatus,
 };

--- a/rust/loopflow/src/lfd/types/money.rs
+++ b/rust/loopflow/src/lfd/types/money.rs
@@ -1,0 +1,156 @@
+//! Money and spend-cap types for wave budgets.
+//!
+//! `Money` is a cents newtype so budget arithmetic never touches floats.
+//! Agent harnesses report cost as USD (`f64`); we convert once at the boundary
+//! and account in integer cents thereafter.
+
+use serde::{Deserialize, Serialize};
+
+/// A monetary amount in whole US cents. Wire shape: a bare integer.
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Default, Serialize, Deserialize, Hash,
+)]
+#[serde(transparent)]
+pub struct Money {
+    cents: i64,
+}
+
+impl Money {
+    pub const ZERO: Money = Money { cents: 0 };
+
+    pub fn from_cents(cents: i64) -> Self {
+        Self { cents }
+    }
+
+    /// Convert a USD amount (as reported by an agent harness) into cents,
+    /// rounding to the nearest cent. Negative or NaN inputs clamp to zero.
+    pub fn from_usd(usd: f64) -> Self {
+        if !usd.is_finite() || usd <= 0.0 {
+            return Self::ZERO;
+        }
+        Self {
+            cents: (usd * 100.0).round() as i64,
+        }
+    }
+
+    pub fn cents(&self) -> i64 {
+        self.cents
+    }
+
+    pub fn as_usd(&self) -> f64 {
+        self.cents as f64 / 100.0
+    }
+
+    pub fn is_zero(&self) -> bool {
+        self.cents == 0
+    }
+
+    pub fn saturating_add(self, other: Money) -> Money {
+        Money {
+            cents: self.cents.saturating_add(other.cents),
+        }
+    }
+
+    /// Headroom remaining under `cap`; zero once spend meets or exceeds it.
+    pub fn headroom_under(self, cap: Money) -> Money {
+        Money {
+            cents: (cap.cents - self.cents).max(0),
+        }
+    }
+}
+
+impl std::fmt::Display for Money {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "${:.2}", self.as_usd())
+    }
+}
+
+/// A wave's hard spend ceiling. `rate` is the cumulative ceiling for the wave's
+/// activity; `per_iteration` catches a single pathological run. Both in cents.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SpendCap {
+    /// Cumulative spend ceiling. Crossing it pauses the wave and blocks to human.
+    pub rate: Money,
+    /// Ceiling for one iteration's cost. A single run above it pauses+blocks.
+    pub per_iteration: Money,
+}
+
+impl SpendCap {
+    /// Whether cumulative `spent` has reached or crossed the cumulative ceiling.
+    pub fn rate_exceeded(&self, spent: Money) -> bool {
+        !self.rate.is_zero() && spent >= self.rate
+    }
+
+    /// Whether a single iteration's `cost` breaches the per-iteration ceiling.
+    pub fn iteration_exceeded(&self, cost: Money) -> bool {
+        !self.per_iteration.is_zero() && cost > self.per_iteration
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn from_usd_rounds_to_cents() {
+        assert_eq!(Money::from_usd(0.05).cents(), 5);
+        assert_eq!(Money::from_usd(1.239).cents(), 124);
+        assert_eq!(Money::from_usd(0.0).cents(), 0);
+    }
+
+    #[test]
+    fn negative_and_nan_clamp_to_zero() {
+        assert_eq!(Money::from_usd(-1.0), Money::ZERO);
+        assert_eq!(Money::from_usd(f64::NAN), Money::ZERO);
+    }
+
+    #[test]
+    fn money_serializes_as_bare_integer() {
+        let json = serde_json::to_string(&Money::from_cents(4200)).expect("serialize");
+        assert_eq!(json, "4200");
+        let parsed: Money = serde_json::from_str("4200").expect("parse");
+        assert_eq!(parsed, Money::from_cents(4200));
+    }
+
+    #[test]
+    fn headroom_never_negative() {
+        let spent = Money::from_cents(150);
+        assert_eq!(spent.headroom_under(Money::from_cents(100)), Money::ZERO);
+        assert_eq!(
+            Money::from_cents(30).headroom_under(Money::from_cents(100)),
+            Money::from_cents(70)
+        );
+    }
+
+    #[test]
+    fn rate_exceeded_ignores_zero_cap() {
+        let cap = SpendCap {
+            rate: Money::ZERO,
+            per_iteration: Money::from_cents(100),
+        };
+        assert!(!cap.rate_exceeded(Money::from_cents(9999)));
+    }
+
+    #[test]
+    fn rate_and_iteration_thresholds() {
+        let cap = SpendCap {
+            rate: Money::from_cents(500),
+            per_iteration: Money::from_cents(100),
+        };
+        assert!(!cap.rate_exceeded(Money::from_cents(499)));
+        assert!(cap.rate_exceeded(Money::from_cents(500)));
+        assert!(!cap.iteration_exceeded(Money::from_cents(100)));
+        assert!(cap.iteration_exceeded(Money::from_cents(101)));
+    }
+
+    #[test]
+    fn spend_cap_wire_shape() {
+        let cap = SpendCap {
+            rate: Money::from_cents(5000),
+            per_iteration: Money::from_cents(1000),
+        };
+        let json = serde_json::to_value(cap).expect("serialize");
+        assert_eq!(json["rate"], 5000);
+        assert_eq!(json["per_iteration"], 1000);
+    }
+}

--- a/rust/loopflow/src/lfd/types/wave.rs
+++ b/rust/loopflow/src/lfd/types/wave.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 use time::OffsetDateTime;
 
 use crate::lfd::id::LfdId;
+use crate::lfd::types::money::{Money, SpendCap};
 
 fn default_workers() -> u32 {
     1
@@ -251,6 +252,14 @@ pub struct Wave {
     /// Maximum number of active runs this wave can have at once.
     #[serde(default = "default_workers")]
     pub workers: u32,
+    /// Hard spend ceiling for this wave. `None` means uncapped (safety floor
+    /// opt-in). Crossing the cap pauses the wave and blocks to a human.
+    #[serde(default)]
+    pub spend_cap: Option<SpendCap>,
+    /// Cumulative agent cost accrued by this wave's runs, in cents. Grows as
+    /// runs finish and report cost; compared against `spend_cap.rate`.
+    #[serde(default)]
+    pub spent: Money,
 }
 
 impl Wave {
@@ -277,6 +286,8 @@ impl Wave {
             paused: false,
             created_at: Some(OffsetDateTime::now_utc()),
             workers: default_workers(),
+            spend_cap: None,
+            spent: Money::ZERO,
         }
     }
 
@@ -375,6 +386,66 @@ impl Wave {
 
     pub fn workers(&self) -> u32 {
         self.workers
+    }
+
+    pub fn spend_cap(&self) -> Option<SpendCap> {
+        self.spend_cap
+    }
+
+    pub fn spent(&self) -> Money {
+        self.spent
+    }
+
+    /// Accrue one run's cost onto the wave's running total. Returns the new
+    /// total so callers can log it.
+    pub fn accrue_spend(&mut self, cost: Money) -> Money {
+        self.spent = self.spent.saturating_add(cost);
+        self.spent
+    }
+
+    /// Why the wave should pause, given a just-finished run's `run_cost`.
+    /// `None` means keep going. Checks the per-iteration ceiling against the
+    /// single run and the cumulative ceiling against total spend-to-date.
+    pub fn spend_pause_reason(&self, run_cost: Money) -> Option<SpendPause> {
+        let cap = self.spend_cap?;
+        if cap.iteration_exceeded(run_cost) {
+            return Some(SpendPause::PerIteration {
+                cost: run_cost,
+                cap: cap.per_iteration,
+            });
+        }
+        if cap.rate_exceeded(self.spent) {
+            return Some(SpendPause::Rate {
+                spent: self.spent,
+                cap: cap.rate,
+            });
+        }
+        None
+    }
+}
+
+/// Which spend ceiling a wave crossed. Carries the numbers for the block's
+/// human-facing summary.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SpendPause {
+    /// A single iteration cost more than `per_iteration` allows.
+    PerIteration { cost: Money, cap: Money },
+    /// Cumulative spend reached the `rate` ceiling.
+    Rate { spent: Money, cap: Money },
+}
+
+impl SpendPause {
+    pub fn summary(&self) -> String {
+        match self {
+            SpendPause::PerIteration { cost, cap } => format!(
+                "One iteration spent {cost}, over the per-iteration cap of {cap}. \
+                 Wave paused; review before resuming."
+            ),
+            SpendPause::Rate { spent, cap } => format!(
+                "Wave has spent {spent}, at or over its spend cap of {cap}. \
+                 Wave paused; raise the cap or resume to continue."
+            ),
+        }
     }
 }
 
@@ -520,5 +591,62 @@ impl Run {
             repair_of: None,
             pr: None,
         }
+    }
+}
+
+#[cfg(test)]
+mod spend_tests {
+    use super::*;
+
+    fn capped_wave(rate_cents: i64, per_iteration_cents: i64) -> Wave {
+        let mut wave = Wave::new(LfdId::new(), "budget".to_string(), "/tmp/repo".to_string());
+        wave.spend_cap = Some(SpendCap {
+            rate: Money::from_cents(rate_cents),
+            per_iteration: Money::from_cents(per_iteration_cents),
+        });
+        wave
+    }
+
+    #[test]
+    fn uncapped_wave_never_pauses() {
+        let mut wave = Wave::new(LfdId::new(), "w".to_string(), "/tmp/repo".to_string());
+        wave.accrue_spend(Money::from_cents(999_999));
+        assert_eq!(wave.spend_pause_reason(Money::from_cents(999_999)), None);
+    }
+
+    #[test]
+    fn accrue_accumulates() {
+        let mut wave = capped_wave(1000, 0);
+        wave.accrue_spend(Money::from_cents(300));
+        wave.accrue_spend(Money::from_cents(250));
+        assert_eq!(wave.spent(), Money::from_cents(550));
+    }
+
+    #[test]
+    fn pauses_when_cumulative_cap_crossed() {
+        let mut wave = capped_wave(500, 0);
+        wave.accrue_spend(Money::from_cents(500));
+        assert!(matches!(
+            wave.spend_pause_reason(Money::from_cents(100)),
+            Some(SpendPause::Rate { .. })
+        ));
+    }
+
+    #[test]
+    fn per_iteration_catches_pathological_run() {
+        // Cumulative is fine, but one run blew past the per-iteration cap.
+        let mut wave = capped_wave(10_000, 200);
+        wave.accrue_spend(Money::from_cents(300));
+        assert!(matches!(
+            wave.spend_pause_reason(Money::from_cents(300)),
+            Some(SpendPause::PerIteration { .. })
+        ));
+    }
+
+    #[test]
+    fn stays_running_below_both_caps() {
+        let mut wave = capped_wave(1000, 500);
+        wave.accrue_spend(Money::from_cents(200));
+        assert_eq!(wave.spend_pause_reason(Money::from_cents(200)), None);
     }
 }

--- a/rust/loopflow/tests/dto_fixtures.rs
+++ b/rust/loopflow/tests/dto_fixtures.rs
@@ -38,6 +38,11 @@ fn wave_fixture_nests_repo_work() {
     assert_eq!(wave.primary_flow, "build");
     assert_eq!(wave.status, "running");
 
+    let cap = wave.spend_cap.expect("spend_cap present");
+    assert_eq!(cap.rate.cents(), 5000);
+    assert_eq!(cap.per_iteration.cents(), 1000);
+    assert_eq!(wave.spent, 1234);
+
     assert_eq!(wave.repos.len(), 1);
     let repo = &wave.repos[0];
     assert_eq!(repo.repo, "/home/user/project");

--- a/rust/loopflow/tests/wave_worktree_tests.rs
+++ b/rust/loopflow/tests/wave_worktree_tests.rs
@@ -47,6 +47,8 @@ fn make_wave(repo: &str, name: &str) -> Wave {
         paused: false,
         created_at: None,
         workers: 1,
+        spend_cap: None,
+        spent: loopflow::lfd::types::Money::ZERO,
     }
 }
 

--- a/swift/ConcertoTests/ContractTests.swift
+++ b/swift/ConcertoTests/ContractTests.swift
@@ -37,6 +37,9 @@ struct ContractTests {
         #expect(wave.status == .running)
         #expect(wave.direction == ["ux", "clarity"])
         #expect(wave.area == ["src/"])
+        #expect(wave.spendCap?.rate == 5000)
+        #expect(wave.spendCap?.perIteration == 1000)
+        #expect(wave.spent == 1234)
 
         #expect(wave.repos.count == 1)
         #expect(wave.repos.first?.repo == "/home/user/project")

--- a/swift/LoopflowCore/Models/Wave.swift
+++ b/swift/LoopflowCore/Models/Wave.swift
@@ -95,6 +95,22 @@ public enum MergeMode: String, Sendable, Codable {
     case land
 }
 
+/// A wave's hard spend ceiling, in cents. Mirrors Rust's `SpendCap`.
+public struct SpendCap: Sendable, Hashable, Codable {
+    public var rate: Int
+    public var perIteration: Int
+
+    public init(rate: Int, perIteration: Int) {
+        self.rate = rate
+        self.perIteration = perIteration
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case rate
+        case perIteration = "per_iteration"
+    }
+}
+
 public enum WaitingReason: Sendable, Hashable {
     case prLimitReached(open: Int, limit: Int)
 
@@ -252,6 +268,10 @@ public struct Wave: Sendable, Identifiable, Hashable {
     public var status: WaveStatus
     public var repos: [RepoWork]
     public var flowSteps: [String]
+    /// Hard spend ceiling, or `nil` when uncapped. Mirrors `WaveDto.spend_cap`.
+    public var spendCap: SpendCap?
+    /// Cumulative agent spend to date, in cents. Mirrors `WaveDto.spent`.
+    public var spent: Int
     public var createdAt: Date?
 
     public init(
@@ -269,6 +289,8 @@ public struct Wave: Sendable, Identifiable, Hashable {
         crons: [WaveCron] = [],
         status: WaveStatus = .idle,
         flowSteps: [String] = [],
+        spendCap: SpendCap? = nil,
+        spent: Int = 0,
         createdAt: Date? = nil
     ) {
         self.id = id
@@ -285,6 +307,8 @@ public struct Wave: Sendable, Identifiable, Hashable {
         self.crons = crons
         self.status = status
         self.flowSteps = flowSteps
+        self.spendCap = spendCap
+        self.spent = spent
         self.createdAt = createdAt
     }
 

--- a/swift/LoopflowCore/Services/LocalWaveService.swift
+++ b/swift/LoopflowCore/Services/LocalWaveService.swift
@@ -994,6 +994,16 @@ public struct WaveService: WaveServiceProtocol, @unchecked Sendable {
             }
         }
 
+        let spendCap: SpendCap?
+        if let capDict = json["spend_cap"] as? [String: Any],
+           let rate = capDict["rate"] as? Int,
+           let perIteration = capDict["per_iteration"] as? Int {
+            spendCap = SpendCap(rate: rate, perIteration: perIteration)
+        } else {
+            spendCap = nil
+        }
+        let spent = json["spent"] as? Int ?? 0
+
         return Wave(
             id: json["id"] as? String ?? UUID().uuidString,
             name: json["name"] as? String ?? "",
@@ -1009,6 +1019,8 @@ public struct WaveService: WaveServiceProtocol, @unchecked Sendable {
             crons: crons,
             status: status,
             flowSteps: flowSteps,
+            spendCap: spendCap,
+            spent: spent,
             createdAt: createdAt
         )
     }

--- a/tests/fixtures/wave.json
+++ b/tests/fixtures/wave.json
@@ -13,6 +13,8 @@
   "flow_steps": ["implement", "compress", "gate"],
   "has_stale_pr_state": false,
   "workers": 1,
+  "spend_cap": {"rate": 5000, "per_iteration": 1000},
+  "spent": 1234,
   "crons": [
     {
       "id": "cron_001",


### PR DESCRIPTION
Implements roadmap item 04 — a Wave carries a first-class `spend_cap`, accrues real agent cost per iteration, and pauses with a human block when spend crosses the cap.

## Resolved open question
The design's open question (how much budget machinery lives in core vs. user-land) is resolved to the "lean" option: **core owns a hard safety floor** — the `spend_cap` field, per-run cost accrual, at-cap pause + block→human — and **user-land owns policy below the ceiling** via an exposed cost signal + the existing pause/block primitive. No rich budgeting policy was built into core.

## Done-when coverage
- **Wave carries a first-class `spend_cap`** — ✅ `Money` cents newtype + `SpendCap { rate, per_iteration }`; `Wave.spend_cap: Option<SpendCap>` + a `Wave.spent` accumulator, persisted (migration 044, sqlite + postgres).
- **Accrues real cost per iteration** — ✅ per-run cost captured from the stream parser (Claude `total_cost_usd`, OpenCode `part.cost`) onto `LaunchResult.cost_usd`; Codex usage, previously dropped, is turned into an *estimated* cost via a new Codex rate entry. The agent writes accrued cost to a `LOOPFLOW_COST_FILE` sidecar; lfd reads it at run finalization (mirroring the tmux exit-file handshake) and rolls it onto the wave.
- **Pauses with a human block when spend crosses the cap** — ✅ enforcement sits beside the max-iterations valve: the loop ticker refuses to dispatch once cumulative spend reaches `rate`, and run finalization catches a pathological run over `per_iteration`. Both `set_status(Paused)` + upsert a spend-cap `AttentionItem` (algedonic block→human).
- **Cost signal exposure** — ✅ `render_goal` surfaces spent + headroom in an `<lf:spend>` block so a Goal can economize. Caps declared in GOAL.md frontmatter (`spend_cap: { rate_usd, per_iteration_usd }`).

## Single-wave vs. chord-deferred
- **Single-wave cap: shipped** (the design permits shipping it independently).
- **Chord rollup (parent ceiling vs. sum of children): deferred.** It depends on `parent_wave_id` (PR #781, branch `jack-heart.wave-ancestry`), which is not yet on `main`. This branch is off `origin/main`, so ancestry isn't present. Left as a clearly-marked follow-on.

## Known limitations
- **`per_iteration` is a run-boundary catch, not a mid-turn kill.** Cost only surfaces at the `Result` event, so a single runaway turn is caught when the run ends, not interrupted mid-flight.
- Codex cost is an **estimate** (subscription harness reports no dollars); marked as such in `providers.rs`.

## Wire/DTO
`spend_cap` (+ `spent`) mirrored on Rust `WaveDto`, Python `Wave`, and Swift `Wave` as explicit fields (no `#[serde(default)]`/Default). `Money`/`SpendCap` wire shapes pinned; `tests/fixtures/wave.json` carries the fields, asserted in all three languages' round-trip tests.

## Tests
- `cargo fmt --all --check`, `cargo clippy -p loopflow --all-targets -- -D warnings` — clean.
- `cargo test -p loopflow` — 845 lib + all integration tests pass (incl. new `money`, `spend_tests`, stream/provider cost, DTO fixture tests).
- `uv run pytest python/tests/test_contract.py` — 3 passed.
- `swift test --package-path swift --filter ContractTests` — 3 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)