### PR TITLE
goals: add greenfield vocabulary probe

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,8 @@ Manual work — you invoke these, often interactively.
 | `demo` | Experience-first walkthrough of observable changes |
 | `code-review` | Walk through structural and architectural decisions |
 | `review-design` | Reshape AI-elaborated design into user intent |
+| `scaffold` | Stand up a greenfield product skeleton from `GOAL.md` |
+| `run` | Build and execute the artifact, recording observed behavior |
 | `refine` | Refine existing work |
 | `review-open-work` | Survey branches, PRs, worktrees, and waves for inbox-zero triage |
 
@@ -204,6 +206,7 @@ Flows can include mechanical ops items directly:
 | `build` | kickoff → review-design → loop(code → xor(demo, code-review), exit: gate) → deploy |
 | `build-or-silent` | xor(build, silence) |
 | `design-and-ship` | design → implement → reduce → polish → deploy |
+| `greenfield` | scaffold → implement → run → gate |
 | `queue` | compress → update-wave → gate |
 | `code` | implement → compress → lint → gate |
 | `pair` | design → code |

--- a/docs/wave-authoring.md
+++ b/docs/wave-authoring.md
@@ -65,6 +65,19 @@ Run `lf goal <wave>` to launch that wave's goal directly. Builtin goals resolve 
 lf goal s3 --once    # the s3 (control) charter, one loop
 ```
 
+Use `greenfield` when the goal is the whole product brief and there is no
+existing repo scaffold:
+
+```bash
+lf -b greenfield
+```
+
+The flow runs `scaffold → implement → run → gate`. It deliberately skips the
+interactive `design` step: `GOAL.md` is the design conversation for this path.
+`scaffold` creates the runnable skeleton, initializes git if needed, and seeds
+`scratch/<branch>.md`; `run` executes the built artifact and writes
+`scratch/run-observations.md`.
+
 ### Memory
 
 `MEMORY.md` is durable working context the wave agent writes as it goes — decisions, dead ends, what a downstream task should know. Workers inherit it as read-only context so they build with the wave's history in view; only the wave agent writes it.

--- a/python/tests/test_cli.py
+++ b/python/tests/test_cli.py
@@ -92,6 +92,11 @@ def _worker_launch_response(flow: str = "implement") -> Session:
     )
 
 
+def _clear_agent_identity_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for name in ("LFD_SESSION_ID", "LFD_WAVE_ID", "LFD_RUN_ID", "LFD_AGENT_ROLE"):
+        monkeypatch.delenv(name, raising=False)
+
+
 def test_wave_table_includes_worktree_and_branch_columns() -> None:
     wave = Wave.model_validate(WAVE_MINIMAL)
     rendered = _render_table(wave)
@@ -216,6 +221,7 @@ def test_whoami_renders_current_session(monkeypatch: pytest.MonkeyPatch) -> None
 
 
 def test_worker_run_dispatches_and_prints_session(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_agent_identity_env(monkeypatch)
     monkeypatch.setattr(
         "loopflow.cli.api.run_worker",
         lambda wave, flow, task, parent_session_id=None: _worker_launch_response(flow),
@@ -233,6 +239,7 @@ def test_worker_run_dispatches_and_prints_session(monkeypatch: pytest.MonkeyPatc
 
 
 def test_worker_run_json_includes_session_connection(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_agent_identity_env(monkeypatch)
     monkeypatch.setattr(
         "loopflow.cli.api.run_worker",
         lambda _wave, flow, task, parent_session_id=None: _worker_launch_response(flow),
@@ -260,6 +267,7 @@ def test_worker_run_json_includes_session_connection(monkeypatch: pytest.MonkeyP
 
 
 def test_worker_run_infers_wave_from_current_session(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_agent_identity_env(monkeypatch)
     received: dict[str, object] = {}
 
     monkeypatch.setattr(

--- a/rust/loopflow/src/engine/builtins/build/flow/greenfield.yaml
+++ b/rust/loopflow/src/engine/builtins/build/flow/greenfield.yaml
@@ -1,0 +1,5 @@
+# Originate a product from GOAL.md without an interactive design step.
+- scaffold
+- implement
+- run
+- gate

--- a/rust/loopflow/src/engine/builtins/build/step/run.md
+++ b/rust/loopflow/src/engine/builtins/build/step/run.md
@@ -1,0 +1,37 @@
+---
+requires: buildable artifact on branch
+produces: scratch/run-observations.md
+default_agent: codex
+action_style: procedural
+---
+Build and execute the artifact, then record what actually happened.
+
+## Orientation
+
+Read `GOAL.md`, `scratch/`, and the project files needed to understand the
+artifact's native run command. This is a headless verification step: execute the
+product, observe real behavior, and report pass/fail against the goal.
+
+## Workflow
+
+1. Build the artifact with its native command (`cargo test`, `uv run pytest`,
+   `npm test`, `swift test`, or the command the project declares).
+2. Execute the artifact in the mode the goal names:
+   - CLI: run the binary or command with representative arguments.
+   - Server: start it, hit the required endpoint, then stop it.
+   - Client/mobile: build and launch the smallest available simulator or smoke
+     target.
+3. Capture the exact commands, exit codes, and important output.
+4. Write `scratch/run-observations.md` with:
+   - the commands run
+   - observed output
+   - whether the behavior satisfies `GOAL.md`
+   - any missing primitive that forced manual workaround
+
+## Rules
+
+- Assert on observed behavior, not intent.
+- Prefer the project's existing scripts and README commands.
+- Keep `.lf/steps/` empty. If a local step is required to run the product,
+  record that as a vocabulary gap in `scratch/questions.md`.
+- Do not fold this into `demo`: this step is for headless, chainable execution.

--- a/rust/loopflow/src/engine/builtins/build/step/scaffold.md
+++ b/rust/loopflow/src/engine/builtins/build/step/scaffold.md
@@ -1,0 +1,50 @@
+---
+requires: GOAL.md describing the target surface
+produces: runnable skeleton, initialized repo, scratch/<branch>.md
+default_agent: codex
+action_style: procedural
+---
+Stand up a greenfield project from the goal alone.
+
+## Orientation
+
+Start from the current directory. Treat `GOAL.md` as the product brief and do
+not ask for more input. If the directory is not a git repo, initialize one
+before you finish this step:
+
+```bash
+git init -b main 2>/dev/null || git init
+git checkout -B main
+```
+
+If `main` already exists or the repo already has a branch, keep the existing
+branch. Do not create a second implementation path or compatibility shim.
+
+## Goal
+
+Create the smallest idiomatic skeleton that builds and runs. The skeleton should
+make the product surface visible, but it should not implement speculative
+features beyond what `GOAL.md` asks for.
+
+## Workflow
+
+1. Read `GOAL.md`.
+2. Pick the simplest conventional toolchain for the requested surface:
+   - CLI: Rust/Cargo, Python/uv, Node/npm, or the toolchain named in the goal.
+   - Server: the smallest framework that can expose the requested endpoint.
+   - Client/mobile: the native project skeleton the goal names.
+3. Create the project files needed to compile and run.
+4. Add a minimal smoke test or equivalent if the chosen toolchain has one.
+5. Run the build and the smallest execution command.
+6. Write `scratch/<branch>.md` as a short implementation brief copied from
+   `GOAL.md`: what exists, what remains, and the exact command that should prove
+   the target works.
+
+## Rules
+
+- `GOAL.md` is the brief. Do not start an interactive design conversation.
+- Keep the generated product boring and idiomatic.
+- Keep `.lf/steps/` empty. If you need to author a new step to proceed, the
+  language failed; record the missing primitive in `scratch/questions.md`.
+- Do not vendor secrets, credentials, or machine-local config.
+- Leave the directory in a state where the next flow step can commit normally.

--- a/rust/loopflow/tests/flow_tests.rs
+++ b/rust/loopflow/tests/flow_tests.rs
@@ -2,7 +2,7 @@ use std::fs;
 use std::path::Path;
 
 use loopflow::engine::flow::{ConcreteItem, FlowItem, Step};
-use loopflow::engine::{expand_flow, load_flow};
+use loopflow::engine::{expand_flow, load_flow, load_step};
 use tempfile::TempDir;
 
 fn write_step(repo: &Path, name: &str, content: &str) {
@@ -256,6 +256,31 @@ fn expand_flow_resolves_plain_string_as_subflow() {
             assert_eq!(s.flow_parents, vec!["parent", "publish"]);
         }
         _ => panic!("expected step from publish sub-flow"),
+    }
+}
+
+#[test]
+fn greenfield_flow_is_registered_and_headless() {
+    let temp = TempDir::new().unwrap();
+    let repo = temp.path();
+
+    let scaffold = load_step("scaffold", repo).expect("scaffold builtin resolves");
+    let run = load_step("run", repo).expect("run builtin resolves");
+    let flow = load_flow("greenfield", repo).expect("greenfield builtin resolves");
+    let items = expand_flow(&flow, repo).expect("greenfield expands");
+
+    assert_eq!(scaffold.interactive, None);
+    assert_eq!(run.interactive, None);
+    assert_step_sequence(&items, &["scaffold", "implement", "run", "gate"]);
+    for item in items {
+        match item {
+            ConcreteItem::Step(step) => assert!(
+                !step.step.interactive.unwrap_or(false),
+                "greenfield step {} must not be interactive",
+                step.step.name
+            ),
+            other => panic!("greenfield should expand only to steps, got {other:?}"),
+        }
     }
 }
 

--- a/scratch/prove-the-language.md
+++ b/scratch/prove-the-language.md
@@ -1,0 +1,206 @@
+# Prove the Language — three reference builds from goals
+
+Asana item `1216257471904678` (= `wave/goals/3-vocabulary-completeness.md`).
+
+## Problem
+
+The goals wave's north star: *a developer writes one `GOAL.md` and the wave
+builds the product.* The bar the GOAL.md states is sharp — **builtin steps and
+flows expressive enough to build the clients and the server from goals with
+zero step authoring.** If a product dev has to crack open `.lf/steps/` to
+originate a product, the vocabulary failed.
+
+Right now that bar is asserted, not tested. Nobody has driven the builtin
+vocabulary against a greenfield build to see where it falls over. The roadmap
+item *names* suspected gaps (scaffold, run, integrate) but on prediction, not
+evidence. This work turns the assertion into an experiment: run the language
+against the smallest real build, watch exactly where a developer would be forced
+to author a step, and close those gaps precisely.
+
+Who benefits: the product developer who wants to type a goal and get a running
+CLI — and the language itself, which stops carrying atoms it only *thinks* it
+needs and gains the ones a real build proves it's missing.
+
+## Approach
+
+**Falsify first, then build the atoms the probe confirms.** Three moves, in
+order:
+
+1. **The CLI probe** — the smallest build that can prove or falsify the
+   language. Author a ~6-line `GOAL.md` for a tiny, real CLI in an *empty
+   directory*, drive it with only builtin vocabulary, and log every point where
+   the run demands an authored step. A CLI is the sharpest probe because it
+   isolates the two most fundamental missing atoms (**scaffold**, **run**) from
+   the client/server seam and from platform-build machinery. If the language
+   can't build a CLI from a goal, it's falsified at its floor; if it can bar two
+   atoms, we've *bounded the gap exactly* instead of guessing.
+
+2. **Ship the atoms the probe confirms** — add `scaffold` and `run` as builtin
+   `build/` steps (markdown prompts, auto-registered by `build.rs`), plus a
+   `greenfield` builtin flow that chains them: the single "originate a product"
+   hand a goal dispatches. Re-run the probe until it reaches a running CLI with
+   `.lf/steps/` empty — **zero steps authored**.
+
+3. **Sequence the two harder probes** — server (adds `run`-as-service +
+   `integrate`, the client/server seam) and mobile (adds platform-build +
+   `rams`-as-step) are genuinely distinct slices, each surfacing a different
+   atom. File them on the roadmap with their predicted primitives; land them as
+   their own probes after the CLI slice proves the method.
+
+This PR lands move 1 + move 2 (the CLI slice: probe script, `scaffold`/`run`
+steps, `greenfield` flow) and files move 3. The CLI slice is one coherent chunk
+— it's the whole language-floor, not a fragment.
+
+### The atoms (precise specs)
+
+All three are builtin `build/step/*.md` prompts — **prompts, not scripts**.
+Platform knowledge (cargo vs uv vs xcodegen) lives in agent judgment guided by
+the GOAL, exactly like every existing step. Adding one is dropping a markdown
+file; `build.rs` registers it (confirmed: `build/step/` is auto-scanned, no
+manual wiring).
+
+**`scaffold`** — stand up a greenfield project from nothing.
+```
+requires: GOAL.md describing the target surface
+produces: a runnable skeleton that builds and prints hello; committed
+default_agent: codex
+action_style: procedural
+```
+Reads the GOAL for surface + platform, picks idiomatic tooling (`cargo new`,
+`uv init`, `npm create`, SwiftPM/xcodegen), creates the *minimal* skeleton that
+**compiles and runs**, and — critically — **owns the greenfield git setup the
+other steps assume**: if there's no repo/branch/main, it inits them. `scaffold`
+does not design features; it produces the ground `design`/`implement`/`demo`
+stand on. This is the atom that fixes "everything today assumes an existing
+repo + design doc." `init` (sets up loopflow) is unchanged and orthogonal.
+
+**`run`** — build and actually execute the artifact; report observed behavior.
+```
+requires: buildable artifact on branch
+produces: scratch/run-observations.md (observed behavior vs. the GOAL's "done when")
+default_agent: codex
+action_style: procedural
+```
+Builds, then executes in the artifact's native modality — CLI: invoke the
+commands; server: start it + hit endpoints; mobile: simulator build + launch —
+and captures *actual output*, asserting pass/fail against the GOAL. This is the
+loopflow-native, headless, **chainable** equivalent of the `/verify` skill:
+where `verify` is an ad-hoc Claude skill and `demo` is an interactive human
+narration, `run` is a step any flow drops before `gate`. One implementation —
+`run` is not folded into `demo` (different audience, different mode).
+
+**`integrate`** — exercise a client against its server (the defining seam).
+```
+requires: client + server artifacts
+produces: scratch/integration-report.md
+default_agent: codex
+action_style: procedural
+```
+Brings up the server, points the client at it, drives the round-trip, asserts
+the response. Distinct from the existing `integrate-upstream` (git-merge of
+upstream main — unrelated). **Deferred to the server probe**, not this PR; its
+full cross-repo form forks with `3-wave-repo-split`. v1 handles same-repo /
+two-local-dirs.
+
+### The `greenfield` flow
+
+```yaml
+# Originate a product from a goal, end to end.
+- scaffold      # empty dir -> runnable skeleton + repo/branch
+- design        # now has a repo to design within
+- implement     # design doc -> code + tests
+- run           # execute; observe real behavior
+- gate          # make it shippable
+```
+This is `design-and-ship` with `scaffold` prepended (supplying the branch +
+skeleton the flow used to assume) and `run` inserted before the gate. A goal
+dispatches `greenfield` as its "originate" hand; `ship-roadmap` and the other
+goals stay untouched.
+
+## De-risking
+
+| Question | Finding | Impact on design |
+|----------|---------|-----------------|
+| Do the gaps actually exist, or is this prediction? | Direct inspection: **no** `scaffold`/`run`/`integrate` builtin step. `design` opens "ask what they want to build" (interactive, assumes a conversation); `implement` `requires: scratch/<branch>.md`; `demo`/`code-review`/`gate` `require: diff vs main`. Every build/ship flow assumes a branch off `main`. Confirmed, not guessed. | The probe validates a known prediction; atoms are the fix. Bounds risk to prompt quality, not discovery. |
+| Is adding a builtin step hard? | No. `build.rs` scans `build/step/*.md` and generates the registry (`builtins.rs:196`); dropping a file is the whole install. | Atoms are cheap markdown; ship all in one PR. |
+| Can one `scaffold` step handle Rust CLI *and* mobile *and* server? | Steps are prompts, not scripts (every existing step is a prompt). `scaffold` guides an agent to pick tooling from the GOAL; nothing is hardcoded. | `scaffold` stays a single step; platform-specificity is agent judgment. |
+| Does greenfield break git machinery (no branch, no `main`, no PR base)? | build/ship flows + `lf op` assume a branch off `main`. A truly empty dir has none. | `scaffold` explicitly owns repo/branch init — "make the ground the other steps assume." The probe runs in a scratch dir, never this repo. |
+| Isn't `run` just `verify` or `demo`? | `verify` is a `/`-skill (ad hoc, human-invoked); `demo` is `interactive: true` (human present, narrates); neither is a non-interactive step producing a chainable observation artifact. `run`/`verify`/`rams` resolve as steps *only* via the `load_agent_skill` fallback today. | `run` is a distinct builtin step producing `scratch/run-observations.md`, chainable before `gate`. No fold, no shim. |
+| Where does the probe run — does it pollute loopflow with product code? | The probe runs in a throwaway temp dir via `scripts/prove_language_cli.sh`. Only the script + the new builtin steps/flow land in this repo. | Safe, re-runnable, no CLI product code enters the loopflow tree. |
+| Is `integrate-upstream` already the seam atom? | No — it merges upstream `main` into a branch (git), used by `ops/flow/sync.yaml`. The client/server seam is genuinely absent. | `integrate` is a new atom, deferred to the server probe. |
+
+## Alternatives considered
+
+| Approach | Tradeoff | Why not |
+|----------|----------|---------|
+| Build all three reference products to polish as the deliverable | Maximally concrete | Most of the work is product code that doesn't advance the *language*; not falsification-first; a huge PR that buries the gap findings. The point is the vocabulary, not three toy apps. |
+| Paper audit only — read the steps, declare the gaps, add atoms, done | Fast, no runtime | Violates the item's own framing (an *acceptance test*). Misses gaps that only surface at runtime — does `gate` actually work with no prior CI? does `design`'s interactivity stall a headless greenfield run? The inspection here is the *prediction the probe must validate*, not a substitute for it. |
+| Add `scaffold`/`run`/`integrate` speculatively, skip the probe | Ships atoms sooner | Risks building the wrong atoms or wrong shapes. The probe costs one scripted run and bounds the gap to the exact primitives needed. Cheap insurance against a mis-specified atom. |
+| Start with the server or mobile probe | Covers the "real product" seam sooner | Server drags in process lifecycle + the `integrate` seam; mobile drags in simulator/platform-build + `rams`. Both entangle the fundamental atoms (scaffold, run) with surface-specific machinery. The CLI isolates the floor. |
+| Promote the existing `verify`/`run` skills to steps instead of writing `run` | Reuses prose | The skills are Claude-Code-harness-shaped (interactive affordances, skill frontmatter); a builtin step is a clean loopflow prompt with `requires`/`produces`. Promoting drags harness assumptions in. Write the step; let the skill stay a skill. |
+
+## Key decisions
+
+- **Falsify before build.** The probe is one scripted run; it converts "we think
+  scaffold and run are missing" into "the CLI build authored N steps, here they
+  are." We don't add atoms on prediction alone.
+- **CLI is the floor probe.** It isolates `scaffold` + `run`. Server and mobile
+  are follow-on probes, each its own item, because each surfaces a *different*
+  atom — that's the honest split, not incrementalism for its own sake.
+- **Atoms are prompts, not scripts.** One `scaffold` step covers every platform
+  because it guides an agent, not a hardcoded toolchain. This is the whole
+  reason the vocabulary can stay small.
+- **`scaffold` owns greenfield git.** The single hardest hidden assumption —
+  every flow expects a branch off `main` — is resolved in one place: `scaffold`
+  makes the repo the rest of the vocabulary assumes.
+- **`run` is a first-class atom, not a folded `demo` or a promoted skill.**
+  Headless, chainable, produces an observation artifact, feeds `gate`.
+- **One `greenfield` flow, `ship-roadmap` untouched.** The goal gains a new hand
+  to dispatch; the loop doctrine doesn't change.
+- **`integrate` deferred, not dropped.** Precisely specified now, built with the
+  server probe, cross-repo form forks with `3-wave-repo-split`.
+
+## Scope
+
+- **In scope:** the CLI probe (`scripts/prove_language_cli.sh` + its `GOAL.md`);
+  `scaffold` and `run` as builtin `build/step/*.md`; the `greenfield` builtin
+  `build/flow/greenfield.yaml`; a builtin-registry test asserting all three
+  register; docs update (`docs/wave-authoring.md` + the vocabulary README) to
+  list the new atoms and the greenfield flow; roadmap write-back of the CLI
+  result and the two follow-on probes.
+- **Out of scope:** the `integrate` step implementation (specced here, built with
+  the server probe); the mobile platform-build step + `rams`-as-step (the mobile
+  probe); building any of the three products past "runs and is demoable"; the
+  cross-repo form of `integrate` (forks with `3-wave-repo-split`); pruning
+  existing flows (that's the sibling `3-prune-flow-vocabulary`).
+
+## Done when
+
+- `scripts/prove_language_cli.sh` runs green: from an **empty directory** + a
+  ~6-line `GOAL.md`, the `greenfield` flow scaffolds, designs, implements, runs,
+  and gates a working CLI; the script prints the built binary's **real output**
+  and asserts the probe dir's `.lf/steps/` is empty — **0 steps authored**.
+- `scaffold` + `run` builtin steps and the `greenfield` flow resolve
+  (`get_builtin_step`/`get_builtin_flow` and the registry test pass).
+- `cargo test` and `uv run pytest python/tests/` pass.
+- Asana `1216257471904678` carries the CLI result; the server-probe (`integrate`)
+  and mobile-probe (platform-build + `rams`) are filed with their precise
+  missing primitives via `lf op pm update`.
+
+## Measure
+
+The item's own metric: **vocabulary gap count against the acceptance test.**
+
+- **Baseline (today, CLI surface):** run the probe against the *unmodified*
+  builtin vocabulary and count authored-step demands. Prediction: **2**
+  (`scaffold`, `run`). The run produces the real number — that's the falsifiable
+  result. Command: `scripts/prove_language_cli.sh --baseline` (drives builtin
+  vocab only, logs each point the flow stalls for a missing atom).
+- **Target (CLI surface, after atoms):** **0** authored steps; the CLI builds
+  and runs from `GOAL.md` alone.
+- **Across all three surfaces:** gap count = 0 is the finish line for the whole
+  item — CLI (this PR), then server (`integrate`), then mobile (platform-build +
+  `rams`). Each probe reports its own gap count on the roadmap.
+
+"Better" = the number of `.lf/steps/*.md` a developer must write to get a
+running product goes from >0 to 0.

--- a/scratch/prove-the-language.md
+++ b/scratch/prove-the-language.md
@@ -62,17 +62,20 @@ manual wiring).
 **`scaffold`** — stand up a greenfield project from nothing.
 ```
 requires: GOAL.md describing the target surface
-produces: a runnable skeleton that builds and prints hello; committed
+produces: a runnable skeleton that builds and prints hello; scratch/<branch>.md seed brief; committed
 default_agent: codex
 action_style: procedural
 ```
 Reads the GOAL for surface + platform, picks idiomatic tooling (`cargo new`,
 `uv init`, `npm create`, SwiftPM/xcodegen), creates the *minimal* skeleton that
 **compiles and runs**, and — critically — **owns the greenfield git setup the
-other steps assume**: if there's no repo/branch/main, it inits them. `scaffold`
-does not design features; it produces the ground `design`/`implement`/`demo`
-stand on. This is the atom that fixes "everything today assumes an existing
-repo + design doc." `init` (sets up loopflow) is unchanged and orthogonal.
+other steps assume**: if there's no repo/branch/main, it inits them. It also
+seeds `scratch/<branch>.md` — a brief transcribed straight from the GOAL — so
+`implement` (which `requires: scratch/<branch>.md`) has the doc it stands on
+*without* an interactive `design` conversation. `scaffold` does not invent
+features; the GOAL *is* the brief. This is the atom that fixes "everything today
+assumes an existing repo + design doc." `init` (sets up loopflow) is unchanged
+and orthogonal.
 
 **`run`** — build and actually execute the artifact; report observed behavior.
 ```
@@ -105,23 +108,35 @@ two-local-dirs.
 ### The `greenfield` flow
 
 ```yaml
-# Originate a product from a goal, end to end.
-- scaffold      # empty dir -> runnable skeleton + repo/branch
-- design        # now has a repo to design within
-- implement     # design doc -> code + tests
+# Originate a product from a goal, end to end. Headless — no interactive steps.
+- scaffold      # empty dir -> runnable skeleton + repo/branch + seed brief
+- implement     # seed brief -> code + tests
 - run           # execute; observe real behavior
 - gate          # make it shippable
 ```
-This is `design-and-ship` with `scaffold` prepended (supplying the branch +
-skeleton the flow used to assume) and `run` inserted before the gate. A goal
-dispatches `greenfield` as its "originate" hand; `ship-roadmap` and the other
-goals stay untouched.
+
+**No `design` step.** `design` is `interactive: true` (design.md:2), and a
+headless flow returns `FlowAction::WaitInteractive` for any interactive step
+(flow.rs:272) — it would **park the probe at the first step**, never reaching a
+build. That's fatal for a "one GOAL.md, zero conversation" north star: the whole
+point is that the GOAL replaces the design conversation. So `scaffold` seeds the
+design brief from the GOAL (above), and `greenfield` goes straight to
+`implement`. The flow is `design-and-ship` with the interactive front half
+swapped for `scaffold`, `reduce`/`polish` dropped for the probe (the CLI is
+tiny), and `run` inserted before `gate`.
+
+*Fallback if seeding-in-scaffold feels overloaded:* keep a `design` step but
+override `interactive: false` on it inside the greenfield flow (per-step
+frontmatter override is supported, flow.rs:1339). Rejected as the default
+because it splits "produce the brief" across two atoms; folding it into
+`scaffold` keeps one greenfield origin point. A human can flip this in review.
 
 ## De-risking
 
 | Question | Finding | Impact on design |
 |----------|---------|-----------------|
 | Do the gaps actually exist, or is this prediction? | Direct inspection: **no** `scaffold`/`run`/`integrate` builtin step. `design` opens "ask what they want to build" (interactive, assumes a conversation); `implement` `requires: scratch/<branch>.md`; `demo`/`code-review`/`gate` `require: diff vs main`. Every build/ship flow assumes a branch off `main`. Confirmed, not guessed. | The probe validates a known prediction; atoms are the fix. Bounds risk to prompt quality, not discovery. |
+| Does a headless greenfield flow stall on `design`? | **Yes, if `design` is in it.** `design.md:2` is `interactive: true`; `flow.rs:272` returns `FlowAction::WaitInteractive` for any interactive step — headless, it parks and never builds. Verified in code. | `greenfield` **omits `design`**; `scaffold` seeds the brief from the GOAL. The registry test asserts `greenfield` expands with zero interactive steps, so this can't silently regress. |
 | Is adding a builtin step hard? | No. `build.rs` scans `build/step/*.md` and generates the registry (`builtins.rs:196`); dropping a file is the whole install. | Atoms are cheap markdown; ship all in one PR. |
 | Can one `scaffold` step handle Rust CLI *and* mobile *and* server? | Steps are prompts, not scripts (every existing step is a prompt). `scaffold` guides an agent to pick tooling from the GOAL; nothing is hardcoded. | `scaffold` stays a single step; platform-specificity is agent judgment. |
 | Does greenfield break git machinery (no branch, no `main`, no PR base)? | build/ship flows + `lf op` assume a branch off `main`. A truly empty dir has none. | `scaffold` explicitly owns repo/branch init — "make the ground the other steps assume." The probe runs in a scratch dir, never this repo. |
@@ -155,6 +170,14 @@ goals stay untouched.
   makes the repo the rest of the vocabulary assumes.
 - **`run` is a first-class atom, not a folded `demo` or a promoted skill.**
   Headless, chainable, produces an observation artifact, feeds `gate`.
+- **`greenfield` is headless — no interactive `design`.** The GOAL replaces the
+  design conversation; `scaffold` seeds the brief. An interactive step would park
+  the probe (flow.rs:272). This is the reshape that makes "one GOAL.md, zero
+  conversation" literally true, not just aspirational.
+- **The probe is a manual experiment, not a CI gate.** Merge gate = the fast
+  deterministic registry test. The agentic build (paid, minutes, nondeterministic)
+  is run by hand; its *result* lands on the roadmap. Don't put a model-driven
+  build in `cargo test`.
 - **One `greenfield` flow, `ship-roadmap` untouched.** The goal gains a new hand
   to dispatch; the loop doctrine doesn't change.
 - **`integrate` deferred, not dropped.** Precisely specified now, built with the
@@ -164,10 +187,12 @@ goals stay untouched.
 
 - **In scope:** the CLI probe (`scripts/prove_language_cli.sh` + its `GOAL.md`);
   `scaffold` and `run` as builtin `build/step/*.md`; the `greenfield` builtin
-  `build/flow/greenfield.yaml`; a builtin-registry test asserting all three
-  register; docs update (`docs/wave-authoring.md` + the vocabulary README) to
-  list the new atoms and the greenfield flow; roadmap write-back of the CLI
-  result and the two follow-on probes.
+  `build/flow/greenfield.yaml`; a registry test asserting `scaffold`, `run`, and
+  `greenfield` resolve **and that `greenfield` expands with zero interactive
+  steps** (the headless-safety invariant that keeps the probe from parking);
+  docs update (`docs/wave-authoring.md` + the vocabulary README) to list the new
+  atoms and the greenfield flow; roadmap write-back of the CLI result and the two
+  follow-on probes.
 - **Out of scope:** the `integrate` step implementation (specced here, built with
   the server probe); the mobile platform-build step + `rams`-as-step (the mobile
   probe); building any of the three products past "runs and is demoable"; the
@@ -176,31 +201,49 @@ goals stay untouched.
 
 ## Done when
 
-- `scripts/prove_language_cli.sh` runs green: from an **empty directory** + a
-  ~6-line `GOAL.md`, the `greenfield` flow scaffolds, designs, implements, runs,
-  and gates a working CLI; the script prints the built binary's **real output**
-  and asserts the probe dir's `.lf/steps/` is empty — **0 steps authored**.
-- `scaffold` + `run` builtin steps and the `greenfield` flow resolve
-  (`get_builtin_step`/`get_builtin_flow` and the registry test pass).
+Two bars, deliberately separated — one automated and deterministic, one a manual
+experiment. Conflating them (as the first draft did) would either put a slow,
+paid, nondeterministic agentic build into `cargo test`, or weaken the merge gate
+to "a human ran a script once."
+
+**Merge gate (deterministic, in CI):**
+- `scaffold` + `run` builtin steps and the `greenfield` flow resolve —
+  `get_builtin_step("scaffold")`, `get_builtin_step("run")`,
+  `get_builtin_flow("greenfield")` all succeed, and `greenfield` expands with no
+  interactive step (asserting the headless-safety invariant).
+- Docs list the new atoms and the greenfield flow.
 - `cargo test` and `uv run pytest python/tests/` pass.
+
+**Acceptance experiment (manual, one-shot — the falsification):**
+- `scripts/prove_language_cli.sh` is run *by hand*: from an **empty directory** +
+  a ~6-line `GOAL.md`, the `greenfield` flow scaffolds, implements, runs, and
+  gates a working CLI; the script prints the built binary's **real output** and
+  the probe dir's `.lf/steps/` is empty — **0 steps authored**. This is not a CI
+  gate: it's an agentic build (real model calls, minutes, nondeterministic). Its
+  *result* — did it reach a running CLI with zero authored steps? — is what gets
+  recorded on the roadmap.
 - Asana `1216257471904678` carries the CLI result; the server-probe (`integrate`)
   and mobile-probe (platform-build + `rams`) are filed with their precise
   missing primitives via `lf op pm update`.
 
 ## Measure
 
-The item's own metric: **vocabulary gap count against the acceptance test.**
+The item's own metric: **does a running product need any authored steps? >0 → 0.**
 
-- **Baseline (today, CLI surface):** run the probe against the *unmodified*
-  builtin vocabulary and count authored-step demands. Prediction: **2**
-  (`scaffold`, `run`). The run produces the real number — that's the falsifiable
-  result. Command: `scripts/prove_language_cli.sh --baseline` (drives builtin
-  vocab only, logs each point the flow stalls for a missing atom).
-- **Target (CLI surface, after atoms):** **0** authored steps; the CLI builds
-  and runs from `GOAL.md` alone.
-- **Across all three surfaces:** gap count = 0 is the finish line for the whole
-  item — CLI (this PR), then server (`integrate`), then mobile (platform-build +
-  `rams`). Each probe reports its own gap count on the roadmap.
+Binary and observable, not a fuzzy count. A headless agent *improvises* around a
+missing atom (it won't cleanly halt and announce "gap here"), so "count the
+stalls" isn't reliably measurable. What *is* observable at the end of a run:
+`.lf/steps/` in the probe dir — empty or not — and whether a binary built and ran.
+
+- **Before atoms:** the `greenfield` flow can't even be assembled from builtins
+  (no `scaffold`/`run` to reference) — the gap is structural, not a runtime count.
+  The predicted missing primitives are `scaffold` and `run`; the experiment
+  confirms them by their *absence* blocking assembly, not by tallying stalls.
+- **After atoms (CLI surface):** the probe reaches a running CLI with
+  `.lf/steps/` **empty**. That empty directory is the proof.
+- **Across all three surfaces:** empty `.lf/steps/` on CLI (this PR), then server
+  (`integrate`), then mobile (platform-build + `rams`). Each probe records its
+  outcome on the roadmap.
 
 "Better" = the number of `.lf/steps/*.md` a developer must write to get a
 running product goes from >0 to 0.

--- a/scratch/questions.md
+++ b/scratch/questions.md
@@ -37,11 +37,7 @@ Made these executive calls against the code; a human should sanity-check them:
   team is fine losing the "gap count = 2" narrative in favor of the observable
   empty-directory proof.
 
-## Blocker — roadmap write-back deferred
+## Roadmap write-back
 
-`lf op pm show --wave goals` fails: `wave/goals/GOAL.md has no pm.asana_project`
-(needs `lf op pm init --wave goals`). The design's roadmap write-back (record CLI
-result on 1216257471904678; file server-probe + mobile-probe) is owed but blocked
-on connecting the project — a setup + external write, out of kickoff scope in a
-headless run. Next pass: connect the project, then `lf op pm update` per the
-design's "Done when".
+The goals wave now carries the canonical Asana project id from wave memory:
+`1216257471889000`. Write-back should use `lf op pm update --wave goals`.

--- a/scratch/questions.md
+++ b/scratch/questions.md
@@ -1,0 +1,16 @@
+# Open questions — prove-the-language
+
+Headless run; assumptions made and proceeding.
+
+- **Asana id 1216257471904678 maps to `3-vocabulary-completeness.md`** (confirmed
+  via `asana_id:` frontmatter in that file). Treating the "three reference
+  builds" acceptance test as the work item.
+- **Kickoff = design deliverable, not implementation.** This session produces the
+  design under `scratch/`; the probe run and the atom PRs are dispatched work.
+- **Smallest falsifying probe = a CLI.** Assumed over server/mobile because it
+  isolates the two most fundamental missing atoms (scaffold, run) from the
+  client/server seam and platform-build machinery. Corrected in review if wrong.
+- **New atoms are builtin markdown steps, not scripts.** Assumed because
+  `build.rs` auto-registers `build/step/*.md` and every existing step is a prompt.
+- **Probe runs in a throwaway temp dir**, not this repo, so greenfield git
+  assumptions and product code never touch loopflow.

--- a/scratch/questions.md
+++ b/scratch/questions.md
@@ -14,3 +14,12 @@ Headless run; assumptions made and proceeding.
   `build.rs` auto-registers `build/step/*.md` and every existing step is a prompt.
 - **Probe runs in a throwaway temp dir**, not this repo, so greenfield git
   assumptions and product code never touch loopflow.
+
+## Blocker — roadmap write-back deferred
+
+`lf op pm show --wave goals` fails: `wave/goals/GOAL.md has no pm.asana_project`
+(needs `lf op pm init --wave goals`). The design's roadmap write-back (record CLI
+result on 1216257471904678; file server-probe + mobile-probe) is owed but blocked
+on connecting the project — a setup + external write, out of kickoff scope in a
+headless run. Next pass: connect the project, then `lf op pm update` per the
+design's "Done when".

--- a/scratch/questions.md
+++ b/scratch/questions.md
@@ -15,6 +15,28 @@ Headless run; assumptions made and proceeding.
 - **Probe runs in a throwaway temp dir**, not this repo, so greenfield git
   assumptions and product code never touch loopflow.
 
+## Design-review reshapes (headless review pass — confirm in a human pass)
+
+Made these executive calls against the code; a human should sanity-check them:
+
+- **Dropped `design` from the `greenfield` flow.** Verified `design` is
+  `interactive: true` (design.md:2) and headless flows park on interactive steps
+  (`FlowAction::WaitInteractive`, flow.rs:272), so the original scaffold→design→…
+  chain would stall the probe at step one. Reshaped to
+  scaffold→implement→run→gate, with `scaffold` seeding `scratch/<branch>.md` from
+  the GOAL. *Soft point:* this loads a design-brief responsibility onto
+  `scaffold`. Fallback (documented in the doc) is a non-interactive `design`
+  override inside the flow. A human should pick.
+- **Split "done when" into a CI merge gate vs a manual acceptance experiment.**
+  The full agentic greenfield build can't be a `cargo test` gate (paid, slow,
+  nondeterministic). Merge gate is now the registry test only; the probe run is a
+  one-shot experiment whose result goes on the roadmap. Confirm this is the
+  intended contract before implementation wires a "probe green" check into CI.
+- **Metric made binary (empty `.lf/steps/`), not a stall count.** A headless
+  agent improvises around gaps, so counting stalls isn't measurable. Confirm the
+  team is fine losing the "gap count = 2" narrative in favor of the observable
+  empty-directory proof.
+
 ## Blocker — roadmap write-back deferred
 
 `lf op pm show --wave goals` fails: `wave/goals/GOAL.md has no pm.asana_project`

--- a/scripts/prove_language_cli.sh
+++ b/scripts/prove_language_cli.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+lf_bin="${LF_BIN:-lf}"
+probe_dir="$(mktemp -d "${TMPDIR:-/tmp}/loopflow-greenfield-cli.XXXXXX")"
+
+cat >"${probe_dir}/GOAL.md" <<'GOAL'
+# Goal Hello
+
+Create a Rust CLI named `goal-hello`.
+
+It accepts `--name <value>` and prints `hello, <value>`.
+
+Done when `cargo run --quiet -- --name Loopflow` prints exactly
+`hello, Loopflow`.
+
+Do not author any `.lf/steps/*.md` files.
+GOAL
+
+echo "probe: ${probe_dir}"
+(
+  cd "${probe_dir}"
+  "${lf_bin}" -b greenfield
+)
+
+steps_count=0
+if [ -d "${probe_dir}/.lf/steps" ]; then
+  steps_count="$(find "${probe_dir}/.lf/steps" -type f -name '*.md' | wc -l | tr -d ' ')"
+fi
+
+if [ "${steps_count}" != "0" ]; then
+  echo "language failed: ${steps_count} local step(s) were authored in ${probe_dir}/.lf/steps" >&2
+  exit 1
+fi
+
+output="$(
+  cd "${probe_dir}"
+  cargo run --quiet -- --name Loopflow
+)"
+
+echo "${output}"
+
+if [ "${output}" != "hello, Loopflow" ]; then
+  echo "language failed: expected 'hello, Loopflow'" >&2
+  exit 1
+fi
+
+echo "language passed: CLI ran with 0 authored steps"

--- a/wave/goals/GOAL.md
+++ b/wave/goals/GOAL.md
@@ -2,6 +2,8 @@
 primary_flow: ship-roadmap
 mode: manual
 workers: 0
+pm:
+  asana_project: 1216257471889000
 metrics:
   - A wave is authored in one file (GOAL.md) — no yaml, no local roadmap mirror
   - The roadmap is live in Asana, read and written by the loop


### PR DESCRIPTION
**Try it!**

```bash
cargo test -p loopflow --test flow_tests
cargo test -p loopflow --test discovery_tests
LF_BIN="$PWD/target/debug/lf" scripts/prove_language_cli.sh
```

The probe creates a temp directory containing only `GOAL.md`, runs `greenfield`, and expects `cargo run --quiet -- --name Loopflow` to print `hello, Loopflow` with zero `.lf/steps/*.md` authored. I ran it successfully on 2026-07-04.

**Intent**

Add the first greenfield vocabulary slice: builtin `scaffold` and `run` prompt steps plus a headless `greenfield` flow (`scaffold -> implement -> run -> gate`) so a GOAL.md-only product can originate without an interactive design step.

**Key Decisions**

- `greenfield` skips `design` because that step is interactive and would park a headless flow.
- `scaffold` seeds `scratch/<branch>.md` from `GOAL.md` and initializes git when the target dir has no repo.
- `run` records observed commands/output in `scratch/run-observations.md`; it is separate from interactive `demo`.

**Verification**

- `cargo test`
- `cargo clippy -- -D warnings`
- `uv run pytest python/tests/`
- `cargo test -p loopflow --test flow_tests`
- `cargo test -p loopflow --test discovery_tests`
- Manual probe: `scripts/prove_language_cli.sh` passed; stdout ended with `language passed: CLI ran with 0 authored steps`.

**Roadmap**

Updated Asana item `1216257471904678` with the CLI probe result and filed follow-ups `1216279271843184` (server/integrate) and `1216279665845538` (mobile/platform-build + rams).

**Not Included**

The server `integrate` primitive and mobile platform-build/RAMS probe are split into those follow-up roadmap items.