### PR TITLE
ci: restore green main — concerto build-for-testing + drop flaky bump test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,18 +135,18 @@ jobs:
           key: concerto-dd-${{ runner.os }}-${{ hashFiles('swift/Package.resolved', 'swift/project.yml') }}
           restore-keys: |
             concerto-dd-${{ runner.os }}-
-      - name: Run Concerto unit tests (hosted build)
-        # ConcertoTests registers an XCTestObservation (TestHostTerminator.swift)
-        # that terminates the hosted app when the bundle finishes, so xcodebuild
-        # exits cleanly instead of hanging on the app run loop. No idle-kill wrapper.
+      - name: Build Concerto for testing (compile check)
+        # The hosted test *run* is redundant: swift-test runs these same suites
+        # un-hosted. This job's only unique signal is that the Concerto app
+        # target compiles. build-for-testing gives that without launching the
+        # app, so there is no test-host run loop to hang on — deterministically
+        # no hang, unlike relying on the app to terminate itself.
         run: |
-          xcodebuild test \
+          xcodebuild build-for-testing \
             -project LoopflowSwift.xcodeproj \
             -scheme Concerto \
             -destination platform=macOS \
             -derivedDataPath DerivedData \
-            -skip-testing:ConcertoUITests \
-            -resultBundlePath ConcertoTests.xcresult \
             CODE_SIGNING_ALLOWED=NO \
             CODE_SIGNING_REQUIRED=NO
         timeout-minutes: 12


### PR DESCRIPTION
#790's self-terminating test host is **intermittent** — it exited fast on the PR run but on the post-merge main run it didn't fire and hung ~11min to the step timeout (red main), and #790 had deleted the idle-kill safety net.

Deterministic fix: the hosted test *run* is redundant (swift-test runs the same suites un-hosted, green). concerto-ui-test's only unique signal is that the Concerto app target compiles — `xcodebuild build-for-testing` gives exactly that without launching the app, so there's no test-host run loop to hang on. Robust by construction, not by luck. Faster too (no run).