### PR TITLE
lfd: repo-grain token usage + `lf usage` command

### DIFF
--- a/rust/loopflow/src/bin/lf.rs
+++ b/rust/loopflow/src/bin/lf.rs
@@ -44,7 +44,7 @@ const BOOL_FLAGS: &[&str] = &[
 ];
 
 /// Known subcommands that should not be treated as step names.
-const KNOWN_COMMANDS: &[&str] = &[":", "op", "goal", "wave", "loop", "help"];
+const KNOWN_COMMANDS: &[&str] = &[":", "op", "goal", "wave", "loop", "usage", "help"];
 
 fn is_value_flag(arg: &str) -> bool {
     VALUE_FLAGS.contains(&arg)
@@ -303,6 +303,7 @@ fn main() -> anyhow::Result<()> {
         Some(Commands::Wave { name }) => {
             in_repo_runtime(&args, |_| loopflow::lf::commands::r#loop::run(name))
         }
+        Some(Commands::Usage) => loopflow::lf::commands::usage::run(),
         Some(Commands::External(external_args)) => {
             let (name, step_args) = loopflow::lf::commands::run::split_step_args(external_args)?;
             let message = join_args(&step_args);

--- a/rust/loopflow/src/lf/commands/mod.rs
+++ b/rust/loopflow/src/lf/commands/mod.rs
@@ -5,4 +5,5 @@ pub mod list;
 pub mod r#loop;
 pub mod ops;
 pub mod run;
+pub mod usage;
 pub mod util;

--- a/rust/loopflow/src/lf/commands/usage.rs
+++ b/rust/loopflow/src/lf/commands/usage.rs
@@ -1,0 +1,191 @@
+use std::time::Duration;
+
+use anyhow::{anyhow, Result};
+
+use crate::lf::output::Colors;
+use crate::lfd::client::{authorize, blocking_client, resolve_base_url};
+use crate::lfd::http::dto::{ProviderUsageDto, RepoProviderUsageDto, UsageReportDto};
+
+const FETCH_TIMEOUT: Duration = Duration::from_secs(10);
+const REPO_WIDTH: usize = 32;
+const PROVIDER_WIDTH: usize = 12;
+const NUM_WIDTH: usize = 14;
+
+/// Fetch token usage from a running `lfd` and print a repo x provider table
+/// with per-provider and grand-total rollups.
+pub fn run() -> Result<()> {
+    let report = fetch_report()?;
+    print_report(&report);
+    Ok(())
+}
+
+fn fetch_report() -> Result<UsageReportDto> {
+    let client = blocking_client(FETCH_TIMEOUT)?;
+    let url = format!("{}/v0/usage", resolve_base_url());
+    let response = authorize(client.get(&url))
+        .send()
+        .map_err(|err| anyhow!("failed to reach lfd at {url}: {err}"))?;
+    if !response.status().is_success() {
+        return Err(anyhow!(
+            "lfd returned status {} for {url}",
+            response.status()
+        ));
+    }
+    response
+        .json::<UsageReportDto>()
+        .map_err(|err| anyhow!("failed to parse usage report: {err}"))
+}
+
+fn print_report(report: &UsageReportDto) {
+    let colors = Colors::default();
+
+    if report.by_repo_provider.is_empty() {
+        println!("No token usage recorded yet.");
+        return;
+    }
+
+    print_repo_header(&colors);
+    let (mut grand_input, mut grand_output) = (0u64, 0u64);
+    for row in &report.by_repo_provider {
+        print_repo_row(row);
+        grand_input += row.input_tokens;
+        grand_output += row.output_tokens;
+    }
+    println!();
+
+    print_provider_header(&colors);
+    for row in &report.by_provider {
+        print_provider_row(row);
+    }
+    println!();
+
+    print_total_row(&colors, grand_input, grand_output);
+}
+
+fn print_repo_header(colors: &Colors) {
+    println!(
+        "{bold}{repo:<repo_w$}  {provider:<prov_w$}  {input:>num_w$}  {output:>num_w$}  {total:>num_w$}{reset}",
+        bold = colors.bold,
+        reset = colors.reset,
+        repo = "REPO",
+        provider = "PROVIDER",
+        input = "INPUT",
+        output = "OUTPUT",
+        total = "TOTAL",
+        repo_w = REPO_WIDTH,
+        prov_w = PROVIDER_WIDTH,
+        num_w = NUM_WIDTH,
+    );
+}
+
+fn print_repo_row(row: &RepoProviderUsageDto) {
+    let repo = row.repo.as_deref().unwrap_or("(unattributed)");
+    let total = row.input_tokens + row.output_tokens;
+    println!(
+        "{repo:<repo_w$}  {provider:<prov_w$}  {input:>num_w$}  {output:>num_w$}  {total:>num_w$}",
+        repo = truncate(&short_repo(repo), REPO_WIDTH),
+        provider = row.provider,
+        input = format_int(row.input_tokens),
+        output = format_int(row.output_tokens),
+        total = format_int(total),
+        repo_w = REPO_WIDTH,
+        prov_w = PROVIDER_WIDTH,
+        num_w = NUM_WIDTH,
+    );
+}
+
+fn print_provider_header(colors: &Colors) {
+    println!(
+        "{bold}{provider:<prov_w$}  {input:>num_w$}  {output:>num_w$}  {total:>num_w$}{reset}",
+        bold = colors.bold,
+        reset = colors.reset,
+        provider = "PROVIDER",
+        input = "INPUT",
+        output = "OUTPUT",
+        total = "TOTAL",
+        prov_w = PROVIDER_WIDTH,
+        num_w = NUM_WIDTH,
+    );
+}
+
+fn print_provider_row(row: &ProviderUsageDto) {
+    let total = row.input_tokens + row.output_tokens;
+    println!(
+        "{provider:<prov_w$}  {input:>num_w$}  {output:>num_w$}  {total:>num_w$}",
+        provider = row.provider,
+        input = format_int(row.input_tokens),
+        output = format_int(row.output_tokens),
+        total = format_int(total),
+        prov_w = PROVIDER_WIDTH,
+        num_w = NUM_WIDTH,
+    );
+}
+
+fn print_total_row(colors: &Colors, input: u64, output: u64) {
+    println!(
+        "{bold}{label:<prov_w$}  {input:>num_w$}  {output:>num_w$}  {total:>num_w$}{reset}",
+        bold = colors.bold,
+        reset = colors.reset,
+        label = "TOTAL",
+        input = format_int(input),
+        output = format_int(output),
+        total = format_int(input + output),
+        prov_w = PROVIDER_WIDTH,
+        num_w = NUM_WIDTH,
+    );
+}
+
+/// Show just the final path component when the repo is an absolute path, so
+/// the table stays scannable; keep short names or slugs verbatim.
+fn short_repo(repo: &str) -> String {
+    repo.rsplit('/')
+        .find(|segment| !segment.is_empty())
+        .unwrap_or(repo)
+        .to_string()
+}
+
+fn truncate(value: &str, width: usize) -> String {
+    if value.chars().count() <= width {
+        return value.to_string();
+    }
+    let head: String = value.chars().take(width.saturating_sub(1)).collect();
+    format!("{head}\u{2026}")
+}
+
+fn format_int(value: u64) -> String {
+    let digits = value.to_string();
+    let mut out = String::new();
+    for (idx, ch) in digits.chars().rev().enumerate() {
+        if idx > 0 && idx % 3 == 0 {
+            out.push(',');
+        }
+        out.push(ch);
+    }
+    out.chars().rev().collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{format_int, short_repo, truncate};
+
+    #[test]
+    fn format_int_groups_thousands() {
+        assert_eq!(format_int(0), "0");
+        assert_eq!(format_int(999), "999");
+        assert_eq!(format_int(1_000), "1,000");
+        assert_eq!(format_int(1_234_567), "1,234,567");
+    }
+
+    #[test]
+    fn short_repo_takes_last_path_segment() {
+        assert_eq!(short_repo("/Users/jack/src/loopflow"), "loopflow");
+        assert_eq!(short_repo("loopflow"), "loopflow");
+        assert_eq!(short_repo("/Users/jack/src/cadenza/"), "cadenza");
+    }
+
+    #[test]
+    fn truncate_adds_ellipsis_past_width() {
+        assert_eq!(truncate("short", 10), "short");
+        assert_eq!(truncate("abcdefghij", 5), "abcd\u{2026}");
+    }
+}

--- a/rust/loopflow/src/lf/mod.rs
+++ b/rust/loopflow/src/lf/mod.rs
@@ -154,6 +154,8 @@ pub enum Commands {
         /// Wave name (matches wave/<name>/)
         name: String,
     },
+    /// Show token usage by repo and provider (from a running lfd)
+    Usage,
     /// External: step/flow name (when no subcommand matches)
     #[command(external_subcommand)]
     External(Vec<String>),

--- a/rust/loopflow/src/lfd/executor/wave/mod.rs
+++ b/rust/loopflow/src/lfd/executor/wave/mod.rs
@@ -714,6 +714,7 @@ impl WaveExecutor {
         let usage = RunTokenUsage {
             run_id: run.id.clone(),
             wave: run.wave_id.clone(),
+            repo: Some(run.repo.clone()),
             provider: provider.to_string(),
             model: None,
             input_tokens: totals.input_tokens,

--- a/rust/loopflow/src/lfd/http/dto.rs
+++ b/rust/loopflow/src/lfd/http/dto.rs
@@ -3,6 +3,7 @@ use std::collections::{BTreeMap, HashMap};
 use time::OffsetDateTime;
 
 use crate::lfd::queue::QueueRunView;
+use crate::lfd::store::TokenUsageReport;
 use crate::lfd::types::{
     ActivationLog, AttentionItem, ChatMemoryBlock, ChatMessage, LivePullRequestState, Run,
     RunStatus, Session, Trigger, WaveCron,
@@ -543,6 +544,82 @@ pub struct WorktreeDto {
     pub prunable: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub wave_id: Option<String>,
+}
+
+/// Token usage summed for one (repo, provider) pair. `repo` is Optional
+/// because usage rows recorded before the repo dimension existed carry none.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct RepoProviderUsageDto {
+    pub repo: Option<String>,
+    pub provider: String,
+    pub input_tokens: u64,
+    pub output_tokens: u64,
+    pub cache_read_tokens: u64,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct WaveProviderUsageDto {
+    pub wave_id: String,
+    pub provider: String,
+    pub input_tokens: u64,
+    pub output_tokens: u64,
+    pub cache_read_tokens: u64,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ProviderUsageDto {
+    pub provider: String,
+    pub input_tokens: u64,
+    pub output_tokens: u64,
+    pub cache_read_tokens: u64,
+}
+
+/// Aggregated token usage across the whole store: per (repo, provider), per
+/// (wave, provider), and per-provider rollups.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct UsageReportDto {
+    pub object: String,
+    pub by_repo_provider: Vec<RepoProviderUsageDto>,
+    pub by_wave_provider: Vec<WaveProviderUsageDto>,
+    pub by_provider: Vec<ProviderUsageDto>,
+}
+
+pub fn usage_report_dto(report: TokenUsageReport) -> UsageReportDto {
+    UsageReportDto {
+        object: "usage_report".to_string(),
+        by_repo_provider: report
+            .by_repo_provider
+            .into_iter()
+            .map(|row| RepoProviderUsageDto {
+                repo: row.repo,
+                provider: row.provider,
+                input_tokens: row.input_tokens,
+                output_tokens: row.output_tokens,
+                cache_read_tokens: row.cache_read_tokens,
+            })
+            .collect(),
+        by_wave_provider: report
+            .by_wave_provider
+            .into_iter()
+            .map(|row| WaveProviderUsageDto {
+                wave_id: row.wave.to_string(),
+                provider: row.provider,
+                input_tokens: row.input_tokens,
+                output_tokens: row.output_tokens,
+                cache_read_tokens: row.cache_read_tokens,
+            })
+            .collect(),
+        by_provider: report
+            .by_provider
+            .into_iter()
+            .map(|row| ProviderUsageDto {
+                provider: row.provider,
+                input_tokens: row.input_tokens,
+                output_tokens: row.output_tokens,
+                cache_read_tokens: row.cache_read_tokens,
+            })
+            .collect(),
+    }
 }
 
 #[derive(Debug, Clone, Serialize)]

--- a/rust/loopflow/src/lfd/http/mod.rs
+++ b/rust/loopflow/src/lfd/http/mod.rs
@@ -15,7 +15,7 @@ use crate::lfd::auth;
 use crate::lfd::http::dto::{ErrorDetail, ErrorResponse};
 use crate::lfd::http::routes::{
     attention, auth as auth_routes, catalog, flows, hooks, providers, repos, runs,
-    session_controls, system, waves, worktrees, ws,
+    session_controls, system, usage, waves, worktrees, ws,
 };
 use crate::lfd::redaction::sanitize_operator_message;
 use crate::lfd::store::StoreError;
@@ -180,6 +180,7 @@ pub fn router(state: HttpState) -> Router {
         )
         .route("/waves/{wave_id}/logs", get(runs::wave_logs_handler))
         .route("/runs", get(runs::list_runs_handler))
+        .route("/usage", get(usage::usage_handler))
         .route("/worktrees", get(worktrees::list_worktrees_handler))
         .layer(DefaultBodyLimit::max(max_json_body_bytes))
         .route_layer(middleware::from_fn_with_state(

--- a/rust/loopflow/src/lfd/http/routes/mod.rs
+++ b/rust/loopflow/src/lfd/http/routes/mod.rs
@@ -9,6 +9,7 @@ pub mod runs;
 pub mod secrets;
 pub mod session_controls;
 pub mod system;
+pub mod usage;
 pub mod wave_config;
 pub mod waves;
 pub mod worktrees;

--- a/rust/loopflow/src/lfd/http/routes/usage.rs
+++ b/rust/loopflow/src/lfd/http/routes/usage.rs
@@ -1,0 +1,17 @@
+use axum::extract::State;
+use axum::Json;
+
+use crate::lfd::http::dto::{usage_report_dto, UsageReportDto};
+use crate::lfd::http::state::HttpState;
+use crate::lfd::http::{map_store_error, ApiResult};
+
+/// Aggregated token usage across every recorded run, grouped by repo/provider,
+/// wave/provider, and provider. The attribution primitive for cross-repo spend.
+pub async fn usage_handler(State(state): State<HttpState>) -> ApiResult<UsageReportDto> {
+    let report = state
+        .store
+        .aggregate_token_usage()
+        .await
+        .map_err(map_store_error)?;
+    Ok(Json(usage_report_dto(report)))
+}

--- a/rust/loopflow/src/lfd/store/catalog.rs
+++ b/rust/loopflow/src/lfd/store/catalog.rs
@@ -83,6 +83,7 @@ pub(crate) enum Query {
     ListChildWaves,
     RecordRunTokenUsage,
     AggregateTokenUsageByWaveProvider,
+    AggregateTokenUsageByRepoProvider,
 }
 
 impl Query {
@@ -161,10 +162,11 @@ impl Query {
         Self::ListChildWaves,
         Self::RecordRunTokenUsage,
         Self::AggregateTokenUsageByWaveProvider,
+        Self::AggregateTokenUsageByRepoProvider,
     ];
 }
 
-const QUERY_COUNT: usize = Query::AggregateTokenUsageByWaveProvider as usize + 1;
+const QUERY_COUNT: usize = Query::AggregateTokenUsageByRepoProvider as usize + 1;
 
 #[derive(Debug, Clone, Copy)]
 struct QueryDef {
@@ -558,7 +560,7 @@ const QUERY_DEFS: [QueryDef; QUERY_COUNT] = [
     },
     // RecordRunTokenUsage — one row per run, replaced if re-recorded.
     QueryDef {
-        template: "INSERT INTO run_token_usage (\n                run_id, wave, provider, model, input_tokens, output_tokens, cache_read_tokens, recorded_at\n            ) VALUES ({p1}, {p2}, {p3}, {p4}, {p5}, {p6}, {p7}, {p8})\n            ON CONFLICT(run_id) DO UPDATE SET\n                wave = excluded.wave,\n                provider = excluded.provider,\n                model = excluded.model,\n                input_tokens = excluded.input_tokens,\n                output_tokens = excluded.output_tokens,\n                cache_read_tokens = excluded.cache_read_tokens,\n                recorded_at = excluded.recorded_at",
+        template: "INSERT INTO run_token_usage (\n                run_id, wave, provider, model, input_tokens, output_tokens, cache_read_tokens, recorded_at, repo\n            ) VALUES ({p1}, {p2}, {p3}, {p4}, {p5}, {p6}, {p7}, {p8}, {p9})\n            ON CONFLICT(run_id) DO UPDATE SET\n                wave = excluded.wave,\n                provider = excluded.provider,\n                model = excluded.model,\n                input_tokens = excluded.input_tokens,\n                output_tokens = excluded.output_tokens,\n                cache_read_tokens = excluded.cache_read_tokens,\n                recorded_at = excluded.recorded_at,\n                repo = excluded.repo",
         sqlite_override: None,
         postgres_override: None,
     },
@@ -566,6 +568,14 @@ const QUERY_DEFS: [QueryDef; QUERY_COUNT] = [
     // CAST keeps postgres SUM(BIGINT) (NUMERIC) readable as i64, matching sqlite.
     QueryDef {
         template: "SELECT wave, provider,\n                    CAST(COALESCE(SUM(input_tokens), 0) AS BIGINT),\n                    CAST(COALESCE(SUM(output_tokens), 0) AS BIGINT),\n                    CAST(COALESCE(SUM(cache_read_tokens), 0) AS BIGINT)\n             FROM run_token_usage\n             GROUP BY wave, provider\n             ORDER BY wave, provider",
+        sqlite_override: None,
+        postgres_override: None,
+    },
+    // AggregateTokenUsageByRepoProvider — totals grouped by repo and provider.
+    // repo is nullable (rows recorded before migration 043 have NULL); NULLs
+    // group together. CAST mirrors the wave/provider aggregate above.
+    QueryDef {
+        template: "SELECT repo, provider,\n                    CAST(COALESCE(SUM(input_tokens), 0) AS BIGINT),\n                    CAST(COALESCE(SUM(output_tokens), 0) AS BIGINT),\n                    CAST(COALESCE(SUM(cache_read_tokens), 0) AS BIGINT)\n             FROM run_token_usage\n             GROUP BY repo, provider\n             ORDER BY repo, provider",
         sqlite_override: None,
         postgres_override: None,
     },

--- a/rust/loopflow/src/lfd/store/migrations.rs
+++ b/rust/loopflow/src/lfd/store/migrations.rs
@@ -194,6 +194,10 @@ const ALL_MIGRATIONS: &[Migration] = &[
         version: "045_run_token_usage",
         sql: include_str!("migrations/045_run_token_usage.sql"),
     },
+    Migration {
+        version: "046_run_token_usage_repo",
+        sql: include_str!("migrations/046_run_token_usage_repo.sql"),
+    },
 ];
 
 /// Migrations applicable to a backend. Currently returns all migrations

--- a/rust/loopflow/src/lfd/store/migrations/046_run_token_usage_repo.sql
+++ b/rust/loopflow/src/lfd/store/migrations/046_run_token_usage_repo.sql
@@ -1,0 +1,4 @@
+ALTER TABLE run_token_usage ADD COLUMN repo TEXT;
+
+CREATE INDEX IF NOT EXISTS idx_run_token_usage_repo_provider
+ON run_token_usage(repo, provider);

--- a/rust/loopflow/src/lfd/store/mod.rs
+++ b/rust/loopflow/src/lfd/store/mod.rs
@@ -47,12 +47,14 @@ pub struct ForkRun {
     pub worktree: String,
 }
 
-/// Token usage recorded for a single run, tagged with the wave it belongs to
-/// and the provider (agent) that generated it.
+/// Token usage recorded for a single run, tagged with the wave and repo it
+/// belongs to and the provider (agent) that generated it. `repo` is optional
+/// because rows recorded before migration 043 carry no repo.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RunTokenUsage {
     pub run_id: LfdId,
     pub wave: LfdId,
+    pub repo: Option<String>,
     pub provider: String,
     pub model: Option<String>,
     pub input_tokens: u64,
@@ -71,6 +73,17 @@ pub struct WaveProviderUsage {
     pub cache_read_tokens: u64,
 }
 
+/// Summed token usage for one (repo, provider) pair. `repo` is optional to
+/// account for usage rows recorded before the repo dimension existed.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RepoProviderUsage {
+    pub repo: Option<String>,
+    pub provider: String,
+    pub input_tokens: u64,
+    pub output_tokens: u64,
+    pub cache_read_tokens: u64,
+}
+
 /// Summed token usage for one provider across all waves.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ProviderUsage {
@@ -80,17 +93,23 @@ pub struct ProviderUsage {
     pub cache_read_tokens: u64,
 }
 
-/// Aggregated token usage: per (wave, provider) plus per-provider rollups.
+/// Aggregated token usage: per (repo, provider), per (wave, provider), plus
+/// per-provider rollups.
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct TokenUsageReport {
+    pub by_repo_provider: Vec<RepoProviderUsage>,
     pub by_wave_provider: Vec<WaveProviderUsage>,
     pub by_provider: Vec<ProviderUsage>,
 }
 
 impl TokenUsageReport {
-    /// Build the report from the per-(wave, provider) rows, folding the
-    /// per-provider totals. Rows are assumed to be one per (wave, provider).
-    pub fn from_wave_provider(by_wave_provider: Vec<WaveProviderUsage>) -> Self {
+    /// Build the report from the per-(repo, provider) and per-(wave, provider)
+    /// grouped rows, folding the per-provider totals from the wave rows. Rows
+    /// are assumed to be one per group.
+    pub fn from_grouped(
+        by_repo_provider: Vec<RepoProviderUsage>,
+        by_wave_provider: Vec<WaveProviderUsage>,
+    ) -> Self {
         let mut by_provider: Vec<ProviderUsage> = Vec::new();
         for row in &by_wave_provider {
             match by_provider
@@ -111,6 +130,7 @@ impl TokenUsageReport {
             }
         }
         Self {
+            by_repo_provider,
             by_wave_provider,
             by_provider,
         }
@@ -2662,6 +2682,7 @@ mod tests {
             .record_run_usage(&RunTokenUsage {
                 run_id: claude_run.id.clone(),
                 wave: wave.id().clone(),
+                repo: Some(wave.repo().to_string()),
                 provider: "claude".to_string(),
                 model: Some("claude-opus-4-8".to_string()),
                 input_tokens: 100,
@@ -2675,6 +2696,7 @@ mod tests {
             .record_run_usage(&RunTokenUsage {
                 run_id: codex_run.id.clone(),
                 wave: wave.id().clone(),
+                repo: Some(wave.repo().to_string()),
                 provider: "codex".to_string(),
                 model: None,
                 input_tokens: 200,
@@ -2726,6 +2748,7 @@ mod tests {
             .record_run_usage(&RunTokenUsage {
                 run_id: claude_run.id.clone(),
                 wave: wave.id().clone(),
+                repo: Some(wave.repo().to_string()),
                 provider: "claude".to_string(),
                 model: None,
                 input_tokens: 10,
@@ -2746,6 +2769,77 @@ mod tests {
             .expect("claude row after replace");
         assert_eq!(claude.input_tokens, 10);
         assert_eq!(claude.cache_read_tokens, 0);
+    }
+
+    #[tokio::test]
+    async fn token_usage_aggregates_by_repo_and_provider() {
+        let db_path = env::temp_dir().join(format!("lfd-test-{}.db", LfdId::new()));
+        let config = StorageConfig::sqlite(db_path);
+        let store = super::open_store(&config).await.expect("store should open");
+
+        // Two runs in one repo (different providers) plus a run in a second repo.
+        let wave_a = make_wave("/repo-alpha");
+        let wave_b = make_wave("/repo-beta");
+        store.create_wave(&wave_a).await.expect("create wave a");
+        store.create_wave(&wave_b).await.expect("create wave b");
+        let alpha_claude = make_run(&wave_a, RunStatus::Completed);
+        let alpha_codex = make_run(&wave_a, RunStatus::Completed);
+        let beta_claude = make_run(&wave_b, RunStatus::Completed);
+        store.create_run(&alpha_claude).await.expect("create run");
+        store.create_run(&alpha_codex).await.expect("create run");
+        store.create_run(&beta_claude).await.expect("create run");
+
+        for (run, wave, provider, input, output, cache) in [
+            (&alpha_claude, &wave_a, "claude", 100u64, 50u64, 10u64),
+            (&alpha_codex, &wave_a, "codex", 200, 80, 0),
+            (&beta_claude, &wave_b, "claude", 300, 100, 5),
+        ] {
+            store
+                .record_run_usage(&RunTokenUsage {
+                    run_id: run.id.clone(),
+                    wave: wave.id().clone(),
+                    repo: Some(wave.repo().to_string()),
+                    provider: provider.to_string(),
+                    model: None,
+                    input_tokens: input,
+                    output_tokens: output,
+                    cache_read_tokens: cache,
+                    recorded_at: OffsetDateTime::now_utc().unix_timestamp(),
+                })
+                .await
+                .expect("record usage");
+        }
+
+        let report = store.aggregate_token_usage().await.expect("aggregate");
+
+        // Three (repo, provider) groups: (alpha, claude), (alpha, codex), (beta, claude).
+        assert_eq!(report.by_repo_provider.len(), 3);
+        let find = |repo: &str, provider: &str| {
+            report
+                .by_repo_provider
+                .iter()
+                .find(|row| row.repo.as_deref() == Some(repo) && row.provider == provider)
+                .expect("repo/provider row")
+        };
+        let alpha_claude_row = find("/repo-alpha", "claude");
+        assert_eq!(alpha_claude_row.input_tokens, 100);
+        assert_eq!(alpha_claude_row.output_tokens, 50);
+        assert_eq!(alpha_claude_row.cache_read_tokens, 10);
+        let alpha_codex_row = find("/repo-alpha", "codex");
+        assert_eq!(alpha_codex_row.input_tokens, 200);
+        let beta_claude_row = find("/repo-beta", "claude");
+        assert_eq!(beta_claude_row.input_tokens, 300);
+        assert_eq!(beta_claude_row.cache_read_tokens, 5);
+
+        // Per-provider rollup sums across repos: claude spans both repos.
+        let claude_total = report
+            .by_provider
+            .iter()
+            .find(|row| row.provider == "claude")
+            .expect("claude total");
+        assert_eq!(claude_total.input_tokens, 400);
+        assert_eq!(claude_total.output_tokens, 150);
+        assert_eq!(claude_total.cache_read_tokens, 15);
     }
 
     #[tokio::test]

--- a/rust/loopflow/src/lfd/store/postgres.rs
+++ b/rust/loopflow/src/lfd/store/postgres.rs
@@ -13,8 +13,9 @@ use crate::lfd::store::catalog::{
 use crate::lfd::store::rows::{
     map_activation_log_row, map_agent_row, map_chat_memory_block_row, map_chat_message_row,
     map_fork_run_row, map_live_pr_state_row, map_pending_activation_row, map_repo_edge_row,
-    map_repo_row, map_run_row, map_summary_row, map_trigger_row, map_wave_cron_row,
-    map_wave_provider_usage_row, map_wave_repo_row, map_wave_row, now_unix, serialize_pr,
+    map_repo_provider_usage_row, map_repo_row, map_run_row, map_summary_row, map_trigger_row,
+    map_wave_cron_row, map_wave_provider_usage_row, map_wave_repo_row, map_wave_row, now_unix,
+    serialize_pr,
 };
 use crate::lfd::store::token_crypto;
 use crate::lfd::store::{
@@ -1987,6 +1988,7 @@ impl PostgresStore {
                         &(usage.output_tokens as i64),
                         &(usage.cache_read_tokens as i64),
                         &usage.recorded_at,
+                        &usage.repo,
                     ],
                 )
                 .await?;
@@ -1997,14 +1999,26 @@ impl PostgresStore {
 
     pub async fn aggregate_token_usage(&self) -> StoreResult<TokenUsageReport> {
         self.with_client(|client| async move {
-            let rows = client
+            let repo_rows = client
+                .query(Self::sql(Query::AggregateTokenUsageByRepoProvider), &[])
+                .await?;
+            let by_repo_provider = repo_rows
+                .iter()
+                .map(map_repo_provider_usage_row)
+                .collect::<StoreResult<Vec<_>>>()?;
+
+            let wave_rows = client
                 .query(Self::sql(Query::AggregateTokenUsageByWaveProvider), &[])
                 .await?;
-            let by_wave_provider = rows
+            let by_wave_provider = wave_rows
                 .iter()
                 .map(map_wave_provider_usage_row)
                 .collect::<StoreResult<Vec<_>>>()?;
-            Ok(TokenUsageReport::from_wave_provider(by_wave_provider))
+
+            Ok(TokenUsageReport::from_grouped(
+                by_repo_provider,
+                by_wave_provider,
+            ))
         })
         .await
     }

--- a/rust/loopflow/src/lfd/store/rows.rs
+++ b/rust/loopflow/src/lfd/store/rows.rs
@@ -1,5 +1,7 @@
 use crate::lfd::id::LfdId;
-use crate::lfd::store::{ForkRun, ForkRunStatus, StoreError, StoreResult, WaveProviderUsage};
+use crate::lfd::store::{
+    ForkRun, ForkRunStatus, RepoProviderUsage, StoreError, StoreResult, WaveProviderUsage,
+};
 use crate::lfd::types::{
     ActivationLog, ActivationOutcome, ChatMemoryBlock, ChatMessage, ExecutionProcess,
     ExecutionProcessStatus, LivePrState, LivePullRequestState, PendingActivation, PullRequest,
@@ -363,6 +365,17 @@ pub fn map_chat_memory_block_row(row: &impl StoreRow) -> StoreResult<ChatMemoryB
 pub fn map_wave_provider_usage_row(row: &impl StoreRow) -> StoreResult<WaveProviderUsage> {
     Ok(WaveProviderUsage {
         wave: LfdId::from_raw(row.text(0)?),
+        provider: row.text(1)?,
+        input_tokens: row.bigint(2)?.max(0) as u64,
+        output_tokens: row.bigint(3)?.max(0) as u64,
+        cache_read_tokens: row.bigint(4)?.max(0) as u64,
+    })
+}
+
+/// SELECT repo, provider, SUM(input_tokens), SUM(output_tokens), SUM(cache_read_tokens)
+pub fn map_repo_provider_usage_row(row: &impl StoreRow) -> StoreResult<RepoProviderUsage> {
+    Ok(RepoProviderUsage {
+        repo: row.opt_text(0)?,
         provider: row.text(1)?,
         input_tokens: row.bigint(2)?.max(0) as u64,
         output_tokens: row.bigint(3)?.max(0) as u64,

--- a/rust/loopflow/src/lfd/store/sqlite.rs
+++ b/rust/loopflow/src/lfd/store/sqlite.rs
@@ -12,8 +12,9 @@ use crate::lfd::store::catalog::{
 use crate::lfd::store::rows::{
     map_activation_log_row, map_agent_row, map_chat_memory_block_row, map_chat_message_row,
     map_fork_run_row, map_live_pr_state_row, map_pending_activation_row, map_repo_edge_row,
-    map_repo_row, map_run_row, map_summary_row, map_trigger_row, map_wave_cron_row,
-    map_wave_provider_usage_row, map_wave_repo_row, map_wave_row, now_unix, serialize_pr,
+    map_repo_provider_usage_row, map_repo_row, map_run_row, map_summary_row, map_trigger_row,
+    map_wave_cron_row, map_wave_provider_usage_row, map_wave_repo_row, map_wave_row, now_unix,
+    serialize_pr,
 };
 use crate::lfd::store::token_crypto;
 use crate::lfd::store::{
@@ -1852,6 +1853,7 @@ impl SqliteStore {
                 usage.output_tokens as i64,
                 usage.cache_read_tokens as i64,
                 usage.recorded_at,
+                usage.repo,
             ],
         )?;
         Ok(())
@@ -1859,12 +1861,24 @@ impl SqliteStore {
 
     pub fn aggregate_token_usage(&self) -> StoreResult<TokenUsageReport> {
         let conn = self.conn.lock().expect("store mutex poisoned");
-        let mut stmt = conn.prepare(Self::sql(Query::AggregateTokenUsageByWaveProvider))?;
-        let rows = stmt.query_map([], |row| Ok(map_wave_provider_usage_row(row)))?;
+
+        let mut repo_stmt = conn.prepare(Self::sql(Query::AggregateTokenUsageByRepoProvider))?;
+        let repo_rows = repo_stmt.query_map([], |row| Ok(map_repo_provider_usage_row(row)))?;
+        let mut by_repo_provider = Vec::new();
+        for row in repo_rows {
+            by_repo_provider.push(row??);
+        }
+
+        let mut wave_stmt = conn.prepare(Self::sql(Query::AggregateTokenUsageByWaveProvider))?;
+        let wave_rows = wave_stmt.query_map([], |row| Ok(map_wave_provider_usage_row(row)))?;
         let mut by_wave_provider = Vec::new();
-        for row in rows {
+        for row in wave_rows {
             by_wave_provider.push(row??);
         }
-        Ok(TokenUsageReport::from_wave_provider(by_wave_provider))
+
+        Ok(TokenUsageReport::from_grouped(
+            by_repo_provider,
+            by_wave_provider,
+        ))
     }
 }

--- a/rust/loopflow/tests/dto_fixtures.rs
+++ b/rust/loopflow/tests/dto_fixtures.rs
@@ -5,7 +5,7 @@
 
 use std::path::PathBuf;
 
-use loopflow::lfd::http::dto::{CreateSessionRequestDto, SessionDto, WaveDto};
+use loopflow::lfd::http::dto::{CreateSessionRequestDto, SessionDto, UsageReportDto, WaveDto};
 use serde_json::Value;
 
 fn load_fixture(name: &str) -> Value {
@@ -78,4 +78,45 @@ fn create_session_request_fixture_pins_required_fields() {
     assert_eq!(request.flow, "ship");
     assert_eq!(request.worktree, "/tmp/repo.Desktop");
     assert_eq!(request.agent, "codex");
+}
+
+#[test]
+fn usage_report_fixture_pins_repo_provider_shape() {
+    let value = load_fixture("usage_report.json");
+    assert_eq!(value["object"], "usage_report");
+    let report: UsageReportDto =
+        serde_json::from_value(value).expect("usage report fixture should parse");
+
+    assert_eq!(report.by_repo_provider.len(), 3);
+    let loopflow_claude = report
+        .by_repo_provider
+        .iter()
+        .find(|row| row.repo.as_deref() == Some("/Users/jack/src/loopflow"))
+        .expect("loopflow/claude row");
+    assert_eq!(loopflow_claude.provider, "claude");
+    assert_eq!(loopflow_claude.input_tokens, 400);
+    assert_eq!(loopflow_claude.cache_read_tokens, 15);
+
+    // repo is explicitly Optional: a null repo round-trips as None.
+    let unattributed = report
+        .by_repo_provider
+        .iter()
+        .find(|row| row.repo.is_none())
+        .expect("null-repo row");
+    assert_eq!(unattributed.provider, "claude");
+
+    assert_eq!(report.by_wave_provider.len(), 1);
+    assert_eq!(
+        report.by_wave_provider[0].wave_id,
+        "lfdwave_01HNX7XYZ0AZ1B2C3D4E5F6G7H"
+    );
+    assert_eq!(report.by_provider.len(), 2);
+
+    // Round-trip: serializing back preserves the explicit null repo.
+    let roundtrip = serde_json::to_value(&report).expect("serialize usage report");
+    assert!(roundtrip["by_repo_provider"]
+        .as_array()
+        .expect("array")
+        .iter()
+        .any(|row| row["repo"].is_null()));
 }

--- a/tests/fixtures/dto/usage_report.json
+++ b/tests/fixtures/dto/usage_report.json
@@ -1,0 +1,49 @@
+{
+  "object": "usage_report",
+  "by_repo_provider": [
+    {
+      "repo": "/Users/jack/src/loopflow",
+      "provider": "claude",
+      "input_tokens": 400,
+      "output_tokens": 150,
+      "cache_read_tokens": 15
+    },
+    {
+      "repo": "/Users/jack/src/cadenza",
+      "provider": "codex",
+      "input_tokens": 200,
+      "output_tokens": 80,
+      "cache_read_tokens": 0
+    },
+    {
+      "repo": null,
+      "provider": "claude",
+      "input_tokens": 50,
+      "output_tokens": 10,
+      "cache_read_tokens": 0
+    }
+  ],
+  "by_wave_provider": [
+    {
+      "wave_id": "lfdwave_01HNX7XYZ0AZ1B2C3D4E5F6G7H",
+      "provider": "claude",
+      "input_tokens": 450,
+      "output_tokens": 160,
+      "cache_read_tokens": 15
+    }
+  ],
+  "by_provider": [
+    {
+      "provider": "claude",
+      "input_tokens": 450,
+      "output_tokens": 160,
+      "cache_read_tokens": 15
+    },
+    {
+      "provider": "codex",
+      "input_tokens": 200,
+      "output_tokens": 80,
+      "cache_read_tokens": 0
+    }
+  ]
+}


### PR DESCRIPTION
The attribution primitive for cross-repo spend allocation. Extends token-usage tracking to **repo × provider** and exposes it.

- Migration **046** adds a nullable `repo` to `run_token_usage` + a `(repo, provider)` index; `persist_run_usage` tags rows with `run.repo`.
- `TokenUsageReport` gains `by_repo_provider` alongside `by_wave_provider`/`by_provider`; new `AggregateTokenUsageByRepoProvider` query.
- `GET /v0/usage` returns a `UsageReportDto` (wire DTO: no serde defaults, every field required-or-Optional) + a round-trip fixture (`tests/fixtures/dto/usage_report.json`, includes a `repo: null` row).
- `lf usage` prints repo × provider × tokens + per-provider rollup + grand total.

This is what the studio billing dashboard consumes: allocate each vendor's Mercury dollars across repos by token share. Rebased onto main (migration renumbered 043→046 after #782's 042–045); clippy + 841 tests green incl. the repo×provider aggregation round-trip and the DTO fixture.