### PR TITLE
ci: -gnone on swift-test build (~10-15s/run)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,7 +111,10 @@ jobs:
           restore-keys: |
             swiftpm-${{ runner.os }}-
       - name: Run Swift tests
-        run: swift test --package-path swift
+        # -gnone skips debug-info generation; `swift test` here is ~95% compile,
+        # and CI never symbolicates. Failure locations come from #file/#line
+        # macros, not debug info, so they're preserved.
+        run: swift test --package-path swift -Xswiftc -gnone
       - name: Check Swift multiplatform boundaries
         run: uv run python scripts/check_swift_multiplatform_boundaries.py
 


### PR DESCRIPTION
`swift test` in this job is ~95% compilation, ~0% execution (281 tests run in 0.25s). `-Xswiftc -gnone` skips debug-info generation (DWARF per file + dSYM on links), cutting the clean build 33s→28s locally (~15%), roughly **10-15s** off the ~1.7min job. Unlike dep-trimming this lands on cold *and* warm-cache runs, orthogonal to #782's `.build` cache.

Risk low: Swift Testing `#expect` and XCTest failure locations come from compile-time `#file/#line` macros, not debug info — verified a deliberate failing `#expect` under -gnone still reported `WaveTests.swift:830:9: Expectation failed`. Only trade-off: a rare native-crash backtrace would be unsymbolicated (fine for CI; one flag to re-enable for a debug run).

Follow-up (not here): `swift test` links a 32MB standalone Concerto executable the tests never use (~5s) — killing it needs a library/executable module split, too risky for this PR.