### PR TITLE
ci: run rust tests with cargo-nextest (~15-30s/run)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,8 +51,9 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           key: test
+      - uses: taiki-e/install-action@nextest
       - name: Run Rust tests
-        run: cargo test --all
+        run: cargo nextest run --all
 
   python-test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The rust suite is ~1031 tests across ~20 test binaries that overwhelmingly shell out to `git`. `cargo test --all` runs the binaries serially (parallelizing only within each), so runners sit blocked-on-I/O between binaries. nextest overlaps them.

Local (warm build): `cargo test --all` ~40s → `cargo nextest run --all` ~12s across three runs each. Zero doctests in the crate, so nextest (which skips doctests) covers the whole suite. Conservative CI estimate: ~15-30s off `rust-test`, net of the prebuilt `taiki-e/install-action@nextest` step (~1-2s).

Same tests, same semantics; 1031/1031 passed every local run. `docker-smoke`'s filtered `cargo test` left untouched to keep blast radius minimal.