### PR TITLE
lf wave: per-wave chat server with Concerto WaveChat surface

### DIFF
--- a/rust/loopflow/src/engine/agent.rs
+++ b/rust/loopflow/src/engine/agent.rs
@@ -711,6 +711,18 @@ fn launch_streaming(
     let mut logged_first_output = false;
     let mut parser = StreamParser::new();
 
+    // When `lf wave` runs this pass it sets `LF_WAVE_EVENT_SINK` to a per-wave
+    // NDJSON path. We append every raw stdout line (the agent's stream-json) so
+    // the wave's in-process chat server can tail it and assemble ChatTurns. The
+    // sink is best-effort and independent of terminal rendering.
+    let mut event_sink = std::env::var_os("LF_WAVE_EVENT_SINK").and_then(|path| {
+        std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(path)
+            .ok()
+    });
+
     let use_color = match stream_format {
         StreamFormat::Human(c) => Some(c),
         StreamFormat::Raw => None,
@@ -730,6 +742,10 @@ fn launch_streaming(
                 }
                 match stream {
                     StreamKind::Stdout => {
+                        if let Some(sink) = event_sink.as_mut() {
+                            use std::io::Write;
+                            let _ = writeln!(sink, "{line}");
+                        }
                         if let Some(color) = use_color {
                             match parser.feed_line(&line) {
                                 ParseResult::Events(events) => {

--- a/rust/loopflow/src/lf/commands/goal.rs
+++ b/rust/loopflow/src/lf/commands/goal.rs
@@ -301,12 +301,34 @@ fn build_goal_message(
     };
 
     let mut message = render_goal(&goal, &ctx);
+    if let Some(mailbox) = drain_mailbox(repo, wave_name) {
+        message.push_str(&format!(
+            "\n\n<lf:mailbox>\nNew messages from the operator since the last pass. Treat these as \
+             high-priority direction:\n\n{mailbox}\n</lf:mailbox>"
+        ));
+    }
     if once {
         message.push_str(
             "\n\n<lf:goal-once>\nRun a single loop iteration, then stop and summarize.\n</lf:goal-once>",
         );
     }
     Ok(message)
+}
+
+/// Read and clear `wave/<wave>/MAILBOX.md` — the drop point for human messages
+/// posted to the wave's chat server (`POST /chat`). Returns the messages so the
+/// next pass folds them into its prompt, then truncates the file so each message
+/// is delivered exactly once. Returns `None` when the mailbox is empty/absent.
+fn drain_mailbox(repo: &Path, wave_name: &str) -> Option<String> {
+    let path = repo.join("wave").join(wave_name).join("MAILBOX.md");
+    let contents = std::fs::read_to_string(&path).ok()?;
+    let trimmed = contents.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    let messages = trimmed.to_string();
+    let _ = std::fs::write(&path, b"");
+    Some(messages)
 }
 
 /// Best-effort fetch of the wave's open dispatches from a running `lfd`.

--- a/rust/loopflow/src/lf/commands/loop.rs
+++ b/rust/loopflow/src/lf/commands/loop.rs
@@ -1,40 +1,104 @@
-use std::path::Path;
+use std::io::{BufRead, BufReader, Seek, SeekFrom};
+use std::path::{Path, PathBuf};
 use std::process::{Command, ExitStatus};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::{anyhow, Context, Result};
 
+use crate::engine::stream::StreamParser;
 use crate::engine::worktrees::main_repo_root;
 use crate::lf::commands::util::find_repo_root;
+use crate::lfd::conversations::server::{self, ChatState};
 use crate::lfd::executor::helpers::resolve_lf_binary;
 use crate::ops::util::resolve_wave_name;
 
 /// Dropping this file into `wave/<wave>/` stops the loop after the current pass.
 const STOP_FILE: &str = "STOP";
 
+/// Per-wave NDJSON sink: each inner pass appends its raw agent stream-json here
+/// (via `LF_WAVE_EVENT_SINK`), and the chat server tails it into `ChatTurn`s.
+const EVENT_SINK_FILE: &str = ".chat-events.ndjson";
+
 /// Cooldown after a failed pass so a broken inner run can't hot-spin the loop.
 /// A successful pass repeats immediately — loopflow owns the cadence, gated only
 /// on the inner pass finishing.
 const FAILURE_COOLDOWN: Duration = Duration::from_secs(3);
 
-/// Run the progress loop for a wave.
+/// Run the progress loop for a wave, hosting its live chat server in-process.
 ///
 /// loopflow owns the *outer* loop: each pass is a single bounded
 /// `lf -b goal <wave> --once`, and the loop fires the next pass as soon as the
 /// previous one finishes. This is the deterministic controller that replaces
 /// relying on the model's own goal loop (which gets stuck). It repeats until
 /// interrupted (Ctrl-C) or until `wave/<wave>/STOP` appears.
+///
+/// Alongside the loop, `lf wave` hosts a per-wave chat server (see
+/// [`crate::lfd::conversations::server`]). Each pass writes its raw agent
+/// stream-json to a per-wave sink; a tailer folds that into `ChatTurn`s the
+/// server streams to Concerto. The server's `host:port` is published to
+/// `wave/<wave>/.chat-endpoint`.
 pub fn run(name: &str) -> Result<()> {
     let repo_root = find_repo_root()?;
     let main_repo = main_repo_root(&repo_root).unwrap_or(repo_root);
     let wave_name = resolve_wave_name(&main_repo, Some(name))
         .ok_or_else(|| anyhow!("invalid wave name: '{name}'"))?;
 
-    let stop_file = main_repo.join("wave").join(&wave_name).join(STOP_FILE);
+    let wave_dir = main_repo.join("wave").join(&wave_name);
+    std::fs::create_dir_all(&wave_dir)
+        .with_context(|| format!("create wave dir {}", wave_dir.display()))?;
+    let stop_file = wave_dir.join(STOP_FILE);
+    let sink_path = wave_dir.join(EVENT_SINK_FILE);
+    // Fresh sink per run so the transcript reflects this session's passes.
+    let _ = std::fs::write(&sink_path, b"");
     let lf = resolve_lf_binary();
 
-    println!("lf wave · {wave_name} · loopflow owns the outer loop (Ctrl-C to stop)");
+    // Bring up the chat server before the first pass so Concerto can attach
+    // immediately. Held in `_rt` for the life of the loop; dropping it stops the
+    // server.
+    let state = ChatState::new(wave_name.clone(), wave_dir.clone());
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .context("build wave chat runtime")?;
+    let listener = rt
+        .block_on(server::bind(&wave_dir))
+        .context("start wave chat server")?;
+    let addr = listener.local_addr().context("resolve chat server addr")?;
+    let router = server::router(state.clone());
+    rt.spawn(async move {
+        if let Err(err) = axum::serve(listener, router).await {
+            tracing::error!(error = %err, "wave chat server exited");
+        }
+    });
 
+    // Tail the sink file into the chat server on a plain thread — ingest is sync.
+    let stop_tailer = Arc::new(AtomicBool::new(false));
+    let tailer = spawn_tailer(sink_path.clone(), state.clone(), stop_tailer.clone());
+
+    // Inner passes inherit this env and append their stream-json to the sink.
+    std::env::set_var("LF_WAVE_EVENT_SINK", &sink_path);
+
+    println!("lf wave · {wave_name} · loopflow owns the outer loop (Ctrl-C to stop)");
+    println!("lf wave · {wave_name} · chat: http://{addr} (wave/{wave_name}/.chat-endpoint)");
+
+    let result = run_loop(&lf, &main_repo, &wave_name, &stop_file, &state);
+
+    // Tear down: stop tailing, remove discovery file, let the runtime drop.
+    stop_tailer.store(true, Ordering::SeqCst);
+    let _ = tailer.join();
+    server::remove_endpoint_file(&wave_dir);
+    result
+}
+
+fn run_loop(
+    lf: &Path,
+    main_repo: &Path,
+    wave_name: &str,
+    stop_file: &Path,
+    state: &Arc<ChatState>,
+) -> Result<()> {
     let mut pass: u32 = 0;
     loop {
         if stop_file.exists() {
@@ -46,9 +110,10 @@ pub fn run(name: &str) -> Result<()> {
         }
 
         pass += 1;
+        state.begin_pass();
         println!("-- lf wave · {wave_name} · pass {pass} --");
 
-        match run_pass(&lf, &main_repo, &wave_name)? {
+        match run_pass(lf, main_repo, wave_name)? {
             PassOutcome::Ok => {}
             PassOutcome::Failed(status) => {
                 eprintln!(
@@ -97,6 +162,57 @@ fn run_pass(lf: &Path, repo: &Path, wave: &str) -> Result<PassOutcome> {
     })
 }
 
+/// Follow the per-wave event sink, feeding each complete stream-json line to the
+/// chat server. Plain thread + polling — the child pass is the only writer, so a
+/// short poll is enough and avoids inotify/kqueue platform differences.
+fn spawn_tailer(
+    sink: PathBuf,
+    state: Arc<ChatState>,
+    stop: Arc<AtomicBool>,
+) -> std::thread::JoinHandle<()> {
+    std::thread::spawn(move || {
+        let mut parser = StreamParser::new();
+        let mut offset: u64 = 0;
+        while !stop.load(Ordering::SeqCst) {
+            offset = drain_sink(&sink, offset, &mut parser, &state);
+            std::thread::sleep(Duration::from_millis(100));
+        }
+        // Final drain so the last pass's tail isn't lost on shutdown.
+        drain_sink(&sink, offset, &mut parser, &state);
+    })
+}
+
+/// Read complete newline-terminated lines from `sink` starting at `offset`,
+/// feeding each to the chat server. Returns the new offset (past the last full
+/// line); a trailing partial line is left for the next drain.
+fn drain_sink(sink: &Path, offset: u64, parser: &mut StreamParser, state: &Arc<ChatState>) -> u64 {
+    let Ok(file) = std::fs::File::open(sink) else {
+        return offset;
+    };
+    let mut reader = BufReader::new(file);
+    if reader.seek(SeekFrom::Start(offset)).is_err() {
+        return offset;
+    }
+    let mut pos = offset;
+    let mut line = String::new();
+    loop {
+        line.clear();
+        let read = match reader.read_line(&mut line) {
+            Ok(0) => break,
+            Ok(n) => n,
+            Err(_) => break,
+        };
+        if line.ends_with('\n') {
+            pos += read as u64;
+            state.ingest_line(parser, line.trim_end_matches(['\n', '\r']));
+        } else {
+            // Partial line: leave it for the next drain.
+            break;
+        }
+    }
+    pos
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -108,5 +224,35 @@ mod tests {
         let missing = Path::new("/definitely/not/a/real/lf-binary");
         let result = run_pass(missing, Path::new("/tmp"), "ghost");
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn drain_sink_feeds_complete_lines_and_holds_partial() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let sink = dir.path().join("events.ndjson");
+        let state = ChatState::new("demo".to_string(), dir.path().to_path_buf());
+        let mut parser = StreamParser::new();
+
+        state.begin_pass();
+        std::fs::write(
+            &sink,
+            "{\"type\":\"item.completed\",\"item\":{\"id\":\"i1\",\"type\":\"agent_message\",\"text\":\"hi\"}}\n{\"type\":\"turn.completed\"",
+        )
+        .expect("write sink");
+
+        let offset = drain_sink(&sink, 0, &mut parser, &state);
+        // The complete first line produced an in-progress turn; the partial
+        // second line is held (offset stops before it).
+        assert!(offset > 0);
+        assert_eq!(state.turn_count(), 1);
+
+        // Complete the partial line; the next drain finalizes the turn.
+        std::fs::write(
+            &sink,
+            "{\"type\":\"item.completed\",\"item\":{\"id\":\"i1\",\"type\":\"agent_message\",\"text\":\"hi\"}}\n{\"type\":\"turn.completed\",\"usage\":{\"input_tokens\":1,\"output_tokens\":1}}\n",
+        )
+        .expect("rewrite sink");
+        let _ = drain_sink(&sink, offset, &mut parser, &state);
+        assert_eq!(state.turn_count(), 1);
     }
 }

--- a/rust/loopflow/src/lfd/conversations/README.md
+++ b/rust/loopflow/src/lfd/conversations/README.md
@@ -1,0 +1,60 @@
+# Conversations
+
+The reusable stream → conversation-turn engine, plus the per-wave chat server it
+feeds. There is no central conversation daemon — `lf wave <name>` hosts the chat
+server in-process (see `server.rs`).
+
+## Layers
+
+- **`harness/` + `types.rs`** — vendor stream engines (codex/claude/opencode) that
+  map raw agent output into `ConversationItem`s and `ConversationEvent`s.
+  `harness/conformance_tests.rs` pins the mapping against captured traces under
+  `harness/testdata/`.
+- **`turns.rs`** — folds a live `StreamEvent` sequence (from `engine::stream`,
+  which normalizes `codex exec --json`) into `ChatTurn`s.
+- **`server.rs`** — the per-wave HTTP chat server Concerto observes.
+
+## Chat server
+
+`lf wave <name>` binds an ephemeral loopback port and publishes it to
+`wave/<name>/.chat-endpoint` (`127.0.0.1:<port>`, one line). Concerto reads that
+file to find the server.
+
+```bash
+PORT=$(cat wave/<name>/.chat-endpoint)
+
+curl "http://$PORT/health"           # { "status", "wave", "pass", "turns" }
+curl "http://$PORT/chat"             # { "wave", "turns": [ChatTurn, …] }
+curl -N "http://$PORT/chat/stream"   # SSE: replay current turns, then live
+
+curl -X POST "http://$PORT/chat" \
+  -H 'Content-Type: application/json' \
+  -d '{"text":"also check the tests"}'
+```
+
+`GET /chat/stream` is Server-Sent Events. Each event is named `turn`; its `data`
+is one `ChatTurn` JSON object. The stream replays the current turns on connect,
+then emits new/updated turns live (an in-progress turn is re-sent as its text
+grows).
+
+`POST /chat` appends the message to `wave/<name>/MAILBOX.md` and records a `user`
+turn. The next `lf goal --once` pass folds the mailbox into its prompt under an
+`<lf:mailbox>` tag, then clears the file — each message is delivered once.
+
+### ChatTurn shape
+
+```json
+{
+  "id": "turn-1",
+  "role": "assistant",            // "user" | "assistant"
+  "text": "Ran the tests, all green.",
+  "status": "completed",          // "in_progress" | "completed" | "failed"
+  "items": [                      // tool/command/file/message items, in order
+    { "type": "command", "id": "item-0", "command": ["cargo test"], "cwd": "", "status": "completed" }
+  ],
+  "created_at": "2026-07-03T22:14:05Z"
+}
+```
+
+`user` turns use ids `user-<n>` and are always `completed` with no items.
+Assistant turns use ids `turn-<n>`.

--- a/rust/loopflow/src/lfd/conversations/harness/claude.rs
+++ b/rust/loopflow/src/lfd/conversations/harness/claude.rs
@@ -1,0 +1,277 @@
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::{anyhow, Result};
+use async_trait::async_trait;
+use tokio::io::{AsyncBufReadExt, BufReader};
+use tokio::process::{Child, Command};
+use tokio::sync::mpsc;
+use tokio::task::JoinHandle;
+
+use crate::engine::agent::{build_claude_session_turn_args, AgentConfig};
+use crate::lfd::conversations::harness::claude_mapping::ReaderState;
+use crate::lfd::conversations::harness::common::{spawn_stderr_logger, TurnInProgressGuard};
+use crate::lfd::conversations::harness::{claude_mapping, Harness, HarnessError};
+use crate::lfd::conversations::types::{ConversationEvent, TurnStatus};
+
+pub struct ClaudeHarness {
+    events: mpsc::UnboundedSender<ConversationEvent>,
+    config: Option<AgentConfig>,
+    should_seed_task_prompt: bool,
+    provider_session_id: Option<String>,
+    turn_in_progress: Arc<AtomicBool>,
+    child: Option<Child>,
+    reader_task: Option<JoinHandle<()>>,
+    stderr_task: Option<JoinHandle<()>>,
+    shutdown_requested: Arc<AtomicBool>,
+}
+
+impl std::fmt::Debug for ClaudeHarness {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ClaudeHarness").finish()
+    }
+}
+
+impl ClaudeHarness {
+    pub fn new(events: mpsc::UnboundedSender<ConversationEvent>) -> Self {
+        Self {
+            events,
+            config: None,
+            should_seed_task_prompt: true,
+            provider_session_id: None,
+            turn_in_progress: Arc::new(AtomicBool::new(false)),
+            child: None,
+            reader_task: None,
+            stderr_task: None,
+            shutdown_requested: Arc::new(AtomicBool::new(false)),
+        }
+    }
+}
+
+#[async_trait]
+impl Harness for ClaudeHarness {
+    async fn start(&mut self, config: &AgentConfig) -> Result<()> {
+        // Validate claude binary on PATH.
+        let output = Command::new("claude").arg("--version").output().await;
+        match output {
+            Ok(out) if out.status.success() => {
+                let version = String::from_utf8_lossy(&out.stdout);
+                tracing::info!(version = %version.trim(), "claude binary found");
+            }
+            Ok(out) => {
+                let stderr = String::from_utf8_lossy(&out.stderr);
+                return Err(anyhow!(
+                    "claude --version failed (exit {}): {stderr}",
+                    out.status
+                ));
+            }
+            Err(err) => {
+                return Err(anyhow!(
+                    "claude binary not found on PATH: {err}. Install Claude Code first."
+                ));
+            }
+        }
+
+        self.config = Some(config.clone());
+        self.should_seed_task_prompt = true;
+        Ok(())
+    }
+
+    async fn send_input(&mut self, content: &str) -> Result<()> {
+        if self
+            .turn_in_progress
+            .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+            .is_err()
+        {
+            return Err(HarnessError::TurnAlreadyInProgress.into());
+        }
+        let mut turn_guard = TurnInProgressGuard::new(self.turn_in_progress.clone());
+
+        let config = self
+            .config
+            .as_ref()
+            .ok_or_else(|| anyhow!("claude harness not started"))?;
+        let mut turn_content = content.to_string();
+        if self.should_seed_task_prompt {
+            self.should_seed_task_prompt = false;
+            if !config.task_prompt.trim().is_empty() {
+                turn_content = format!("{}\n\n{}", config.task_prompt.trim(), content);
+            }
+        }
+
+        let turn_id = format!("turn_{}", uuid::Uuid::new_v4());
+
+        let _ = self.events.send(ConversationEvent::TurnStarted {
+            turn_id: turn_id.clone(),
+        });
+
+        let args = build_claude_session_turn_args(
+            &turn_content,
+            config,
+            self.provider_session_id.as_deref(),
+        );
+        let mut cmd = Command::new("claude");
+        cmd.args(&args);
+        cmd.stdout(std::process::Stdio::piped());
+        cmd.stderr(std::process::Stdio::piped());
+        cmd.stdin(std::process::Stdio::null());
+
+        if let Some(cwd) = &config.cwd {
+            cmd.current_dir(cwd);
+        }
+
+        self.shutdown_requested.store(false, Ordering::SeqCst);
+
+        let mut child = cmd
+            .spawn()
+            .map_err(|err| anyhow!("failed to spawn claude: {err}"))?;
+
+        let stdout = match child.stdout.take() {
+            Some(stdout) => stdout,
+            None => {
+                let _ = child.kill().await;
+                let _ = child.wait().await;
+                return Err(anyhow!("failed to capture claude stdout"));
+            }
+        };
+        let stderr = match child.stderr.take() {
+            Some(stderr) => stderr,
+            None => {
+                let _ = child.kill().await;
+                let _ = child.wait().await;
+                return Err(anyhow!("failed to capture claude stderr"));
+            }
+        };
+
+        self.child = Some(child);
+
+        // Spawn reader task for NDJSON stdout.
+        let events = self.events.clone();
+        let turn_in_progress = self.turn_in_progress.clone();
+        let shutdown = self.shutdown_requested.clone();
+        let reader_turn_id = turn_id.clone();
+        self.reader_task = Some(tokio::spawn(async move {
+            let reader = BufReader::new(stdout);
+            let mut lines = reader.lines();
+            let mut state = ReaderState::default();
+            let mut saw_turn_completed = false;
+
+            while let Ok(Some(line)) = lines.next_line().await {
+                if shutdown.load(Ordering::Relaxed) {
+                    break;
+                }
+                if line.trim().is_empty() {
+                    continue;
+                }
+
+                if claude_mapping::process_line(&line, &reader_turn_id, &events, &mut state) {
+                    saw_turn_completed = true;
+                    break;
+                }
+            }
+
+            if !saw_turn_completed && !shutdown.load(Ordering::Relaxed) {
+                tracing::warn!(
+                    turn_id = %reader_turn_id,
+                    "claude turn ended without result event"
+                );
+                for item in state.drain_failed_items() {
+                    let _ = events.send(ConversationEvent::ItemCompleted {
+                        turn_id: reader_turn_id.clone(),
+                        item,
+                    });
+                }
+                let _ = events.send(ConversationEvent::TurnCompleted {
+                    turn_id: reader_turn_id,
+                    status: TurnStatus::Failed,
+                });
+            }
+
+            turn_in_progress.store(false, Ordering::SeqCst);
+        }));
+
+        self.stderr_task = Some(spawn_stderr_logger(stderr, "claude_harness"));
+
+        turn_guard.disarm();
+        Ok(())
+    }
+
+    async fn stop(&mut self) -> Result<()> {
+        self.shutdown_requested.store(true, Ordering::SeqCst);
+
+        if let Some(mut child) = self.child.take() {
+            let _ = child.kill().await;
+            let _ = child.wait().await;
+        }
+
+        if let Some(task) = self.reader_task.take() {
+            let mut task = task;
+            if tokio::time::timeout(Duration::from_secs(2), &mut task)
+                .await
+                .is_err()
+            {
+                tracing::warn!("timed out waiting for claude reader task shutdown; aborting");
+                task.abort();
+                let _ = task.await;
+            }
+        }
+        if let Some(task) = self.stderr_task.take() {
+            task.abort();
+        }
+
+        self.turn_in_progress.store(false, Ordering::SeqCst);
+        Ok(())
+    }
+
+    fn set_provider_session_id(&mut self, provider_session_id: Option<String>) {
+        self.provider_session_id = provider_session_id;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // build_claude_session_turn_args coverage lives in engine::agent::tests.
+
+    #[tokio::test]
+    async fn send_input_spawn_failure_releases_turn_guard() {
+        let (tx, _rx) = mpsc::unbounded_channel();
+        let mut harness = ClaudeHarness::new(tx);
+        harness.config = Some(AgentConfig {
+            system_prompt: String::new(),
+            task_prompt: "task".to_string(),
+            agent: None,
+            cwd: Some(format!("/tmp/loopflow-missing-{}", uuid::Uuid::new_v4()).into()),
+            max_turns: None,
+            skip_permissions: false,
+            structured_replies: Vec::new(),
+            directive_relay: None,
+        });
+
+        let first = harness
+            .send_input("first")
+            .await
+            .expect_err("spawn should fail for missing cwd");
+        assert!(
+            !matches!(
+                first.downcast_ref::<HarnessError>(),
+                Some(HarnessError::TurnAlreadyInProgress)
+            ),
+            "first failure should not be turn-in-progress"
+        );
+
+        let second = harness
+            .send_input("second")
+            .await
+            .expect_err("turn guard should be released after setup failure");
+        assert!(
+            !matches!(
+                second.downcast_ref::<HarnessError>(),
+                Some(HarnessError::TurnAlreadyInProgress)
+            ),
+            "second failure should not be turn-in-progress"
+        );
+    }
+}

--- a/rust/loopflow/src/lfd/conversations/harness/claude_mapping.rs
+++ b/rust/loopflow/src/lfd/conversations/harness/claude_mapping.rs
@@ -1,0 +1,933 @@
+use std::collections::HashMap;
+
+use serde_json::Value;
+use tokio::sync::mpsc;
+
+use crate::lfd::conversations::harness::lf_tag::LfTagParser;
+use crate::lfd::conversations::types::{
+    ConversationEvent, ConversationItem, FileEdit, ItemStatus, TurnStatus, TurnUsage,
+};
+
+/// Reader-local state for tracking in-flight content blocks.
+#[derive(Debug, Default)]
+pub(super) struct ReaderState {
+    /// Map block index -> tool use state for streaming deltas.
+    tool_blocks: HashMap<usize, ToolUseState>,
+    /// Map tool_use_id -> block index for direct completion lookup.
+    tool_indexes: HashMap<String, usize>,
+    /// Streaming parser for `<lf:...>` tagged payloads.
+    tag_parser: LfTagParser,
+}
+
+#[derive(Debug, Default)]
+struct ToolUseState {
+    id: String,
+    name: String,
+    input_json: String,
+    input: Option<Value>,
+}
+
+impl ToolUseState {
+    fn parsed_input(&self) -> Option<Value> {
+        if self.input_json.is_empty() {
+            return self.input.clone();
+        }
+
+        serde_json::from_str(&self.input_json)
+            .ok()
+            .or_else(|| self.input.clone())
+    }
+}
+
+impl ReaderState {
+    fn track_tool(
+        &mut self,
+        index: usize,
+        tool_id: &str,
+        tool_name: &str,
+        input: Option<Value>,
+    ) -> bool {
+        if let Some(existing_index) = self.tool_indexes.get(tool_id).copied() {
+            if let Some(existing) = self.tool_blocks.get_mut(&existing_index) {
+                if existing.input.is_none() {
+                    existing.input = input;
+                }
+            }
+            return false;
+        }
+
+        self.tool_indexes.insert(tool_id.to_string(), index);
+        self.tool_blocks.insert(
+            index,
+            ToolUseState {
+                id: tool_id.to_string(),
+                name: tool_name.to_string(),
+                input_json: String::new(),
+                input,
+            },
+        );
+        true
+    }
+
+    fn append_input_json(&mut self, index: usize, partial_json: &str) {
+        if let Some(tool) = self.tool_blocks.get_mut(&index) {
+            tool.input_json.push_str(partial_json);
+        }
+    }
+
+    fn tool_by_id(&self, tool_use_id: &str) -> Option<&ToolUseState> {
+        let index = self.tool_indexes.get(tool_use_id)?;
+        self.tool_blocks.get(index)
+    }
+
+    pub(super) fn drain_failed_items(&mut self) -> Vec<ConversationItem> {
+        let mut tools: Vec<_> = self.tool_blocks.drain().map(|(_, tool)| tool).collect();
+        self.tool_indexes.clear();
+        tools.sort_by(|left, right| left.id.cmp(&right.id));
+        tools
+            .into_iter()
+            .map(|tool| {
+                build_item(
+                    &tool.name,
+                    &tool.id,
+                    tool.parsed_input(),
+                    ItemStatus::Failed,
+                    None,
+                )
+            })
+            .collect()
+    }
+}
+
+/// Parse a single NDJSON line and emit conversation events.
+pub(super) fn process_line(
+    line: &str,
+    turn_id: &str,
+    events: &mpsc::UnboundedSender<ConversationEvent>,
+    state: &mut ReaderState,
+) -> bool {
+    let Ok(value) = serde_json::from_str::<Value>(line) else {
+        return false;
+    };
+    let event = value
+        .get("stream_event")
+        .and_then(|stream| stream.get("event"))
+        .unwrap_or(&value);
+
+    let Some(event_type) = event.get("type").and_then(Value::as_str) else {
+        return false;
+    };
+
+    match event_type {
+        "system" => {
+            if let Some(session_id) = event
+                .get("session_id")
+                .or_else(|| value.get("session_id"))
+                .and_then(Value::as_str)
+            {
+                let _ = events.send(ConversationEvent::ProviderSessionId {
+                    provider_session_id: session_id.to_string(),
+                });
+            }
+        }
+
+        "content_block_start" => {
+            let Some(index) = event.get("index").and_then(Value::as_u64) else {
+                return false;
+            };
+            let Some(block) = event.get("content_block") else {
+                return false;
+            };
+            let Some(block_type) = block.get("type").and_then(Value::as_str) else {
+                return false;
+            };
+            let index = index as usize;
+
+            if block_type == "tool_use" {
+                let Some(tool_id) = block.get("id").and_then(Value::as_str) else {
+                    return false;
+                };
+                let Some(tool_name) = block.get("name").and_then(Value::as_str) else {
+                    return false;
+                };
+                if state.track_tool(index, tool_id, tool_name, None) {
+                    let item = infer_item(tool_name, tool_id, None);
+                    let _ = events.send(ConversationEvent::ItemStarted {
+                        turn_id: turn_id.to_string(),
+                        item,
+                    });
+                }
+            }
+        }
+
+        "content_block_delta" => {
+            let index = event
+                .get("index")
+                .and_then(Value::as_u64)
+                .map(|v| v as usize);
+            let Some(delta) = event.get("delta") else {
+                return false;
+            };
+            let Some(delta_type) = delta.get("type").and_then(Value::as_str) else {
+                return false;
+            };
+
+            match delta_type {
+                "text_delta" => {
+                    if let Some(text) = delta.get("text").and_then(Value::as_str) {
+                        emit_text_delta(events, state, turn_id, text);
+                    }
+                }
+                "thinking_delta" | "summary_delta" => {
+                    if let Some(text) = delta
+                        .get("thinking")
+                        .or_else(|| delta.get("summary"))
+                        .and_then(Value::as_str)
+                    {
+                        let _ = events.send(ConversationEvent::ReasoningDelta {
+                            turn_id: turn_id.to_string(),
+                            content: text.to_string(),
+                        });
+                    }
+                }
+                "input_json_delta" => {
+                    if let (Some(idx), Some(json_chunk)) =
+                        (index, delta.get("partial_json").and_then(Value::as_str))
+                    {
+                        state.append_input_json(idx, json_chunk);
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        "content_block_stop" => {
+            // Tool blocks will get completed when we see the tool result.
+            // Text blocks don't need explicit completion.
+        }
+
+        "result" => {
+            flush_text_delta_parser(events, state, turn_id);
+            let usage = map_turn_usage(event);
+            let status = if event
+                .get("is_error")
+                .and_then(Value::as_bool)
+                .unwrap_or(false)
+            {
+                TurnStatus::Failed
+            } else {
+                TurnStatus::Completed
+            };
+            let _ = events.send(ConversationEvent::TurnCompleted {
+                turn_id: turn_id.to_string(),
+                status,
+            });
+            let _ = events.send(ConversationEvent::TurnUsage {
+                turn_id: turn_id.to_string(),
+                usage,
+            });
+            return true;
+        }
+
+        // Claude emits "assistant" events with full message content.
+        // These contain tool_use blocks and text blocks.
+        "assistant" => {
+            process_assistant_message(event, turn_id, events, state);
+        }
+
+        // Tool result events: type "user" with tool_result content.
+        "user" => {
+            process_user_message(event, turn_id, events, state);
+        }
+
+        _ => {}
+    }
+
+    false
+}
+
+fn map_turn_usage(event: &Value) -> TurnUsage {
+    TurnUsage {
+        input_tokens: event
+            .pointer("/usage/input_tokens")
+            .and_then(Value::as_u64)
+            .unwrap_or(0),
+        output_tokens: event
+            .pointer("/usage/output_tokens")
+            .and_then(Value::as_u64)
+            .unwrap_or(0),
+        reasoning_tokens: event
+            .pointer("/usage/reasoning_tokens")
+            .and_then(Value::as_u64),
+        cache_read_tokens: event
+            .pointer("/usage/cache_read_input_tokens")
+            .and_then(Value::as_u64),
+        cache_write_tokens: event
+            .pointer("/usage/cache_creation_input_tokens")
+            .and_then(Value::as_u64),
+        model: event
+            .get("model")
+            .and_then(Value::as_str)
+            .map(ToString::to_string),
+        cost_usd: event
+            .get("cost_usd")
+            .or_else(|| event.get("total_cost_usd"))
+            .and_then(Value::as_f64),
+    }
+}
+
+/// Map Claude tool name to a ConversationItem category.
+fn infer_item(tool_name: &str, tool_use_id: &str, input: Option<Value>) -> ConversationItem {
+    build_item(tool_name, tool_use_id, input, ItemStatus::InProgress, None)
+}
+
+fn build_item(
+    tool_name: &str,
+    tool_use_id: &str,
+    input: Option<Value>,
+    status: ItemStatus,
+    output: Option<String>,
+) -> ConversationItem {
+    match tool_name {
+        "Bash" => ConversationItem::Command {
+            id: tool_use_id.to_string(),
+            command: command_from_input(input.as_ref()),
+            cwd: String::new(),
+            status,
+            output,
+            exit_code: None,
+            duration_ms: None,
+        },
+        "Edit" | "Write" | "NotebookEdit" => ConversationItem::File {
+            id: tool_use_id.to_string(),
+            changes: file_changes_from_input(tool_name, input.as_ref()),
+            status,
+        },
+        _ => ConversationItem::Tool {
+            id: tool_use_id.to_string(),
+            name: tool_name.to_string(),
+            status,
+            input,
+            output,
+        },
+    }
+}
+
+fn command_from_input(input: Option<&Value>) -> Vec<String> {
+    let command = input
+        .and_then(|value| value.get("command"))
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    if command.is_empty() {
+        Vec::new()
+    } else {
+        vec![command.to_string()]
+    }
+}
+
+fn file_changes_from_input(tool_name: &str, input: Option<&Value>) -> Vec<FileEdit> {
+    let Some(input) = input else {
+        return Vec::new();
+    };
+    let path = input
+        .get("file_path")
+        .or_else(|| input.get("notebook_path"))
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    if path.is_empty() {
+        return Vec::new();
+    }
+
+    let diff = if tool_name == "Edit" {
+        synthesize_edit_diff(path, input)
+    } else {
+        None
+    };
+
+    vec![FileEdit {
+        path: path.to_string(),
+        kind: Some(tool_name.to_lowercase()),
+        diff,
+    }]
+}
+
+fn synthesize_edit_diff(path: &str, input: &Value) -> Option<String> {
+    let old = input.get("old_string").and_then(Value::as_str)?;
+    let new = input.get("new_string").and_then(Value::as_str)?;
+    if old == new {
+        return None;
+    }
+
+    let mut lines = Vec::new();
+    lines.push(format!("--- a/{path}"));
+    lines.push(format!("+++ b/{path}"));
+    for line in old.lines() {
+        lines.push(format!("-{line}"));
+    }
+    for line in new.lines() {
+        lines.push(format!("+{line}"));
+    }
+    Some(lines.join("\n"))
+}
+
+fn process_assistant_message(
+    value: &Value,
+    turn_id: &str,
+    events: &mpsc::UnboundedSender<ConversationEvent>,
+    state: &mut ReaderState,
+) {
+    let Some(blocks) = message_content(value) else {
+        return;
+    };
+
+    for (idx, block) in blocks.iter().enumerate() {
+        let Some(block_type) = block.get("type").and_then(Value::as_str) else {
+            continue;
+        };
+        match block_type {
+            "tool_use" => {
+                let tool_id = block
+                    .get("id")
+                    .and_then(Value::as_str)
+                    .unwrap_or_default()
+                    .to_string();
+                let tool_name = block
+                    .get("name")
+                    .and_then(Value::as_str)
+                    .unwrap_or_default()
+                    .to_string();
+                let input = block.get("input").cloned();
+
+                // If we haven't already emitted ItemStarted via streaming,
+                // emit both started and track it.
+                if state.track_tool(idx, &tool_id, &tool_name, input.clone()) {
+                    let item = infer_item(&tool_name, &tool_id, input);
+                    let _ = events.send(ConversationEvent::ItemStarted {
+                        turn_id: turn_id.to_string(),
+                        item,
+                    });
+                }
+            }
+            "text" => {
+                if let Some(text) = block.get("text").and_then(Value::as_str) {
+                    if !text.is_empty() {
+                        emit_text_delta(events, state, turn_id, text);
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+fn process_user_message(
+    value: &Value,
+    turn_id: &str,
+    events: &mpsc::UnboundedSender<ConversationEvent>,
+    state: &mut ReaderState,
+) {
+    let Some(blocks) = message_content(value) else {
+        return;
+    };
+
+    for block in blocks {
+        let Some(block_type) = block.get("type").and_then(Value::as_str) else {
+            continue;
+        };
+        match block_type {
+            "tool_result" => {
+                let tool_use_id = block
+                    .get("tool_use_id")
+                    .and_then(Value::as_str)
+                    .unwrap_or_default();
+
+                let Some(tool) = state.tool_by_id(tool_use_id) else {
+                    continue;
+                };
+
+                // Extract output from content array or text.
+                let output = extract_tool_result_text(block);
+                let input = tool.parsed_input();
+                let completed_item =
+                    build_item(&tool.name, &tool.id, input, ItemStatus::Completed, output);
+                let _ = events.send(ConversationEvent::ItemCompleted {
+                    turn_id: turn_id.to_string(),
+                    item: completed_item,
+                });
+            }
+            // Text blocks in user messages are Claude echoing back input the
+            // client already displayed. Emitting them would duplicate messages.
+            "text" => {}
+            _ => {}
+        }
+    }
+}
+
+fn message_content(value: &Value) -> Option<&[Value]> {
+    value
+        .get("message")
+        .and_then(|m| m.get("content"))
+        .and_then(Value::as_array)
+        .map(Vec::as_slice)
+}
+
+fn extract_tool_result_text(block: &Value) -> Option<String> {
+    // Try nested content array first.
+    if let Some(content) = block.get("content").and_then(Value::as_array) {
+        let texts: Vec<&str> = content
+            .iter()
+            .filter_map(|c| {
+                if c.get("type").and_then(Value::as_str) == Some("text") {
+                    c.get("text").and_then(Value::as_str)
+                } else {
+                    None
+                }
+            })
+            .collect();
+        if !texts.is_empty() {
+            return Some(texts.join("\n"));
+        }
+    }
+    // Try direct text field.
+    block
+        .get("content")
+        .and_then(Value::as_str)
+        .map(String::from)
+}
+
+fn emit_text_delta(
+    events: &mpsc::UnboundedSender<ConversationEvent>,
+    state: &mut ReaderState,
+    turn_id: &str,
+    content: &str,
+) {
+    for event in state.tag_parser.consume_text(turn_id, content) {
+        let _ = events.send(event);
+    }
+}
+
+fn flush_text_delta_parser(
+    events: &mpsc::UnboundedSender<ConversationEvent>,
+    state: &mut ReaderState,
+    turn_id: &str,
+) {
+    for event in state.tag_parser.finish_turn(turn_id) {
+        let _ = events.send(event);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn infer_item_bash_to_command() {
+        let item = infer_item("Bash", "tu_1", Some(json!({"command": "cargo test"})));
+        match item {
+            ConversationItem::Command { id, command, .. } => {
+                assert_eq!(id, "tu_1");
+                assert_eq!(command, vec!["cargo test"]);
+            }
+            other => panic!("expected Command, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn infer_item_edit_to_file() {
+        let item = infer_item("Edit", "tu_2", Some(json!({"file_path": "src/main.rs"})));
+        match item {
+            ConversationItem::File { id, changes, .. } => {
+                assert_eq!(id, "tu_2");
+                assert_eq!(changes[0].path, "src/main.rs");
+                assert_eq!(changes[0].kind.as_deref(), Some("edit"));
+            }
+            other => panic!("expected File, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn infer_item_write_to_file() {
+        let item = infer_item("Write", "tu_3", Some(json!({"file_path": "new.txt"})));
+        match item {
+            ConversationItem::File { id, changes, .. } => {
+                assert_eq!(id, "tu_3");
+                assert_eq!(changes[0].path, "new.txt");
+                assert_eq!(changes[0].kind.as_deref(), Some("write"));
+            }
+            other => panic!("expected File, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn infer_item_notebook_edit_to_file() {
+        let item = infer_item(
+            "NotebookEdit",
+            "tu_4",
+            Some(json!({"notebook_path": "analysis.ipynb"})),
+        );
+        match item {
+            ConversationItem::File { id, changes, .. } => {
+                assert_eq!(id, "tu_4");
+                assert_eq!(changes[0].path, "analysis.ipynb");
+            }
+            other => panic!("expected File, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn infer_item_unknown_to_tool() {
+        let item = infer_item("WebSearch", "tu_5", Some(json!({"query": "rust async"})));
+        match item {
+            ConversationItem::Tool {
+                id, name, input, ..
+            } => {
+                assert_eq!(id, "tu_5");
+                assert_eq!(name, "WebSearch");
+                assert_eq!(input, Some(json!({"query": "rust async"})));
+            }
+            other => panic!("expected Tool, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn process_line_system_event() {
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let mut state = ReaderState::default();
+        let line = r#"{"type":"system","session_id":"sess_abc123","tools":[]}"#;
+
+        let result = process_line(line, "turn_1", &tx, &mut state);
+        assert!(!result);
+
+        let event = rx.try_recv().expect("should have event");
+        match event {
+            ConversationEvent::ProviderSessionId {
+                provider_session_id,
+            } => {
+                assert_eq!(provider_session_id, "sess_abc123");
+            }
+            other => panic!("expected ProviderSessionId event, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn process_line_wrapped_stream_event() {
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let mut state = ReaderState::default();
+        let line = r#"{"stream_event":{"event":{"type":"system","session_id":"sess_wrapped"}}}"#;
+
+        let result = process_line(line, "turn_1", &tx, &mut state);
+        assert!(!result);
+
+        let event = rx.try_recv().expect("should have event");
+        match event {
+            ConversationEvent::ProviderSessionId {
+                provider_session_id,
+            } => {
+                assert_eq!(provider_session_id, "sess_wrapped");
+            }
+            other => panic!("expected ProviderSessionId event, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn process_line_text_delta() {
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let mut state = ReaderState::default();
+        let line = r#"{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello world"}}"#;
+
+        process_line(line, "turn_1", &tx, &mut state);
+
+        let event = rx.try_recv().expect("should have event");
+        match event {
+            ConversationEvent::TextDelta { turn_id, content } => {
+                assert_eq!(turn_id, "turn_1");
+                assert_eq!(content, "Hello world");
+            }
+            other => panic!("expected TextDelta, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn process_line_text_delta_emits_suggested_actions_event() {
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let mut state = ReaderState::default();
+        let line = r#"{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"<lf:suggest_actions>[{\"label\":\"Land PR\"}]</lf:suggest_actions>"}}"#;
+
+        process_line(line, "turn_1", &tx, &mut state);
+
+        let event = rx.try_recv().expect("should have event");
+        match event {
+            ConversationEvent::SuggestedActions { turn_id, actions } => {
+                assert_eq!(turn_id, "turn_1");
+                assert_eq!(actions.len(), 1);
+                assert_eq!(actions[0].label, "Land PR");
+            }
+            other => panic!("expected SuggestedActions, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn process_line_thinking_delta() {
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let mut state = ReaderState::default();
+        let line = r#"{"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"Let me think..."}}"#;
+
+        process_line(line, "turn_1", &tx, &mut state);
+
+        let event = rx.try_recv().expect("should have event");
+        match event {
+            ConversationEvent::ReasoningDelta { turn_id, content } => {
+                assert_eq!(turn_id, "turn_1");
+                assert_eq!(content, "Let me think...");
+            }
+            other => panic!("expected ReasoningDelta, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn process_line_result_completes_turn() {
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let mut state = ReaderState::default();
+        let line = r#"{"type":"result","duration_ms":1234,"cost_usd":0.01,"is_error":false,"result":"done","session_id":"sess_abc"}"#;
+
+        let result = process_line(line, "turn_1", &tx, &mut state);
+        assert!(result);
+
+        let event = rx.try_recv().expect("should have event");
+        match event {
+            ConversationEvent::TurnCompleted { turn_id, status } => {
+                assert_eq!(turn_id, "turn_1");
+                assert_eq!(status, TurnStatus::Completed);
+            }
+            other => panic!("expected TurnCompleted, got {other:?}"),
+        }
+
+        let usage_event = rx.try_recv().expect("should have usage event");
+        match usage_event {
+            ConversationEvent::TurnUsage { turn_id, usage } => {
+                assert_eq!(turn_id, "turn_1");
+                assert_eq!(usage.input_tokens, 0);
+                assert_eq!(usage.output_tokens, 0);
+                assert_eq!(usage.cost_usd, Some(0.01));
+            }
+            other => panic!("expected TurnUsage, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn process_line_result_error_marks_failed() {
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let mut state = ReaderState::default();
+        let line = r#"{"type":"result","is_error":true,"result":"failed"}"#;
+
+        let result = process_line(line, "turn_1", &tx, &mut state);
+        assert!(result);
+
+        let event = rx.try_recv().expect("should have event");
+        match event {
+            ConversationEvent::TurnCompleted { turn_id, status } => {
+                assert_eq!(turn_id, "turn_1");
+                assert_eq!(status, TurnStatus::Failed);
+            }
+            other => panic!("expected TurnCompleted, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn process_line_result_extracts_turn_usage_tokens() {
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let mut state = ReaderState::default();
+        let line = r#"{"type":"result","is_error":false,"model":"claude-sonnet-4","total_cost_usd":0.2,"usage":{"input_tokens":321,"output_tokens":123,"reasoning_tokens":9,"cache_read_input_tokens":11,"cache_creation_input_tokens":5}}"#;
+
+        let result = process_line(line, "turn_42", &tx, &mut state);
+        assert!(result);
+
+        let _completed = rx.try_recv().expect("completion event");
+        let usage_event = rx.try_recv().expect("usage event");
+        match usage_event {
+            ConversationEvent::TurnUsage { turn_id, usage } => {
+                assert_eq!(turn_id, "turn_42");
+                assert_eq!(usage.input_tokens, 321);
+                assert_eq!(usage.output_tokens, 123);
+                assert_eq!(usage.reasoning_tokens, Some(9));
+                assert_eq!(usage.cache_read_tokens, Some(11));
+                assert_eq!(usage.cache_write_tokens, Some(5));
+                assert_eq!(usage.model.as_deref(), Some("claude-sonnet-4"));
+                assert_eq!(usage.cost_usd, Some(0.2));
+            }
+            other => panic!("expected TurnUsage, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn process_line_tool_use_start() {
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let mut state = ReaderState::default();
+        let line = r#"{"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"tu_bash_1","name":"Bash"}}"#;
+
+        process_line(line, "turn_1", &tx, &mut state);
+
+        assert!(state.tool_blocks.contains_key(&1));
+        let tool = &state.tool_blocks[&1];
+        assert_eq!(tool.id, "tu_bash_1");
+        assert_eq!(tool.name, "Bash");
+        assert_eq!(state.tool_indexes.get("tu_bash_1"), Some(&1));
+
+        let event = rx.try_recv().expect("should have event");
+        match event {
+            ConversationEvent::ItemStarted { turn_id, item } => {
+                assert_eq!(turn_id, "turn_1");
+                assert!(matches!(item, ConversationItem::Command { .. }));
+            }
+            other => panic!("expected ItemStarted, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn process_line_input_json_delta_accumulates() {
+        let (tx, _rx) = mpsc::unbounded_channel();
+        let mut state = ReaderState::default();
+
+        // Start a tool block first.
+        let start_line = r#"{"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"tu_1","name":"Bash"}}"#;
+        process_line(start_line, "turn_1", &tx, &mut state);
+
+        // Send partial input.
+        let delta1 = r#"{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"com"}}"#;
+        let delta2 = r#"{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"mand\":\"ls\"}"}}"#;
+        process_line(delta1, "turn_1", &tx, &mut state);
+        process_line(delta2, "turn_1", &tx, &mut state);
+
+        assert_eq!(
+            state
+                .tool_blocks
+                .get(&0)
+                .map(|tool| tool.input_json.as_str()),
+            Some("{\"command\":\"ls\"}")
+        );
+    }
+
+    #[test]
+    fn process_line_user_text_is_dropped() {
+        let (tx, rx) = mpsc::unbounded_channel();
+        let mut state = ReaderState::default();
+        // Text blocks in user messages are Claude echoing back input the
+        // client already displayed — emitting them would duplicate messages.
+        let line = r#"{"type":"user","message":{"content":[{"type":"text","text":"Design the architecture before coding."}]}}"#;
+
+        process_line(line, "turn_1", &tx, &mut state);
+
+        assert!(rx.is_empty(), "user text blocks should not emit events");
+    }
+
+    #[test]
+    fn synthesize_edit_diff_formats_unified_lines() {
+        let input = json!({
+            "old_string": "fn old() {}",
+            "new_string": "fn new() {}"
+        });
+
+        let diff = synthesize_edit_diff("src/main.rs", &input).expect("expected diff");
+
+        assert_eq!(
+            diff,
+            "--- a/src/main.rs\n+++ b/src/main.rs\n-fn old() {}\n+fn new() {}"
+        );
+    }
+
+    #[test]
+    fn synthesize_edit_diff_returns_none_for_empty_or_equal_input() {
+        let equal_input = json!({
+            "old_string": "same",
+            "new_string": "same"
+        });
+        assert!(synthesize_edit_diff("src/main.rs", &equal_input).is_none());
+
+        let empty_input = json!({
+            "old_string": "",
+            "new_string": ""
+        });
+        assert!(synthesize_edit_diff("src/main.rs", &empty_input).is_none());
+    }
+
+    #[test]
+    fn edit_tool_synthesizes_diff() {
+        let item = infer_item(
+            "Edit",
+            "tu_10",
+            Some(json!({
+                "file_path": "src/main.rs",
+                "old_string": "fn old() {}",
+                "new_string": "fn new() {}"
+            })),
+        );
+        match item {
+            ConversationItem::File { changes, .. } => {
+                let diff = changes[0].diff.as_deref().unwrap();
+                assert!(diff.contains("--- a/src/main.rs"));
+                assert!(diff.contains("+++ b/src/main.rs"));
+                assert!(diff.contains("-fn old() {}"));
+                assert!(diff.contains("+fn new() {}"));
+            }
+            other => panic!("expected File, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn write_tool_no_diff() {
+        let item = infer_item(
+            "Write",
+            "tu_13",
+            Some(json!({
+                "file_path": "new.txt",
+                "content": "hello world"
+            })),
+        );
+        match item {
+            ConversationItem::File { changes, .. } => {
+                assert!(changes[0].diff.is_none());
+            }
+            other => panic!("expected File, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn synthesize_edit_diff_multiline() {
+        let input = json!({
+            "old_string": "fn old() {\n    println!(\"hi\");\n}",
+            "new_string": "fn new() {\n    println!(\"hello\");\n    println!(\"world\");\n}"
+        });
+
+        let diff = synthesize_edit_diff("src/lib.rs", &input).expect("expected diff");
+        let lines: Vec<&str> = diff.lines().collect();
+
+        assert_eq!(lines[0], "--- a/src/lib.rs");
+        assert_eq!(lines[1], "+++ b/src/lib.rs");
+        assert_eq!(lines[2], "-fn old() {");
+        assert_eq!(lines[3], "-    println!(\"hi\");");
+        assert_eq!(lines[4], "-}");
+        assert_eq!(lines[5], "+fn new() {");
+        assert_eq!(lines[6], "+    println!(\"hello\");");
+        assert_eq!(lines[7], "+    println!(\"world\");");
+        assert_eq!(lines[8], "+}");
+    }
+
+    #[test]
+    fn edit_without_old_string_no_diff() {
+        let item = infer_item(
+            "Edit",
+            "tu_14",
+            Some(json!({
+                "file_path": "src/main.rs",
+                "new_string": "fn new() {}"
+            })),
+        );
+        match item {
+            ConversationItem::File { changes, .. } => {
+                assert!(changes[0].diff.is_none());
+            }
+            other => panic!("expected File, got {other:?}"),
+        }
+    }
+}

--- a/rust/loopflow/src/lfd/conversations/harness/codex.rs
+++ b/rust/loopflow/src/lfd/conversations/harness/codex.rs
@@ -1,0 +1,433 @@
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::{anyhow, Result};
+use async_trait::async_trait;
+use serde_json::{json, Value};
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::process::{Child, Command};
+use tokio::sync::{mpsc, oneshot, Mutex};
+use tokio::task::JoinHandle;
+
+use crate::engine::agent::{
+    build_codex_thread_start_params, system_prompt_with_structured_replies, AgentConfig,
+};
+use crate::lfd::conversations::harness::codex_mapping::ItemPhase;
+use crate::lfd::conversations::harness::common::spawn_stderr_logger;
+use crate::lfd::conversations::harness::lf_tag::LfTagParser;
+use crate::lfd::conversations::harness::{codex_mapping, Harness};
+use crate::lfd::conversations::types::ConversationEvent;
+
+async fn resolve_turn_id(
+    turn_id_from_params: Option<&str>,
+    current_turn_id: &Arc<Mutex<Option<String>>>,
+) -> String {
+    if let Some(turn_id) = turn_id_from_params {
+        return turn_id.to_string();
+    }
+    current_turn_id
+        .lock()
+        .await
+        .clone()
+        .unwrap_or_else(|| "unknown".to_string())
+}
+
+#[derive(Debug)]
+enum OutboundRpc {
+    Request {
+        id: i64,
+        method: String,
+        params: Value,
+    },
+    Response {
+        id: Value,
+        result: Value,
+    },
+}
+
+pub struct CodexHarness {
+    events: mpsc::UnboundedSender<ConversationEvent>,
+    child: Option<Child>,
+    outbound_tx: Option<mpsc::Sender<OutboundRpc>>,
+    writer_task: Option<JoinHandle<()>>,
+    reader_task: Option<JoinHandle<()>>,
+    stderr_task: Option<JoinHandle<()>>,
+    next_request_id: i64,
+    turn_in_progress: Arc<AtomicBool>,
+    current_turn_id: Arc<Mutex<Option<String>>>,
+    shutdown_requested: Arc<AtomicBool>,
+    launch: Option<AgentConfig>,
+    should_seed_prompt: bool,
+}
+
+impl std::fmt::Debug for CodexHarness {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CodexHarness").finish()
+    }
+}
+
+impl CodexHarness {
+    pub fn new(events: mpsc::UnboundedSender<ConversationEvent>) -> Self {
+        Self {
+            events,
+            child: None,
+            outbound_tx: None,
+            writer_task: None,
+            reader_task: None,
+            stderr_task: None,
+            next_request_id: 1,
+            turn_in_progress: Arc::new(AtomicBool::new(false)),
+            current_turn_id: Arc::new(Mutex::new(None)),
+            shutdown_requested: Arc::new(AtomicBool::new(false)),
+            launch: None,
+            should_seed_prompt: true,
+        }
+    }
+
+    async fn send_request(&mut self, method: &str, params: Value) -> Result<()> {
+        let Some(tx) = &self.outbound_tx else {
+            return Err(anyhow!("codex harness not started"));
+        };
+        let id = self.next_request_id;
+        self.next_request_id += 1;
+        tx.send(OutboundRpc::Request {
+            id,
+            method: method.to_string(),
+            params,
+        })
+        .await
+        .map_err(|_| anyhow!("codex writer task unavailable"))
+    }
+
+    async fn shutdown_tasks(&mut self) {
+        self.outbound_tx.take();
+
+        if let Some(handle) = self.writer_task.take() {
+            let _ = handle.await;
+        }
+        if let Some(handle) = self.reader_task.take() {
+            handle.abort();
+            let _ = handle.await;
+        }
+        if let Some(handle) = self.stderr_task.take() {
+            handle.abort();
+            let _ = handle.await;
+        }
+    }
+}
+
+#[async_trait]
+impl Harness for CodexHarness {
+    async fn start(&mut self, config: &AgentConfig) -> Result<()> {
+        if self.child.is_some() {
+            return Ok(());
+        }
+        self.shutdown_requested.store(false, Ordering::Relaxed);
+        self.launch = Some(config.clone());
+        self.should_seed_prompt = true;
+
+        let start_result = self.start_inner(config).await;
+        if let Err(err) = start_result {
+            let _ = self.stop().await;
+            return Err(err);
+        }
+        Ok(())
+    }
+
+    async fn send_input(&mut self, content: &str) -> Result<()> {
+        let text = content.trim();
+        if text.is_empty() {
+            return Ok(());
+        }
+        let turn_content = if self.should_seed_prompt {
+            self.should_seed_prompt = false;
+            if let Some(launch) = &self.launch {
+                let mut parts = Vec::new();
+                let system_prompt = system_prompt_with_structured_replies(launch);
+                if !system_prompt.trim().is_empty() {
+                    parts.push(system_prompt.trim().to_string());
+                }
+                if !launch.task_prompt.trim().is_empty() {
+                    parts.push(launch.task_prompt.trim().to_string());
+                }
+                parts.push(text.to_string());
+                parts.join("\n\n")
+            } else {
+                text.to_string()
+            }
+        } else {
+            text.to_string()
+        };
+
+        let method = if self.turn_in_progress.load(Ordering::Relaxed) {
+            "turn/steer"
+        } else {
+            "turn/start"
+        };
+
+        self.send_request(method, json!({ "content": turn_content }))
+            .await
+    }
+
+    async fn stop(&mut self) -> Result<()> {
+        self.shutdown_requested.store(true, Ordering::Relaxed);
+
+        if self.turn_in_progress.load(Ordering::Relaxed) {
+            let _ = self.send_request("turn/interrupt", json!({})).await;
+        }
+
+        if let Some(child) = self.child.as_mut() {
+            let _ = child.start_kill();
+            let _ = child.wait().await;
+        }
+        self.child = None;
+        self.turn_in_progress.store(false, Ordering::Relaxed);
+        *self.current_turn_id.lock().await = None;
+
+        self.shutdown_tasks().await;
+
+        Ok(())
+    }
+}
+
+impl CodexHarness {
+    async fn start_inner(&mut self, launch: &AgentConfig) -> Result<()> {
+        let mut child = Command::new("codex")
+            .arg("--app-server")
+            .stdin(std::process::Stdio::piped())
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .spawn()
+            .map_err(|err| anyhow!("failed to spawn codex --app-server: {err}"))?;
+
+        let stdin = child
+            .stdin
+            .take()
+            .ok_or_else(|| anyhow!("missing codex stdin"))?;
+        let stdout = child
+            .stdout
+            .take()
+            .ok_or_else(|| anyhow!("missing codex stdout"))?;
+        let stderr = child
+            .stderr
+            .take()
+            .ok_or_else(|| anyhow!("missing codex stderr"))?;
+
+        let (outbound_tx, mut outbound_rx) = mpsc::channel::<OutboundRpc>(128);
+        let writer_task = tokio::spawn(async move {
+            let mut writer = stdin;
+            while let Some(message) = outbound_rx.recv().await {
+                let payload = match message {
+                    OutboundRpc::Request { id, method, params } => {
+                        json!({ "jsonrpc": "2.0", "id": id, "method": method, "params": params })
+                    }
+                    OutboundRpc::Response { id, result } => {
+                        json!({ "jsonrpc": "2.0", "id": id, "result": result })
+                    }
+                };
+                let Ok(line) = serde_json::to_string(&payload) else {
+                    continue;
+                };
+                if writer.write_all(line.as_bytes()).await.is_err() {
+                    break;
+                }
+                if writer.write_all(b"\n").await.is_err() {
+                    break;
+                }
+                if writer.flush().await.is_err() {
+                    break;
+                }
+            }
+        });
+
+        let (initialized_tx, initialized_rx) = oneshot::channel::<()>();
+        let turn_in_progress = self.turn_in_progress.clone();
+        let current_turn_id = self.current_turn_id.clone();
+        let shutdown_requested = self.shutdown_requested.clone();
+        let event_tx = self.events.clone();
+        let approval_tx = outbound_tx.clone();
+        let reader_task = tokio::spawn(async move {
+            let mut lines = BufReader::new(stdout).lines();
+            let mut initialized_tx = Some(initialized_tx);
+            let mut tag_parser = LfTagParser::default();
+
+            while let Ok(Some(line)) = lines.next_line().await {
+                let Ok(value) = serde_json::from_str::<Value>(&line) else {
+                    continue;
+                };
+
+                let method = value
+                    .get("method")
+                    .and_then(Value::as_str)
+                    .unwrap_or_default();
+                let params = value.get("params").cloned().unwrap_or_else(|| json!({}));
+
+                if method.is_empty() {
+                    continue;
+                }
+
+                if method == "initialized" {
+                    if let Some(tx) = initialized_tx.take() {
+                        let _ = tx.send(());
+                    }
+                    continue;
+                }
+
+                // Any server request (method + id) is treated as approval and accepted.
+                if let Some(id) = value.get("id") {
+                    let _ = approval_tx
+                        .send(OutboundRpc::Response {
+                            id: id.clone(),
+                            result: json!("accept"),
+                        })
+                        .await;
+                    continue;
+                }
+
+                // Resolve turn_id from notification params or tracked state.
+                let turn_id_from_params = codex_mapping::extract_turn_id(&params);
+
+                match method {
+                    "turn/started" => {
+                        let tid = turn_id_from_params
+                            .clone()
+                            .unwrap_or_else(|| format!("turn_{}", uuid::Uuid::new_v4()));
+                        turn_in_progress.store(true, Ordering::Relaxed);
+                        *current_turn_id.lock().await = Some(tid.clone());
+                        let _ = event_tx.send(ConversationEvent::TurnStarted { turn_id: tid });
+                    }
+                    "turn/completed" => {
+                        let tid =
+                            resolve_turn_id(turn_id_from_params.as_deref(), &current_turn_id).await;
+                        for parsed_event in tag_parser.finish_turn(&tid) {
+                            let _ = event_tx.send(parsed_event);
+                        }
+                        turn_in_progress.store(false, Ordering::Relaxed);
+                        *current_turn_id.lock().await = None;
+                        let status = codex_mapping::map_turn_status(&params);
+                        let _ = event_tx.send(ConversationEvent::TurnCompleted {
+                            turn_id: tid.clone(),
+                            status,
+                        });
+                        let _ = event_tx.send(ConversationEvent::TurnUsage {
+                            turn_id: tid,
+                            usage: codex_mapping::map_turn_usage(&params),
+                        });
+                    }
+                    "item/started" => {
+                        let tid =
+                            resolve_turn_id(turn_id_from_params.as_deref(), &current_turn_id).await;
+                        let item = codex_mapping::build_item(&params, ItemPhase::Started);
+                        let _ =
+                            event_tx.send(ConversationEvent::ItemStarted { turn_id: tid, item });
+                    }
+                    "item/completed" => {
+                        let tid =
+                            resolve_turn_id(turn_id_from_params.as_deref(), &current_turn_id).await;
+                        let item = codex_mapping::build_item(&params, ItemPhase::Completed);
+                        let _ =
+                            event_tx.send(ConversationEvent::ItemCompleted { turn_id: tid, item });
+                    }
+                    "item/agentMessage/delta" => {
+                        if let Some(content) = codex_mapping::text_content(&params) {
+                            let tid =
+                                resolve_turn_id(turn_id_from_params.as_deref(), &current_turn_id)
+                                    .await;
+                            for parsed_event in tag_parser.consume_text(&tid, &content) {
+                                let _ = event_tx.send(parsed_event);
+                            }
+                        }
+                    }
+                    "item/agentMessage/completed" | "item/agentMessage/done" => {
+                        // Final agent message text is captured in item/completed.
+                    }
+                    "item/reasoning/summaryTextDelta" | "item/reasoning/textDelta" => {
+                        if let Some(content) = codex_mapping::text_content(&params) {
+                            let tid =
+                                resolve_turn_id(turn_id_from_params.as_deref(), &current_turn_id)
+                                    .await;
+                            let _ = event_tx.send(ConversationEvent::ReasoningDelta {
+                                turn_id: tid,
+                                content,
+                            });
+                        }
+                    }
+                    "item/commandExecution/outputDelta"
+                    | "item/fileChange/outputDelta"
+                    | "item/plan/delta" => {
+                        if let Some(data) = codex_mapping::map_item_delta(method, &params) {
+                            let tid =
+                                resolve_turn_id(turn_id_from_params.as_deref(), &current_turn_id)
+                                    .await;
+                            let item_id = codex_mapping::map_item_id(&params);
+                            let _ = event_tx.send(ConversationEvent::ItemUpdated {
+                                turn_id: tid,
+                                item_id,
+                                data,
+                            });
+                        }
+                    }
+                    "turn/diff/updated" => {
+                        if let Some(diff) = params
+                            .get("diff")
+                            .and_then(Value::as_str)
+                            .map(ToString::to_string)
+                        {
+                            let tid =
+                                resolve_turn_id(turn_id_from_params.as_deref(), &current_turn_id)
+                                    .await;
+                            let _ = event_tx
+                                .send(ConversationEvent::DiffUpdated { turn_id: tid, diff });
+                        }
+                    }
+                    "error" => {
+                        let _ = event_tx.send(ConversationEvent::Error {
+                            code: params
+                                .get("code")
+                                .and_then(Value::as_str)
+                                .unwrap_or("codex_error")
+                                .to_string(),
+                            message: params
+                                .get("message")
+                                .and_then(Value::as_str)
+                                .unwrap_or("codex error")
+                                .to_string(),
+                        });
+                    }
+                    _ => {
+                        // Unknown notifications silently ignored.
+                    }
+                }
+            }
+
+            turn_in_progress.store(false, Ordering::Relaxed);
+            if !shutdown_requested.load(Ordering::Relaxed) {
+                let _ = event_tx.send(ConversationEvent::Error {
+                    code: "codex_disconnected".to_string(),
+                    message: "codex app-server disconnected".to_string(),
+                });
+            }
+        });
+
+        let stderr_task = spawn_stderr_logger(stderr, "lfd::conversations::codex");
+
+        self.child = Some(child);
+        self.outbound_tx = Some(outbound_tx);
+        self.writer_task = Some(writer_task);
+        self.reader_task = Some(reader_task);
+        self.stderr_task = Some(stderr_task);
+
+        self.send_request("initialize", json!({})).await?;
+        tokio::time::timeout(Duration::from_secs(15), initialized_rx)
+            .await
+            .map_err(|_| anyhow!("timed out waiting for codex initialize"))?
+            .map_err(|_| anyhow!("codex initialize channel closed"))?;
+
+        let thread_params = build_codex_thread_start_params(launch);
+        self.send_request("thread/start", Value::Object(thread_params))
+            .await?;
+
+        Ok(())
+    }
+}

--- a/rust/loopflow/src/lfd/conversations/harness/codex_mapping.rs
+++ b/rust/loopflow/src/lfd/conversations/harness/codex_mapping.rs
@@ -1,0 +1,373 @@
+use serde_json::{json, Value};
+
+use crate::lfd::conversations::types::{
+    ConversationItem, FileEdit, ItemDelta, ItemStatus, TurnStatus, TurnUsage,
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum ItemPhase {
+    Started,
+    Completed,
+}
+
+pub(super) fn extract_turn_id(params: &Value) -> Option<String> {
+    params
+        .get("turn")
+        .and_then(|t| t.get("id"))
+        .and_then(Value::as_str)
+        .or_else(|| params.get("turnId").and_then(Value::as_str))
+        .map(ToString::to_string)
+}
+
+pub(super) fn map_turn_status(params: &Value) -> TurnStatus {
+    let turn_status = params
+        .get("turn")
+        .and_then(|t| t.get("status"))
+        .and_then(Value::as_str)
+        .or_else(|| params.get("status").and_then(Value::as_str))
+        .unwrap_or_default();
+    match turn_status {
+        "interrupted" | "cancelled" => TurnStatus::Interrupted,
+        "failed" | "error" => TurnStatus::Failed,
+        _ => TurnStatus::Completed,
+    }
+}
+
+pub(super) fn map_turn_usage(params: &Value) -> TurnUsage {
+    TurnUsage {
+        input_tokens: params
+            .pointer("/usage/input_tokens")
+            .and_then(Value::as_u64)
+            .unwrap_or(0),
+        output_tokens: params
+            .pointer("/usage/output_tokens")
+            .and_then(Value::as_u64)
+            .unwrap_or(0),
+        reasoning_tokens: params
+            .pointer("/usage/reasoning_tokens")
+            .and_then(Value::as_u64),
+        cache_read_tokens: None,
+        cache_write_tokens: None,
+        model: params
+            .get("model")
+            .and_then(Value::as_str)
+            .map(ToString::to_string),
+        cost_usd: None,
+    }
+}
+
+pub(super) fn map_item_id(params: &Value) -> String {
+    item_payload(params)
+        .get("id")
+        .and_then(Value::as_str)
+        .or_else(|| params.get("itemId").and_then(Value::as_str))
+        .or_else(|| params.get("id").and_then(Value::as_str))
+        .unwrap_or("unknown")
+        .to_string()
+}
+
+pub(super) fn build_item(params: &Value, phase: ItemPhase) -> ConversationItem {
+    let id = map_item_id(params);
+    let item_type = map_item_type(params);
+    let item = item_payload(params);
+    let status = map_item_status(params);
+    let completed = phase == ItemPhase::Completed;
+
+    match item_type {
+        "commandExecution" => ConversationItem::Command {
+            id,
+            command: parse_command(item),
+            cwd: required_text_field(item, "cwd"),
+            status,
+            output: if completed {
+                text_field(item, "aggregatedOutput")
+            } else {
+                None
+            },
+            exit_code: if completed {
+                item.get("exitCode")
+                    .and_then(Value::as_i64)
+                    .map(|v| v as i32)
+            } else {
+                None
+            },
+            duration_ms: if completed {
+                item.get("durationMs").and_then(Value::as_u64)
+            } else {
+                None
+            },
+        },
+        "fileChange" => ConversationItem::File {
+            id,
+            changes: parse_file_changes(item),
+            status,
+        },
+        "mcpToolCall" => ConversationItem::Tool {
+            id,
+            name: mcp_tool_name(item),
+            status,
+            input: Some(item.get("arguments").cloned().unwrap_or_else(|| json!({}))),
+            output: if completed {
+                text_field(item, "result").or_else(|| text_field(item, "error"))
+            } else {
+                None
+            },
+        },
+        "agentMessage" => ConversationItem::Message {
+            id,
+            text: required_text_field(item, "text"),
+            phase: text_field(item, "phase"),
+        },
+        "plan" => ConversationItem::Thought {
+            id,
+            text: required_text_field(item, "text"),
+        },
+        _ => ConversationItem::Tool {
+            id,
+            name: item_type.to_string(),
+            status,
+            input: item.get("input").cloned(),
+            output: if completed {
+                text_field(item, "output")
+            } else {
+                None
+            },
+        },
+    }
+}
+
+pub(super) fn map_item_delta(method: &str, params: &Value) -> Option<ItemDelta> {
+    let content = text_content(params)?;
+    match method {
+        "item/commandExecution/outputDelta" | "item/fileChange/outputDelta" => {
+            Some(ItemDelta::Output { content })
+        }
+        "item/plan/delta" => Some(ItemDelta::PlanText { content }),
+        _ => None,
+    }
+}
+
+pub(super) fn text_content(params: &Value) -> Option<String> {
+    params
+        .get("content")
+        .and_then(Value::as_str)
+        .or_else(|| params.get("delta").and_then(Value::as_str))
+        .or_else(|| params.get("output").and_then(Value::as_str))
+        .map(ToString::to_string)
+}
+
+fn item_payload(params: &Value) -> &Value {
+    params.get("item").unwrap_or(params)
+}
+
+fn text_field(value: &Value, key: &str) -> Option<String> {
+    value
+        .get(key)
+        .and_then(Value::as_str)
+        .map(ToString::to_string)
+}
+
+fn required_text_field(value: &Value, key: &str) -> String {
+    text_field(value, key).unwrap_or_default()
+}
+
+fn map_item_type(params: &Value) -> &str {
+    item_payload(params)
+        .get("type")
+        .and_then(Value::as_str)
+        .or_else(|| params.get("kind").and_then(Value::as_str))
+        .unwrap_or("tool")
+}
+
+fn map_item_status(params: &Value) -> ItemStatus {
+    let status = item_payload(params)
+        .get("status")
+        .and_then(Value::as_str)
+        .or_else(|| params.get("status").and_then(Value::as_str))
+        .unwrap_or("in_progress");
+    match status {
+        "completed" => ItemStatus::Completed,
+        "failed" | "error" => ItemStatus::Failed,
+        "declined" => ItemStatus::Declined,
+        _ => ItemStatus::InProgress,
+    }
+}
+
+fn parse_command(item: &Value) -> Vec<String> {
+    item.get("command")
+        .and_then(Value::as_array)
+        .map(|arr| {
+            arr.iter()
+                .filter_map(Value::as_str)
+                .map(ToString::to_string)
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn mcp_tool_name(item: &Value) -> String {
+    let tool = required_text_field(item, "tool");
+    let server = text_field(item, "server").unwrap_or_default();
+    if server.is_empty() {
+        if tool.is_empty() {
+            "mcp_tool_call".to_string()
+        } else {
+            tool
+        }
+    } else if tool.is_empty() {
+        server
+    } else {
+        format!("{server}/{tool}")
+    }
+}
+
+fn parse_file_changes(item: &Value) -> Vec<FileEdit> {
+    item.get("changes")
+        .and_then(Value::as_array)
+        .map(|arr| {
+            arr.iter()
+                .map(|c| FileEdit {
+                    path: c
+                        .get("path")
+                        .and_then(Value::as_str)
+                        .unwrap_or_default()
+                        .to_string(),
+                    kind: c
+                        .get("kind")
+                        .and_then(Value::as_str)
+                        .map(ToString::to_string),
+                    diff: c
+                        .get("diff")
+                        .and_then(Value::as_str)
+                        .map(ToString::to_string),
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn build_item_maps_file_change_to_file() {
+        let params = json!({
+            "item": {
+                "id": "item_1",
+                "type": "fileChange",
+                "status": "completed",
+                "changes": [
+                    {"path": "src/main.rs", "kind": "update", "diff": "-a\n+b"}
+                ]
+            }
+        });
+
+        let item = build_item(&params, ItemPhase::Completed);
+        match item {
+            ConversationItem::File {
+                id,
+                changes,
+                status,
+            } => {
+                assert_eq!(id, "item_1");
+                assert_eq!(status, ItemStatus::Completed);
+                assert_eq!(changes.len(), 1);
+                assert_eq!(changes[0].path, "src/main.rs");
+            }
+            other => panic!("expected file item, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn build_item_maps_agent_message_to_message() {
+        let params = json!({
+            "item": {
+                "id": "item_2",
+                "type": "agentMessage",
+                "text": "Done",
+                "phase": "final"
+            }
+        });
+
+        let item = build_item(&params, ItemPhase::Completed);
+        match item {
+            ConversationItem::Message { id, text, phase } => {
+                assert_eq!(id, "item_2");
+                assert_eq!(text, "Done");
+                assert_eq!(phase.as_deref(), Some("final"));
+            }
+            other => panic!("expected message item, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn build_item_maps_plan_to_thought() {
+        let params = json!({
+            "item": {
+                "id": "item_3",
+                "type": "plan",
+                "text": "Run tests first"
+            }
+        });
+
+        let item = build_item(&params, ItemPhase::Completed);
+        match item {
+            ConversationItem::Thought { id, text } => {
+                assert_eq!(id, "item_3");
+                assert_eq!(text, "Run tests first");
+            }
+            other => panic!("expected thought item, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn build_item_maps_mcp_tool_call_to_generic_tool() {
+        let params = json!({
+            "item": {
+                "id": "item_4",
+                "type": "mcpToolCall",
+                "status": "completed",
+                "server": "github",
+                "tool": "search",
+                "arguments": { "query": "regression" },
+                "result": "ok"
+            }
+        });
+
+        let item = build_item(&params, ItemPhase::Completed);
+        match item {
+            ConversationItem::Tool {
+                id,
+                name,
+                status,
+                input,
+                output,
+            } => {
+                assert_eq!(id, "item_4");
+                assert_eq!(name, "github/search");
+                assert_eq!(status, ItemStatus::Completed);
+                assert_eq!(input, Some(json!({ "query": "regression" })));
+                assert_eq!(output.as_deref(), Some("ok"));
+            }
+            other => panic!("expected tool item, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn map_turn_usage_reads_token_payload() {
+        let usage = map_turn_usage(&json!({
+            "model": "gpt-5.1-codex",
+            "usage": {
+                "input_tokens": 144,
+                "output_tokens": 55,
+                "reasoning_tokens": 3
+            }
+        }));
+
+        assert_eq!(usage.input_tokens, 144);
+        assert_eq!(usage.output_tokens, 55);
+        assert_eq!(usage.reasoning_tokens, Some(3));
+        assert_eq!(usage.model.as_deref(), Some("gpt-5.1-codex"));
+    }
+}

--- a/rust/loopflow/src/lfd/conversations/harness/common.rs
+++ b/rust/loopflow/src/lfd/conversations/harness/common.rs
@@ -1,0 +1,44 @@
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+
+use tokio::io::{AsyncBufReadExt, AsyncRead, BufReader};
+use tokio::task::JoinHandle;
+
+#[derive(Debug)]
+pub(super) struct TurnInProgressGuard {
+    flag: Arc<AtomicBool>,
+    armed: bool,
+}
+
+impl TurnInProgressGuard {
+    pub(super) fn new(flag: Arc<AtomicBool>) -> Self {
+        Self { flag, armed: true }
+    }
+
+    pub(super) fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for TurnInProgressGuard {
+    fn drop(&mut self) {
+        if self.armed {
+            self.flag.store(false, Ordering::SeqCst);
+        }
+    }
+}
+
+pub(super) fn spawn_stderr_logger<R>(stderr: R, target: &'static str) -> JoinHandle<()>
+where
+    R: AsyncRead + Unpin + Send + 'static,
+{
+    tokio::spawn(async move {
+        let reader = BufReader::new(stderr);
+        let mut lines = reader.lines();
+        while let Ok(Some(line)) = lines.next_line().await {
+            if !line.trim().is_empty() {
+                tracing::debug!(stderr_target = target, "{line}");
+            }
+        }
+    })
+}

--- a/rust/loopflow/src/lfd/conversations/harness/conformance_tests.rs
+++ b/rust/loopflow/src/lfd/conversations/harness/conformance_tests.rs
@@ -1,0 +1,419 @@
+use std::fs;
+use std::path::Path;
+
+use serde_json::{json, Value};
+use tokio::sync::mpsc;
+
+use super::claude_mapping::{self, ReaderState};
+use super::codex_mapping::{self, ItemPhase};
+use super::opencode_mapping;
+use crate::lfd::conversations::types::{ConversationEvent, ConversationItem, TurnStatus};
+
+fn read_trace_lines(file_name: &str) -> Vec<String> {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("src/lfd/conversations/harness/testdata")
+        .join(file_name);
+    fs::read_to_string(path)
+        .expect("trace file should exist")
+        .lines()
+        .map(ToString::to_string)
+        .collect()
+}
+
+fn drain_events(
+    rx: &mut mpsc::UnboundedReceiver<ConversationEvent>,
+    out: &mut Vec<ConversationEvent>,
+) {
+    while let Ok(event) = rx.try_recv() {
+        out.push(event);
+    }
+}
+
+fn replay_claude_trace(file_name: &str) -> Vec<ConversationEvent> {
+    let (tx, mut rx) = mpsc::unbounded_channel();
+    let mut events = Vec::new();
+    let mut state = ReaderState::default();
+    let mut saw_turn_completed = false;
+
+    for line in read_trace_lines(file_name) {
+        if line.trim().is_empty() {
+            continue;
+        }
+        if claude_mapping::process_line(&line, "turn_trace", &tx, &mut state) {
+            saw_turn_completed = true;
+        }
+        drain_events(&mut rx, &mut events);
+        if saw_turn_completed {
+            break;
+        }
+    }
+
+    if !saw_turn_completed {
+        for item in state.drain_failed_items() {
+            events.push(ConversationEvent::ItemCompleted {
+                turn_id: "turn_trace".to_string(),
+                item,
+            });
+        }
+        events.push(ConversationEvent::TurnCompleted {
+            turn_id: "turn_trace".to_string(),
+            status: TurnStatus::Failed,
+        });
+    }
+
+    events
+}
+
+fn resolve_turn_id(
+    turn_id_from_params: Option<String>,
+    current_turn_id: &Option<String>,
+) -> String {
+    turn_id_from_params
+        .or_else(|| current_turn_id.clone())
+        .unwrap_or_else(|| "unknown".to_string())
+}
+
+fn replay_codex_trace(file_name: &str) -> Vec<ConversationEvent> {
+    replay_codex_lines(read_trace_lines(file_name))
+}
+
+fn replay_codex_lines(lines: Vec<String>) -> Vec<ConversationEvent> {
+    let mut events = Vec::new();
+    let mut current_turn_id: Option<String> = None;
+
+    for line in lines {
+        if line.trim().is_empty() {
+            continue;
+        }
+
+        let value: Value = serde_json::from_str(&line).expect("trace line should be valid json");
+        let method = value
+            .get("method")
+            .and_then(Value::as_str)
+            .unwrap_or_default();
+        let params = value.get("params").cloned().unwrap_or_else(|| json!({}));
+        let turn_id_from_params = codex_mapping::extract_turn_id(&params);
+
+        match method {
+            "turn/started" => {
+                let turn_id = turn_id_from_params.unwrap_or_else(|| "unknown".to_string());
+                current_turn_id = Some(turn_id.clone());
+                events.push(ConversationEvent::TurnStarted { turn_id });
+            }
+            "turn/completed" => {
+                let turn_id = resolve_turn_id(turn_id_from_params, &current_turn_id);
+                current_turn_id = None;
+                events.push(ConversationEvent::TurnCompleted {
+                    turn_id: turn_id.clone(),
+                    status: codex_mapping::map_turn_status(&params),
+                });
+                events.push(ConversationEvent::TurnUsage {
+                    turn_id,
+                    usage: codex_mapping::map_turn_usage(&params),
+                });
+            }
+            "item/started" => {
+                let turn_id = resolve_turn_id(turn_id_from_params, &current_turn_id);
+                let item = codex_mapping::build_item(&params, ItemPhase::Started);
+                events.push(ConversationEvent::ItemStarted { turn_id, item });
+            }
+            "item/completed" => {
+                let turn_id = resolve_turn_id(turn_id_from_params, &current_turn_id);
+                let item = codex_mapping::build_item(&params, ItemPhase::Completed);
+                events.push(ConversationEvent::ItemCompleted { turn_id, item });
+            }
+            "item/agentMessage/delta" => {
+                if let Some(content) = codex_mapping::text_content(&params) {
+                    let turn_id = resolve_turn_id(turn_id_from_params, &current_turn_id);
+                    events.push(ConversationEvent::TextDelta { turn_id, content });
+                }
+            }
+            "item/reasoning/summaryTextDelta" | "item/reasoning/textDelta" => {
+                if let Some(content) = codex_mapping::text_content(&params) {
+                    let turn_id = resolve_turn_id(turn_id_from_params, &current_turn_id);
+                    events.push(ConversationEvent::ReasoningDelta { turn_id, content });
+                }
+            }
+            "item/commandExecution/outputDelta"
+            | "item/fileChange/outputDelta"
+            | "item/plan/delta" => {
+                if let Some(data) = codex_mapping::map_item_delta(method, &params) {
+                    let turn_id = resolve_turn_id(turn_id_from_params, &current_turn_id);
+                    let item_id = codex_mapping::map_item_id(&params);
+                    events.push(ConversationEvent::ItemUpdated {
+                        turn_id,
+                        item_id,
+                        data,
+                    });
+                }
+            }
+            "turn/diff/updated" => {
+                if let Some(diff) = params
+                    .get("diff")
+                    .and_then(Value::as_str)
+                    .map(ToString::to_string)
+                {
+                    let turn_id = resolve_turn_id(turn_id_from_params, &current_turn_id);
+                    events.push(ConversationEvent::DiffUpdated { turn_id, diff });
+                }
+            }
+            "error" => {
+                events.push(ConversationEvent::Error {
+                    code: params
+                        .get("code")
+                        .and_then(Value::as_str)
+                        .unwrap_or("codex_error")
+                        .to_string(),
+                    message: params
+                        .get("message")
+                        .and_then(Value::as_str)
+                        .unwrap_or("codex error")
+                        .to_string(),
+                });
+            }
+            _ => {}
+        }
+    }
+
+    events
+}
+
+fn replay_opencode_trace(file_name: &str) -> Vec<ConversationEvent> {
+    let mut lines = read_trace_lines(file_name)
+        .into_iter()
+        .filter(|line| !line.trim().is_empty());
+    let session_create: Value = serde_json::from_str(
+        &lines
+            .next()
+            .expect("opencode trace should start with session create payload"),
+    )
+    .expect("session create payload should be valid json");
+    let session_id = session_create
+        .get("id")
+        .and_then(Value::as_str)
+        .expect("session create payload should include canonical id")
+        .to_string();
+    let mut state = opencode_mapping::ReaderState::new(session_id);
+    let mut events = Vec::new();
+
+    for line in lines {
+        let value: Value = serde_json::from_str(&line).expect("trace line should be valid json");
+        let mapped = opencode_mapping::map_event(&value, &mut state);
+        events.extend(mapped.events);
+    }
+
+    events
+}
+
+#[test]
+fn claude_trace_normal_turn() {
+    let events = replay_claude_trace("claude_normal_turn.ndjson");
+    let event_types: Vec<_> = events.iter().map(ConversationEvent::event_type).collect();
+    assert_eq!(
+        event_types,
+        vec![
+            "provider_session_id",
+            "text_delta",
+            "turn_completed",
+            "turn_usage",
+        ]
+    );
+    assert!(matches!(
+        events
+            .iter()
+            .find(|event| matches!(event, ConversationEvent::TurnCompleted { .. })),
+        Some(ConversationEvent::TurnCompleted {
+            status: TurnStatus::Completed,
+            ..
+        })
+    ));
+}
+
+#[test]
+fn claude_trace_crash_mid_tool_marks_failed_items() {
+    let events = replay_claude_trace("claude_crash_mid_tool.ndjson");
+
+    assert!(matches!(
+        events.first(),
+        Some(ConversationEvent::ItemStarted {
+            item: ConversationItem::Command { .. },
+            ..
+        })
+    ));
+
+    assert!(events.iter().any(|event| {
+        matches!(
+            event,
+            ConversationEvent::ItemCompleted {
+                item: ConversationItem::Command { status, .. },
+                ..
+            } if *status == crate::lfd::conversations::types::ItemStatus::Failed
+        )
+    }));
+
+    assert!(matches!(
+        events.last(),
+        Some(ConversationEvent::TurnCompleted {
+            status: TurnStatus::Failed,
+            ..
+        })
+    ));
+}
+
+#[test]
+fn claude_trace_multi_tool_lifecycle() {
+    let events = replay_claude_trace("claude_multi_tool.ndjson");
+    let started = events
+        .iter()
+        .filter(|event| matches!(event, ConversationEvent::ItemStarted { .. }))
+        .count();
+    let completed = events
+        .iter()
+        .filter(|event| matches!(event, ConversationEvent::ItemCompleted { .. }))
+        .count();
+
+    assert_eq!(started, 2);
+    assert_eq!(completed, 2);
+    assert!(matches!(
+        events
+            .iter()
+            .find(|event| matches!(event, ConversationEvent::TurnCompleted { .. })),
+        Some(ConversationEvent::TurnCompleted {
+            status: TurnStatus::Completed,
+            ..
+        })
+    ));
+}
+
+#[test]
+fn codex_trace_normal_turn() {
+    let events = replay_codex_trace("codex_normal_turn.jsonl");
+    let event_types: Vec<_> = events.iter().map(ConversationEvent::event_type).collect();
+    assert_eq!(
+        event_types,
+        vec![
+            "turn_started",
+            "item_started",
+            "text_delta",
+            "item_completed",
+            "turn_completed",
+            "turn_usage",
+        ]
+    );
+    assert!(matches!(
+        events
+            .iter()
+            .find(|event| matches!(event, ConversationEvent::TurnCompleted { .. })),
+        Some(ConversationEvent::TurnCompleted {
+            status: TurnStatus::Completed,
+            ..
+        })
+    ));
+}
+
+#[test]
+fn codex_turn_completed_maps_usage_payload() {
+    let events = replay_codex_lines(vec![
+        r#"{"method":"turn/started","params":{"turn":{"id":"turn_codex_usage"}}}"#.to_string(),
+        r#"{"method":"turn/completed","params":{"turn":{"id":"turn_codex_usage","status":"completed"},"model":"gpt-5.1-codex","usage":{"input_tokens":144,"output_tokens":55,"reasoning_tokens":3}}}"#.to_string(),
+    ]);
+
+    assert!(matches!(
+        events[1],
+        ConversationEvent::TurnCompleted {
+            ref turn_id,
+            status: TurnStatus::Completed
+        } if turn_id == "turn_codex_usage"
+    ));
+    assert!(matches!(
+        events[2],
+        ConversationEvent::TurnUsage {
+            ref turn_id,
+            ref usage,
+        } if turn_id == "turn_codex_usage"
+            && usage.input_tokens == 144
+            && usage.output_tokens == 55
+            && usage.reasoning_tokens == Some(3)
+            && usage.model.as_deref() == Some("gpt-5.1-codex")
+    ));
+}
+
+#[test]
+fn codex_trace_error_turn() {
+    let events = replay_codex_trace("codex_error.jsonl");
+    let event_types: Vec<_> = events.iter().map(ConversationEvent::event_type).collect();
+    assert_eq!(
+        event_types,
+        vec!["turn_started", "error", "turn_completed", "turn_usage"]
+    );
+    assert!(matches!(
+        events[1],
+        ConversationEvent::Error { ref code, .. } if code == "codex_internal"
+    ));
+    assert!(matches!(
+        events
+            .iter()
+            .find(|event| matches!(event, ConversationEvent::TurnCompleted { .. })),
+        Some(ConversationEvent::TurnCompleted {
+            status: TurnStatus::Failed,
+            ..
+        })
+    ));
+}
+
+#[test]
+fn opencode_trace_normal_turn() {
+    let events = replay_opencode_trace("opencode_normal_turn.ndjson");
+    let event_types: Vec<_> = events.iter().map(ConversationEvent::event_type).collect();
+    assert_eq!(
+        event_types,
+        vec!["turn_started", "text_delta", "turn_completed"]
+    );
+    assert!(matches!(
+        events.last(),
+        Some(ConversationEvent::TurnCompleted {
+            status: TurnStatus::Completed,
+            ..
+        })
+    ));
+}
+
+#[test]
+fn opencode_trace_tool_lifecycle() {
+    let events = replay_opencode_trace("opencode_tool_lifecycle.ndjson");
+    let event_types: Vec<_> = events.iter().map(ConversationEvent::event_type).collect();
+    assert_eq!(
+        event_types,
+        vec![
+            "turn_started",
+            "item_started",
+            "item_completed",
+            "turn_completed"
+        ]
+    );
+    assert!(matches!(
+        events.last(),
+        Some(ConversationEvent::TurnCompleted {
+            status: TurnStatus::Completed,
+            ..
+        })
+    ));
+}
+
+#[test]
+fn opencode_trace_error_turn() {
+    let events = replay_opencode_trace("opencode_error_turn.ndjson");
+    let event_types: Vec<_> = events.iter().map(ConversationEvent::event_type).collect();
+    assert_eq!(event_types, vec!["turn_started", "turn_completed", "error"]);
+    assert!(matches!(
+        events[1],
+        ConversationEvent::TurnCompleted {
+            status: TurnStatus::Failed,
+            ..
+        }
+    ));
+    assert!(matches!(
+        events[2],
+        ConversationEvent::Error { ref code, .. } if code == "command_failed"
+    ));
+}

--- a/rust/loopflow/src/lfd/conversations/harness/lf_tag.rs
+++ b/rust/loopflow/src/lfd/conversations/harness/lf_tag.rs
@@ -1,0 +1,244 @@
+use crate::lfd::conversations::types::{ConversationEvent, SuggestedActionPayload};
+
+const SUGGEST_ACTIONS_OPEN: &str = "<lf:suggest_actions>";
+const SUGGEST_ACTIONS_CLOSE: &str = "</lf:suggest_actions>";
+
+/// Streaming parser for `<lf:...>` tag output embedded in text deltas.
+#[derive(Debug, Default)]
+pub(super) struct LfTagParser {
+    stream_buffer: String,
+    in_suggest_actions_tag: bool,
+    suggest_actions_payload: String,
+}
+
+impl LfTagParser {
+    pub(super) fn consume_text(&mut self, turn_id: &str, text: &str) -> Vec<ConversationEvent> {
+        if text.is_empty() {
+            return Vec::new();
+        }
+
+        self.stream_buffer.push_str(text);
+        let mut events = Vec::new();
+
+        loop {
+            if self.in_suggest_actions_tag {
+                if let Some(close_idx) = self.stream_buffer.find(SUGGEST_ACTIONS_CLOSE) {
+                    self.suggest_actions_payload
+                        .push_str(&take_prefix(&mut self.stream_buffer, close_idx));
+                    drop_prefix(&mut self.stream_buffer, SUGGEST_ACTIONS_CLOSE.len());
+                    self.in_suggest_actions_tag = false;
+
+                    if let Ok(actions) = serde_json::from_str::<Vec<SuggestedActionPayload>>(
+                        self.suggest_actions_payload.trim(),
+                    ) {
+                        events.push(ConversationEvent::SuggestedActions {
+                            turn_id: turn_id.to_string(),
+                            actions,
+                        });
+                    }
+                    self.suggest_actions_payload.clear();
+                    continue;
+                }
+
+                self.suggest_actions_payload.push_str(&take_stable_prefix(
+                    &mut self.stream_buffer,
+                    SUGGEST_ACTIONS_CLOSE,
+                ));
+                break;
+            }
+
+            if let Some(open_idx) = find_tag_start(&self.stream_buffer, SUGGEST_ACTIONS_OPEN) {
+                push_text_delta(
+                    &mut events,
+                    turn_id,
+                    take_prefix(&mut self.stream_buffer, open_idx),
+                );
+                drop_prefix(&mut self.stream_buffer, SUGGEST_ACTIONS_OPEN.len());
+                self.in_suggest_actions_tag = true;
+                continue;
+            }
+
+            push_text_delta(
+                &mut events,
+                turn_id,
+                take_stable_prefix(&mut self.stream_buffer, SUGGEST_ACTIONS_OPEN),
+            );
+            break;
+        }
+
+        events
+    }
+
+    pub(super) fn finish_turn(&mut self, turn_id: &str) -> Vec<ConversationEvent> {
+        let mut events = Vec::new();
+        let trailing = std::mem::take(&mut self.stream_buffer);
+
+        if self.in_suggest_actions_tag {
+            let mut raw = String::from(SUGGEST_ACTIONS_OPEN);
+            raw.push_str(&self.suggest_actions_payload);
+            raw.push_str(&trailing);
+            push_text_delta(&mut events, turn_id, raw);
+        } else {
+            push_text_delta(&mut events, turn_id, trailing);
+        }
+
+        self.suggest_actions_payload.clear();
+        self.in_suggest_actions_tag = false;
+
+        events
+    }
+}
+
+fn take_prefix(buffer: &mut String, byte_len: usize) -> String {
+    let tail = buffer.split_off(byte_len);
+    let prefix = std::mem::take(buffer);
+    *buffer = tail;
+    prefix
+}
+
+fn drop_prefix(buffer: &mut String, byte_len: usize) {
+    if byte_len > 0 {
+        buffer.drain(..byte_len);
+    }
+}
+
+fn take_stable_prefix(buffer: &mut String, marker: &str) -> String {
+    let keep = suffix_prefix_len(buffer, marker);
+    let stable_len = buffer.len().saturating_sub(keep);
+    take_prefix(buffer, stable_len)
+}
+
+fn suffix_prefix_len(value: &str, marker: &str) -> usize {
+    let max = std::cmp::min(value.len(), marker.len().saturating_sub(1));
+    for len in (1..=max).rev() {
+        if value.ends_with(&marker[..len]) {
+            return len;
+        }
+    }
+    0
+}
+
+fn find_tag_start(buffer: &str, marker: &str) -> Option<usize> {
+    let mut search_from = 0;
+    while let Some(relative_idx) = buffer[search_from..].find(marker) {
+        let idx = search_from + relative_idx;
+        if is_line_start_or_indented(buffer, idx) {
+            return Some(idx);
+        }
+        search_from = idx + 1;
+    }
+    None
+}
+
+fn is_line_start_or_indented(buffer: &str, idx: usize) -> bool {
+    if idx == 0 {
+        return true;
+    }
+
+    let line_start = buffer[..idx].rfind('\n').map_or(0, |newline| newline + 1);
+    buffer[line_start..idx]
+        .chars()
+        .all(|char| matches!(char, ' ' | '\t' | '\r'))
+}
+
+fn push_text_delta(events: &mut Vec<ConversationEvent>, turn_id: &str, content: String) {
+    if content.is_empty() {
+        return;
+    }
+    events.push(ConversationEvent::TextDelta {
+        turn_id: turn_id.to_string(),
+        content,
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parser_emits_text_and_suggested_actions() {
+        let mut parser = LfTagParser::default();
+        let events = parser.consume_text(
+            "turn_1",
+            "Hello\n<lf:suggest_actions>[{\"label\":\"Land PR\"}]</lf:suggest_actions>\nDone",
+        );
+
+        assert_eq!(events.len(), 3);
+        assert!(matches!(
+            events[0],
+            ConversationEvent::TextDelta { ref content, .. } if content == "Hello\n"
+        ));
+        assert!(matches!(
+            events[1],
+            ConversationEvent::SuggestedActions { ref actions, .. } if actions.len() == 1 && actions[0].label == "Land PR"
+        ));
+        assert!(matches!(
+            events[2],
+            ConversationEvent::TextDelta { ref content, .. } if content == "\nDone"
+        ));
+
+        let trailing = parser.finish_turn("turn_1");
+        assert!(trailing.is_empty());
+    }
+
+    #[test]
+    fn parser_handles_split_tag_across_chunks() {
+        let mut parser = LfTagParser::default();
+        let first = parser.consume_text("turn_1", "<lf:suggest_actions>[{\"label\":\"Run");
+        assert!(first.is_empty());
+
+        let second = parser.consume_text("turn_1", " tests\"}]</lf:suggest_actions>");
+        assert_eq!(second.len(), 1);
+        assert!(matches!(
+            second[0],
+            ConversationEvent::SuggestedActions { ref actions, .. } if actions[0].label == "Run tests"
+        ));
+    }
+
+    #[test]
+    fn parser_drops_invalid_json_payload() {
+        let mut parser = LfTagParser::default();
+        let events = parser.consume_text(
+            "turn_1",
+            "<lf:suggest_actions>not-json</lf:suggest_actions>",
+        );
+        assert!(events.is_empty());
+    }
+
+    #[test]
+    fn parser_flushes_unclosed_tag_as_text_on_finish() {
+        let mut parser = LfTagParser::default();
+        let _ = parser.consume_text("turn_1", "<lf:suggest_actions>[{");
+        let events = parser.finish_turn("turn_1");
+        assert_eq!(events.len(), 1);
+        assert!(matches!(
+            events[0],
+            ConversationEvent::TextDelta { ref content, .. } if content == "<lf:suggest_actions>[{"
+        ));
+    }
+
+    #[test]
+    fn parser_does_not_delay_regular_text() {
+        let mut parser = LfTagParser::default();
+        let events = parser.consume_text("turn_1", "hello");
+        assert_eq!(events.len(), 1);
+        assert!(matches!(
+            events[0],
+            ConversationEvent::TextDelta { ref content, .. } if content == "hello"
+        ));
+    }
+
+    #[test]
+    fn parser_ignores_inline_tag_examples() {
+        let mut parser = LfTagParser::default();
+        let input =
+            "Emit as `<lf:suggest_actions>[{\"label\":\"Run tests\"}]</lf:suggest_actions>`";
+        let events = parser.consume_text("turn_1", input);
+
+        assert_eq!(events.len(), 1);
+        assert!(matches!(
+            events[0],
+            ConversationEvent::TextDelta { ref content, .. } if content == input
+        ));
+    }
+}

--- a/rust/loopflow/src/lfd/conversations/harness/mod.rs
+++ b/rust/loopflow/src/lfd/conversations/harness/mod.rs
@@ -1,0 +1,143 @@
+pub mod claude;
+mod claude_mapping;
+pub mod codex;
+mod codex_mapping;
+mod common;
+#[cfg(test)]
+mod conformance_tests;
+mod lf_tag;
+pub mod opencode;
+mod opencode_mapping;
+
+use anyhow::Result;
+use async_trait::async_trait;
+use tokio::sync::mpsc;
+
+use crate::engine::agent::AgentConfig;
+use crate::lfd::conversations::types::ConversationEvent;
+
+#[derive(Debug, thiserror::Error)]
+pub enum HarnessError {
+    #[error("turn already in progress")]
+    TurnAlreadyInProgress,
+}
+
+pub fn is_turn_in_progress(err: &anyhow::Error) -> bool {
+    matches!(
+        err.downcast_ref::<HarnessError>(),
+        Some(HarnessError::TurnAlreadyInProgress)
+    )
+}
+
+pub fn is_terminal_harness_error(code: &str) -> bool {
+    matches!(
+        code,
+        "codex_disconnected" | "claude_harness_crashed" | "opencode_disconnected"
+    )
+}
+
+#[async_trait]
+pub trait Harness: Send + Sync {
+    async fn start(&mut self, config: &AgentConfig) -> Result<()>;
+    async fn send_input(&mut self, content: &str) -> Result<()>;
+    async fn stop(&mut self) -> Result<()>;
+    fn set_provider_session_id(&mut self, _provider_session_id: Option<String>) {}
+}
+
+/// Constructor fn: `(harness_kind, event_tx) -> harness`.
+pub type CreateHarnessFn =
+    fn(&str, mpsc::UnboundedSender<ConversationEvent>) -> Result<Box<dyn Harness>>;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HarnessKind {
+    Codex,
+    Claude,
+    OpenCode,
+}
+
+impl HarnessKind {
+    pub fn parse(name: &str) -> Option<Self> {
+        match name.trim().to_ascii_lowercase().as_str() {
+            "codex" => Some(Self::Codex),
+            "claude" => Some(Self::Claude),
+            "opencode" => Some(Self::OpenCode),
+            _ => None,
+        }
+    }
+
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Codex => "codex",
+            Self::Claude => "claude",
+            Self::OpenCode => "opencode",
+        }
+    }
+
+    pub fn input_supported(self) -> bool {
+        match self {
+            Self::Codex => true,
+            Self::Claude => false,
+            Self::OpenCode => false,
+        }
+    }
+
+    fn create(self, event_tx: mpsc::UnboundedSender<ConversationEvent>) -> Box<dyn Harness> {
+        match self {
+            Self::Codex => Box::new(codex::CodexHarness::new(event_tx)),
+            Self::Claude => Box::new(claude::ClaudeHarness::new(event_tx)),
+            Self::OpenCode => Box::new(opencode::OpenCodeHarness::new(event_tx)),
+        }
+    }
+}
+
+pub fn canonical_harness(name: &str) -> Option<&'static str> {
+    HarnessKind::parse(name).map(HarnessKind::as_str)
+}
+
+pub fn default_create_harness(
+    name: &str,
+    event_tx: mpsc::UnboundedSender<ConversationEvent>,
+) -> Result<Box<dyn Harness>> {
+    if let Some(kind) = HarnessKind::parse(name) {
+        return Ok(kind.create(event_tx));
+    }
+    anyhow::bail!(
+        "unsupported session harness: {}",
+        name.trim().to_lowercase()
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn canonical_harness_is_case_insensitive_and_trimmed() {
+        assert_eq!(canonical_harness(" claUDe "), Some("claude"));
+        assert_eq!(canonical_harness(" CODEX"), Some("codex"));
+        assert_eq!(canonical_harness("OpenCode"), Some("opencode"));
+        assert_eq!(canonical_harness("lfharness"), None);
+    }
+
+    #[test]
+    fn default_create_harness_rejects_unknown() {
+        let (tx, _rx) = mpsc::unbounded_channel();
+        match default_create_harness("lfharness", tx) {
+            Ok(_) => panic!("should reject unknown harness"),
+            Err(err) => assert!(err.to_string().contains("unsupported session harness")),
+        }
+    }
+
+    #[test]
+    fn terminal_harness_error_recognizes_opencode_disconnect() {
+        assert!(is_terminal_harness_error("opencode_disconnected"));
+        assert!(!is_terminal_harness_error("opencode_error"));
+    }
+
+    #[test]
+    fn input_supported_is_codex_only() {
+        assert!(HarnessKind::Codex.input_supported());
+        assert!(!HarnessKind::Claude.input_supported());
+        assert!(!HarnessKind::OpenCode.input_supported());
+    }
+}

--- a/rust/loopflow/src/lfd/conversations/harness/opencode.rs
+++ b/rust/loopflow/src/lfd/conversations/harness/opencode.rs
@@ -1,0 +1,645 @@
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use anyhow::{anyhow, Result};
+use async_trait::async_trait;
+use reqwest::Method;
+use serde_json::{json, Value};
+use tokio::process::{Child, Command};
+use tokio::sync::mpsc;
+use tokio::task::JoinHandle;
+
+use crate::engine::agent::AgentConfig;
+use crate::engine::config::parse_agent;
+use crate::lfd::conversations::harness::common::{spawn_stderr_logger, TurnInProgressGuard};
+use crate::lfd::conversations::harness::{opencode_mapping, Harness, HarnessError};
+use crate::lfd::conversations::opencode_runtime;
+use crate::lfd::conversations::types::ConversationEvent;
+
+const OPENCODE_DISCONNECTED_CODE: &str = "opencode_disconnected";
+
+pub struct OpenCodeHarness {
+    events: mpsc::UnboundedSender<ConversationEvent>,
+    client: reqwest::Client,
+    config: Option<AgentConfig>,
+    should_seed_prompt: bool,
+    turn_in_progress: Arc<AtomicBool>,
+    shutdown_requested: Arc<AtomicBool>,
+    child: Option<Child>,
+    stderr_task: Option<JoinHandle<()>>,
+    sse_task: Option<JoinHandle<()>>,
+    server_base_url: Option<String>,
+    provider_session_id: Option<String>,
+}
+
+impl std::fmt::Debug for OpenCodeHarness {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("OpenCodeHarness").finish()
+    }
+}
+
+impl OpenCodeHarness {
+    pub fn new(events: mpsc::UnboundedSender<ConversationEvent>) -> Self {
+        Self {
+            events,
+            client: reqwest::Client::new(),
+            config: None,
+            should_seed_prompt: true,
+            turn_in_progress: Arc::new(AtomicBool::new(false)),
+            shutdown_requested: Arc::new(AtomicBool::new(false)),
+            child: None,
+            stderr_task: None,
+            sse_task: None,
+            server_base_url: None,
+            provider_session_id: None,
+        }
+    }
+
+    async fn start_inner(&mut self, config: &AgentConfig) -> Result<()> {
+        let port = allocate_port()?;
+        let mut command = Command::new("opencode");
+        command
+            .arg("serve")
+            .arg("--port")
+            .arg(port.to_string())
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::piped());
+        if let Some(cwd) = &config.cwd {
+            command.current_dir(cwd);
+        }
+
+        let mut child = command
+            .spawn()
+            .map_err(|err| anyhow!("failed to spawn opencode serve: {err}"))?;
+        let stderr = child
+            .stderr
+            .take()
+            .ok_or_else(|| anyhow!("missing opencode stderr"))?;
+
+        let base_url = format!("http://127.0.0.1:{port}");
+        if let Err(err) = wait_for_server(&self.client, &base_url, &mut child).await {
+            shutdown_child(&mut child).await;
+            return Err(err);
+        }
+
+        let provider_session_id = match create_provider_session(&self.client, &base_url).await {
+            Ok(provider_session_id) => provider_session_id,
+            Err(err) => {
+                shutdown_child(&mut child).await;
+                return Err(err);
+            }
+        };
+
+        let _ = self.events.send(ConversationEvent::ProviderSessionId {
+            provider_session_id: provider_session_id.clone(),
+        });
+
+        let event_tx = self.events.clone();
+        let client = self.client.clone();
+        let shutdown_requested = self.shutdown_requested.clone();
+        let turn_in_progress = self.turn_in_progress.clone();
+        let reader_base_url = base_url.clone();
+        let reader_session_id = provider_session_id.clone();
+
+        let sse_task = tokio::spawn(async move {
+            let stream_url = format!("{reader_base_url}/event");
+            let request = client
+                .get(&stream_url)
+                .header(reqwest::header::ACCEPT, "text/event-stream");
+            let mut response = match request.send().await {
+                Ok(response) => response,
+                Err(err) => {
+                    send_disconnect_error(
+                        &event_tx,
+                        &shutdown_requested,
+                        format!("failed to connect to OpenCode SSE stream: {err}"),
+                    );
+                    return;
+                }
+            };
+            if let Err(err) = response.error_for_status_ref() {
+                send_disconnect_error(
+                    &event_tx,
+                    &shutdown_requested,
+                    format!("OpenCode SSE stream failed: {err}"),
+                );
+                return;
+            }
+
+            let mut parser = SseParser::default();
+            let mut state = opencode_mapping::ReaderState::new(reader_session_id.clone());
+
+            loop {
+                if shutdown_requested.load(Ordering::Relaxed) {
+                    break;
+                }
+
+                let chunk = match response.chunk().await {
+                    Ok(chunk) => chunk,
+                    Err(err) => {
+                        tracing::warn!(error = %err, "opencode SSE chunk read failed");
+                        break;
+                    }
+                };
+                let Some(chunk) = chunk else {
+                    break;
+                };
+
+                for payload in parser.push(&chunk) {
+                    if payload.trim().is_empty() || payload.trim() == "[DONE]" {
+                        continue;
+                    }
+
+                    let parsed = serde_json::from_str::<Value>(&payload);
+                    let raw = match parsed {
+                        Ok(raw) => raw,
+                        Err(err) => {
+                            tracing::debug!(error = %err, payload = %payload, "invalid SSE data");
+                            continue;
+                        }
+                    };
+
+                    let mapped = opencode_mapping::map_event(&raw, &mut state);
+                    for event in mapped.events {
+                        match &event {
+                            ConversationEvent::TurnStarted { .. } => {
+                                turn_in_progress.store(true, Ordering::SeqCst)
+                            }
+                            ConversationEvent::TurnCompleted { .. } => {
+                                turn_in_progress.store(false, Ordering::SeqCst)
+                            }
+                            _ => {}
+                        }
+                        let _ = event_tx.send(event);
+                    }
+
+                    for request_id in mapped.permission_requests {
+                        if let Err(err) = approve_permission(
+                            &client,
+                            &reader_base_url,
+                            &reader_session_id,
+                            &request_id,
+                        )
+                        .await
+                        {
+                            tracing::warn!(
+                                request_id = %request_id,
+                                error = %err,
+                                "failed to auto-approve OpenCode permission request"
+                            );
+                        }
+                    }
+                }
+            }
+
+            turn_in_progress.store(false, Ordering::SeqCst);
+            send_disconnect_error(
+                &event_tx,
+                &shutdown_requested,
+                "OpenCode event stream disconnected",
+            );
+        });
+
+        let stderr_task = spawn_stderr_logger(stderr, "lfd::conversations::opencode");
+
+        let opencode_pid = child.id();
+        if let Some(pid) = opencode_pid {
+            if let Err(err) = opencode_runtime::register_opencode_server(pid) {
+                tracing::warn!(
+                    opencode_pid = pid,
+                    error = %err,
+                    "failed to register OpenCode server runtime metadata"
+                );
+            }
+        }
+
+        self.child = Some(child);
+        self.stderr_task = Some(stderr_task);
+        self.sse_task = Some(sse_task);
+        self.server_base_url = Some(base_url);
+        self.provider_session_id = Some(provider_session_id);
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl Harness for OpenCodeHarness {
+    async fn start(&mut self, config: &AgentConfig) -> Result<()> {
+        if self.child.is_some() {
+            return Ok(());
+        }
+
+        self.shutdown_requested.store(false, Ordering::SeqCst);
+        self.config = Some(config.clone());
+        self.should_seed_prompt = true;
+
+        let start_result = self.start_inner(config).await;
+        if let Err(err) = start_result {
+            let _ = self.stop().await;
+            return Err(err);
+        }
+        Ok(())
+    }
+
+    async fn send_input(&mut self, content: &str) -> Result<()> {
+        let config = self
+            .config
+            .as_ref()
+            .ok_or_else(|| anyhow!("opencode harness not started"))?;
+
+        let first_turn = self.should_seed_prompt;
+        let turn_content = build_turn_content(content, config, first_turn);
+        let Some(turn_content) = turn_content else {
+            return Ok(());
+        };
+
+        if self
+            .turn_in_progress
+            .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+            .is_err()
+        {
+            return Err(HarnessError::TurnAlreadyInProgress.into());
+        }
+        let mut turn_guard = TurnInProgressGuard::new(self.turn_in_progress.clone());
+
+        let base_url = self
+            .server_base_url
+            .clone()
+            .ok_or_else(|| anyhow!("opencode server not started"))?;
+        let provider_session_id = self
+            .provider_session_id
+            .clone()
+            .ok_or_else(|| anyhow!("opencode provider session id is not available"))?;
+
+        let payload = build_turn_payload(&turn_content, config, first_turn);
+
+        let message_url = format!("{base_url}/session/{provider_session_id}/message");
+        send_request_with_retry(&self.client, Method::POST, &message_url, Some(payload)).await?;
+
+        self.should_seed_prompt = false;
+        turn_guard.disarm();
+        Ok(())
+    }
+
+    async fn stop(&mut self) -> Result<()> {
+        self.shutdown_requested.store(true, Ordering::SeqCst);
+
+        if let (Some(base_url), Some(provider_session_id)) =
+            (&self.server_base_url, &self.provider_session_id)
+        {
+            let abort_url = format!("{base_url}/session/{provider_session_id}/abort");
+            let _ =
+                send_request_with_retry(&self.client, Method::POST, &abort_url, Some(json!({})))
+                    .await;
+
+            let delete_url = format!("{base_url}/session/{provider_session_id}");
+            let _ = send_request_with_retry(&self.client, Method::DELETE, &delete_url, None).await;
+        }
+
+        let opencode_pid = self.child.as_ref().and_then(|child| child.id());
+        if let Some(child) = self.child.as_mut() {
+            shutdown_child(child).await;
+        }
+        self.child = None;
+        if let Some(pid) = opencode_pid {
+            if let Err(err) = opencode_runtime::unregister_opencode_server(pid) {
+                tracing::warn!(
+                    opencode_pid = pid,
+                    error = %err,
+                    "failed to unregister OpenCode server runtime metadata"
+                );
+            }
+        }
+
+        if let Some(task) = self.sse_task.take() {
+            task.abort();
+            let _ = task.await;
+        }
+        if let Some(task) = self.stderr_task.take() {
+            task.abort();
+            let _ = task.await;
+        }
+
+        self.turn_in_progress.store(false, Ordering::SeqCst);
+        self.provider_session_id = None;
+        self.server_base_url = None;
+
+        Ok(())
+    }
+
+    fn set_provider_session_id(&mut self, provider_session_id: Option<String>) {
+        self.provider_session_id = provider_session_id;
+    }
+}
+
+async fn shutdown_child(child: &mut Child) {
+    let _ = child.start_kill();
+    let _ = child.wait().await;
+}
+
+async fn create_provider_session(client: &reqwest::Client, base_url: &str) -> Result<String> {
+    let session_url = format!("{base_url}/session");
+    let response =
+        send_request_with_retry(client, Method::POST, &session_url, Some(json!({}))).await?;
+    let body: Value = response
+        .json()
+        .await
+        .map_err(|err| anyhow!("failed to parse opencode session response: {err}"))?;
+
+    parse_session_id(&body).ok_or_else(|| {
+        anyhow!(
+            "opencode session response did not include session id: {}",
+            body
+        )
+    })
+}
+
+fn send_disconnect_error(
+    event_tx: &mpsc::UnboundedSender<ConversationEvent>,
+    shutdown_requested: &AtomicBool,
+    message: impl Into<String>,
+) {
+    if shutdown_requested.load(Ordering::Relaxed) {
+        return;
+    }
+
+    let _ = event_tx.send(ConversationEvent::Error {
+        code: OPENCODE_DISCONNECTED_CODE.to_string(),
+        message: message.into(),
+    });
+}
+
+fn allocate_port() -> Result<u16> {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0")
+        .map_err(|err| anyhow!("failed to allocate port for OpenCode: {err}"))?;
+    let port = listener
+        .local_addr()
+        .map_err(|err| anyhow!("failed to read allocated OpenCode port: {err}"))?
+        .port();
+    Ok(port)
+}
+
+async fn wait_for_server(
+    client: &reqwest::Client,
+    base_url: &str,
+    child: &mut Child,
+) -> Result<()> {
+    let deadline = Instant::now() + Duration::from_secs(15);
+    let mut delay = Duration::from_millis(100);
+
+    loop {
+        if let Some(exit_status) = child
+            .try_wait()
+            .map_err(|err| anyhow!("failed to poll opencode serve process: {err}"))?
+        {
+            return Err(anyhow!(
+                "opencode serve exited before becoming ready: {exit_status}"
+            ));
+        }
+
+        if client.get(base_url).send().await.is_ok() {
+            return Ok(());
+        }
+
+        if Instant::now() >= deadline {
+            return Err(anyhow!(
+                "timed out waiting for opencode serve health check at {base_url}"
+            ));
+        }
+
+        tokio::time::sleep(delay).await;
+        delay = std::cmp::min(delay * 2, Duration::from_secs(1));
+    }
+}
+
+async fn send_request_with_retry(
+    client: &reqwest::Client,
+    method: Method,
+    url: &str,
+    payload: Option<Value>,
+) -> Result<reqwest::Response> {
+    let mut attempt = 0;
+
+    loop {
+        let mut request = client.request(method.clone(), url);
+        if let Some(body) = payload.clone() {
+            request = request.json(&body);
+        }
+
+        match request.send().await {
+            Ok(response) if response.status().is_server_error() && attempt == 0 => {
+                attempt += 1;
+                tokio::time::sleep(Duration::from_millis(200)).await;
+            }
+            Ok(response) => {
+                return response
+                    .error_for_status()
+                    .map_err(|err| anyhow!("OpenCode request failed ({method} {url}): {err}"));
+            }
+            Err(err) if attempt == 0 && (err.is_timeout() || err.is_connect()) => {
+                attempt += 1;
+                tokio::time::sleep(Duration::from_millis(200)).await;
+            }
+            Err(err) => {
+                return Err(anyhow!("OpenCode request failed ({method} {url}): {err}"));
+            }
+        }
+    }
+}
+
+async fn approve_permission(
+    client: &reqwest::Client,
+    base_url: &str,
+    session_id: &str,
+    request_id: &str,
+) -> Result<()> {
+    let url = format!("{base_url}/session/{session_id}/permissions/{request_id}");
+    let payload = json!({ "response": "always" });
+    let _ = send_request_with_retry(client, Method::POST, &url, Some(payload)).await?;
+    Ok(())
+}
+
+fn parse_session_id(value: &Value) -> Option<String> {
+    value
+        .get("id")
+        .and_then(Value::as_str)
+        .map(ToString::to_string)
+}
+
+fn build_turn_content(content: &str, config: &AgentConfig, first_turn: bool) -> Option<String> {
+    if first_turn {
+        let mut parts = Vec::new();
+        if !config.task_prompt.trim().is_empty() {
+            parts.push(config.task_prompt.trim().to_string());
+        }
+        if !content.trim().is_empty() {
+            parts.push(content.trim().to_string());
+        }
+        if parts.is_empty() {
+            None
+        } else {
+            Some(parts.join("\n\n"))
+        }
+    } else {
+        let text = content.trim();
+        if text.is_empty() {
+            None
+        } else {
+            Some(text.to_string())
+        }
+    }
+}
+
+fn build_turn_payload(content: &str, config: &AgentConfig, first_turn: bool) -> Value {
+    let mut payload = json!({
+        "parts": [
+            { "type": "text", "text": content }
+        ]
+    });
+
+    if first_turn && !config.system_prompt.trim().is_empty() {
+        payload["system"] = Value::String(config.system_prompt.trim().to_string());
+    }
+
+    if let Some((provider_id, model_id)) = opencode_model(config) {
+        payload["model"] = json!({
+            "providerID": provider_id,
+            "modelID": model_id,
+        });
+    }
+
+    payload
+}
+
+fn opencode_model(config: &AgentConfig) -> Option<(String, String)> {
+    let agent_str = config.agent.as_deref()?;
+    let (harness, variant) = parse_agent(agent_str);
+    if harness != "opencode" {
+        return None;
+    }
+    let variant = variant?;
+    let (provider_id, model_id) = variant.split_once('/')?;
+    if provider_id.is_empty() || model_id.is_empty() {
+        return None;
+    }
+    Some((provider_id.to_string(), model_id.to_string()))
+}
+
+#[derive(Debug, Default)]
+struct SseParser {
+    buffer: String,
+}
+
+impl SseParser {
+    fn push(&mut self, chunk: &[u8]) -> Vec<String> {
+        self.buffer.push_str(&String::from_utf8_lossy(chunk));
+        if self.buffer.contains('\r') {
+            self.buffer = self.buffer.replace("\r\n", "\n").replace('\r', "\n");
+        }
+
+        let mut events = Vec::new();
+        while let Some(separator) = self.buffer.find("\n\n") {
+            let frame = self.buffer[..separator].to_string();
+            self.buffer.drain(..separator + 2);
+            if let Some(data) = parse_data_frame(&frame) {
+                events.push(data);
+            }
+        }
+        events
+    }
+}
+
+fn parse_data_frame(frame: &str) -> Option<String> {
+    let mut data_lines = Vec::new();
+    for line in frame.lines() {
+        if let Some(data) = line.strip_prefix("data:") {
+            data_lines.push(data.trim_start().to_string());
+        }
+    }
+    if data_lines.is_empty() {
+        None
+    } else {
+        Some(data_lines.join("\n"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn build_turn_content_includes_task_prompt_on_first_turn() {
+        let content = build_turn_content(
+            "",
+            &AgentConfig {
+                task_prompt: "task".to_string(),
+                ..Default::default()
+            },
+            true,
+        );
+        assert_eq!(content.as_deref(), Some("task"));
+    }
+
+    #[test]
+    fn sse_parser_collects_data_lines() {
+        let mut parser = SseParser::default();
+        let events = parser.push(b"event: message\ndata: {\"a\":1}\n\n");
+        assert_eq!(events, vec!["{\"a\":1}".to_string()]);
+    }
+
+    #[test]
+    fn sse_parser_handles_split_crlf_frames() {
+        let mut parser = SseParser::default();
+        assert!(parser.push(b"data: {\"a\":").is_empty());
+        let events = parser.push(b"1}\r\n\r\n");
+        assert_eq!(events, vec!["{\"a\":1}".to_string()]);
+    }
+
+    #[test]
+    fn parse_session_id_requires_canonical_top_level_id() {
+        assert_eq!(
+            parse_session_id(&json!({"id": "session_1"})),
+            Some("session_1".to_string())
+        );
+        assert_eq!(
+            parse_session_id(&json!({"session": {"id": "session_2"}})),
+            None
+        );
+        assert_eq!(parse_session_id(&json!({"sessionID": "session_3"})), None);
+    }
+
+    #[test]
+    fn build_turn_payload_includes_explicit_opencode_model() {
+        let payload = build_turn_payload(
+            "hello",
+            &AgentConfig {
+                agent: Some("opencode:moonshotai/kimi-k2".to_string()),
+                ..Default::default()
+            },
+            false,
+        );
+        assert_eq!(
+            payload.get("model"),
+            Some(&json!({
+                "providerID": "moonshotai",
+                "modelID": "kimi-k2"
+            }))
+        );
+    }
+
+    #[test]
+    fn build_turn_payload_omits_model_for_non_opencode_agent_model() {
+        let payload = build_turn_payload(
+            "hello",
+            &AgentConfig {
+                agent: Some("claude:sonnet".to_string()),
+                ..Default::default()
+            },
+            false,
+        );
+        assert!(payload.get("model").is_none());
+    }
+}

--- a/rust/loopflow/src/lfd/conversations/harness/opencode_mapping.rs
+++ b/rust/loopflow/src/lfd/conversations/harness/opencode_mapping.rs
@@ -1,0 +1,747 @@
+use std::collections::HashMap;
+
+use serde_json::Value;
+
+use crate::lfd::conversations::types::{
+    ConversationEvent, ConversationItem, FileEdit, ItemStatus, TurnStatus, TurnUsage,
+};
+
+#[derive(Debug, Default)]
+pub(super) struct ReaderState {
+    session_id: String,
+    status: SessionState,
+    current_turn_id: Option<String>,
+    tools: HashMap<String, ToolLifecycle>,
+}
+
+impl ReaderState {
+    pub(super) fn new(session_id: String) -> Self {
+        Self {
+            session_id,
+            status: SessionState::Unknown,
+            current_turn_id: None,
+            tools: HashMap::new(),
+        }
+    }
+
+    fn current_turn_id(&self) -> Option<&str> {
+        self.current_turn_id.as_deref()
+    }
+
+    fn accepts(&self, properties: &Value) -> bool {
+        match session_id(properties) {
+            Some(event_session_id) => event_session_id == self.session_id,
+            None => {
+                tracing::debug!(
+                    properties = ?properties,
+                    "opencode event missing canonical properties.sessionID"
+                );
+                false
+            }
+        }
+    }
+}
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+enum SessionState {
+    #[default]
+    Unknown,
+    Idle,
+    Active,
+    Error,
+}
+
+#[derive(Debug, Default)]
+struct ToolLifecycle {
+    started: bool,
+    completed: bool,
+}
+
+#[derive(Debug, Default)]
+pub(super) struct MappedEvent {
+    pub(super) events: Vec<ConversationEvent>,
+    pub(super) permission_requests: Vec<String>,
+}
+
+pub(super) fn map_event(raw: &Value, state: &mut ReaderState) -> MappedEvent {
+    let mut mapped = MappedEvent::default();
+    let event_type = raw.get("type").and_then(Value::as_str).unwrap_or_default();
+    let properties = raw.get("properties").unwrap_or(raw);
+
+    if !state.accepts(properties) {
+        return mapped;
+    }
+
+    match event_type {
+        "session.status" => map_status(properties, state, &mut mapped),
+        "message.part.updated" => map_part_updated(properties, state, &mut mapped),
+        "permission.asked" => map_permission(properties, &mut mapped),
+        "session.diff" => map_diff(properties, state, &mut mapped),
+        "session.error" => map_error(properties, state, &mut mapped),
+        _ => {}
+    }
+
+    mapped
+}
+
+fn map_status(properties: &Value, state: &mut ReaderState, mapped: &mut MappedEvent) {
+    let next_state = parse_session_state(properties);
+    if next_state == SessionState::Unknown || next_state == state.status {
+        return;
+    }
+
+    let was_active = state.status == SessionState::Active;
+    state.status = next_state;
+
+    match next_state {
+        SessionState::Active => {
+            let turn_id = format!("turn_{}", uuid::Uuid::new_v4());
+            state.current_turn_id = Some(turn_id.clone());
+            state.tools.clear();
+            mapped
+                .events
+                .push(ConversationEvent::TurnStarted { turn_id });
+        }
+        SessionState::Idle => {
+            if was_active {
+                let usage = map_turn_usage(properties);
+                complete_turn(state, TurnStatus::Completed, usage, mapped);
+            }
+        }
+        SessionState::Error => {
+            if was_active {
+                complete_turn(state, TurnStatus::Failed, None, mapped);
+            }
+        }
+        SessionState::Unknown => {}
+    }
+}
+
+fn complete_turn(
+    state: &mut ReaderState,
+    status: TurnStatus,
+    usage: Option<TurnUsage>,
+    mapped: &mut MappedEvent,
+) {
+    let turn_id = state
+        .current_turn_id
+        .take()
+        .unwrap_or_else(|| "unknown".to_string());
+    state.tools.clear();
+    mapped.events.push(ConversationEvent::TurnCompleted {
+        turn_id: turn_id.clone(),
+        status,
+    });
+    if let Some(usage) = usage {
+        mapped
+            .events
+            .push(ConversationEvent::TurnUsage { turn_id, usage });
+    }
+}
+
+fn map_turn_usage(properties: &Value) -> Option<TurnUsage> {
+    properties.get("usage").map(|usage| TurnUsage {
+        input_tokens: usage
+            .pointer("/input_tokens")
+            .and_then(Value::as_u64)
+            .unwrap_or(0),
+        output_tokens: usage
+            .pointer("/output_tokens")
+            .and_then(Value::as_u64)
+            .unwrap_or(0),
+        model: properties
+            .get("model")
+            .and_then(Value::as_str)
+            .map(ToString::to_string),
+        cost_usd: usage.get("cost").and_then(Value::as_f64),
+        ..TurnUsage::default()
+    })
+}
+
+fn parse_session_state(properties: &Value) -> SessionState {
+    let value = properties
+        .get("status")
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        .to_ascii_lowercase();
+
+    match value.as_str() {
+        "active" | "running" | "busy" => SessionState::Active,
+        "idle" => SessionState::Idle,
+        "error" | "failed" => SessionState::Error,
+        _ => SessionState::Unknown,
+    }
+}
+
+fn map_part_updated(properties: &Value, state: &mut ReaderState, mapped: &mut MappedEvent) {
+    let part = properties.get("part").unwrap_or(properties);
+    let part_type = part
+        .get("type")
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        .to_ascii_lowercase();
+
+    if part_type.contains("reasoning") || part_type.contains("thinking") {
+        if let (Some(turn_id), Some(content)) = (state.current_turn_id(), delta_text(part)) {
+            mapped.events.push(ConversationEvent::ReasoningDelta {
+                turn_id: turn_id.to_string(),
+                content,
+            });
+        }
+        return;
+    }
+
+    if part_type.contains("text") && !part_type.contains("tool") {
+        if let (Some(turn_id), Some(content)) = (state.current_turn_id(), delta_text(part)) {
+            mapped.events.push(ConversationEvent::TextDelta {
+                turn_id: turn_id.to_string(),
+                content,
+            });
+        }
+        return;
+    }
+
+    if part_type.contains("tool") {
+        map_tool_part(part, state, mapped);
+    }
+}
+
+fn map_tool_part(part: &Value, state: &mut ReaderState, mapped: &mut MappedEvent) {
+    let Some(turn_id) = state.current_turn_id() else {
+        return;
+    };
+    let turn_id = turn_id.to_string();
+
+    let Some(tool_id) = tool_id(part) else {
+        tracing::debug!(part = ?part, "opencode tool part missing canonical id");
+        return;
+    };
+    let Some(status) = tool_status(part) else {
+        tracing::debug!(part = ?part, "opencode tool part missing canonical state");
+        return;
+    };
+    let lifecycle = state.tools.entry(tool_id.clone()).or_default();
+
+    if !lifecycle.started {
+        lifecycle.started = true;
+        mapped.events.push(ConversationEvent::ItemStarted {
+            turn_id: turn_id.clone(),
+            item: build_tool_item(part, &tool_id, ItemStatus::InProgress, false),
+        });
+    }
+
+    if matches!(
+        status,
+        ItemStatus::Completed | ItemStatus::Failed | ItemStatus::Declined
+    ) && !lifecycle.completed
+    {
+        lifecycle.completed = true;
+        mapped.events.push(ConversationEvent::ItemCompleted {
+            turn_id,
+            item: build_tool_item(part, &tool_id, status, true),
+        });
+    }
+}
+
+fn map_permission(properties: &Value, mapped: &mut MappedEvent) {
+    if let Some(request_id) = properties.get("requestID").and_then(Value::as_str) {
+        mapped.permission_requests.push(request_id.to_string());
+    } else {
+        tracing::debug!(
+            properties = ?properties,
+            "opencode permission event missing canonical requestID"
+        );
+    }
+}
+
+fn map_diff(properties: &Value, state: &ReaderState, mapped: &mut MappedEvent) {
+    let Some(turn_id) = state.current_turn_id() else {
+        return;
+    };
+    let Some(diff) = properties
+        .get("diff")
+        .and_then(Value::as_str)
+        .map(ToString::to_string)
+    else {
+        return;
+    };
+    mapped.events.push(ConversationEvent::DiffUpdated {
+        turn_id: turn_id.to_string(),
+        diff,
+    });
+}
+
+fn map_error(properties: &Value, state: &mut ReaderState, mapped: &mut MappedEvent) {
+    let code = properties
+        .get("code")
+        .and_then(Value::as_str)
+        .map(ToString::to_string)
+        .unwrap_or_else(|| "opencode_error".to_string());
+    let message = properties
+        .get("message")
+        .and_then(Value::as_str)
+        .map(ToString::to_string)
+        .unwrap_or_else(|| "opencode error".to_string());
+
+    if state.status == SessionState::Active {
+        state.status = SessionState::Error;
+        complete_turn(state, TurnStatus::Failed, None, mapped);
+    }
+
+    mapped
+        .events
+        .push(ConversationEvent::Error { code, message });
+}
+
+fn value_by_keys<'a>(value: &'a Value, keys: &[&str]) -> Option<&'a Value> {
+    keys.iter().find_map(|key| value.get(*key))
+}
+
+fn string_by_keys(value: &Value, keys: &[&str]) -> Option<String> {
+    value_by_keys(value, keys)
+        .and_then(Value::as_str)
+        .map(ToString::to_string)
+}
+
+fn part_or_input_value<'a>(
+    part: &'a Value,
+    input: Option<&'a Value>,
+    keys: &[&str],
+) -> Option<&'a Value> {
+    value_by_keys(part, keys).or_else(|| input.and_then(|value| value_by_keys(value, keys)))
+}
+
+fn part_or_input_text(part: &Value, input: Option<&Value>, keys: &[&str]) -> Option<String> {
+    part_or_input_value(part, input, keys)
+        .and_then(Value::as_str)
+        .map(ToString::to_string)
+}
+
+fn delta_text(part: &Value) -> Option<String> {
+    part.get("delta")
+        .or_else(|| part.get("text"))
+        .and_then(Value::as_str)
+        .filter(|text| !text.is_empty())
+        .map(ToString::to_string)
+}
+
+fn tool_id(part: &Value) -> Option<String> {
+    part.get("id")
+        .and_then(Value::as_str)
+        .map(ToString::to_string)
+}
+
+fn tool_status(part: &Value) -> Option<ItemStatus> {
+    let raw = part
+        .get("state")
+        .and_then(Value::as_str)?
+        .to_ascii_lowercase();
+    match raw.as_str() {
+        "running" => Some(ItemStatus::InProgress),
+        "completed" => Some(ItemStatus::Completed),
+        "failed" => Some(ItemStatus::Failed),
+        "declined" => Some(ItemStatus::Declined),
+        _ => {
+            tracing::debug!(state = %raw, "opencode tool part had unknown canonical state");
+            None
+        }
+    }
+}
+
+fn build_tool_item(
+    part: &Value,
+    tool_id: &str,
+    status: ItemStatus,
+    include_output: bool,
+) -> ConversationItem {
+    let input = tool_input(part);
+    let input_ref = input.as_ref();
+    let output = if include_output {
+        tool_output(part)
+    } else {
+        None
+    };
+
+    if let Some(command) = part_or_input_value(part, input_ref, &["command"]) {
+        return ConversationItem::Command {
+            id: tool_id.to_string(),
+            command: command_args(command),
+            cwd: part_or_input_text(part, input_ref, &["cwd"]).unwrap_or_default(),
+            status,
+            output,
+            exit_code: integer_field(part, "exitCode"),
+            duration_ms: unsigned_field(part, "durationMs"),
+        };
+    }
+
+    if let Some(path) = part_or_input_text(part, input_ref, &["file", "path"]) {
+        return ConversationItem::File {
+            id: tool_id.to_string(),
+            changes: if path.is_empty() {
+                Vec::new()
+            } else {
+                vec![FileEdit {
+                    path,
+                    kind: string_by_keys(part, &["kind"]),
+                    diff: string_by_keys(part, &["diff"]),
+                }]
+            },
+            status,
+        };
+    }
+
+    ConversationItem::Tool {
+        id: tool_id.to_string(),
+        name: tool_name(part),
+        status,
+        input,
+        output,
+    }
+}
+
+fn tool_name(part: &Value) -> String {
+    part.get("name")
+        .and_then(Value::as_str)
+        .map(ToString::to_string)
+        .unwrap_or_else(|| {
+            tracing::debug!(part = ?part, "opencode tool part missing canonical name");
+            "tool".to_string()
+        })
+}
+
+fn tool_input(part: &Value) -> Option<Value> {
+    value_by_keys(part, &["input", "arguments", "args"]).cloned()
+}
+
+fn tool_output(part: &Value) -> Option<String> {
+    value_by_keys(part, &["output", "result", "error"]).and_then(value_as_string)
+}
+
+fn value_as_string(value: &Value) -> Option<String> {
+    match value {
+        Value::Null => None,
+        Value::String(text) => Some(text.clone()),
+        other => Some(other.to_string()),
+    }
+}
+
+fn command_args(command: &Value) -> Vec<String> {
+    if let Some(array) = command.as_array() {
+        return array
+            .iter()
+            .filter_map(Value::as_str)
+            .map(ToString::to_string)
+            .collect();
+    }
+    if let Some(text) = command.as_str() {
+        return text.split_whitespace().map(ToString::to_string).collect();
+    }
+    Vec::new()
+}
+
+fn integer_field(value: &Value, key: &str) -> Option<i32> {
+    value
+        .get(key)
+        .and_then(Value::as_i64)
+        .map(|number| number as i32)
+}
+
+fn unsigned_field(value: &Value, key: &str) -> Option<u64> {
+    value.get(key).and_then(Value::as_u64)
+}
+
+fn session_id(properties: &Value) -> Option<&str> {
+    properties.get("sessionID").and_then(Value::as_str)
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn session_status_transitions_emit_turn_boundaries() {
+        let mut state = ReaderState::new("session_1".to_string());
+
+        let started = map_event(
+            &json!({
+                "type": "session.status",
+                "properties": { "sessionID": "session_1", "status": "active" }
+            }),
+            &mut state,
+        );
+        assert_eq!(started.events.len(), 1);
+        let started_turn_id = match &started.events[0] {
+            ConversationEvent::TurnStarted { turn_id } => turn_id.clone(),
+            other => panic!("expected TurnStarted, got {other:?}"),
+        };
+
+        let completed = map_event(
+            &json!({
+                "type": "session.status",
+                "properties": { "sessionID": "session_1", "status": "idle" }
+            }),
+            &mut state,
+        );
+        assert_eq!(completed.events.len(), 1);
+        match &completed.events[0] {
+            ConversationEvent::TurnCompleted { turn_id, status } => {
+                assert_eq!(turn_id, &started_turn_id);
+                assert_eq!(*status, TurnStatus::Completed);
+            }
+            other => panic!("expected TurnCompleted, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn session_status_idle_with_usage_emits_turn_usage() {
+        let mut state = ReaderState::new("session_1".to_string());
+
+        let started = map_event(
+            &json!({
+                "type": "session.status",
+                "properties": { "sessionID": "session_1", "status": "active" }
+            }),
+            &mut state,
+        );
+        let started_turn_id = match &started.events[0] {
+            ConversationEvent::TurnStarted { turn_id } => turn_id.clone(),
+            other => panic!("expected TurnStarted, got {other:?}"),
+        };
+
+        let completed = map_event(
+            &json!({
+                "type": "session.status",
+                "properties": {
+                    "sessionID": "session_1",
+                    "status": "idle",
+                    "usage": {
+                        "input_tokens": 222,
+                        "output_tokens": 77,
+                        "cost": 0.13
+                    }
+                }
+            }),
+            &mut state,
+        );
+
+        assert_eq!(completed.events.len(), 2);
+        assert!(matches!(
+            &completed.events[0],
+            ConversationEvent::TurnCompleted { turn_id, status }
+                if turn_id == &started_turn_id && *status == TurnStatus::Completed
+        ));
+        assert!(matches!(
+            &completed.events[1],
+            ConversationEvent::TurnUsage { turn_id, usage }
+                if turn_id == &started_turn_id
+                    && usage.input_tokens == 222
+                    && usage.output_tokens == 77
+                    && usage.cost_usd == Some(0.13)
+        ));
+    }
+
+    #[test]
+    fn text_part_maps_to_text_delta() {
+        let mut state = ReaderState::new("session_1".to_string());
+        let _ = map_event(
+            &json!({
+                "type": "session.status",
+                "properties": { "sessionID": "session_1", "status": "active" }
+            }),
+            &mut state,
+        );
+
+        let mapped = map_event(
+            &json!({
+                "type": "message.part.updated",
+                "properties": {
+                    "sessionID": "session_1",
+                    "part": { "id": "part_1", "type": "TextPart", "delta": "hello" }
+                }
+            }),
+            &mut state,
+        );
+
+        assert_eq!(mapped.events.len(), 1);
+        match &mapped.events[0] {
+            ConversationEvent::TextDelta { content, .. } => assert_eq!(content, "hello"),
+            other => panic!("expected TextDelta, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn tool_part_deduplicates_lifecycle_events() {
+        let mut state = ReaderState::new("session_1".to_string());
+        let _ = map_event(
+            &json!({
+                "type": "session.status",
+                "properties": { "sessionID": "session_1", "status": "active" }
+            }),
+            &mut state,
+        );
+
+        let started = map_event(
+            &json!({
+                "type": "message.part.updated",
+                "properties": {
+                    "sessionID": "session_1",
+                    "part": {
+                        "id": "tool_1",
+                        "type": "ToolPart",
+                        "state": "running",
+                        "name": "Bash",
+                        "command": ["echo", "ok"]
+                    }
+                }
+            }),
+            &mut state,
+        );
+        assert_eq!(started.events.len(), 1);
+        assert!(matches!(
+            started.events[0],
+            ConversationEvent::ItemStarted { .. }
+        ));
+
+        let duplicate_start = map_event(
+            &json!({
+                "type": "message.part.updated",
+                "properties": {
+                    "sessionID": "session_1",
+                    "part": {
+                        "id": "tool_1",
+                        "type": "ToolPart",
+                        "state": "running",
+                        "name": "Bash",
+                        "command": ["echo", "ok"]
+                    }
+                }
+            }),
+            &mut state,
+        );
+        assert!(duplicate_start.events.is_empty());
+
+        let completed = map_event(
+            &json!({
+                "type": "message.part.updated",
+                "properties": {
+                    "sessionID": "session_1",
+                    "part": {
+                        "id": "tool_1",
+                        "type": "ToolPart",
+                        "state": "completed",
+                        "name": "Bash",
+                        "command": ["echo", "ok"],
+                        "output": "ok"
+                    }
+                }
+            }),
+            &mut state,
+        );
+        assert_eq!(completed.events.len(), 1);
+        match &completed.events[0] {
+            ConversationEvent::ItemCompleted {
+                item: ConversationItem::Command { output, .. },
+                ..
+            } => assert_eq!(output.as_deref(), Some("ok")),
+            other => panic!("expected ItemCompleted command, got {other:?}"),
+        }
+
+        let duplicate_complete = map_event(
+            &json!({
+                "type": "message.part.updated",
+                "properties": {
+                    "sessionID": "session_1",
+                    "part": {
+                        "id": "tool_1",
+                        "type": "ToolPart",
+                        "state": "completed",
+                        "name": "Bash",
+                        "command": ["echo", "ok"],
+                        "output": "ok"
+                    }
+                }
+            }),
+            &mut state,
+        );
+        assert!(duplicate_complete.events.is_empty());
+    }
+
+    #[test]
+    fn permission_event_collects_request_id() {
+        let mut state = ReaderState::new("session_1".to_string());
+        let mapped = map_event(
+            &json!({
+                "type": "permission.asked",
+                "properties": { "sessionID": "session_1", "requestID": "perm_1" }
+            }),
+            &mut state,
+        );
+        assert_eq!(mapped.permission_requests, vec!["perm_1".to_string()]);
+        assert!(mapped.events.is_empty());
+    }
+
+    #[test]
+    fn ignores_events_for_other_sessions() {
+        let mut state = ReaderState::new("session_1".to_string());
+        let mapped = map_event(
+            &json!({
+                "type": "session.status",
+                "properties": { "sessionID": "session_2", "status": "active" }
+            }),
+            &mut state,
+        );
+        assert!(mapped.events.is_empty());
+    }
+
+    #[test]
+    fn session_error_while_active_completes_turn_as_failed() {
+        let mut state = ReaderState::new("session_1".to_string());
+        let _ = map_event(
+            &json!({
+                "type": "session.status",
+                "properties": { "sessionID": "session_1", "status": "active" }
+            }),
+            &mut state,
+        );
+
+        let mapped = map_event(
+            &json!({
+                "type": "session.error",
+                "properties": {
+                    "sessionID": "session_1",
+                    "code": "boom",
+                    "message": "failed"
+                }
+            }),
+            &mut state,
+        );
+
+        assert_eq!(mapped.events.len(), 2);
+        assert!(matches!(
+            mapped.events[0],
+            ConversationEvent::TurnCompleted {
+                status: TurnStatus::Failed,
+                ..
+            }
+        ));
+        assert!(matches!(mapped.events[1], ConversationEvent::Error { .. }));
+    }
+
+    #[test]
+    fn ignores_noncanonical_session_id_shape() {
+        let mut state = ReaderState::new("session_1".to_string());
+        let mapped = map_event(
+            &json!({
+                "type": "session.status",
+                "properties": {
+                    "session": { "id": "session_1", "status": "active" }
+                }
+            }),
+            &mut state,
+        );
+
+        assert!(mapped.events.is_empty());
+    }
+}

--- a/rust/loopflow/src/lfd/conversations/harness/testdata/claude_crash_mid_tool.ndjson
+++ b/rust/loopflow/src/lfd/conversations/harness/testdata/claude_crash_mid_tool.ndjson
@@ -1,0 +1,2 @@
+{"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"tool_crash_1","name":"Bash"}}
+{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"command\":\"ls"}}

--- a/rust/loopflow/src/lfd/conversations/harness/testdata/claude_multi_tool.ndjson
+++ b/rust/loopflow/src/lfd/conversations/harness/testdata/claude_multi_tool.ndjson
@@ -1,0 +1,5 @@
+{"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"tool_multi_1","name":"Bash"}}
+{"type":"user","message":{"content":[{"type":"tool_result","tool_use_id":"tool_multi_1","content":[{"type":"text","text":"command done"}]}]}}
+{"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"tool_multi_2","name":"Write"}}
+{"type":"user","message":{"content":[{"type":"tool_result","tool_use_id":"tool_multi_2","content":[{"type":"text","text":"file written"}]}]}}
+{"type":"result","is_error":false,"result":"done"}

--- a/rust/loopflow/src/lfd/conversations/harness/testdata/claude_normal_turn.ndjson
+++ b/rust/loopflow/src/lfd/conversations/harness/testdata/claude_normal_turn.ndjson
@@ -1,0 +1,3 @@
+{"type":"system","session_id":"sess_claude_normal"}
+{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello from Claude"}}
+{"type":"result","is_error":false,"result":"done"}

--- a/rust/loopflow/src/lfd/conversations/harness/testdata/codex_error.jsonl
+++ b/rust/loopflow/src/lfd/conversations/harness/testdata/codex_error.jsonl
@@ -1,0 +1,3 @@
+{"method":"turn/started","params":{"turn":{"id":"turn_codex_err"}}}
+{"method":"error","params":{"code":"codex_internal","message":"boom"}}
+{"method":"turn/completed","params":{"turn":{"id":"turn_codex_err","status":"failed"}}}

--- a/rust/loopflow/src/lfd/conversations/harness/testdata/codex_normal_turn.jsonl
+++ b/rust/loopflow/src/lfd/conversations/harness/testdata/codex_normal_turn.jsonl
@@ -1,0 +1,5 @@
+{"method":"turn/started","params":{"turn":{"id":"turn_codex_1"}}}
+{"method":"item/started","params":{"turn":{"id":"turn_codex_1"},"item":{"id":"item_msg_1","type":"agentMessage","text":"Working","status":"in_progress"}}}
+{"method":"item/agentMessage/delta","params":{"turn":{"id":"turn_codex_1"},"content":"Hello from Codex"}}
+{"method":"item/completed","params":{"turn":{"id":"turn_codex_1"},"item":{"id":"item_msg_1","type":"agentMessage","text":"Working","status":"completed"}}}
+{"method":"turn/completed","params":{"turn":{"id":"turn_codex_1","status":"completed"}}}

--- a/rust/loopflow/src/lfd/conversations/harness/testdata/opencode_error_turn.ndjson
+++ b/rust/loopflow/src/lfd/conversations/harness/testdata/opencode_error_turn.ndjson
@@ -1,0 +1,3 @@
+{"id":"sess_opencode_error"}
+{"type":"session.status","properties":{"sessionID":"sess_opencode_error","status":"active"}}
+{"type":"session.error","properties":{"sessionID":"sess_opencode_error","code":"command_failed","message":"Bash exited 1"}}

--- a/rust/loopflow/src/lfd/conversations/harness/testdata/opencode_normal_turn.ndjson
+++ b/rust/loopflow/src/lfd/conversations/harness/testdata/opencode_normal_turn.ndjson
@@ -1,0 +1,4 @@
+{"id":"sess_opencode_normal"}
+{"type":"session.status","properties":{"sessionID":"sess_opencode_normal","status":"active"}}
+{"type":"message.part.updated","properties":{"sessionID":"sess_opencode_normal","part":{"id":"part_text_1","type":"TextPart","delta":"Hello from OpenCode"}}}
+{"type":"session.status","properties":{"sessionID":"sess_opencode_normal","status":"idle"}}

--- a/rust/loopflow/src/lfd/conversations/harness/testdata/opencode_tool_lifecycle.ndjson
+++ b/rust/loopflow/src/lfd/conversations/harness/testdata/opencode_tool_lifecycle.ndjson
@@ -1,0 +1,5 @@
+{"id":"sess_opencode_tool"}
+{"type":"session.status","properties":{"sessionID":"sess_opencode_tool","status":"active"}}
+{"type":"message.part.updated","properties":{"sessionID":"sess_opencode_tool","part":{"id":"tool_1","type":"ToolPart","state":"running","name":"Bash","command":["echo","ok"]}}}
+{"type":"message.part.updated","properties":{"sessionID":"sess_opencode_tool","part":{"id":"tool_1","type":"ToolPart","state":"completed","name":"Bash","command":["echo","ok"],"output":"ok"}}}
+{"type":"session.status","properties":{"sessionID":"sess_opencode_tool","status":"idle"}}

--- a/rust/loopflow/src/lfd/conversations/harness/testdata/opencode_trace_manifest.json
+++ b/rust/loopflow/src/lfd/conversations/harness/testdata/opencode_trace_manifest.json
@@ -1,0 +1,31 @@
+{
+  "provider": "opencode",
+  "captured_at": "2026-02-26T00:00:00Z",
+  "opencode_version": "unknown",
+  "scenarios": [
+    {
+      "name": "normal_turn",
+      "fixture": "opencode_normal_turn.ndjson",
+      "session_id": "sess_opencode_normal",
+      "session_create_response": {
+        "id": "sess_opencode_normal"
+      }
+    },
+    {
+      "name": "tool_lifecycle",
+      "fixture": "opencode_tool_lifecycle.ndjson",
+      "session_id": "sess_opencode_tool",
+      "session_create_response": {
+        "id": "sess_opencode_tool"
+      }
+    },
+    {
+      "name": "error_turn",
+      "fixture": "opencode_error_turn.ndjson",
+      "session_id": "sess_opencode_error",
+      "session_create_response": {
+        "id": "sess_opencode_error"
+      }
+    }
+  ]
+}

--- a/rust/loopflow/src/lfd/conversations/mod.rs
+++ b/rust/loopflow/src/lfd/conversations/mod.rs
@@ -1,0 +1,21 @@
+//! Per-wave conversation subsystem.
+//!
+//! Restored from the removed central "conversations" subsystem, re-homed for the
+//! per-wave `lf wave` runtime. There is no central conversation daemon anymore —
+//! these modules are consumed in-process by the `lf wave` chat server.
+//!
+//! Two layers:
+//!
+//! - [`harness`] + [`types`]: the reusable vendor stream → conversation-turn
+//!   engine (codex/claude/opencode). It maps raw agent output into
+//!   [`types::ConversationItem`]s and [`types::ConversationEvent`]s. The
+//!   conformance tests under `harness/` pin this mapping against captured traces.
+//! - [`turns`] + [`server`]: the live per-wave chat surface. [`turns`] assembles
+//!   the agent's streamed events into [`turns::ChatTurn`]s; [`server`] hosts them
+//!   over an in-process HTTP API that Concerto observes.
+
+pub mod harness;
+pub mod opencode_runtime;
+pub mod server;
+pub mod turns;
+pub mod types;

--- a/rust/loopflow/src/lfd/conversations/opencode_runtime.rs
+++ b/rust/loopflow/src/lfd/conversations/opencode_runtime.rs
@@ -1,0 +1,289 @@
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+
+const OPENCODE_REGISTRY_FILE: &str = "runtime/opencode-servers.json";
+
+/// Outcome of reaping orphaned opencode `serve` processes. Public so the
+/// per-wave runtime can call [`reap_orphaned_opencode_servers`] at startup to
+/// clear servers left behind by a crashed `lf wave`.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct OpenCodeReapReport {
+    pub reaped: u32,
+    pub errors: u32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+struct OpenCodeServerEntry {
+    opencode_pid: u32,
+    owner_lfd_pid: u32,
+}
+
+pub(crate) fn register_opencode_server(opencode_pid: u32) -> Result<()> {
+    register_opencode_server_at_path(&registry_path(), opencode_pid, std::process::id())
+}
+
+pub(crate) fn unregister_opencode_server(opencode_pid: u32) -> Result<()> {
+    unregister_opencode_server_at_path(&registry_path(), opencode_pid)
+}
+
+pub fn reap_orphaned_opencode_servers() -> OpenCodeReapReport {
+    reap_orphaned_opencode_servers_at_path(
+        &registry_path(),
+        pid_is_alive,
+        process_looks_like_opencode_serve,
+        terminate_process,
+    )
+}
+
+fn registry_path() -> PathBuf {
+    crate::lfd::lf_home_dir().join(OPENCODE_REGISTRY_FILE)
+}
+
+fn register_opencode_server_at_path(
+    path: &Path,
+    opencode_pid: u32,
+    owner_lfd_pid: u32,
+) -> Result<()> {
+    let mut entries = read_registry_entries(path)?;
+    entries.retain(|entry| entry.opencode_pid != opencode_pid);
+    entries.push(OpenCodeServerEntry {
+        opencode_pid,
+        owner_lfd_pid,
+    });
+    write_registry_entries(path, &entries)
+}
+
+fn unregister_opencode_server_at_path(path: &Path, opencode_pid: u32) -> Result<()> {
+    let mut entries = read_registry_entries(path)?;
+    let original_len = entries.len();
+    entries.retain(|entry| entry.opencode_pid != opencode_pid);
+    if entries.len() == original_len {
+        return Ok(());
+    }
+    write_registry_entries(path, &entries)
+}
+
+fn reap_orphaned_opencode_servers_at_path(
+    path: &Path,
+    owner_pid_alive: impl Fn(u32) -> bool,
+    process_matches_opencode: impl Fn(u32) -> bool,
+    terminate_pid: impl Fn(u32) -> bool,
+) -> OpenCodeReapReport {
+    let mut report = OpenCodeReapReport::default();
+    let entries = match read_registry_entries(path) {
+        Ok(entries) => entries,
+        Err(err) => {
+            tracing::warn!(path = %path.display(), error = %err, "failed to read OpenCode registry");
+            report.errors += 1;
+            return report;
+        }
+    };
+
+    let mut retained = Vec::with_capacity(entries.len());
+    for entry in entries {
+        if owner_pid_alive(entry.owner_lfd_pid) {
+            retained.push(entry);
+            continue;
+        }
+
+        if !process_matches_opencode(entry.opencode_pid) {
+            continue;
+        }
+
+        if terminate_pid(entry.opencode_pid) {
+            report.reaped += 1;
+        } else {
+            tracing::warn!(
+                opencode_pid = entry.opencode_pid,
+                owner_lfd_pid = entry.owner_lfd_pid,
+                "failed to terminate orphaned OpenCode server"
+            );
+            report.errors += 1;
+            retained.push(entry);
+        }
+    }
+
+    if let Err(err) = write_registry_entries(path, &retained) {
+        tracing::warn!(
+            path = %path.display(),
+            error = %err,
+            "failed to update OpenCode registry after orphan cleanup"
+        );
+        report.errors += 1;
+    }
+
+    report
+}
+
+fn read_registry_entries(path: &Path) -> Result<Vec<OpenCodeServerEntry>> {
+    let content = match std::fs::read_to_string(path) {
+        Ok(content) => content,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(err) => return Err(err.into()),
+    };
+
+    if content.trim().is_empty() {
+        return Ok(Vec::new());
+    }
+
+    serde_json::from_str(&content)
+        .with_context(|| format!("failed parsing OpenCode registry at {}", path.display()))
+}
+
+fn write_registry_entries(path: &Path, entries: &[OpenCodeServerEntry]) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("failed creating runtime dir {}", parent.display()))?;
+    }
+
+    let json = serde_json::to_string_pretty(entries)
+        .context("failed serializing OpenCode server registry")?;
+    std::fs::write(path, json)
+        .with_context(|| format!("failed writing OpenCode registry at {}", path.display()))?;
+    Ok(())
+}
+
+fn pid_is_alive(pid: u32) -> bool {
+    if pid == 0 {
+        return false;
+    }
+
+    Command::new("kill")
+        .arg("-0")
+        .arg(pid.to_string())
+        .status()
+        .is_ok_and(|status| status.success())
+}
+
+fn process_looks_like_opencode_serve(pid: u32) -> bool {
+    let output = match Command::new("ps")
+        .arg("-o")
+        .arg("command=")
+        .arg("-p")
+        .arg(pid.to_string())
+        .output()
+    {
+        Ok(output) => output,
+        Err(_) => return false,
+    };
+
+    if !output.status.success() {
+        return false;
+    }
+
+    let command = String::from_utf8_lossy(&output.stdout).to_ascii_lowercase();
+    command.contains("opencode") && command.contains("serve")
+}
+
+fn terminate_process(pid: u32) -> bool {
+    if pid == 0 {
+        return false;
+    }
+
+    Command::new("kill")
+        .arg("-TERM")
+        .arg(pid.to_string())
+        .status()
+        .is_ok_and(|status| status.success())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+    use std::sync::Mutex;
+
+    use tempfile::tempdir;
+
+    use super::*;
+
+    fn registry_path(root: &Path) -> PathBuf {
+        root.join("runtime").join("opencode-servers.json")
+    }
+
+    fn entry(opencode_pid: u32, owner_lfd_pid: u32) -> OpenCodeServerEntry {
+        OpenCodeServerEntry {
+            opencode_pid,
+            owner_lfd_pid,
+        }
+    }
+
+    #[test]
+    fn register_and_unregister_opencode_server_updates_registry() {
+        let tmp = tempdir().expect("tempdir");
+        let path = registry_path(tmp.path());
+
+        register_opencode_server_at_path(&path, 111, 222).expect("register pid");
+        let entries = read_registry_entries(&path).expect("read entries");
+        assert_eq!(entries, vec![entry(111, 222)]);
+
+        register_opencode_server_at_path(&path, 111, 444).expect("overwrite existing pid");
+        let entries = read_registry_entries(&path).expect("read entries");
+        assert_eq!(entries, vec![entry(111, 444)]);
+
+        unregister_opencode_server_at_path(&path, 111).expect("unregister pid");
+        let entries = read_registry_entries(&path).expect("read entries");
+        assert!(entries.is_empty());
+    }
+
+    #[test]
+    fn reap_orphaned_opencode_servers_reaps_owned_servers_and_prunes_stale_entries() {
+        let tmp = tempdir().expect("tempdir");
+        let path = registry_path(tmp.path());
+        write_registry_entries(
+            &path,
+            &[entry(10, 1), entry(11, 2), entry(12, 2), entry(13, 2)],
+        )
+        .expect("write registry");
+
+        let owner_alive: HashSet<u32> = [1].into_iter().collect();
+        let opencode_pids: HashSet<u32> = [11].into_iter().collect();
+        let killed = Mutex::new(Vec::new());
+
+        let report = reap_orphaned_opencode_servers_at_path(
+            &path,
+            |pid| owner_alive.contains(&pid),
+            |pid| opencode_pids.contains(&pid),
+            |pid| {
+                killed.lock().expect("lock killed list").push(pid);
+                true
+            },
+        );
+
+        assert_eq!(
+            report,
+            OpenCodeReapReport {
+                reaped: 1,
+                errors: 0
+            }
+        );
+        assert_eq!(*killed.lock().expect("lock killed list"), vec![11]);
+        assert_eq!(
+            read_registry_entries(&path).expect("read entries"),
+            vec![entry(10, 1)]
+        );
+    }
+
+    #[test]
+    fn reap_orphaned_opencode_servers_is_idempotent() {
+        let tmp = tempdir().expect("tempdir");
+        let path = registry_path(tmp.path());
+        write_registry_entries(&path, &[entry(20, 2)]).expect("write registry");
+
+        let first =
+            reap_orphaned_opencode_servers_at_path(&path, |_| false, |pid| pid == 20, |_| true);
+        assert_eq!(
+            first,
+            OpenCodeReapReport {
+                reaped: 1,
+                errors: 0
+            }
+        );
+
+        let second =
+            reap_orphaned_opencode_servers_at_path(&path, |_| false, |pid| pid == 20, |_| true);
+        assert_eq!(second, OpenCodeReapReport::default());
+    }
+}

--- a/rust/loopflow/src/lfd/conversations/server.rs
+++ b/rust/loopflow/src/lfd/conversations/server.rs
@@ -1,0 +1,343 @@
+//! Per-wave chat server, hosted in-process by `lf wave`.
+//!
+//! `lf wave <name>` owns the wave's runtime. This module is the chat surface of
+//! that runtime: a small HTTP server that Concerto observes to render the wave's
+//! live conversation. It is deliberately per-wave and ephemeral — there is no
+//! central conversation daemon.
+//!
+//! ## Discovery
+//!
+//! On start the server binds an ephemeral port on `127.0.0.1` and writes
+//! `wave/<name>/.chat-endpoint` containing a single line, `127.0.0.1:<port>`.
+//! Concerto reads that file to learn where to connect; it is removed on shutdown.
+//!
+//! ## Endpoints
+//!
+//! - `GET  /health` → `{ "status", "wave", "pass", "turns" }`
+//! - `GET  /chat` → `{ "wave", "turns": [ChatTurn, …] }` (snapshot)
+//! - `GET  /chat/stream` → SSE of `ChatTurn`s (event name `turn`): replays the
+//!   current turns, then streams new/updated turns live.
+//! - `POST /chat` `{ "text": "…" }` → enqueues a human message; it is appended to
+//!   `wave/<name>/MAILBOX.md` (which the next `lf goal --once` pass folds into its
+//!   prompt) and recorded as a `user` turn. Returns the created `ChatTurn`.
+//!
+//! ## Turn source
+//!
+//! [`ChatState::ingest_line`] takes raw agent stream-json lines (the wave's inner
+//! `codex exec --json` pass), parses them through [`crate::engine::stream`], and
+//! folds the events into [`ChatTurn`]s via [`TurnBuilder`].
+
+use std::net::SocketAddr;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+
+use anyhow::{Context, Result};
+use axum::extract::State;
+use axum::response::sse::{Event, KeepAlive, Sse};
+use axum::response::IntoResponse;
+use axum::routing::get;
+use axum::{Json, Router};
+use serde::Deserialize;
+use serde_json::json;
+use tokio::net::TcpListener;
+use tokio::sync::broadcast;
+use tokio_stream::wrappers::BroadcastStream;
+use tokio_stream::StreamExt;
+
+use crate::engine::stream::{ParseResult, StreamParser};
+use crate::lfd::conversations::turns::{ChatTurn, TurnBuilder};
+
+const ENDPOINT_FILE: &str = ".chat-endpoint";
+const MAILBOX_FILE: &str = "MAILBOX.md";
+const UPDATE_BUFFER: usize = 256;
+
+/// Live chat state for one wave. Shared between the HTTP handlers and the tailer
+/// that ingests the inner pass's agent stream.
+#[derive(Debug)]
+pub struct ChatState {
+    wave: String,
+    wave_dir: PathBuf,
+    inner: Mutex<ChatInner>,
+    updates: broadcast::Sender<ChatTurn>,
+}
+
+#[derive(Debug)]
+struct ChatInner {
+    builder: TurnBuilder,
+    /// Finalized assistant turns and human `user` turns, in arrival order.
+    turns: Vec<ChatTurn>,
+    /// Number of inner passes started so far.
+    pass: u32,
+    user_seq: u64,
+}
+
+impl ChatState {
+    pub fn new(wave: String, wave_dir: PathBuf) -> Arc<Self> {
+        let (updates, _rx) = broadcast::channel(UPDATE_BUFFER);
+        Arc::new(Self {
+            wave,
+            wave_dir,
+            inner: Mutex::new(ChatInner {
+                builder: TurnBuilder::new(),
+                turns: Vec::new(),
+                pass: 0,
+                user_seq: 0,
+            }),
+            updates,
+        })
+    }
+
+    /// Mark the start of a new inner pass. Any turn still open from a prior pass
+    /// (a pass that ended without a clean result) is finalized as failed.
+    pub fn begin_pass(&self) {
+        let mut inner = self.inner.lock().expect("chat state poisoned");
+        inner.pass += 1;
+        if let Some(turn) = inner.builder.finish_open() {
+            inner.turns.push(turn.clone());
+            let _ = self.updates.send(turn);
+        }
+    }
+
+    /// Ingest one raw agent stream-json line from the inner pass.
+    pub fn ingest_line(&self, parser: &mut StreamParser, line: &str) {
+        match parser.feed_line(line) {
+            ParseResult::Events(events) => {
+                for event in &events {
+                    self.ingest_event(event);
+                }
+            }
+            ParseResult::Skipped | ParseResult::Passthrough => {}
+        }
+    }
+
+    fn ingest_event(&self, event: &crate::engine::stream::StreamEvent) {
+        let mut inner = self.inner.lock().expect("chat state poisoned");
+        if let Some(finished) = inner.builder.feed(event) {
+            inner.turns.push(finished.clone());
+            let _ = self.updates.send(finished);
+        } else if let Some(open) = inner.builder.snapshot().cloned() {
+            // Broadcast the in-progress snapshot so subscribers see partial text.
+            let _ = self.updates.send(open);
+        }
+    }
+
+    /// Record a human message: append to the wave mailbox and add a `user` turn.
+    pub fn record_user_message(&self, text: &str) -> Result<ChatTurn> {
+        append_to_mailbox(&self.wave_dir, text)?;
+        let mut inner = self.inner.lock().expect("chat state poisoned");
+        inner.user_seq += 1;
+        let turn = ChatTurn::user(format!("user-{}", inner.user_seq), text.to_string());
+        inner.turns.push(turn.clone());
+        let _ = self.updates.send(turn.clone());
+        Ok(turn)
+    }
+
+    /// Snapshot: finalized turns plus any in-progress assistant turn.
+    fn turns_snapshot(&self) -> Vec<ChatTurn> {
+        let inner = self.inner.lock().expect("chat state poisoned");
+        let mut turns = inner.turns.clone();
+        if let Some(open) = inner.builder.snapshot() {
+            turns.push(open.clone());
+        }
+        turns
+    }
+
+    fn pass(&self) -> u32 {
+        self.inner.lock().expect("chat state poisoned").pass
+    }
+
+    /// Number of turns currently visible (finalized + any in-progress turn).
+    pub fn turn_count(&self) -> usize {
+        self.turns_snapshot().len()
+    }
+}
+
+/// Append a human message to `wave/<name>/MAILBOX.md`, timestamped. The next
+/// `lf goal --once` pass reads and clears this file (see `goal::drain_mailbox`).
+fn append_to_mailbox(wave_dir: &Path, text: &str) -> Result<()> {
+    use std::io::Write;
+
+    std::fs::create_dir_all(wave_dir)
+        .with_context(|| format!("create wave dir {}", wave_dir.display()))?;
+    let path = wave_dir.join(MAILBOX_FILE);
+    let stamp = time::OffsetDateTime::now_utc()
+        .format(&time::format_description::well_known::Rfc3339)
+        .unwrap_or_default();
+    let mut file = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&path)
+        .with_context(|| format!("open mailbox {}", path.display()))?;
+    writeln!(file, "- [{stamp}] {}", text.replace('\n', " "))
+        .with_context(|| format!("append mailbox {}", path.display()))?;
+    Ok(())
+}
+
+// ── HTTP ────────────────────────────────────────────────────────────────────
+
+pub fn router(state: Arc<ChatState>) -> Router {
+    Router::new()
+        .route("/health", get(health))
+        .route("/chat", get(get_chat).post(post_chat))
+        .route("/chat/stream", get(stream_chat))
+        .with_state(state)
+}
+
+async fn health(State(state): State<Arc<ChatState>>) -> impl IntoResponse {
+    let turns = state.turns_snapshot().len();
+    Json(json!({
+        "status": "ok",
+        "wave": state.wave,
+        "pass": state.pass(),
+        "turns": turns,
+    }))
+}
+
+async fn get_chat(State(state): State<Arc<ChatState>>) -> impl IntoResponse {
+    Json(json!({
+        "wave": state.wave,
+        "turns": state.turns_snapshot(),
+    }))
+}
+
+#[derive(Debug, Deserialize)]
+struct PostChat {
+    text: String,
+}
+
+async fn post_chat(
+    State(state): State<Arc<ChatState>>,
+    Json(body): Json<PostChat>,
+) -> impl IntoResponse {
+    match state.record_user_message(&body.text) {
+        Ok(turn) => (axum::http::StatusCode::OK, Json(json!(turn))).into_response(),
+        Err(err) => (
+            axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({ "error": { "message": err.to_string() } })),
+        )
+            .into_response(),
+    }
+}
+
+async fn stream_chat(State(state): State<Arc<ChatState>>) -> impl IntoResponse {
+    let rx = state.updates.subscribe();
+    // Replay the current turns first so a late subscriber gets full context,
+    // then follow live updates.
+    let initial = state.turns_snapshot();
+    let replay = tokio_stream::iter(initial.into_iter().map(Ok));
+    let live = BroadcastStream::new(rx).filter_map(|item| item.ok().map(Ok));
+    let stream = replay.chain(live).map(|turn: Result<ChatTurn, _>| {
+        turn.and_then(|turn| Event::default().event("turn").json_data(turn))
+    });
+    Sse::new(stream).keep_alive(KeepAlive::default())
+}
+
+// ── Discovery ────────────────────────────────────────────────────────────────
+
+/// Bind the chat server's listener on an ephemeral loopback port and publish the
+/// `.chat-endpoint` discovery file under the wave directory.
+pub async fn bind(wave_dir: &Path) -> Result<TcpListener> {
+    let listener = TcpListener::bind(("127.0.0.1", 0))
+        .await
+        .context("bind wave chat listener")?;
+    let addr = listener
+        .local_addr()
+        .context("resolve chat listener addr")?;
+    write_endpoint_file(wave_dir, addr)?;
+    Ok(listener)
+}
+
+fn write_endpoint_file(wave_dir: &Path, addr: SocketAddr) -> Result<()> {
+    std::fs::create_dir_all(wave_dir)
+        .with_context(|| format!("create wave dir {}", wave_dir.display()))?;
+    let path = wave_dir.join(ENDPOINT_FILE);
+    std::fs::write(&path, format!("{addr}\n"))
+        .with_context(|| format!("write endpoint file {}", path.display()))?;
+    Ok(())
+}
+
+/// Remove the discovery file. Best-effort; called on shutdown.
+pub fn remove_endpoint_file(wave_dir: &Path) {
+    let _ = std::fs::remove_file(wave_dir.join(ENDPOINT_FILE));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::engine::stream::{ResultSubtype, StreamEvent};
+
+    fn tmp_state() -> (tempfile::TempDir, Arc<ChatState>) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let state = ChatState::new("demo".to_string(), dir.path().to_path_buf());
+        (dir, state)
+    }
+
+    #[test]
+    fn ingest_builds_turns_from_codex_stream() {
+        let (_dir, state) = tmp_state();
+        let mut parser = StreamParser::new();
+        state.begin_pass();
+        state.ingest_line(
+            &mut parser,
+            r#"{"type":"item.completed","item":{"id":"i1","type":"agent_message","text":"Done."}}"#,
+        );
+        state.ingest_line(
+            &mut parser,
+            r#"{"type":"turn.completed","usage":{"input_tokens":1,"output_tokens":1}}"#,
+        );
+        let turns = state.turns_snapshot();
+        assert_eq!(turns.len(), 1);
+        assert_eq!(turns[0].text, "Done.");
+    }
+
+    #[test]
+    fn user_message_writes_mailbox_and_records_turn() {
+        let (dir, state) = tmp_state();
+        let turn = state
+            .record_user_message("check the tests")
+            .expect("record");
+        assert_eq!(turn.text, "check the tests");
+        let mailbox = std::fs::read_to_string(dir.path().join(MAILBOX_FILE)).expect("mailbox");
+        assert!(mailbox.contains("check the tests"));
+        assert_eq!(state.turns_snapshot().len(), 1);
+    }
+
+    #[test]
+    fn begin_pass_finalizes_dangling_turn_as_failed() {
+        let (_dir, state) = tmp_state();
+        state.begin_pass();
+        // Open a turn but never finish it, then start a new pass.
+        state.ingest_event(&StreamEvent::Text("half".into()));
+        assert_eq!(state.turns_snapshot().len(), 1); // in-progress snapshot
+        state.begin_pass();
+        let turns = state.turns_snapshot();
+        assert_eq!(turns.len(), 1);
+        assert_eq!(
+            turns[0].status,
+            crate::lfd::conversations::turns::ChatTurnStatus::Failed
+        );
+    }
+
+    #[test]
+    fn bind_writes_discovery_file() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let rt = tokio::runtime::Runtime::new().expect("rt");
+        let listener = rt.block_on(bind(dir.path())).expect("bind");
+        let contents = std::fs::read_to_string(dir.path().join(ENDPOINT_FILE)).expect("endpoint");
+        assert!(contents.trim().starts_with("127.0.0.1:"));
+        assert_eq!(
+            contents.trim(),
+            listener.local_addr().expect("addr").to_string()
+        );
+    }
+
+    #[test]
+    fn result_event_reference_compiles() {
+        // Guards against StreamEvent::Result field drift used by TurnBuilder.
+        let _ = StreamEvent::Result {
+            subtype: ResultSubtype::Success,
+            cost_usd: None,
+            duration_secs: None,
+        };
+    }
+}

--- a/rust/loopflow/src/lfd/conversations/turns.rs
+++ b/rust/loopflow/src/lfd/conversations/turns.rs
@@ -1,0 +1,275 @@
+//! Turn assembly: agent stream events → `ChatTurn`s.
+//!
+//! The wave's inner pass runs `codex exec --json` (see [`crate::engine::stream`],
+//! which normalizes codex/claude/opencode JSON into [`StreamEvent`]s). This module
+//! adds the richer turn/item layer on top: it folds a live stream of events into
+//! [`ChatTurn`]s, the wire type the per-wave chat [`server`](super::server) serves
+//! to Concerto.
+//!
+//! Mapping:
+//! - the operator's standing directive becomes one `user` turn;
+//! - each agent turn (text + tool activity, closed by a result) becomes one
+//!   `assistant` turn whose `items` capture the commands/edits/messages it ran.
+
+use serde::{Deserialize, Serialize};
+use time::OffsetDateTime;
+
+use crate::engine::stream::{ResultSubtype, StreamEvent};
+use crate::lfd::conversations::types::ConversationItem;
+
+/// Who authored a turn. Mirrors Swift `MessageRole` (user/assistant).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ChatRole {
+    User,
+    Assistant,
+}
+
+/// Lifecycle of an assistant turn. A `user` turn is always `Completed`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ChatTurnStatus {
+    InProgress,
+    Completed,
+    Failed,
+}
+
+/// One turn in a wave's conversation — the unit the chat server streams.
+///
+/// Wire type consumed by Concerto. Every field is required (no serde defaults):
+/// the same shape round-trips through Rust and Swift.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ChatTurn {
+    /// Stable within a running server: `"turn-1"`, `"turn-2"`, …
+    pub id: String,
+    pub role: ChatRole,
+    /// Accumulated assistant prose (or the human message for a `user` turn).
+    pub text: String,
+    pub status: ChatTurnStatus,
+    /// Tool/command/file/message items the agent produced, in order.
+    pub items: Vec<ConversationItem>,
+    /// RFC 3339 timestamp of when the turn opened.
+    pub created_at: String,
+}
+
+impl ChatTurn {
+    fn now_rfc3339() -> String {
+        OffsetDateTime::now_utc()
+            .format(&time::format_description::well_known::Rfc3339)
+            .unwrap_or_default()
+    }
+
+    /// A completed `user` turn carrying a human message.
+    pub fn user(id: String, text: String) -> Self {
+        Self {
+            id,
+            role: ChatRole::User,
+            text,
+            status: ChatTurnStatus::Completed,
+            items: Vec::new(),
+            created_at: Self::now_rfc3339(),
+        }
+    }
+}
+
+/// Folds a live `StreamEvent` sequence into `ChatTurn`s.
+///
+/// One builder spans the whole life of a wave server; `feed` is called for every
+/// event parsed from the agent's stream. It opens an assistant turn on the first
+/// content event and closes it on a `Result`, returning the completed turn so the
+/// server can broadcast it. `snapshot` exposes the turn currently in progress so a
+/// late subscriber sees partial text.
+#[derive(Debug, Default)]
+pub struct TurnBuilder {
+    next_index: u64,
+    open: Option<ChatTurn>,
+}
+
+impl TurnBuilder {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// The assistant turn currently being assembled, if any.
+    pub fn snapshot(&self) -> Option<&ChatTurn> {
+        self.open.as_ref()
+    }
+
+    fn open_turn(&mut self) -> &mut ChatTurn {
+        if self.open.is_none() {
+            self.next_index += 1;
+            self.open = Some(ChatTurn {
+                id: format!("turn-{}", self.next_index),
+                role: ChatRole::Assistant,
+                text: String::new(),
+                status: ChatTurnStatus::InProgress,
+                items: Vec::new(),
+                created_at: ChatTurn::now_rfc3339(),
+            });
+        }
+        self.open.as_mut().expect("turn just opened")
+    }
+
+    /// Feed one stream event. Returns `Some(turn)` when a turn is finalized.
+    pub fn feed(&mut self, event: &StreamEvent) -> Option<ChatTurn> {
+        match event {
+            StreamEvent::Text(text) => {
+                let turn = self.open_turn();
+                if !turn.text.is_empty() {
+                    turn.text.push('\n');
+                }
+                turn.text.push_str(text);
+                None
+            }
+            StreamEvent::ToolUse { name, summary } => {
+                let index = self.open_turn().items.len();
+                let turn = self.open_turn();
+                turn.items.push(tool_item(index, name, summary));
+                None
+            }
+            StreamEvent::Usage { .. } => None,
+            StreamEvent::Result { subtype, .. } => {
+                let mut turn = self.open.take()?;
+                turn.status = match subtype {
+                    ResultSubtype::Success => ChatTurnStatus::Completed,
+                    ResultSubtype::Error => ChatTurnStatus::Failed,
+                };
+                Some(turn)
+            }
+        }
+    }
+
+    /// Close any in-progress turn (e.g. the pass ended without a `Result`).
+    /// Returns the finalized turn, marked failed since it never resolved.
+    pub fn finish_open(&mut self) -> Option<ChatTurn> {
+        let mut turn = self.open.take()?;
+        turn.status = ChatTurnStatus::Failed;
+        Some(turn)
+    }
+}
+
+fn tool_item(index: usize, name: &str, summary: &str) -> ConversationItem {
+    use crate::lfd::conversations::types::{FileEdit, ItemStatus};
+
+    let id = format!("item-{index}");
+    match name {
+        "Bash" => ConversationItem::Command {
+            id,
+            command: vec![summary.to_string()],
+            cwd: String::new(),
+            status: ItemStatus::Completed,
+            output: None,
+            exit_code: None,
+            duration_ms: None,
+        },
+        "Edit" | "Write" => ConversationItem::File {
+            id,
+            changes: summary
+                .split(", ")
+                .filter(|p| !p.is_empty())
+                .map(|p| FileEdit {
+                    path: p.to_string(),
+                    kind: None,
+                    diff: None,
+                })
+                .collect(),
+            status: ItemStatus::Completed,
+        },
+        _ => ConversationItem::Tool {
+            id,
+            name: name.to_string(),
+            status: ItemStatus::Completed,
+            input: None,
+            output: if summary.is_empty() {
+                None
+            } else {
+                Some(summary.to_string())
+            },
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn text_and_result_produce_one_completed_turn() {
+        let mut builder = TurnBuilder::new();
+        assert!(builder.feed(&StreamEvent::Text("hello".into())).is_none());
+        assert!(builder.feed(&StreamEvent::Text("world".into())).is_none());
+        let turn = builder
+            .feed(&StreamEvent::Result {
+                subtype: ResultSubtype::Success,
+                cost_usd: None,
+                duration_secs: None,
+            })
+            .expect("turn finalized on result");
+        assert_eq!(turn.id, "turn-1");
+        assert_eq!(turn.role, ChatRole::Assistant);
+        assert_eq!(turn.text, "hello\nworld");
+        assert_eq!(turn.status, ChatTurnStatus::Completed);
+        assert!(builder.snapshot().is_none());
+    }
+
+    #[test]
+    fn tool_use_becomes_command_item() {
+        let mut builder = TurnBuilder::new();
+        builder.feed(&StreamEvent::ToolUse {
+            name: "Bash".into(),
+            summary: "cargo test".into(),
+        });
+        let snap = builder.snapshot().expect("open turn");
+        assert_eq!(snap.items.len(), 1);
+        assert!(matches!(
+            &snap.items[0],
+            ConversationItem::Command { command, .. } if command == &vec!["cargo test".to_string()]
+        ));
+    }
+
+    #[test]
+    fn error_result_marks_turn_failed() {
+        let mut builder = TurnBuilder::new();
+        builder.feed(&StreamEvent::Text("boom".into()));
+        let turn = builder
+            .feed(&StreamEvent::Result {
+                subtype: ResultSubtype::Error,
+                cost_usd: None,
+                duration_secs: None,
+            })
+            .expect("turn finalized");
+        assert_eq!(turn.status, ChatTurnStatus::Failed);
+    }
+
+    #[test]
+    fn each_turn_gets_a_fresh_id() {
+        let mut builder = TurnBuilder::new();
+        builder.feed(&StreamEvent::Text("one".into()));
+        let first = builder
+            .feed(&StreamEvent::Result {
+                subtype: ResultSubtype::Success,
+                cost_usd: None,
+                duration_secs: None,
+            })
+            .expect("first turn");
+        builder.feed(&StreamEvent::Text("two".into()));
+        let second = builder
+            .feed(&StreamEvent::Result {
+                subtype: ResultSubtype::Success,
+                cost_usd: None,
+                duration_secs: None,
+            })
+            .expect("second turn");
+        assert_eq!(first.id, "turn-1");
+        assert_eq!(second.id, "turn-2");
+    }
+
+    #[test]
+    fn user_turn_round_trips_through_json() {
+        let turn = ChatTurn::user("turn-0".into(), "please fix the build".into());
+        let value = serde_json::to_value(&turn).expect("serialize");
+        let decoded: ChatTurn = serde_json::from_value(value).expect("deserialize");
+        assert_eq!(decoded, turn);
+        assert_eq!(decoded.role, ChatRole::User);
+    }
+}

--- a/rust/loopflow/src/lfd/conversations/types.rs
+++ b/rust/loopflow/src/lfd/conversations/types.rs
@@ -1,0 +1,490 @@
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use time::OffsetDateTime;
+
+use crate::engine::prompt::{ContextBreakdown, DiffTier, DocumentSource, Surface};
+use crate::lfd::id::LfdId;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+#[serde(rename_all = "snake_case")]
+pub enum ConversationStatus {
+    Starting,
+    Active,
+    Ending,
+    Ended,
+    Failed,
+}
+
+impl ConversationStatus {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Starting => "starting",
+            Self::Active => "active",
+            Self::Ending => "ending",
+            Self::Ended => "ended",
+            Self::Failed => "failed",
+        }
+    }
+
+    pub fn is_terminal(self) -> bool {
+        matches!(self, Self::Ended | Self::Failed)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+#[serde(rename_all = "snake_case")]
+pub enum TurnStatus {
+    Completed,
+    Interrupted,
+    Failed,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+#[serde(rename_all = "snake_case")]
+pub enum ItemStatus {
+    InProgress,
+    Completed,
+    Failed,
+    Declined,
+}
+
+// -- Typed items --
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct FileEdit {
+    pub path: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub kind: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub diff: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum ConversationItem {
+    Command {
+        id: String,
+        #[serde(default)]
+        command: Vec<String>,
+        #[serde(default)]
+        cwd: String,
+        status: ItemStatus,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        output: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        exit_code: Option<i32>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        duration_ms: Option<u64>,
+    },
+    File {
+        id: String,
+        #[serde(default)]
+        changes: Vec<FileEdit>,
+        status: ItemStatus,
+    },
+    Message {
+        id: String,
+        #[serde(default)]
+        text: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        phase: Option<String>,
+    },
+    Thought {
+        id: String,
+        #[serde(default)]
+        text: String,
+    },
+    /// Generic fallback for harnesses that don't distinguish item types.
+    Tool {
+        id: String,
+        name: String,
+        status: ItemStatus,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        input: Option<Value>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        output: Option<String>,
+    },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum ItemDelta {
+    Output { content: String },
+    PlanText { content: String },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SuggestedActionPayload {
+    pub label: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+}
+
+/// Token usage for a single agent turn.
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
+pub struct TurnUsage {
+    pub input_tokens: u64,
+    pub output_tokens: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reasoning_tokens: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cache_read_tokens: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cache_write_tokens: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cost_usd: Option<f64>,
+}
+
+/// Prompt composition snapshot at session start.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct DocumentEntry {
+    pub path: String,
+    pub source: String,
+    pub tokens: u64,
+}
+
+/// Prompt composition snapshot at session start.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ContextSnapshot {
+    /// Tokens per source category ("step", "direction", "diff", "docs", etc.)
+    #[serde(default)]
+    pub sources: HashMap<String, u64>,
+    /// Document counts per source category.
+    #[serde(default)]
+    pub source_counts: HashMap<String, u64>,
+    /// Per-document entries for file-level breakdown.
+    #[serde(default)]
+    pub documents: Vec<DocumentEntry>,
+    /// Total tokens used.
+    pub total: u64,
+    /// Diff representation tier ("UnifiedDiff", "StatOnly", "None").
+    pub diff_tier: String,
+    #[serde(default)]
+    pub step_name: Option<String>,
+    #[serde(default)]
+    pub direction_names: Vec<String>,
+    pub wave_name: Option<String>,
+    #[serde(default)]
+    pub has_clipboard: bool,
+}
+
+impl From<&ContextBreakdown> for ContextSnapshot {
+    fn from(breakdown: &ContextBreakdown) -> Self {
+        let mut sources: HashMap<String, u64> = breakdown
+            .source_tokens
+            .iter()
+            .map(|(source, tokens)| (source_key(*source), *tokens as u64))
+            .collect();
+        sources.insert("system".to_string(), breakdown.system_tokens as u64);
+
+        Self {
+            sources,
+            source_counts: breakdown
+                .source_counts
+                .iter()
+                .map(|(source, count)| (source_key(*source), *count as u64))
+                .collect(),
+            documents: breakdown
+                .documents
+                .iter()
+                .map(|d| DocumentEntry {
+                    path: d.path.clone(),
+                    source: source_key(d.source),
+                    tokens: d.tokens as u64,
+                })
+                .collect(),
+            total: breakdown.total() as u64,
+            diff_tier: diff_tier_key(&breakdown.diff_tier).to_string(),
+            step_name: breakdown.step_name.clone(),
+            direction_names: breakdown.direction_names.clone(),
+            wave_name: breakdown.wave_name.clone(),
+            has_clipboard: breakdown.has_clipboard,
+        }
+    }
+}
+
+fn source_key(source: DocumentSource) -> String {
+    match source {
+        DocumentSource::Step => "step",
+        DocumentSource::Direction => "direction",
+        DocumentSource::Diff => "diff",
+        DocumentSource::Docs => "docs",
+        DocumentSource::Scratch => "scratch",
+        DocumentSource::Wave => "wave",
+        DocumentSource::WaveMemory => "wave_memory",
+        DocumentSource::Summary => "summary",
+        DocumentSource::Clipboard => "clipboard",
+    }
+    .to_string()
+}
+
+fn diff_tier_key(diff_tier: &DiffTier) -> &'static str {
+    match diff_tier {
+        DiffTier::UnifiedDiff => "UnifiedDiff",
+        DiffTier::StatOnly => "StatOnly",
+        DiffTier::None => "None",
+    }
+}
+
+// -- Event stream --
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum ConversationEvent {
+    // Turn boundaries
+    TurnStarted {
+        turn_id: String,
+    },
+    TurnCompleted {
+        turn_id: String,
+        status: TurnStatus,
+    },
+    /// Token usage for a completed turn. Emitted after TurnCompleted.
+    TurnUsage {
+        turn_id: String,
+        usage: TurnUsage,
+    },
+    /// Prompt composition snapshot. Emitted once at session start, before first TurnStarted.
+    ContextSnapshot {
+        snapshot: ContextSnapshot,
+    },
+
+    // Item lifecycle
+    ItemStarted {
+        turn_id: String,
+        item: ConversationItem,
+    },
+    ItemUpdated {
+        turn_id: String,
+        item_id: String,
+        data: ItemDelta,
+    },
+    ItemCompleted {
+        turn_id: String,
+        item: ConversationItem,
+    },
+
+    // High-frequency streaming
+    TextDelta {
+        turn_id: String,
+        content: String,
+    },
+    ReasoningDelta {
+        turn_id: String,
+        content: String,
+    },
+
+    // Turn-level aggregates
+    DiffUpdated {
+        turn_id: String,
+        diff: String,
+    },
+    SuggestedActions {
+        turn_id: String,
+        actions: Vec<SuggestedActionPayload>,
+    },
+
+    // Conversation-level
+    StatusChanged {
+        status: ConversationStatus,
+    },
+    Error {
+        code: String,
+        message: String,
+    },
+
+    // Internal (not persisted or forwarded to SSE clients)
+    ProviderSessionId {
+        provider_session_id: String,
+    },
+}
+
+impl ConversationEvent {
+    pub fn event_type(&self) -> &'static str {
+        match self {
+            Self::TurnStarted { .. } => "turn_started",
+            Self::TurnCompleted { .. } => "turn_completed",
+            Self::TurnUsage { .. } => "turn_usage",
+            Self::ContextSnapshot { .. } => "context_snapshot",
+            Self::ItemStarted { .. } => "item_started",
+            Self::ItemUpdated { .. } => "item_updated",
+            Self::ItemCompleted { .. } => "item_completed",
+            Self::TextDelta { .. } => "text_delta",
+            Self::ReasoningDelta { .. } => "reasoning_delta",
+            Self::DiffUpdated { .. } => "diff_updated",
+            Self::SuggestedActions { .. } => "suggested_actions",
+            Self::StatusChanged { .. } => "status_changed",
+            Self::Error { .. } => "error",
+            Self::ProviderSessionId { .. } => "provider_session_id",
+        }
+    }
+}
+
+// -- Conversation config and record --
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct ConversationConfig {
+    #[serde(default)]
+    pub step: String,
+    #[serde(default)]
+    pub repo_root: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub directions: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub area: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub wave: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub surface: Option<Surface>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub agent: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cwd: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_turns: Option<u32>,
+    #[serde(default)]
+    pub yolo_mode: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub client_has_ui: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub client_compact: Option<bool>,
+}
+
+/// Conversation and usage record for a single interactive agent session.
+///
+/// `Conversation` stores persisted chat/session lifecycle and token usage events.
+/// For process-level lifecycle (PID/container/run status), see `ExecutionProcess`.
+/// When present, `run_id` links this session back to the corresponding
+/// wave execution lineage.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Conversation {
+    pub id: LfdId,
+    pub harness: String,
+    pub status: ConversationStatus,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub run_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub provider_session_id: Option<String>,
+    pub config: ConversationConfig,
+    pub created_at: OffsetDateTime,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ended_at: Option<OffsetDateTime>,
+}
+
+#[derive(Debug, Clone)]
+pub struct PersistedConversationEvent {
+    pub conversation_id: LfdId,
+    pub seq: i64,
+    pub event: ConversationEvent,
+    pub created_at: OffsetDateTime,
+}
+
+#[derive(Debug, Clone)]
+pub struct CreateConversationParams {
+    pub harness: String,
+    pub run_id: Option<String>,
+    pub config: ConversationConfig,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn context_snapshot_from_breakdown_preserves_source_tokens() {
+        let breakdown = ContextBreakdown {
+            source_tokens: HashMap::from([
+                (DocumentSource::Step, 120),
+                (DocumentSource::Direction, 80),
+                (DocumentSource::Diff, 450),
+            ]),
+            source_counts: HashMap::from([(DocumentSource::Diff, 8), (DocumentSource::Docs, 2)]),
+            documents: vec![crate::engine::prompt::DocumentEntry {
+                path: "README.md".to_string(),
+                source: DocumentSource::Docs,
+                tokens: 100,
+            }],
+            system_tokens: 25,
+            diff_tier: DiffTier::StatOnly,
+            step_name: Some("implement".to_string()),
+            direction_names: vec!["clarity".to_string(), "care".to_string()],
+            wave_name: Some("context-ui".to_string()),
+            has_clipboard: true,
+            ..ContextBreakdown::default()
+        };
+
+        let snapshot = ContextSnapshot::from(&breakdown);
+        assert_eq!(snapshot.sources.get("step"), Some(&120));
+        assert_eq!(snapshot.sources.get("direction"), Some(&80));
+        assert_eq!(snapshot.sources.get("diff"), Some(&450));
+        assert_eq!(snapshot.sources.get("system"), Some(&25));
+        assert_eq!(snapshot.source_counts.get("diff"), Some(&8));
+        assert_eq!(snapshot.source_counts.get("docs"), Some(&2));
+        assert_eq!(
+            snapshot.documents,
+            vec![DocumentEntry {
+                path: "README.md".to_string(),
+                source: "docs".to_string(),
+                tokens: 100,
+            }]
+        );
+        assert_eq!(snapshot.total, 675);
+        assert_eq!(snapshot.diff_tier, "StatOnly");
+        assert_eq!(snapshot.step_name.as_deref(), Some("implement"));
+        assert_eq!(snapshot.direction_names, vec!["clarity", "care"]);
+        assert_eq!(snapshot.wave_name.as_deref(), Some("context-ui"));
+        assert!(snapshot.has_clipboard);
+    }
+
+    #[test]
+    fn turn_usage_round_trips_through_json() {
+        let usage = TurnUsage {
+            input_tokens: 123,
+            output_tokens: 45,
+            reasoning_tokens: Some(12),
+            cache_read_tokens: Some(17),
+            cache_write_tokens: Some(9),
+            model: Some("claude-3-7-sonnet".to_string()),
+            cost_usd: Some(0.021),
+        };
+
+        let value = serde_json::to_value(&usage).expect("serialize usage");
+        let decoded: TurnUsage = serde_json::from_value(value).expect("deserialize usage");
+        assert_eq!(decoded, usage);
+    }
+
+    #[test]
+    fn context_snapshot_round_trips_through_json() {
+        let snapshot = ContextSnapshot {
+            sources: HashMap::from([("step".to_string(), 200), ("direction".to_string(), 50)]),
+            source_counts: HashMap::from([("docs".to_string(), 3)]),
+            documents: vec![DocumentEntry {
+                path: "README.md".to_string(),
+                source: "docs".to_string(),
+                tokens: 180,
+            }],
+            total: 250,
+            diff_tier: "UnifiedDiff".to_string(),
+            step_name: Some("implement".to_string()),
+            direction_names: vec!["clarity".to_string()],
+            wave_name: Some("context-ui".to_string()),
+            has_clipboard: false,
+        };
+
+        let value = serde_json::to_value(&snapshot).expect("serialize snapshot");
+        let decoded: ContextSnapshot = serde_json::from_value(value).expect("deserialize snapshot");
+        assert_eq!(decoded, snapshot);
+    }
+}

--- a/rust/loopflow/src/lfd/mod.rs
+++ b/rust/loopflow/src/lfd/mod.rs
@@ -3,6 +3,7 @@ pub mod attention;
 pub mod auth;
 pub mod client;
 pub mod config;
+pub mod conversations;
 pub mod credential_socket;
 pub mod events;
 pub mod executor;

--- a/rust/loopflow/tests/wave_chat_server.rs
+++ b/rust/loopflow/tests/wave_chat_server.rs
@@ -1,0 +1,115 @@
+//! End-to-end round-trip for the per-wave chat server hosted by `lf wave`.
+//!
+//! Replaces the removed daemon-era `session_input_round_trip.rs`: the central
+//! `/v0/conversations` HTTP surface no longer exists. This exercises the new
+//! contract Concerto consumes — discovery file, `GET /health`, `GET /chat`,
+//! `POST /chat`, and the `GET /chat/stream` SSE — plus the codex stream → turn
+//! ingestion that feeds them.
+
+use std::time::Duration;
+
+use loopflow::engine::stream::StreamParser;
+use loopflow::lfd::conversations::server::{self, ChatState};
+use reqwest::Client;
+use serde_json::Value;
+use tempfile::tempdir;
+
+async fn start(wave_dir: &std::path::Path) -> (String, std::sync::Arc<ChatState>) {
+    let state = ChatState::new("demo".to_string(), wave_dir.to_path_buf());
+    let listener = server::bind(wave_dir).await.expect("bind chat server");
+    let addr = listener.local_addr().expect("addr");
+    let router = server::router(state.clone());
+    tokio::spawn(async move {
+        axum::serve(listener, router).await.expect("serve");
+    });
+    (format!("http://{addr}"), state)
+}
+
+#[tokio::test]
+async fn chat_server_serves_turns_mailbox_and_stream() {
+    let dir = tempdir().expect("tempdir");
+    let wave_dir = dir.path();
+    let (base, state) = start(wave_dir).await;
+    let client = Client::new();
+
+    // Discovery file points at the live server.
+    let endpoint = std::fs::read_to_string(wave_dir.join(".chat-endpoint")).expect("endpoint file");
+    assert!(endpoint.trim().starts_with("127.0.0.1:"));
+
+    // Health is live and reports the wave.
+    let health: Value = client
+        .get(format!("{base}/health"))
+        .send()
+        .await
+        .expect("health")
+        .json()
+        .await
+        .expect("health json");
+    assert_eq!(health["status"], "ok");
+    assert_eq!(health["wave"], "demo");
+
+    // A human message lands in the mailbox and shows as a user turn.
+    let posted: Value = client
+        .post(format!("{base}/chat"))
+        .json(&serde_json::json!({ "text": "check the tests" }))
+        .send()
+        .await
+        .expect("post chat")
+        .json()
+        .await
+        .expect("post json");
+    assert_eq!(posted["role"], "user");
+    assert_eq!(posted["text"], "check the tests");
+    let mailbox = std::fs::read_to_string(wave_dir.join("MAILBOX.md")).expect("mailbox");
+    assert!(mailbox.contains("check the tests"));
+
+    // Feed a codex `exec --json` turn; it becomes an assistant turn.
+    let mut parser = StreamParser::new();
+    state.begin_pass();
+    state.ingest_line(
+        &mut parser,
+        r#"{"type":"item.completed","item":{"id":"i1","type":"agent_message","text":"Ran the tests, all green."}}"#,
+    );
+    state.ingest_line(
+        &mut parser,
+        r#"{"type":"turn.completed","usage":{"input_tokens":10,"output_tokens":4}}"#,
+    );
+
+    let chat: Value = client
+        .get(format!("{base}/chat"))
+        .send()
+        .await
+        .expect("get chat")
+        .json()
+        .await
+        .expect("chat json");
+    let turns = chat["turns"].as_array().expect("turns array");
+    assert_eq!(turns.len(), 2);
+    assert_eq!(turns[0]["role"], "user");
+    assert_eq!(turns[1]["role"], "assistant");
+    assert_eq!(turns[1]["status"], "completed");
+    assert_eq!(turns[1]["text"], "Ran the tests, all green.");
+
+    // The SSE stream replays the current turns.
+    let mut response = client
+        .get(format!("{base}/chat/stream"))
+        .send()
+        .await
+        .expect("sse request");
+    assert_eq!(response.status(), reqwest::StatusCode::OK);
+    let mut buffer = String::new();
+    let mut saw_assistant = false;
+    for _ in 0..20 {
+        let chunk = tokio::time::timeout(Duration::from_secs(5), response.chunk())
+            .await
+            .expect("sse chunk timeout")
+            .expect("sse chunk")
+            .expect("sse stream ended");
+        buffer.push_str(&String::from_utf8_lossy(&chunk));
+        if buffer.contains("Ran the tests, all green.") {
+            saw_assistant = true;
+            break;
+        }
+    }
+    assert!(saw_assistant, "SSE stream should replay the assistant turn");
+}

--- a/scratch/questions.md
+++ b/scratch/questions.md
@@ -1,0 +1,30 @@
+# Open questions — jack-heart.concerto-wavechat
+
+## WaveChat first surface: data source (resolved by best judgment)
+
+The brief assumed `lf wave` writes per-pass logs under `wave/<name>/streams/`
+that WaveChat could parse into turns. That capture was **removed** ("inherit
+terminal instead of teeing passes"): nothing read the streams, and each inner
+`lf -b goal` pass already writes durable logs under the agent's log dir. So
+there is no `streams/` source to parse.
+
+Decision taken (the brief's documented fallback): back `WaveChatView` with a
+small local `WaveChatSource` that reconstructs two turns from the two-file wave
+surface `lf wave` maintains — `GOAL.md` (the operator's directive → opening turn)
+and `MEMORY.md` (the wave's working memory → its reply). A "latest state"
+snapshot, not a live transcript.
+
+## Base branch note
+
+The brief said to open this PR against `jack-heart.lf-loop` (PR #778). By the
+time the slice was ready, #778 had been squash-merged into `main` and its branch
+deleted, so this PR targets `main` instead — which now contains #778.
+
+## Follow-ons (separate PRs, not built here)
+
+- Rust **codex harness** for the wave's inner agent.
+- **Per-wave in-process chat server** exposing streamed `ChatTurn`s.
+- **Live turn updates** in `WaveChatView` (replace the two-file reconstruction).
+- Chat **input/composer** to message a running wave.
+
+`WaveChatSource` is the single seam to swap when the server lands.

--- a/scratch/questions.md
+++ b/scratch/questions.md
@@ -28,3 +28,37 @@ deleted, so this PR targets `main` instead — which now contains #778.
 - Chat **input/composer** to message a running wave.
 
 `WaveChatSource` is the single seam to swap when the server lands.
+
+## WaveChat backend landed (this PR extends #786)
+
+The Rust half of the follow-ons above is now built:
+
+- **Restored** the harness engine (codex/claude/opencode) + conversation `types`
+  + `opencode_runtime` + conformance tests under
+  `rust/loopflow/src/lfd/conversations/`. Analytics (`usage.rs`, usage routes)
+  was intentionally **not** restored.
+- **Built** the per-wave in-process chat server (`conversations/server.rs`) and a
+  `StreamEvent → ChatTurn` builder (`conversations/turns.rs`). `lf wave` now hosts
+  it (`lf/commands/loop.rs`), discovery via `wave/<name>/.chat-endpoint`.
+- **Codex-wired**: inner passes append raw `codex exec --json` to a per-wave sink
+  (`LF_WAVE_EVENT_SINK`, hook in `engine/agent.rs`); a tailer folds it into turns.
+- `POST /chat` → `wave/<name>/MAILBOX.md`, drained into the next pass's prompt
+  (`lf/commands/goal.rs`, `<lf:mailbox>` tag).
+
+### Executive decision: dropped the daemon-era round-trip test
+
+`tests/session_input_round_trip.rs` tested the removed central
+`/v0/conversations` daemon (ConversationManager, HttpState.conversations, store
+persistence). Reviving it would mean reviving the exact central daemon the
+lf-loop model replaced, so it was **not** restored. In its place:
+`tests/wave_chat_server.rs` round-trips the new per-wave contract (discovery,
+`/health`, `/chat`, `POST /chat`, `/chat/stream` SSE, codex ingestion).
+
+### Still stubbed / follow-ons
+
+- Only **codex** is wired to the live sink (claude/opencode harnesses are
+  restored + conformance-tested but not driven by `lf wave` yet).
+- Turn items are summarized from `StreamEvent::ToolUse` (command/file/tool); the
+  richer codex **app-server** item mapping in `codex_mapping.rs` is restored but
+  reserved for a future app-server driver.
+- No cross-pass persistence: turns live in memory for the server's lifetime.

--- a/swift/Concerto/Platform/macOS/Views/MessageRow.swift
+++ b/swift/Concerto/Platform/macOS/Views/MessageRow.swift
@@ -1,0 +1,81 @@
+#if os(macOS)
+import SwiftUI
+import LoopflowCore
+
+/// One turn in a WaveChat transcript. Recovered from the removed Conversations
+/// subsystem and trimmed to what a read-only wave chat needs: role-styled prose
+/// with a selectable assistant body. The reply composer, quote popovers, code-
+/// block segmentation, and streaming cursor were dropped — they belong to the
+/// live per-wave chat server that hasn't landed yet.
+struct MessageRow: View {
+    @Environment(\.palette) private var palette
+    let message: SessionMessage
+    let timestampLabel: String?
+
+    @State private var selectionResetToken = 0
+
+    var body: some View {
+        if message.role == .system {
+            Text(message.content)
+                .font(Typography.caption())
+                .foregroundStyle(palette.textSecondary)
+                .frame(maxWidth: .infinity, alignment: .center)
+                .padding(.vertical, Spacing.xs)
+        } else if message.role == .assistant {
+            messageContent
+                .frame(maxWidth: .infinity, alignment: .leading)
+        } else {
+            HStack(alignment: .top, spacing: Spacing.sm) {
+                accentBar
+                messageContent
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+
+    private var messageContent: some View {
+        VStack(alignment: .leading, spacing: Spacing.xs) {
+            content
+
+            if let timestampLabel {
+                Text(timestampLabel)
+                    .font(Typography.caption(11))
+                    .foregroundStyle(palette.textSecondary)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        if message.role == .assistant {
+            SelectableAssistantMessageTextView(
+                text: message.content,
+                selectionResetToken: selectionResetToken
+            ) { _ in }
+        } else {
+            Text(message.content)
+                .font(Typography.body())
+                .foregroundStyle(message.role == .error ? Color.statusError : palette.text)
+                .textSelection(.enabled)
+        }
+    }
+
+    private var accentBar: some View {
+        RoundedRectangle(cornerRadius: 1.5)
+            .fill(accentColor)
+            .frame(width: 3)
+            .frame(minHeight: Spacing.lg)
+            .accessibilityHidden(true)
+    }
+
+    private var accentColor: Color {
+        switch message.role {
+        case .user: return palette.accent
+        case .assistant: return palette.textSecondary.opacity(0.4)
+        case .error: return Color.statusError
+        case .system: return .clear
+        }
+    }
+}
+
+#endif

--- a/swift/Concerto/Platform/macOS/Views/SelectableAssistantMessageTextView.swift
+++ b/swift/Concerto/Platform/macOS/Views/SelectableAssistantMessageTextView.swift
@@ -1,0 +1,130 @@
+#if os(macOS)
+import SwiftUI
+import AppKit
+
+/// A read-only, text-selectable rendering of an assistant message. Recovered from
+/// the removed Conversations subsystem for WaveChat: it lets the operator select
+/// and copy an assistant turn's prose without the view stealing scroll or growing
+/// unbounded (it sizes to its content).
+struct SelectableAssistantMessageTextView: NSViewRepresentable {
+    let text: String
+    let selectionResetToken: Int
+    let onSelectionChanged: (String?) -> Void
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(onSelectionChanged: onSelectionChanged)
+    }
+
+    func makeNSView(context: Context) -> AutosizingSelectableTextView {
+        let textView = AutosizingSelectableTextView(frame: .zero, textContainer: nil)
+        textView.delegate = context.coordinator
+        textView.string = text
+        return textView
+    }
+
+    func updateNSView(_ nsView: AutosizingSelectableTextView, context: Context) {
+        context.coordinator.onSelectionChanged = onSelectionChanged
+
+        if nsView.string != text {
+            nsView.string = text
+            nsView.invalidateIntrinsicContentSize()
+        }
+
+        if context.coordinator.selectionResetToken != selectionResetToken {
+            context.coordinator.selectionResetToken = selectionResetToken
+            context.coordinator.isResetting = true
+            nsView.setSelectedRange(NSRange(location: 0, length: 0))
+            context.coordinator.isResetting = false
+            onSelectionChanged(nil)
+        }
+    }
+
+    final class Coordinator: NSObject, NSTextViewDelegate {
+        var onSelectionChanged: (String?) -> Void
+        var selectionResetToken = 0
+        var isResetting = false
+
+        init(onSelectionChanged: @escaping (String?) -> Void) {
+            self.onSelectionChanged = onSelectionChanged
+        }
+
+        func textViewDidChangeSelection(_ notification: Notification) {
+            guard !isResetting else { return }
+            guard let textView = notification.object as? NSTextView else { return }
+            let selection = textView.selectedRange()
+            guard selection.length > 0 else {
+                onSelectionChanged(nil)
+                return
+            }
+
+            let fullText = textView.string as NSString
+            guard selection.location + selection.length <= fullText.length else {
+                onSelectionChanged(nil)
+                return
+            }
+
+            let rawSelected = fullText.substring(with: selection)
+            let cleaned = rawSelected.trimmingCharacters(in: .whitespacesAndNewlines)
+            onSelectionChanged(cleaned.isEmpty ? nil : cleaned)
+        }
+    }
+}
+
+final class AutosizingSelectableTextView: NSTextView {
+    override init(frame frameRect: NSRect, textContainer container: NSTextContainer?) {
+        let textStorage = NSTextStorage()
+        let layoutManager = NSLayoutManager()
+        let textContainer = NSTextContainer(size: NSSize(width: frameRect.width, height: .greatestFiniteMagnitude))
+        textContainer.widthTracksTextView = true
+        textContainer.lineFragmentPadding = 0
+
+        textStorage.addLayoutManager(layoutManager)
+        layoutManager.addTextContainer(textContainer)
+
+        super.init(frame: frameRect, textContainer: textContainer)
+
+        isEditable = false
+        isSelectable = true
+        drawsBackground = false
+        isRichText = false
+        allowsUndo = false
+        importsGraphics = false
+        textContainerInset = NSSize(width: 0, height: 0)
+        isVerticallyResizable = true
+        isHorizontallyResizable = false
+        autoresizingMask = [.width]
+
+        font = NSFont(name: "Lato", size: 14) ?? .systemFont(ofSize: 14)
+        textColor = .labelColor
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override var intrinsicContentSize: NSSize {
+        guard let layoutManager, let textContainer else {
+            return super.intrinsicContentSize
+        }
+
+        layoutManager.ensureLayout(for: textContainer)
+        let usedRect = layoutManager.usedRect(for: textContainer)
+        let height = ceil(usedRect.height + textContainerInset.height * 2)
+        return NSSize(width: NSView.noIntrinsicMetric, height: max(20, height))
+    }
+
+    override func layout() {
+        super.layout()
+        invalidateIntrinsicContentSize()
+    }
+
+    override var frame: NSRect {
+        didSet {
+            if oldValue.size.width != frame.size.width {
+                invalidateIntrinsicContentSize()
+            }
+        }
+    }
+}
+
+#endif

--- a/swift/Concerto/Platform/macOS/Views/WaveChatView.swift
+++ b/swift/Concerto/Platform/macOS/Views/WaveChatView.swift
@@ -1,0 +1,80 @@
+#if os(macOS)
+import SwiftUI
+import LoopflowCore
+
+/// WaveChat's first surface: a scrollable transcript of a wave's turns, rendered
+/// with the recovered `MessageRow`. This slice reconstructs the turns from the
+/// wave's on-disk `GOAL.md` + `MEMORY.md` (see `WaveChatSource`) — a "latest
+/// state" snapshot, not a live stream. A per-wave chat server replaces the source
+/// later without touching this view.
+struct WaveChatView: View {
+    let repoPath: String
+    let waveName: String
+
+    @Environment(\.palette) private var palette
+    @State private var turns: [SessionMessage] = []
+    @State private var didLoad = false
+
+    private static let timestampFormatter: RelativeDateTimeFormatter = {
+        let formatter = RelativeDateTimeFormatter()
+        formatter.unitsStyle = .abbreviated
+        return formatter
+    }()
+
+    var body: some View {
+        Group {
+            if turns.isEmpty {
+                emptyState
+            } else {
+                transcript
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(palette.background)
+        .task(id: waveName) {
+            guard !didLoad else { return }
+            // Two small on-disk reads; cheap enough to do inline. A per-wave chat
+            // server replaces this source with a live stream later.
+            turns = WaveChatSource().loadTurns(repoPath: repoPath, waveName: waveName)
+            didLoad = true
+        }
+    }
+
+    private var transcript: some View {
+        ScrollView {
+            LazyVStack(alignment: .leading, spacing: Spacing.lg) {
+                ForEach(turns) { turn in
+                    MessageRow(message: turn, timestampLabel: timestampLabel(for: turn))
+                }
+            }
+            .padding(.horizontal, Spacing.xl)
+            .padding(.vertical, Spacing.lg)
+            .frame(maxWidth: 720, alignment: .leading)
+            .frame(maxWidth: .infinity, alignment: .center)
+        }
+        .accessibilityIdentifier("wave-chat-transcript")
+    }
+
+    private var emptyState: some View {
+        VStack(spacing: Spacing.md) {
+            Image(systemName: "bubble.left.and.bubble.right")
+                .font(Typography.heroTitle(28))
+                .foregroundStyle(palette.textSecondary.opacity(0.5))
+            Text("No conversation yet")
+                .font(Typography.sectionTitle())
+                .foregroundStyle(palette.text)
+            Text("This wave's goal and memory appear here as it runs.")
+                .font(Typography.caption())
+                .foregroundStyle(palette.textSecondary)
+                .multilineTextAlignment(.center)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .padding()
+    }
+
+    private func timestampLabel(for turn: SessionMessage) -> String {
+        Self.timestampFormatter.localizedString(for: turn.timestamp, relativeTo: Date())
+    }
+}
+
+#endif

--- a/swift/Concerto/Platform/macOS/Views/WaveDetailPane.swift
+++ b/swift/Concerto/Platform/macOS/Views/WaveDetailPane.swift
@@ -1,0 +1,55 @@
+#if os(macOS)
+import SwiftUI
+import LoopflowCore
+
+/// The wave detail pane: a header (wave identity + close) over the WaveChat
+/// transcript. WaveChat is the sole detail surface — it replaces the embedded
+/// `/goal` Ghostty terminal that used to live here. The wave itself runs in its
+/// own `lf wave` process; Concerto observes it through WaveChat rather than
+/// hosting the raw terminal.
+struct WaveDetailPane: View {
+    let wave: WaveViewModel
+    let repoPath: String
+    let onClose: () -> Void
+
+    @Environment(\.palette) private var palette
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            Divider()
+            WaveChatView(repoPath: repoPath, waveName: wave.name)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+    }
+
+    private var header: some View {
+        HStack(spacing: Spacing.sm) {
+            Image(systemName: wave.statusIndicator.icon)
+                .foregroundStyle(wave.statusIndicator.color)
+            Text(wave.displayName)
+                .font(Typography.sectionTitle())
+                .foregroundStyle(palette.text)
+            Text("WaveChat")
+                .font(Typography.caption())
+                .foregroundStyle(palette.textSecondary)
+
+            Spacer()
+
+            Button {
+                onClose()
+            } label: {
+                Image(systemName: "xmark")
+                    .font(Typography.caption())
+                    .foregroundStyle(palette.textSecondary)
+            }
+            .buttonStyle(.plain)
+            .help("Close wave")
+            .accessibilityLabel("Close wave")
+        }
+        .padding(.horizontal, Spacing.xl)
+        .padding(.vertical, Spacing.md)
+    }
+}
+
+#endif

--- a/swift/Concerto/Platform/macOS/Views/WavesView.swift
+++ b/swift/Concerto/Platform/macOS/Views/WavesView.swift
@@ -1,9 +1,9 @@
 // The exposed main window: a burgundy repo rail (left) filtering a burgundy wave
-// list (center), with a "+" new-wave launcher, and a terminal detail (right) that
-// attaches the selected wave's /goal agent in an embedded tmux session.
+// list (center), with a "+" new-wave launcher, and a WaveChat detail (right) that
+// shows the selected wave's chat transcript.
 //
 // Reshaped from the battle-tested PortfolioWindow: keeps its connection / daemon /
-// EventService plumbing, swaps the multi-repo card grid for the sidebar+list+terminal
+// EventService plumbing, swaps the multi-repo card grid for the sidebar+list+detail
 // shape sketched by RepoSidebarWindow, and reuses WaveRow + WaveSidebar's burgundy
 // treatment so the style matches the app.
 
@@ -128,7 +128,7 @@ struct WavesView: View {
 
             Divider()
 
-            terminalDetail
+            waveDetail
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
                 .background(palette.background)
         }
@@ -335,46 +335,31 @@ struct WavesView: View {
         .padding()
     }
 
-    // MARK: - Terminal detail
+    // MARK: - Wave detail (WaveChat)
 
     @ViewBuilder
-    private var terminalDetail: some View {
-        if let wave = selectedWave, let state = repoState(for: wave) {
-            WaveAgentTerminalPane(
+    private var waveDetail: some View {
+        if let wave = selectedWave {
+            WaveDetailPane(
                 wave: wave,
-                attach: { _ in try await launchOrAttach(wave: wave, state: state) },
+                repoPath: wave.repo,
                 onClose: { selectedWaveId = nil }
             )
             .id(wave.id)
         } else {
             VStack(spacing: Spacing.md) {
-                Image(systemName: "terminal")
+                Image(systemName: "bubble.left.and.bubble.right")
                     .font(Typography.heroTitle(28))
                     .foregroundStyle(palette.textSecondary.opacity(0.5))
                 Text("Select a wave")
                     .font(Typography.sectionTitle())
                     .foregroundStyle(palette.text)
-                Text("Its /goal agent opens here in an embedded terminal.")
+                Text("Its WaveChat opens here.")
                     .font(Typography.caption())
                     .foregroundStyle(palette.textSecondary)
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
-    }
-
-    /// Attach the wave's /goal agent through local `lf goal --tmux`. The returned
-    /// tmux handle is enough for Ghostty to attach; no lfd run/attach route needed.
-    private func launchOrAttach(wave: WaveViewModel, state: PortfolioRepoState) async throws -> SessionConnectionInfo {
-        let connection = try await state.attachWaveAgent(waveName: wave.name)
-        await refreshAuthoredWaves()
-        return connection
-    }
-
-    private func repoState(for wave: WaveViewModel) -> PortfolioRepoState? {
-        repoStates[wave.repo.normalizedFilePath]
-            ?? repoStates.values.first { state in
-                state.waves.contains { $0.id == wave.id }
-            }
     }
 
     // MARK: - Header helpers
@@ -643,88 +628,6 @@ struct WavesView: View {
 
         case .worktree, .agentStarted, .agentEnded, .output, .attention, .terminalSession, .secrets:
             break
-        }
-    }
-}
-
-/// Embedded terminal for a wave's /goal agent: ensures the agent is running,
-/// resolves its tmux session, and attaches via GhosttyTerminalView. Mirrors the
-/// proven attach flow in TerminalWorkspaceView's SessionTerminalSurface.
-private struct WaveAgentTerminalPane: View {
-    let wave: WaveViewModel
-    let attach: (String) async throws -> SessionConnectionInfo
-    let onClose: () -> Void
-
-    @Environment(\.palette) private var palette
-    @ObservedObject private var ghosttyManager = GhosttyManager.shared
-    @State private var connectionInfo: SessionConnectionInfo?
-    @State private var errorMessage: String?
-
-    var body: some View {
-        VStack(spacing: 0) {
-            header
-            Divider()
-            terminal
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
-                .background(LoopflowPalette.dark.background)
-        }
-        .task(id: wave.id) {
-            guard connectionInfo == nil else { return }
-            if RepoState.uiTestMode() != nil { return }
-            do {
-                connectionInfo = try await attach(wave.id)
-                errorMessage = nil
-            } catch {
-                errorMessage = error.localizedDescription
-            }
-        }
-    }
-
-    private var header: some View {
-        HStack(spacing: Spacing.sm) {
-            Image(systemName: wave.statusIndicator.icon)
-                .foregroundStyle(wave.statusIndicator.color)
-            Text(wave.displayName)
-                .font(Typography.sectionTitle())
-                .foregroundStyle(palette.text)
-            Text("/goal agent")
-                .font(Typography.caption())
-                .foregroundStyle(palette.textSecondary)
-            Spacer()
-            Button {
-                onClose()
-            } label: {
-                Image(systemName: "xmark")
-                    .font(Typography.caption())
-                    .foregroundStyle(palette.textSecondary)
-            }
-            .buttonStyle(.plain)
-            .help("Close terminal")
-        }
-        .padding(.horizontal, Spacing.xl)
-        .padding(.vertical, Spacing.md)
-    }
-
-    @ViewBuilder
-    private var terminal: some View {
-        if let command = connectionInfo.map(TerminalAttachCommand.init) {
-            GhosttyTerminalView(
-                workingDirectory: command.workingDirectory,
-                argv: command.argv,
-                env: command.env,
-                sessionId: "wave-agent-\(wave.id)",
-                manager: ghosttyManager
-            )
-        } else if let errorMessage {
-            ContentUnavailableView(
-                "Terminal unavailable",
-                systemImage: "exclamationmark.triangle",
-                description: Text(errorMessage)
-            )
-        } else {
-            ProgressView("Starting /goal agent…")
-                .tint(.white)
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
     }
 }

--- a/swift/LoopflowCore/Services/WaveChatSource.swift
+++ b/swift/LoopflowCore/Services/WaveChatSource.swift
@@ -1,0 +1,56 @@
+import Foundation
+
+/// Reads a wave's chat turns from the best on-disk source available today.
+///
+/// There is no per-wave chat server yet, so this backs WaveChat with the two-file
+/// wave surface `lf wave` already maintains: `wave/<name>/GOAL.md` (the operator's
+/// standing directive) becomes the opening turn, and `wave/<name>/MEMORY.md` (the
+/// wave's working memory — what the latest passes learned and did) becomes the
+/// wave's reply. It's a faithful "latest state" snapshot, not a live transcript.
+///
+// TODO(wavechat): back with codex harness + per-wave chat server. Once each
+// `lf wave <name>` process hosts an in-process chat API, load real streamed
+// ChatTurns instead of reconstructing two turns from GOAL.md + MEMORY.md.
+public struct WaveChatSource: Sendable {
+    public init() {}
+
+    /// Load the wave's turns from `<repoPath>/wave/<waveName>/`. Returns an empty
+    /// list when neither file exists — the caller renders an empty state.
+    public func loadTurns(repoPath: String, waveName: String) -> [SessionMessage] {
+        let waveDir = URL(fileURLWithPath: repoPath)
+            .appendingPathComponent("wave", isDirectory: true)
+            .appendingPathComponent(waveName, isDirectory: true)
+
+        var turns: [SessionMessage] = []
+
+        if let goal = readTurn(waveDir.appendingPathComponent("GOAL.md"), stripFrontmatter: true) {
+            turns.append(SessionMessage(role: .user, content: goal.body, timestamp: goal.modified))
+        }
+        if let memory = readTurn(waveDir.appendingPathComponent("MEMORY.md"), stripFrontmatter: false) {
+            turns.append(SessionMessage(role: .assistant, content: memory.body, timestamp: memory.modified))
+        }
+
+        return turns
+    }
+
+    private func readTurn(_ url: URL, stripFrontmatter: Bool) -> (body: String, modified: Date)? {
+        guard let raw = try? String(contentsOf: url, encoding: .utf8) else { return nil }
+        let body = (stripFrontmatter ? Self.stripFrontmatter(raw) : raw)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !body.isEmpty else { return nil }
+        let modified = (try? url.resourceValues(forKeys: [.contentModificationDateKey]))?
+            .contentModificationDate ?? Date()
+        return (body, modified)
+    }
+
+    /// Drop a leading `---`-fenced YAML frontmatter block, if present.
+    static func stripFrontmatter(_ text: String) -> String {
+        guard text.hasPrefix("---") else { return text }
+        let lines = text.components(separatedBy: "\n")
+        guard lines.first?.trimmingCharacters(in: .whitespaces) == "---" else { return text }
+        for index in 1..<lines.count where lines[index].trimmingCharacters(in: .whitespaces) == "---" {
+            return lines[(index + 1)...].joined(separator: "\n")
+        }
+        return text
+    }
+}


### PR DESCRIPTION
## Usage

```bash
lf wave <name>            # hosts a chat server in-process alongside the loop

PORT=$(cat wave/<name>/.chat-endpoint)
curl "http://$PORT/chat"             # { "wave", "turns": [ChatTurn, …] }
curl -N "http://$PORT/chat/stream"   # SSE: replay current turns, then live
curl -X POST "http://$PORT/chat" \
  -H 'Content-Type: application/json' \
  -d '{"text":"also check the tests"}'
```

In Concerto, selecting a wave opens WaveChat as its detail surface — a live transcript of the wave's passes with a message box that talks back to the loop.

## Summary

`lf wave` now owns and hosts a per-wave chat server in-process. Each inner pass streams its raw agent stream-json to a per-wave NDJSON sink (via `LF_WAVE_EVENT_SINK`); a tailer folds that into `ChatTurn`s the server streams to Concerto over SSE. Operators can post messages back: `POST /chat` records a user turn and appends to `wave/<name>/MAILBOX.md`, which the next goal pass drains into its prompt under an `<lf:mailbox>` tag and clears, so each message is delivered exactly once. This closes the loop between the running wave and the human watching it.

## Changes

- New `lfd/conversations/` engine: vendor harnesses (claude/codex/opencode) that map raw agent output into `ConversationItem`s/`ConversationEvent`s, pinned against captured traces by conformance tests; `turns.rs` folds a live stream into `ChatTurn`s; `server.rs` is the per-wave HTTP + SSE chat server
- `lf wave` brings up the chat server before the first pass, tails the event sink on a plain polling thread, and publishes `host:port` to `wave/<name>/.chat-endpoint`
- `engine::agent` appends every raw stdout line to the sink when `LF_WAVE_EVENT_SINK` is set (best-effort, independent of terminal rendering)
- `lf goal` drains `MAILBOX.md` into the pass prompt as high-priority operator direction, then truncates it
- Concerto: WaveChatView / MessageRow / WaveDetailPane and a `WaveChatSource` service wire the chat server into the wave detail pane