### PR TITLE
ci: drop debug info in rust-test build (CARGO_PROFILE_TEST_DEBUG=0)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,12 @@ jobs:
           key: test
       - uses: taiki-e/install-action@nextest
       - name: Run Rust tests
+        # debug=0 drops debug-info generation for the test build. This job is
+        # ~95% test-binary compile of the monolithic loopflow crate, and CI
+        # never symbolicates. Panic/assertion locations come from
+        # #[track_caller] line info, not DWARF, so failure output is preserved.
+        env:
+          CARGO_PROFILE_TEST_DEBUG: "0"
         run: cargo nextest run --all
 
   python-test:


### PR DESCRIPTION
rust-test is now compile-bound (nextest fixed execution). Every integration test links the whole `loopflow` rlib, so debug-info codegen + linking dominates — and CI never symbolicates. `CARGO_PROFILE_TEST_DEBUG=0` (scoped to the job's `env`, so local `cargo test`/lldb stay debuggable) cuts the workspace test compile ~22% locally (22.5s→17.9s), ~10–18s off the job. The Rust analog of the swift `-gnone` win.

Failure output preserved — verified deliberately-failing tests still report exact `file:line:col` + values (panic locations come from `#[track_caller]`, not DWARF). Same tests, same semantics.