### PR TITLE
Concerto: WaveChat as the wave detail surface

### DIFF
--- a/scratch/questions.md
+++ b/scratch/questions.md
@@ -1,0 +1,30 @@
+# Open questions — jack-heart.concerto-wavechat
+
+## WaveChat first surface: data source (resolved by best judgment)
+
+The brief assumed `lf wave` writes per-pass logs under `wave/<name>/streams/`
+that WaveChat could parse into turns. That capture was **removed** ("inherit
+terminal instead of teeing passes"): nothing read the streams, and each inner
+`lf -b goal` pass already writes durable logs under the agent's log dir. So
+there is no `streams/` source to parse.
+
+Decision taken (the brief's documented fallback): back `WaveChatView` with a
+small local `WaveChatSource` that reconstructs two turns from the two-file wave
+surface `lf wave` maintains — `GOAL.md` (the operator's directive → opening turn)
+and `MEMORY.md` (the wave's working memory → its reply). A "latest state"
+snapshot, not a live transcript.
+
+## Base branch note
+
+The brief said to open this PR against `jack-heart.lf-loop` (PR #778). By the
+time the slice was ready, #778 had been squash-merged into `main` and its branch
+deleted, so this PR targets `main` instead — which now contains #778.
+
+## Follow-ons (separate PRs, not built here)
+
+- Rust **codex harness** for the wave's inner agent.
+- **Per-wave in-process chat server** exposing streamed `ChatTurn`s.
+- **Live turn updates** in `WaveChatView` (replace the two-file reconstruction).
+- Chat **input/composer** to message a running wave.
+
+`WaveChatSource` is the single seam to swap when the server lands.

--- a/swift/Concerto/Platform/macOS/Views/MessageRow.swift
+++ b/swift/Concerto/Platform/macOS/Views/MessageRow.swift
@@ -1,0 +1,81 @@
+#if os(macOS)
+import SwiftUI
+import LoopflowCore
+
+/// One turn in a WaveChat transcript. Recovered from the removed Conversations
+/// subsystem and trimmed to what a read-only wave chat needs: role-styled prose
+/// with a selectable assistant body. The reply composer, quote popovers, code-
+/// block segmentation, and streaming cursor were dropped — they belong to the
+/// live per-wave chat server that hasn't landed yet.
+struct MessageRow: View {
+    @Environment(\.palette) private var palette
+    let message: SessionMessage
+    let timestampLabel: String?
+
+    @State private var selectionResetToken = 0
+
+    var body: some View {
+        if message.role == .system {
+            Text(message.content)
+                .font(Typography.caption())
+                .foregroundStyle(palette.textSecondary)
+                .frame(maxWidth: .infinity, alignment: .center)
+                .padding(.vertical, Spacing.xs)
+        } else if message.role == .assistant {
+            messageContent
+                .frame(maxWidth: .infinity, alignment: .leading)
+        } else {
+            HStack(alignment: .top, spacing: Spacing.sm) {
+                accentBar
+                messageContent
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+
+    private var messageContent: some View {
+        VStack(alignment: .leading, spacing: Spacing.xs) {
+            content
+
+            if let timestampLabel {
+                Text(timestampLabel)
+                    .font(Typography.caption(11))
+                    .foregroundStyle(palette.textSecondary)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        if message.role == .assistant {
+            SelectableAssistantMessageTextView(
+                text: message.content,
+                selectionResetToken: selectionResetToken
+            ) { _ in }
+        } else {
+            Text(message.content)
+                .font(Typography.body())
+                .foregroundStyle(message.role == .error ? Color.statusError : palette.text)
+                .textSelection(.enabled)
+        }
+    }
+
+    private var accentBar: some View {
+        RoundedRectangle(cornerRadius: 1.5)
+            .fill(accentColor)
+            .frame(width: 3)
+            .frame(minHeight: Spacing.lg)
+            .accessibilityHidden(true)
+    }
+
+    private var accentColor: Color {
+        switch message.role {
+        case .user: return palette.accent
+        case .assistant: return palette.textSecondary.opacity(0.4)
+        case .error: return Color.statusError
+        case .system: return .clear
+        }
+    }
+}
+
+#endif

--- a/swift/Concerto/Platform/macOS/Views/SelectableAssistantMessageTextView.swift
+++ b/swift/Concerto/Platform/macOS/Views/SelectableAssistantMessageTextView.swift
@@ -1,0 +1,130 @@
+#if os(macOS)
+import SwiftUI
+import AppKit
+
+/// A read-only, text-selectable rendering of an assistant message. Recovered from
+/// the removed Conversations subsystem for WaveChat: it lets the operator select
+/// and copy an assistant turn's prose without the view stealing scroll or growing
+/// unbounded (it sizes to its content).
+struct SelectableAssistantMessageTextView: NSViewRepresentable {
+    let text: String
+    let selectionResetToken: Int
+    let onSelectionChanged: (String?) -> Void
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(onSelectionChanged: onSelectionChanged)
+    }
+
+    func makeNSView(context: Context) -> AutosizingSelectableTextView {
+        let textView = AutosizingSelectableTextView(frame: .zero, textContainer: nil)
+        textView.delegate = context.coordinator
+        textView.string = text
+        return textView
+    }
+
+    func updateNSView(_ nsView: AutosizingSelectableTextView, context: Context) {
+        context.coordinator.onSelectionChanged = onSelectionChanged
+
+        if nsView.string != text {
+            nsView.string = text
+            nsView.invalidateIntrinsicContentSize()
+        }
+
+        if context.coordinator.selectionResetToken != selectionResetToken {
+            context.coordinator.selectionResetToken = selectionResetToken
+            context.coordinator.isResetting = true
+            nsView.setSelectedRange(NSRange(location: 0, length: 0))
+            context.coordinator.isResetting = false
+            onSelectionChanged(nil)
+        }
+    }
+
+    final class Coordinator: NSObject, NSTextViewDelegate {
+        var onSelectionChanged: (String?) -> Void
+        var selectionResetToken = 0
+        var isResetting = false
+
+        init(onSelectionChanged: @escaping (String?) -> Void) {
+            self.onSelectionChanged = onSelectionChanged
+        }
+
+        func textViewDidChangeSelection(_ notification: Notification) {
+            guard !isResetting else { return }
+            guard let textView = notification.object as? NSTextView else { return }
+            let selection = textView.selectedRange()
+            guard selection.length > 0 else {
+                onSelectionChanged(nil)
+                return
+            }
+
+            let fullText = textView.string as NSString
+            guard selection.location + selection.length <= fullText.length else {
+                onSelectionChanged(nil)
+                return
+            }
+
+            let rawSelected = fullText.substring(with: selection)
+            let cleaned = rawSelected.trimmingCharacters(in: .whitespacesAndNewlines)
+            onSelectionChanged(cleaned.isEmpty ? nil : cleaned)
+        }
+    }
+}
+
+final class AutosizingSelectableTextView: NSTextView {
+    override init(frame frameRect: NSRect, textContainer container: NSTextContainer?) {
+        let textStorage = NSTextStorage()
+        let layoutManager = NSLayoutManager()
+        let textContainer = NSTextContainer(size: NSSize(width: frameRect.width, height: .greatestFiniteMagnitude))
+        textContainer.widthTracksTextView = true
+        textContainer.lineFragmentPadding = 0
+
+        textStorage.addLayoutManager(layoutManager)
+        layoutManager.addTextContainer(textContainer)
+
+        super.init(frame: frameRect, textContainer: textContainer)
+
+        isEditable = false
+        isSelectable = true
+        drawsBackground = false
+        isRichText = false
+        allowsUndo = false
+        importsGraphics = false
+        textContainerInset = NSSize(width: 0, height: 0)
+        isVerticallyResizable = true
+        isHorizontallyResizable = false
+        autoresizingMask = [.width]
+
+        font = NSFont(name: "Lato", size: 14) ?? .systemFont(ofSize: 14)
+        textColor = .labelColor
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override var intrinsicContentSize: NSSize {
+        guard let layoutManager, let textContainer else {
+            return super.intrinsicContentSize
+        }
+
+        layoutManager.ensureLayout(for: textContainer)
+        let usedRect = layoutManager.usedRect(for: textContainer)
+        let height = ceil(usedRect.height + textContainerInset.height * 2)
+        return NSSize(width: NSView.noIntrinsicMetric, height: max(20, height))
+    }
+
+    override func layout() {
+        super.layout()
+        invalidateIntrinsicContentSize()
+    }
+
+    override var frame: NSRect {
+        didSet {
+            if oldValue.size.width != frame.size.width {
+                invalidateIntrinsicContentSize()
+            }
+        }
+    }
+}
+
+#endif

--- a/swift/Concerto/Platform/macOS/Views/WaveChatView.swift
+++ b/swift/Concerto/Platform/macOS/Views/WaveChatView.swift
@@ -1,0 +1,80 @@
+#if os(macOS)
+import SwiftUI
+import LoopflowCore
+
+/// WaveChat's first surface: a scrollable transcript of a wave's turns, rendered
+/// with the recovered `MessageRow`. This slice reconstructs the turns from the
+/// wave's on-disk `GOAL.md` + `MEMORY.md` (see `WaveChatSource`) — a "latest
+/// state" snapshot, not a live stream. A per-wave chat server replaces the source
+/// later without touching this view.
+struct WaveChatView: View {
+    let repoPath: String
+    let waveName: String
+
+    @Environment(\.palette) private var palette
+    @State private var turns: [SessionMessage] = []
+    @State private var didLoad = false
+
+    private static let timestampFormatter: RelativeDateTimeFormatter = {
+        let formatter = RelativeDateTimeFormatter()
+        formatter.unitsStyle = .abbreviated
+        return formatter
+    }()
+
+    var body: some View {
+        Group {
+            if turns.isEmpty {
+                emptyState
+            } else {
+                transcript
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(palette.background)
+        .task(id: waveName) {
+            guard !didLoad else { return }
+            // Two small on-disk reads; cheap enough to do inline. A per-wave chat
+            // server replaces this source with a live stream later.
+            turns = WaveChatSource().loadTurns(repoPath: repoPath, waveName: waveName)
+            didLoad = true
+        }
+    }
+
+    private var transcript: some View {
+        ScrollView {
+            LazyVStack(alignment: .leading, spacing: Spacing.lg) {
+                ForEach(turns) { turn in
+                    MessageRow(message: turn, timestampLabel: timestampLabel(for: turn))
+                }
+            }
+            .padding(.horizontal, Spacing.xl)
+            .padding(.vertical, Spacing.lg)
+            .frame(maxWidth: 720, alignment: .leading)
+            .frame(maxWidth: .infinity, alignment: .center)
+        }
+        .accessibilityIdentifier("wave-chat-transcript")
+    }
+
+    private var emptyState: some View {
+        VStack(spacing: Spacing.md) {
+            Image(systemName: "bubble.left.and.bubble.right")
+                .font(Typography.heroTitle(28))
+                .foregroundStyle(palette.textSecondary.opacity(0.5))
+            Text("No conversation yet")
+                .font(Typography.sectionTitle())
+                .foregroundStyle(palette.text)
+            Text("This wave's goal and memory appear here as it runs.")
+                .font(Typography.caption())
+                .foregroundStyle(palette.textSecondary)
+                .multilineTextAlignment(.center)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .padding()
+    }
+
+    private func timestampLabel(for turn: SessionMessage) -> String {
+        Self.timestampFormatter.localizedString(for: turn.timestamp, relativeTo: Date())
+    }
+}
+
+#endif

--- a/swift/Concerto/Platform/macOS/Views/WaveDetailPane.swift
+++ b/swift/Concerto/Platform/macOS/Views/WaveDetailPane.swift
@@ -1,0 +1,55 @@
+#if os(macOS)
+import SwiftUI
+import LoopflowCore
+
+/// The wave detail pane: a header (wave identity + close) over the WaveChat
+/// transcript. WaveChat is the sole detail surface — it replaces the embedded
+/// `/goal` Ghostty terminal that used to live here. The wave itself runs in its
+/// own `lf wave` process; Concerto observes it through WaveChat rather than
+/// hosting the raw terminal.
+struct WaveDetailPane: View {
+    let wave: WaveViewModel
+    let repoPath: String
+    let onClose: () -> Void
+
+    @Environment(\.palette) private var palette
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            Divider()
+            WaveChatView(repoPath: repoPath, waveName: wave.name)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+    }
+
+    private var header: some View {
+        HStack(spacing: Spacing.sm) {
+            Image(systemName: wave.statusIndicator.icon)
+                .foregroundStyle(wave.statusIndicator.color)
+            Text(wave.displayName)
+                .font(Typography.sectionTitle())
+                .foregroundStyle(palette.text)
+            Text("WaveChat")
+                .font(Typography.caption())
+                .foregroundStyle(palette.textSecondary)
+
+            Spacer()
+
+            Button {
+                onClose()
+            } label: {
+                Image(systemName: "xmark")
+                    .font(Typography.caption())
+                    .foregroundStyle(palette.textSecondary)
+            }
+            .buttonStyle(.plain)
+            .help("Close wave")
+            .accessibilityLabel("Close wave")
+        }
+        .padding(.horizontal, Spacing.xl)
+        .padding(.vertical, Spacing.md)
+    }
+}
+
+#endif

--- a/swift/Concerto/Platform/macOS/Views/WavesView.swift
+++ b/swift/Concerto/Platform/macOS/Views/WavesView.swift
@@ -1,9 +1,9 @@
 // The exposed main window: a burgundy repo rail (left) filtering a burgundy wave
-// list (center), with a "+" new-wave launcher, and a terminal detail (right) that
-// attaches the selected wave's /goal agent in an embedded tmux session.
+// list (center), with a "+" new-wave launcher, and a WaveChat detail (right) that
+// shows the selected wave's chat transcript.
 //
 // Reshaped from the battle-tested PortfolioWindow: keeps its connection / daemon /
-// EventService plumbing, swaps the multi-repo card grid for the sidebar+list+terminal
+// EventService plumbing, swaps the multi-repo card grid for the sidebar+list+detail
 // shape sketched by RepoSidebarWindow, and reuses WaveRow + WaveSidebar's burgundy
 // treatment so the style matches the app.
 
@@ -128,7 +128,7 @@ struct WavesView: View {
 
             Divider()
 
-            terminalDetail
+            waveDetail
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
                 .background(palette.background)
         }
@@ -335,46 +335,31 @@ struct WavesView: View {
         .padding()
     }
 
-    // MARK: - Terminal detail
+    // MARK: - Wave detail (WaveChat)
 
     @ViewBuilder
-    private var terminalDetail: some View {
-        if let wave = selectedWave, let state = repoState(for: wave) {
-            WaveAgentTerminalPane(
+    private var waveDetail: some View {
+        if let wave = selectedWave {
+            WaveDetailPane(
                 wave: wave,
-                attach: { _ in try await launchOrAttach(wave: wave, state: state) },
+                repoPath: wave.repo,
                 onClose: { selectedWaveId = nil }
             )
             .id(wave.id)
         } else {
             VStack(spacing: Spacing.md) {
-                Image(systemName: "terminal")
+                Image(systemName: "bubble.left.and.bubble.right")
                     .font(Typography.heroTitle(28))
                     .foregroundStyle(palette.textSecondary.opacity(0.5))
                 Text("Select a wave")
                     .font(Typography.sectionTitle())
                     .foregroundStyle(palette.text)
-                Text("Its /goal agent opens here in an embedded terminal.")
+                Text("Its WaveChat opens here.")
                     .font(Typography.caption())
                     .foregroundStyle(palette.textSecondary)
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
-    }
-
-    /// Attach the wave's /goal agent through local `lf goal --tmux`. The returned
-    /// tmux handle is enough for Ghostty to attach; no lfd run/attach route needed.
-    private func launchOrAttach(wave: WaveViewModel, state: PortfolioRepoState) async throws -> SessionConnectionInfo {
-        let connection = try await state.attachWaveAgent(waveName: wave.name)
-        await refreshAuthoredWaves()
-        return connection
-    }
-
-    private func repoState(for wave: WaveViewModel) -> PortfolioRepoState? {
-        repoStates[wave.repo.normalizedFilePath]
-            ?? repoStates.values.first { state in
-                state.waves.contains { $0.id == wave.id }
-            }
     }
 
     // MARK: - Header helpers
@@ -643,88 +628,6 @@ struct WavesView: View {
 
         case .worktree, .agentStarted, .agentEnded, .output, .attention, .terminalSession, .secrets:
             break
-        }
-    }
-}
-
-/// Embedded terminal for a wave's /goal agent: ensures the agent is running,
-/// resolves its tmux session, and attaches via GhosttyTerminalView. Mirrors the
-/// proven attach flow in TerminalWorkspaceView's SessionTerminalSurface.
-private struct WaveAgentTerminalPane: View {
-    let wave: WaveViewModel
-    let attach: (String) async throws -> SessionConnectionInfo
-    let onClose: () -> Void
-
-    @Environment(\.palette) private var palette
-    @ObservedObject private var ghosttyManager = GhosttyManager.shared
-    @State private var connectionInfo: SessionConnectionInfo?
-    @State private var errorMessage: String?
-
-    var body: some View {
-        VStack(spacing: 0) {
-            header
-            Divider()
-            terminal
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
-                .background(LoopflowPalette.dark.background)
-        }
-        .task(id: wave.id) {
-            guard connectionInfo == nil else { return }
-            if RepoState.uiTestMode() != nil { return }
-            do {
-                connectionInfo = try await attach(wave.id)
-                errorMessage = nil
-            } catch {
-                errorMessage = error.localizedDescription
-            }
-        }
-    }
-
-    private var header: some View {
-        HStack(spacing: Spacing.sm) {
-            Image(systemName: wave.statusIndicator.icon)
-                .foregroundStyle(wave.statusIndicator.color)
-            Text(wave.displayName)
-                .font(Typography.sectionTitle())
-                .foregroundStyle(palette.text)
-            Text("/goal agent")
-                .font(Typography.caption())
-                .foregroundStyle(palette.textSecondary)
-            Spacer()
-            Button {
-                onClose()
-            } label: {
-                Image(systemName: "xmark")
-                    .font(Typography.caption())
-                    .foregroundStyle(palette.textSecondary)
-            }
-            .buttonStyle(.plain)
-            .help("Close terminal")
-        }
-        .padding(.horizontal, Spacing.xl)
-        .padding(.vertical, Spacing.md)
-    }
-
-    @ViewBuilder
-    private var terminal: some View {
-        if let command = connectionInfo.map(TerminalAttachCommand.init) {
-            GhosttyTerminalView(
-                workingDirectory: command.workingDirectory,
-                argv: command.argv,
-                env: command.env,
-                sessionId: "wave-agent-\(wave.id)",
-                manager: ghosttyManager
-            )
-        } else if let errorMessage {
-            ContentUnavailableView(
-                "Terminal unavailable",
-                systemImage: "exclamationmark.triangle",
-                description: Text(errorMessage)
-            )
-        } else {
-            ProgressView("Starting /goal agent…")
-                .tint(.white)
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
     }
 }

--- a/swift/LoopflowCore/Services/WaveChatSource.swift
+++ b/swift/LoopflowCore/Services/WaveChatSource.swift
@@ -1,0 +1,56 @@
+import Foundation
+
+/// Reads a wave's chat turns from the best on-disk source available today.
+///
+/// There is no per-wave chat server yet, so this backs WaveChat with the two-file
+/// wave surface `lf wave` already maintains: `wave/<name>/GOAL.md` (the operator's
+/// standing directive) becomes the opening turn, and `wave/<name>/MEMORY.md` (the
+/// wave's working memory — what the latest passes learned and did) becomes the
+/// wave's reply. It's a faithful "latest state" snapshot, not a live transcript.
+///
+// TODO(wavechat): back with codex harness + per-wave chat server. Once each
+// `lf wave <name>` process hosts an in-process chat API, load real streamed
+// ChatTurns instead of reconstructing two turns from GOAL.md + MEMORY.md.
+public struct WaveChatSource: Sendable {
+    public init() {}
+
+    /// Load the wave's turns from `<repoPath>/wave/<waveName>/`. Returns an empty
+    /// list when neither file exists — the caller renders an empty state.
+    public func loadTurns(repoPath: String, waveName: String) -> [SessionMessage] {
+        let waveDir = URL(fileURLWithPath: repoPath)
+            .appendingPathComponent("wave", isDirectory: true)
+            .appendingPathComponent(waveName, isDirectory: true)
+
+        var turns: [SessionMessage] = []
+
+        if let goal = readTurn(waveDir.appendingPathComponent("GOAL.md"), stripFrontmatter: true) {
+            turns.append(SessionMessage(role: .user, content: goal.body, timestamp: goal.modified))
+        }
+        if let memory = readTurn(waveDir.appendingPathComponent("MEMORY.md"), stripFrontmatter: false) {
+            turns.append(SessionMessage(role: .assistant, content: memory.body, timestamp: memory.modified))
+        }
+
+        return turns
+    }
+
+    private func readTurn(_ url: URL, stripFrontmatter: Bool) -> (body: String, modified: Date)? {
+        guard let raw = try? String(contentsOf: url, encoding: .utf8) else { return nil }
+        let body = (stripFrontmatter ? Self.stripFrontmatter(raw) : raw)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !body.isEmpty else { return nil }
+        let modified = (try? url.resourceValues(forKeys: [.contentModificationDateKey]))?
+            .contentModificationDate ?? Date()
+        return (body, modified)
+    }
+
+    /// Drop a leading `---`-fenced YAML frontmatter block, if present.
+    static func stripFrontmatter(_ text: String) -> String {
+        guard text.hasPrefix("---") else { return text }
+        let lines = text.components(separatedBy: "\n")
+        guard lines.first?.trimmingCharacters(in: .whitespaces) == "---" else { return text }
+        for index in 1..<lines.count where lines[index].trimmingCharacters(in: .whitespaces) == "---" {
+            return lines[(index + 1)...].joined(separator: "\n")
+        }
+        return text
+    }
+}


### PR DESCRIPTION
## What this slice does

Brings back the removed Conversations chat UI, **redesigned as WaveChat**, and makes it the **sole detail surface** for a selected wave in Concerto's `WavesView`. WaveChat replaces the embedded `/goal` Ghostty terminal (`WaveAgentTerminalPane`) that used to occupy the detail pane — the wave runs in its own `lf wave` process (#778), and Concerto now *observes* it through WaveChat rather than hosting the raw terminal.

This is **WaveChat's first surface**: a read-only, scrollable transcript.

## Changes

- **Recovered + trimmed** `MessageRow` and `SelectableAssistantMessageTextView` from the deleted conversations subsystem. Kept only what a read-only transcript needs — dropped the reply composer, quote popovers, code-block segmentation, and streaming cursor (those belong to the live chat server that hasn't landed). `ChatTurn.swift` / `ChatMemoryBlock.swift` already survived in the tree.
- **`WaveChatView`** (macOS) renders the turns via `MessageRow`, following VISUAL_DESIGN.md (burgundy, spacing/Typography tokens, theme-aware palette, empty state).
- **`WaveDetailPane`** wraps it with a wave-identity header (status icon, name, close). `WavesView` renders it in place of the terminal; the now-dead `launchOrAttach` / `repoState(for:)` wiring is removed. `TerminalAttachCommand` + `shellEscape` stay put — `TerminalWorkspaceView` shares them.

## Data-source limitation

There is **no per-wave chat server yet**, and #778's `wave/<name>/streams/` capture was removed (nothing read it; the loop now inherits the terminal). So there is no stream log to parse. `WaveChatSource` reconstructs **two turns** from the two-file wave surface `lf wave` maintains: `GOAL.md` (the operator's directive → opening turn) and `MEMORY.md` (the wave's working memory → its reply). A "latest state" snapshot, not a live transcript. `WaveChatSource` is the single seam to swap when a real server lands.

## Base branch note

The task specified base `jack-heart.lf-loop` (PR #778). By the time this slice was ready, **#778 had been squash-merged into `main`** and its branch deleted, so this PR targets **`main`** — which now contains #778.

## Follow-ons (separate PRs, not built here)

- Rust **codex harness** for the wave's inner agent.
- **Per-wave in-process chat server** exposing streamed `ChatTurn`s.
- **Live turn updates** in `WaveChatView` (replace the two-file reconstruction).
- Chat **input/composer** (send a message to a running wave).

## Verification

- `cd swift && xcodegen generate && xcodebuild build -project LoopflowSwift.xcodeproj -scheme Concerto -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO` → **BUILD SUCCEEDED**
- `swift test --package-path swift --filter ContractTests` → **3 tests passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)