### PR TITLE
ci: trim concerto-ui-test post-test hang (~45s/run)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,7 +170,12 @@ jobs:
           failure_pattern = re.compile(
               r"^✗ |Test Suite '.*' failed at |\*\* TEST FAILED \*\*|failed with \d+ failures"
           )
-          idle_success_seconds = 60
+          # The Concerto GUI test host reliably fails to exit after the suite
+          # finishes on headless macos-15, so xcodebuild hangs post-test. We
+          # force-kill once success is proven (XCTest + >=30 Swift suites passed,
+          # no failures). That verdict lands before this wait, so shrinking the
+          # grace only trims dead idle time — it can't truncate a live run.
+          idle_success_seconds = 15
           idle_min_swift_suites = 30
 
           def xcresult_indicates_success(path):


### PR DESCRIPTION
The `concerto-ui-test` step spends ~43% of its wall-clock *idle*: the Concerto GUI app used as the xcodebuild test host reliably fails to exit on headless macos-15, so the run hangs after the suite passes. The harness already force-kills once success is proven (XCTest passed + ≥30 Swift Testing suites passed + no failures) — but waits a fixed 60s grace first. Those success signals land *before* the wait, so the grace can only bound the post-test hang, never truncate a live build or test.

Shrinking `idle_success_seconds` 60→15 saves **~45s/run** (~30% off the critical-path bottleneck). Additive to the DerivedData caching already on main — that trims the ~82s build, this trims the ~61s hang.

Verified against real CI logs (a green run fired the 61s idle-kill). Can't repro locally — the hang only happens headless (locally the app has a display and exits normally). One-line value change + comment.