### PR TITLE
pm: add Linear as a selectable PM provider (dormant)

### DIFF
--- a/rust/loopflow/src/engine/config.rs
+++ b/rust/loopflow/src/engine/config.rs
@@ -144,6 +144,18 @@ pub struct AsanaConfig {
     pub default_team: Option<String>,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
+pub struct LinearConfig {
+    #[serde(default)]
+    pub team: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
+pub struct PmConfig {
+    #[serde(default)]
+    pub provider: Option<String>,
+}
+
 /// Main configuration struct.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Config {
@@ -230,6 +242,14 @@ pub struct Config {
     /// Asana configuration for PM integration.
     #[serde(default)]
     pub asana: AsanaConfig,
+
+    /// Linear configuration for PM integration spikes.
+    #[serde(default)]
+    pub linear: LinearConfig,
+
+    /// PM provider selection.
+    #[serde(default)]
+    pub pm: Option<PmConfig>,
 }
 
 fn default_land() -> String {
@@ -264,6 +284,8 @@ impl Default for Config {
             autoprune: AutopruneConfig::default(),
             release: ReleaseConfig::default(),
             asana: AsanaConfig::default(),
+            linear: LinearConfig::default(),
+            pm: None,
         }
     }
 }

--- a/rust/loopflow/src/engine/wave_config.rs
+++ b/rust/loopflow/src/engine/wave_config.rs
@@ -13,11 +13,15 @@ pub struct WaveCronDef {
     pub schedule: String,
 }
 
-/// The Asana project a wave's roadmap lives in, from `pm.asana_project` in GOAL.md.
+/// The PM project a wave's roadmap lives in, from `pm.*` in GOAL.md.
 #[derive(Debug, Clone, Deserialize, Serialize, Default, PartialEq, Eq)]
 pub struct WavePmConfig {
     #[serde(default)]
+    pub provider: Option<String>,
+    #[serde(default)]
     pub asana_project: Option<String>,
+    #[serde(default)]
+    pub linear_project: Option<String>,
 }
 
 /// Intent read from `wave/<name>/GOAL.md` frontmatter during wave creation.
@@ -237,6 +241,23 @@ mod tests {
         let config = read_wave_config(temp.path(), "scan").expect("config should parse");
         let pm = config.pm.expect("pm config should exist");
         assert_eq!(pm.asana_project.as_deref(), Some("1234567890"));
+    }
+
+    #[test]
+    fn read_wave_config_parses_linear_pm_block() {
+        let temp = tempdir().expect("temp dir");
+        let dir = temp.path().join("wave").join("scan");
+        fs::create_dir_all(&dir).expect("create dir");
+        fs::write(
+            dir.join("GOAL.md"),
+            "---\npm:\n  provider: linear\n  linear_project: \"lin-123\"\n---\nDrive the work.\n",
+        )
+        .expect("write");
+
+        let config = read_wave_config(temp.path(), "scan").expect("config should parse");
+        let pm = config.pm.expect("pm config should exist");
+        assert_eq!(pm.provider.as_deref(), Some("linear"));
+        assert_eq!(pm.linear_project.as_deref(), Some("lin-123"));
     }
 
     /// Crons live in GOAL.md frontmatter — the resident mind's schedule

--- a/rust/loopflow/src/lfd/pm/linear.rs
+++ b/rust/loopflow/src/lfd/pm/linear.rs
@@ -1,0 +1,776 @@
+use reqwest::StatusCode;
+use serde::de::DeserializeOwned;
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+use tokio::time::sleep;
+use tracing::warn;
+
+use crate::lfd::pm::{
+    PmError, PmItem, PmItemCreate, PmItemUpdate, PmProject, PmResult, RATE_LIMIT_RETRIES,
+};
+
+const LINEAR_BASE_URL: &str = "https://api.linear.app/graphql";
+const LIST_ITEMS_PAGE_SIZE: u32 = 50;
+const COMPLETED_STATE_TYPE: &str = "completed";
+const DEFAULT_LOOPFLOW_TEAM_NAME: &str = "Loopflow";
+
+const LIST_TEAMS_QUERY: &str = r#"query ListTeams {
+  teams {
+    nodes {
+      id
+      name
+    }
+  }
+}"#;
+
+const CREATE_TEAM_MUTATION: &str = r#"mutation CreateTeam($name: String!, $key: String!) {
+  teamCreate(input: { name: $name, key: $key }) {
+    team {
+      id
+    }
+  }
+}"#;
+
+const CREATE_PROJECT_MUTATION: &str = r#"mutation CreateProject($name: String!, $description: String!, $teamId: String!) {
+  projectCreate(input: { name: $name, description: $description, teamIds: [$teamId] }) {
+    project {
+      id
+    }
+  }
+}"#;
+
+const LIST_ITEMS_QUERY: &str = r#"query ListProjectIssues($projectId: String!, $after: String, $first: Int!) {
+  project(id: $projectId) {
+    issues(first: $first, after: $after) {
+      nodes {
+        id
+        title
+        description
+        prioritySortOrder
+        sortOrder
+        assignee {
+          id
+        }
+        state {
+          type
+        }
+      }
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+    }
+  }
+}"#;
+
+const CREATE_ITEM_MUTATION: &str = r#"mutation CreateIssue($teamId: String!, $projectId: String!, $title: String!, $description: String!) {
+  issueCreate(input: { teamId: $teamId, projectId: $projectId, title: $title, description: $description }) {
+    issue {
+      id
+    }
+  }
+}"#;
+
+const UPDATE_ITEM_MUTATION: &str = r#"mutation UpdateIssue($id: String!, $title: String, $description: String) {
+  issueUpdate(id: $id, input: { title: $title, description: $description }) {
+    issue {
+      id
+    }
+  }
+}"#;
+
+const COMPLETE_ITEM_MUTATION: &str = r#"mutation CompleteIssue($id: String!, $stateId: String!) {
+  issueUpdate(id: $id, input: { stateId: $stateId }) {
+    issue {
+      id
+    }
+  }
+}"#;
+
+const LIST_COMPLETED_WORKFLOW_STATES_QUERY: &str = r#"query CompletedWorkflowStates($teamId: String!) {
+  workflowStates(filter: { team: { id: { eq: $teamId } }, type: { eq: "completed" } }) {
+    nodes {
+      id
+    }
+  }
+}"#;
+
+const LIST_TEAM_PROJECTS_QUERY: &str = r#"query ListTeamProjects($teamId: String!) {
+  team(id: $teamId) {
+    projects {
+      nodes {
+        id
+        name
+      }
+    }
+  }
+}"#;
+
+const CREATE_COMMENT_MUTATION: &str = r#"mutation CreateComment($issueId: String!, $body: String!) {
+  commentCreate(input: { issueId: $issueId, body: $body }) {
+    comment {
+      id
+    }
+  }
+}"#;
+
+#[derive(Debug, Clone)]
+pub struct LinearClient {
+    client: reqwest::Client,
+    token: String,
+    team_id: Option<String>,
+    base_url: String,
+}
+
+impl LinearClient {
+    pub fn new(token: String, team_id: Option<String>) -> Self {
+        Self {
+            client: reqwest::Client::new(),
+            token,
+            team_id,
+            base_url: LINEAR_BASE_URL.to_string(),
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn with_base_url(token: String, team_id: Option<String>, base_url: String) -> Self {
+        Self {
+            client: reqwest::Client::new(),
+            token,
+            team_id,
+            base_url,
+        }
+    }
+
+    async fn resolve_team_id(&self) -> PmResult<String> {
+        if let Some(team_id) = &self.team_id {
+            return Ok(team_id.clone());
+        }
+
+        let response: TeamsData = self.graphql(LIST_TEAMS_QUERY, json!({})).await?;
+        if let Some(team) = response
+            .teams
+            .nodes
+            .iter()
+            .find(|team| team.name.eq_ignore_ascii_case(DEFAULT_LOOPFLOW_TEAM_NAME))
+        {
+            return Ok(team.id.clone());
+        }
+
+        let response: TeamCreateData = self
+            .graphql(
+                CREATE_TEAM_MUTATION,
+                json!({
+                    "name": DEFAULT_LOOPFLOW_TEAM_NAME,
+                    "key": team_key_from_name(DEFAULT_LOOPFLOW_TEAM_NAME),
+                }),
+            )
+            .await?;
+        Ok(response.team_create.team.id)
+    }
+
+    async fn graphql<T>(&self, query: &str, variables: Value) -> PmResult<T>
+    where
+        T: DeserializeOwned,
+    {
+        let request = GraphqlRequest { query, variables };
+
+        for attempt in 0..=RATE_LIMIT_RETRIES {
+            let response = self
+                .client
+                .post(&self.base_url)
+                .bearer_auth(&self.token)
+                .json(&request)
+                .send()
+                .await
+                .map_err(|err| PmError::Message(format!("linear request failed: {err}")))?;
+
+            if response.status() == StatusCode::TOO_MANY_REQUESTS && attempt < RATE_LIMIT_RETRIES {
+                let delay = super::retry_after_delay(response.headers());
+                warn!(
+                    attempt = attempt + 1,
+                    delay_seconds = delay.as_secs(),
+                    "linear rate limited; retrying"
+                );
+                sleep(delay).await;
+                continue;
+            }
+
+            return parse_graphql_response(response).await;
+        }
+
+        Err(PmError::Message(
+            "linear request failed after retries".to_string(),
+        ))
+    }
+
+    async fn completed_state_id(&self) -> PmResult<String> {
+        let team_id = self.resolve_team_id().await?;
+        let response: WorkflowStatesData = self
+            .graphql(
+                LIST_COMPLETED_WORKFLOW_STATES_QUERY,
+                json!({ "teamId": team_id }),
+            )
+            .await?;
+
+        response
+            .workflow_states
+            .nodes
+            .into_iter()
+            .next()
+            .map(|state| state.id)
+            .ok_or_else(|| {
+                PmError::Message(format!(
+                    "no completed Linear workflow state found for team {team_id}"
+                ))
+            })
+    }
+
+    pub async fn create_project(&self, name: &str, description: &str) -> PmResult<String> {
+        let team_id = self.resolve_team_id().await?;
+        let response: ProjectCreateData = self
+            .graphql(
+                CREATE_PROJECT_MUTATION,
+                json!({
+                    "name": name,
+                    "description": linear_project_description(description),
+                    "teamId": team_id,
+                }),
+            )
+            .await?;
+
+        Ok(response.project_create.project.id)
+    }
+
+    pub async fn list_projects(&self, team_id: &str) -> PmResult<Vec<PmProject>> {
+        let response: TeamProjectsData = self
+            .graphql(LIST_TEAM_PROJECTS_QUERY, json!({ "teamId": team_id }))
+            .await?;
+        Ok(response
+            .team
+            .projects
+            .nodes
+            .into_iter()
+            .map(|project| PmProject {
+                id: project.id,
+                name: project.name,
+            })
+            .collect())
+    }
+
+    pub async fn list_items(&self, project_id: &str) -> PmResult<Vec<PmItem>> {
+        let mut after = None;
+        let mut issues = Vec::new();
+
+        loop {
+            let response: ProjectIssuesData = self
+                .graphql(
+                    LIST_ITEMS_QUERY,
+                    json!({
+                        "projectId": project_id,
+                        "after": after,
+                        "first": LIST_ITEMS_PAGE_SIZE,
+                    }),
+                )
+                .await?;
+
+            let page = response.project.issues;
+            issues.extend(page.nodes);
+
+            if !page.page_info.has_next_page {
+                issues.sort_by(|left, right| {
+                    left.priority_sort_order
+                        .total_cmp(&right.priority_sort_order)
+                        .then_with(|| left.sort_order.total_cmp(&right.sort_order))
+                });
+                return Ok(issues
+                    .into_iter()
+                    .enumerate()
+                    .map(|(rank, issue)| issue.into_pm_item(rank as u32))
+                    .collect());
+            }
+
+            after = page.page_info.end_cursor;
+        }
+    }
+
+    pub async fn create_item(&self, project_id: &str, item: &PmItemCreate) -> PmResult<String> {
+        let team_id = self.resolve_team_id().await?;
+        let response: IssueCreateData = self
+            .graphql(
+                CREATE_ITEM_MUTATION,
+                json!({
+                    "teamId": team_id,
+                    "projectId": project_id,
+                    "title": item.name,
+                    "description": item.description,
+                }),
+            )
+            .await?;
+
+        Ok(response.issue_create.issue.id)
+    }
+
+    pub async fn update_item(&self, item_id: &str, update: &PmItemUpdate) -> PmResult<()> {
+        let Some(update) = update.text_update() else {
+            return Ok(());
+        };
+
+        let _: Value = self
+            .graphql(
+                UPDATE_ITEM_MUTATION,
+                json!({
+                    "id": item_id,
+                    "title": update.name,
+                    "description": update.description,
+                }),
+            )
+            .await?;
+        Ok(())
+    }
+
+    pub async fn complete_item(&self, item_id: &str) -> PmResult<()> {
+        let state_id = self.completed_state_id().await?;
+        let _: Value = self
+            .graphql(
+                COMPLETE_ITEM_MUTATION,
+                json!({
+                    "id": item_id,
+                    "stateId": state_id,
+                }),
+            )
+            .await?;
+        Ok(())
+    }
+
+    pub async fn comment(&self, item_id: &str, body: &str) -> PmResult<()> {
+        let _: Value = self
+            .graphql(
+                CREATE_COMMENT_MUTATION,
+                json!({
+                    "issueId": item_id,
+                    "body": body,
+                }),
+            )
+            .await?;
+        Ok(())
+    }
+}
+
+#[derive(Serialize)]
+struct GraphqlRequest<'a> {
+    query: &'a str,
+    variables: Value,
+}
+
+#[derive(Deserialize)]
+struct GraphqlResponse {
+    #[serde(default)]
+    data: Option<Value>,
+    #[serde(default)]
+    errors: Vec<GraphqlError>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GraphqlError {
+    message: String,
+    #[serde(default)]
+    extensions: Option<GraphqlErrorExtensions>,
+}
+
+impl GraphqlError {
+    fn display_message(&self) -> &str {
+        self.extensions
+            .as_ref()
+            .and_then(|extensions| extensions.user_presentable_message.as_deref())
+            .filter(|message| !message.trim().is_empty())
+            .unwrap_or(&self.message)
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct GraphqlErrorExtensions {
+    #[serde(default)]
+    user_presentable_message: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct ProjectCreateData {
+    #[serde(rename = "projectCreate")]
+    project_create: ProjectPayload,
+}
+
+#[derive(Deserialize)]
+struct IssueCreateData {
+    #[serde(rename = "issueCreate")]
+    issue_create: IssuePayload,
+}
+
+#[derive(Deserialize)]
+struct ProjectPayload {
+    project: IdNode,
+}
+
+#[derive(Deserialize)]
+struct IssuePayload {
+    issue: IdNode,
+}
+
+#[derive(Deserialize)]
+struct IdNode {
+    id: String,
+}
+
+#[derive(Deserialize)]
+struct IssueNode {
+    id: String,
+    #[serde(default)]
+    title: String,
+    #[serde(default)]
+    description: Option<String>,
+    #[serde(rename = "prioritySortOrder", default)]
+    priority_sort_order: f64,
+    #[serde(rename = "sortOrder", default)]
+    sort_order: f64,
+    #[serde(default)]
+    assignee: Option<IdNode>,
+    #[serde(default)]
+    state: Option<WorkflowStateRef>,
+}
+
+impl IssueNode {
+    fn into_pm_item(self, rank: u32) -> PmItem {
+        let completed = self
+            .state
+            .as_ref()
+            .is_some_and(|state| state.r#type.eq_ignore_ascii_case(COMPLETED_STATE_TYPE));
+
+        PmItem {
+            id: self.id,
+            name: self.title,
+            description: self.description.unwrap_or_default(),
+            rank,
+            completed,
+            assignee: self.assignee.map(|assignee| assignee.id),
+        }
+    }
+}
+
+#[derive(Deserialize)]
+struct WorkflowStateRef {
+    #[serde(rename = "type")]
+    r#type: String,
+}
+
+#[derive(Deserialize)]
+struct ProjectIssuesData {
+    project: ProjectWithIssues,
+}
+
+#[derive(Deserialize)]
+struct ProjectWithIssues {
+    issues: IssuesConnection,
+}
+
+#[derive(Deserialize)]
+struct IssuesConnection {
+    nodes: Vec<IssueNode>,
+    #[serde(rename = "pageInfo")]
+    page_info: PageInfo,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct PageInfo {
+    has_next_page: bool,
+    end_cursor: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct WorkflowStatesData {
+    #[serde(rename = "workflowStates")]
+    workflow_states: WorkflowStatesConnection,
+}
+
+#[derive(Deserialize)]
+struct WorkflowStatesConnection {
+    nodes: Vec<WorkflowStateNode>,
+}
+
+#[derive(Deserialize)]
+struct WorkflowStateNode {
+    id: String,
+}
+
+#[derive(Deserialize)]
+struct TeamsData {
+    teams: TeamsConnection,
+}
+
+#[derive(Deserialize)]
+struct TeamsConnection {
+    nodes: Vec<TeamNode>,
+}
+
+#[derive(Deserialize)]
+struct TeamNode {
+    id: String,
+    name: String,
+}
+
+#[derive(Deserialize)]
+struct TeamCreateData {
+    #[serde(rename = "teamCreate")]
+    team_create: TeamCreatePayload,
+}
+
+#[derive(Deserialize)]
+struct TeamCreatePayload {
+    team: IdNode,
+}
+
+#[derive(Deserialize)]
+struct TeamProjectsData {
+    team: TeamWithProjects,
+}
+
+#[derive(Deserialize)]
+struct TeamWithProjects {
+    projects: ProjectsConnection,
+}
+
+#[derive(Deserialize)]
+struct ProjectsConnection {
+    nodes: Vec<ProjectNode>,
+}
+
+#[derive(Deserialize)]
+struct ProjectNode {
+    id: String,
+    name: String,
+}
+
+async fn parse_graphql_response<T: DeserializeOwned>(response: reqwest::Response) -> PmResult<T> {
+    let status = response.status();
+    let body = response
+        .bytes()
+        .await
+        .map_err(|err| PmError::Message(format!("failed to read Linear response: {err}")))?;
+
+    let parsed = serde_json::from_slice::<GraphqlResponse>(&body)
+        .map_err(|err| PmError::Message(format!("failed to decode Linear response: {err}")))?;
+
+    if let Some(error) = parsed.errors.first() {
+        if status.is_success() {
+            return Err(PmError::Message(error.display_message().to_string()));
+        }
+        return Err(PmError::Message(format!(
+            "linear request failed with status {status}: {}",
+            error.display_message()
+        )));
+    }
+
+    if !status.is_success() {
+        let body_text = String::from_utf8_lossy(&body).trim().to_string();
+        if body_text.is_empty() {
+            return Err(PmError::Message(format!(
+                "linear request failed with status {status}"
+            )));
+        }
+        return Err(PmError::Message(format!(
+            "linear request failed with status {status}: {body_text}"
+        )));
+    }
+
+    let data = parsed
+        .data
+        .ok_or_else(|| PmError::Message("linear response missing data".to_string()))?;
+    serde_json::from_value(data)
+        .map_err(|err| PmError::Message(format!("failed to decode Linear response: {err}")))
+}
+
+fn team_key_from_name(name: &str) -> String {
+    let key: String = name
+        .split_whitespace()
+        .filter_map(|word| word.chars().next())
+        .map(|ch| ch.to_ascii_uppercase())
+        .collect();
+    if key.is_empty() {
+        "LF".to_string()
+    } else {
+        key[..key.len().min(5)].to_string()
+    }
+}
+
+fn linear_project_description(description: &str) -> String {
+    let summary = first_meaningful_paragraph(description);
+    if summary.is_empty() {
+        return String::new();
+    }
+
+    const MAX_DESCRIPTION_LEN: usize = 255;
+    summary.chars().take(MAX_DESCRIPTION_LEN).collect()
+}
+
+fn first_meaningful_paragraph(description: &str) -> String {
+    let mut lines = description.lines().peekable();
+    while let Some(line) = lines.next() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() || trimmed.starts_with('#') {
+            continue;
+        }
+
+        let mut paragraph = vec![trimmed];
+        while let Some(next_line) = lines.peek() {
+            let trimmed = next_line.trim();
+            if trimmed.is_empty() {
+                break;
+            }
+            if trimmed.starts_with('#') {
+                lines.next();
+                break;
+            }
+            paragraph.push(trimmed);
+            lines.next();
+        }
+
+        return paragraph.join(" ");
+    }
+
+    String::new()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::lfd::pm::test_server::{self, json_response};
+    use axum::http::StatusCode;
+    use serde_json::json;
+
+    #[tokio::test]
+    async fn list_items_maps_linear_project_issues() {
+        let (base_url, requests) = test_server::spawn(vec![json_response(
+            StatusCode::OK,
+            json!({
+                "data": {
+                    "project": {
+                        "issues": {
+                            "nodes": [
+                                {
+                                    "id": "issue-1",
+                                    "title": "First",
+                                    "description": "one",
+                                    "prioritySortOrder": 10.0,
+                                    "sortOrder": 10.0,
+                                    "assignee": { "id": "user-1" },
+                                    "state": { "type": "unstarted" }
+                                },
+                                {
+                                    "id": "issue-2",
+                                    "title": "Second",
+                                    "description": "two",
+                                    "prioritySortOrder": 0.0,
+                                    "sortOrder": 0.0,
+                                    "state": { "type": "completed" }
+                                }
+                            ],
+                            "pageInfo": {
+                                "hasNextPage": false,
+                                "endCursor": null
+                            }
+                        }
+                    }
+                }
+            }),
+        )])
+        .await;
+        let client = LinearClient::with_base_url(
+            "linear-secret".to_string(),
+            Some("team-9".to_string()),
+            base_url,
+        );
+
+        let items = client
+            .list_items("project-123")
+            .await
+            .expect("list items succeeds");
+
+        assert_eq!(items.len(), 2);
+        assert_eq!(items[0].id, "issue-2");
+        assert!(items[0].completed);
+        assert_eq!(items[1].assignee.as_deref(), Some("user-1"));
+        let requests = requests.lock().await;
+        assert_eq!(requests.len(), 1);
+        assert_eq!(
+            requests[0].authorization.as_deref(),
+            Some("Bearer linear-secret")
+        );
+    }
+
+    #[tokio::test]
+    async fn create_update_and_comment_map_to_linear_mutations() {
+        let (base_url, requests) = test_server::spawn(vec![
+            json_response(
+                StatusCode::OK,
+                json!({ "data": { "issueCreate": { "issue": { "id": "issue-123" } } } }),
+            ),
+            json_response(
+                StatusCode::OK,
+                json!({ "data": { "issueUpdate": { "issue": { "id": "issue-123" } } } }),
+            ),
+            json_response(
+                StatusCode::OK,
+                json!({ "data": { "commentCreate": { "comment": { "id": "comment-1" } } } }),
+            ),
+        ])
+        .await;
+        let client = LinearClient::with_base_url(
+            "linear-secret".to_string(),
+            Some("team-9".to_string()),
+            base_url,
+        );
+
+        let item_id = client
+            .create_item(
+                "project-123",
+                &PmItemCreate {
+                    name: "Implement client".to_string(),
+                    description: "Build the GraphQL adapter".to_string(),
+                    rank: 7,
+                },
+            )
+            .await
+            .expect("create item succeeds");
+        client
+            .update_item(
+                &item_id,
+                &PmItemUpdate {
+                    name: Some("Implement Linear client".to_string()),
+                    description: Some("Build the GraphQL adapter and tests".to_string()),
+                    rank: Some(0),
+                },
+            )
+            .await
+            .expect("update item succeeds");
+        client
+            .comment(&item_id, "Shipped in v0.9.9")
+            .await
+            .expect("comment succeeds");
+
+        assert_eq!(item_id, "issue-123");
+        assert_eq!(requests.lock().await.len(), 3);
+    }
+
+    #[test]
+    fn linear_project_description_skips_headings_and_truncates() {
+        let summary = linear_project_description(
+            "## Vision\n\nThis is the first paragraph.\n\n## Strategy\n\nSecond paragraph.",
+        );
+        assert_eq!(summary, "This is the first paragraph.");
+
+        let long = "a".repeat(300);
+        assert_eq!(linear_project_description(&long).len(), 255);
+        assert_eq!(linear_project_description(""), "");
+    }
+}

--- a/rust/loopflow/src/lfd/pm/mod.rs
+++ b/rust/loopflow/src/lfd/pm/mod.rs
@@ -1,10 +1,56 @@
 pub mod asana;
+pub mod linear;
 mod asana_html;
 
+use std::str::FromStr;
 use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+#[non_exhaustive]
+pub enum PmProviderKind {
+    Asana,
+    Linear,
+}
+
+impl PmProviderKind {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Asana => "asana",
+            Self::Linear => "linear",
+        }
+    }
+
+    pub fn project_key(self) -> &'static str {
+        match self {
+            Self::Asana => "asana_project",
+            Self::Linear => "linear_project",
+        }
+    }
+}
+
+impl std::fmt::Display for PmProviderKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl FromStr for PmProviderKind {
+    type Err = PmError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "asana" => Ok(Self::Asana),
+            "linear" => Ok(Self::Linear),
+            other => Err(PmError::Message(format!(
+                "unsupported PM provider {other:?}; expected \"asana\" or \"linear\""
+            ))),
+        }
+    }
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]

--- a/rust/loopflow/src/lfd/pm/mod.rs
+++ b/rust/loopflow/src/lfd/pm/mod.rs
@@ -1,6 +1,6 @@
 pub mod asana;
-pub mod linear;
 mod asana_html;
+pub mod linear;
 
 use std::str::FromStr;
 use std::time::Duration;

--- a/rust/loopflow/src/ops/pm.rs
+++ b/rust/loopflow/src/ops/pm.rs
@@ -11,12 +11,12 @@ use crate::engine::config::load_config_or_default;
 use crate::engine::wave_config::{read_wave_config, update_wave_goal_config, WavePmConfig};
 use crate::lfd::pm::asana::AsanaClient;
 use crate::lfd::pm::linear::LinearClient;
-use crate::lfd::pm::{PmError, PmItem, PmItemCreate, PmItemUpdate, PmProviderKind};
+use crate::lfd::pm::{PmError, PmItem, PmItemCreate, PmItemUpdate, PmProviderKind, PmResult};
 use crate::lfdb::open_store;
 use crate::ops::error::{OpsError, OpsResult};
 use crate::ops::progress::Progress;
 use crate::ops::util::resolve_wave_name;
-use crate::provider_auth::{refresh_pm_oauth_token, Provider};
+use crate::provider_auth::{refresh_pm_oauth_token, resolve_linear_api_key, Provider};
 
 // ── Options and results ─────────────────────────────────────────────
 
@@ -168,7 +168,11 @@ fn resolve_provider(repo: &Path, wave: &str) -> OpsResult<PmProviderKind> {
     {
         return parse_provider(provider);
     }
-    if wave_pm.as_ref().and_then(|pm| pm.linear_project.as_ref()).is_some() {
+    if wave_pm
+        .as_ref()
+        .and_then(|pm| pm.linear_project.as_ref())
+        .is_some()
+    {
         return Ok(PmProviderKind::Linear);
     }
     Ok(PmProviderKind::Asana)
@@ -181,6 +185,13 @@ fn read_project(repo: &Path, wave: &str, provider: PmProviderKind) -> Option<Str
         PmProviderKind::Linear => pm.linear_project,
     }?;
     Some(project).filter(|project| !project.trim().is_empty())
+}
+
+/// Whether a wave has a roadmap project pinned for its resolved provider.
+fn wave_has_pm_project(repo: &Path, wave: &str) -> bool {
+    resolve_provider(repo, wave)
+        .ok()
+        .is_some_and(|provider| read_project(repo, wave, provider).is_some())
 }
 
 async fn build_client(repo: &Path, provider: PmProviderKind) -> OpsResult<PmClient> {
@@ -216,17 +227,33 @@ async fn resolve_context(repo: &Path, wave: &str) -> OpsResult<PmContext> {
 }
 
 async fn resolve_pm_token(provider: PmProviderKind) -> OpsResult<String> {
+    match provider {
+        PmProviderKind::Asana => resolve_asana_token().await,
+        PmProviderKind::Linear => resolve_linear_token().await,
+    }
+}
+
+/// Linear authenticates with a static personal API key resolved from the
+/// environment (then Doppler); there is no OAuth exchange or refresh.
+async fn resolve_linear_token() -> OpsResult<String> {
+    resolve_linear_api_key().await.ok_or_else(|| {
+        OpsError::Message(
+            "No Linear API key found. Set LINEAR_API_KEY in the environment or Doppler."
+                .to_string(),
+        )
+    })
+}
+
+async fn resolve_asana_token() -> OpsResult<String> {
     let store = open_store(&storage_config_from_env()?)
         .await
         .map_err(|err| OpsError::Message(format!("failed to open lfd credential store: {err}")))?;
     let token = store
-        .get_provider_token(provider.as_str())
+        .get_provider_token("asana")
         .await
-        .map_err(|err| OpsError::Message(format!("failed to load {provider} token: {err}")))?
+        .map_err(|err| OpsError::Message(format!("failed to load asana token: {err}")))?
         .ok_or_else(|| {
-            OpsError::Message(format!(
-                "No {provider} credential found. Run `lf op auth {provider}`."
-            ))
+            OpsError::Message("No asana credential found. Run `lf op auth asana`.".to_string())
         })?;
 
     let expired = token
@@ -236,16 +263,15 @@ async fn resolve_pm_token(provider: PmProviderKind) -> OpsResult<String> {
         return Ok(token.access_token);
     }
 
+    // The stored token is expired but may be refreshable: if it carries a refresh
+    // token and the OAuth client creds are in the env, refresh in place rather than
+    // forcing the user to re-authenticate.
     let refresh_token = token
         .refresh_token
         .as_deref()
         .filter(|value| !value.trim().is_empty());
     if let Some(refresh_token) = refresh_token {
-        let auth_provider = match provider {
-            PmProviderKind::Asana => Provider::Asana,
-            PmProviderKind::Linear => Provider::Linear,
-        };
-        if let Ok(mut refreshed) = refresh_pm_oauth_token(auth_provider, refresh_token).await {
+        if let Ok(mut refreshed) = refresh_pm_oauth_token(Provider::Asana, refresh_token).await {
             if refreshed.refresh_token.is_none() {
                 refreshed.refresh_token = token.refresh_token.clone();
             }
@@ -257,15 +283,15 @@ async fn resolve_pm_token(provider: PmProviderKind) -> OpsResult<String> {
                 .upsert_provider_token(&refreshed)
                 .await
                 .map_err(|err| {
-                    OpsError::Message(format!("failed to persist refreshed {provider} token: {err}"))
+                    OpsError::Message(format!("failed to persist refreshed asana token: {err}"))
                 })?;
             return Ok(access_token);
         }
     }
 
-    Err(OpsError::Message(format!(
-        "Stored {provider} token has expired. Run `lf op auth {provider}` again."
-    )))
+    Err(OpsError::Message(
+        "Stored asana token has expired. Run `lf op auth asana` again.".to_string(),
+    ))
 }
 
 fn storage_config_from_env() -> OpsResult<crate::lfdb::StorageConfig> {
@@ -297,9 +323,10 @@ async fn pm_init_async(
         )));
     }
 
-    if let Some(existing) = read_asana_project(repo, &wave) {
+    let provider = resolve_provider(repo, &wave)?;
+    if let Some(existing) = read_project(repo, &wave, provider) {
         progress.status(&format!(
-            "wave/{wave} already linked to asana project {existing}"
+            "wave/{wave} already linked to {provider} project {existing}"
         ));
         return Ok(PmInitResult {
             wave,
@@ -308,19 +335,19 @@ async fn pm_init_async(
         });
     }
 
-    let client = build_asana_client(repo).await?;
-    progress.status(&format!("creating asana project for wave/{wave}"));
+    let client = build_client(repo, provider).await?;
+    progress.status(&format!("creating {provider} project for wave/{wave}"));
     let project_id = client
         .create_project(&title_case(&wave), "")
         .await
         .map_err(pm_to_ops)?;
-    write_asana_project_to_goal(repo, &wave, &project_id)?;
+    write_project_to_goal(repo, &wave, provider, &project_id)?;
 
     let _ = crate::ops::commit_workflow(
         repo,
         &crate::ops::CommitOptions {
             add: true,
-            message: Some(format!("lf pm: connect {wave} to asana")),
+            message: Some(format!("lf pm: connect {wave} to {provider}")),
             ..crate::ops::CommitOptions::for_task("pm")
         },
         progress,
@@ -360,8 +387,8 @@ async fn fetch_items(
     progress: &impl Progress,
 ) -> OpsResult<PmShowResult> {
     progress.status(&format!(
-        "fetching asana project {} for wave/{wave}",
-        ctx.project
+        "fetching {} project {} for wave/{wave}",
+        ctx.provider, ctx.project
     ));
     let items = ctx
         .client
@@ -370,6 +397,7 @@ async fn fetch_items(
         .map_err(pm_to_ops)?;
     Ok(PmShowResult {
         wave: wave.to_string(),
+        provider: ctx.provider,
         project: ctx.project.clone(),
         items,
     })
@@ -416,7 +444,7 @@ async fn apply_update(
 
     let (id, created) = match options.id.as_ref() {
         Some(id) => {
-            progress.status(&format!("updating asana task {id}"));
+            progress.status(&format!("updating {} task {id}", ctx.provider));
             ctx.client
                 .update_item(
                     id,
@@ -432,8 +460,8 @@ async fn apply_update(
         }
         None => {
             progress.status(&format!(
-                "creating asana task on project {} for wave/{wave}",
-                ctx.project
+                "creating {} task on project {} for wave/{wave}",
+                ctx.provider, ctx.project
             ));
             let id = ctx
                 .client
@@ -460,7 +488,7 @@ async fn apply_update(
         .filter(|pr| !pr.is_empty())
     {
         Some(pr) => {
-            progress.status(&format!("commenting PR link on asana task {id}"));
+            progress.status(&format!("commenting PR link on {} task {id}", ctx.provider));
             let body = if mark_done {
                 format!("Shipped: {pr}")
             } else {
@@ -526,16 +554,18 @@ async fn pm_status_async(
 
     let mut results = Vec::new();
     for wave in waves {
-        let Some(project) = read_asana_project(repo, &wave) else {
+        let provider = resolve_provider(repo, &wave)?;
+        let Some(project) = read_project(repo, &wave, provider) else {
             continue;
         };
-        let client = build_asana_client(repo).await?;
-        progress.status(&format!("checking asana for wave/{wave}"));
+        let client = build_client(repo, provider).await?;
+        progress.status(&format!("checking {provider} for wave/{wave}"));
         let items = client.list_items(&project).await.map_err(pm_to_ops)?;
         let total = items.len();
         let open = items.iter().filter(|item| !item.completed).count();
         results.push(PmWaveStatus {
             wave,
+            provider,
             project,
             open,
             total,
@@ -559,7 +589,7 @@ pub fn list_pm_waves(repo: &Path) -> OpsResult<Vec<String>> {
         let Some(name) = entry.file_name().to_str().map(str::to_string) else {
             continue;
         };
-        if read_asana_project(repo, &name).is_some() {
+        if wave_has_pm_project(repo, &name) {
             waves.push(name);
         }
     }
@@ -569,7 +599,12 @@ pub fn list_pm_waves(repo: &Path) -> OpsResult<Vec<String>> {
 
 // ── helpers ─────────────────────────────────────────────────────────
 
-fn write_asana_project_to_goal(repo: &Path, wave: &str, project_id: &str) -> OpsResult<()> {
+fn write_project_to_goal(
+    repo: &Path,
+    wave: &str,
+    provider: PmProviderKind,
+    project_id: &str,
+) -> OpsResult<()> {
     update_wave_goal_config(repo, wave, |map| {
         let pm_key = serde_yaml_ng::Value::String("pm".to_string());
         let mut pm_map = map
@@ -578,7 +613,7 @@ fn write_asana_project_to_goal(repo: &Path, wave: &str, project_id: &str) -> Ops
             .cloned()
             .unwrap_or_default();
         pm_map.insert(
-            serde_yaml_ng::Value::String("asana_project".to_string()),
+            serde_yaml_ng::Value::String(provider.project_key().to_string()),
             serde_yaml_ng::Value::String(project_id.to_string()),
         );
         map.insert(pm_key, serde_yaml_ng::Value::Mapping(pm_map));
@@ -625,13 +660,70 @@ mod tests {
 
     fn test_ctx(base_url: String, project: &str) -> PmContext {
         PmContext {
-            client: AsanaClient::with_base_url(
+            client: PmClient::Asana(AsanaClient::with_base_url(
                 "test-token".to_string(),
                 AsanaConfig::default(),
                 base_url,
-            ),
+            )),
+            provider: PmProviderKind::Asana,
             project: project.to_string(),
         }
+    }
+
+    fn linear_test_ctx(base_url: String, project: &str) -> PmContext {
+        PmContext {
+            client: PmClient::Linear(crate::lfd::pm::linear::LinearClient::with_base_url(
+                "linear-secret".to_string(),
+                Some("team-9".to_string()),
+                base_url,
+            )),
+            provider: PmProviderKind::Linear,
+            project: project.to_string(),
+        }
+    }
+
+    fn write_goal(repo: &Path, wave: &str, frontmatter: &str) {
+        let dir = repo.join("wave").join(wave);
+        std::fs::create_dir_all(&dir).expect("create wave dir");
+        std::fs::write(
+            dir.join("GOAL.md"),
+            format!("---\n{frontmatter}---\nDrive the work.\n"),
+        )
+        .expect("write GOAL.md");
+    }
+
+    #[test]
+    fn resolve_provider_defaults_to_asana() {
+        let repo = tempfile::tempdir().expect("temp dir");
+        write_goal(repo.path(), "goals", "pm:\n  asana_project: \"123\"\n");
+        assert_eq!(
+            resolve_provider(repo.path(), "goals").unwrap(),
+            PmProviderKind::Asana
+        );
+    }
+
+    #[test]
+    fn resolve_provider_selects_linear_from_frontmatter() {
+        let repo = tempfile::tempdir().expect("temp dir");
+        write_goal(
+            repo.path(),
+            "scan",
+            "pm:\n  provider: linear\n  linear_project: \"lin-1\"\n",
+        );
+        assert_eq!(
+            resolve_provider(repo.path(), "scan").unwrap(),
+            PmProviderKind::Linear
+        );
+    }
+
+    #[test]
+    fn resolve_provider_infers_linear_from_project_key() {
+        let repo = tempfile::tempdir().expect("temp dir");
+        write_goal(repo.path(), "scan", "pm:\n  linear_project: \"lin-1\"\n");
+        assert_eq!(
+            resolve_provider(repo.path(), "scan").unwrap(),
+            PmProviderKind::Linear
+        );
     }
 
     #[test]
@@ -682,6 +774,34 @@ mod tests {
         assert_eq!(result.project, "proj-1");
         assert_eq!(result.items.len(), 2);
         assert_eq!(result.items[0].name, "First");
+    }
+
+    #[tokio::test]
+    async fn fetch_items_dispatches_to_linear_provider() {
+        let (base_url, requests) = test_server::spawn(vec![json_response(
+            StatusCode::OK,
+            json!({ "data": { "project": { "issues": {
+                "nodes": [
+                    { "id": "issue-1", "title": "First", "description": "one",
+                      "prioritySortOrder": 0.0, "sortOrder": 0.0,
+                      "state": { "type": "unstarted" } }
+                ],
+                "pageInfo": { "hasNextPage": false, "endCursor": null }
+            } } } }),
+        )])
+        .await;
+        let ctx = linear_test_ctx(base_url, "project-123");
+
+        let result = fetch_items("scan", &ctx, &NullProgress)
+            .await
+            .expect("fetch succeeds");
+        assert_eq!(result.provider, PmProviderKind::Linear);
+        assert_eq!(result.items.len(), 1);
+        assert_eq!(result.items[0].name, "First");
+        assert_eq!(
+            requests.lock().await[0].authorization.as_deref(),
+            Some("Bearer linear-secret")
+        );
     }
 
     #[tokio::test]

--- a/rust/loopflow/src/ops/pm.rs
+++ b/rust/loopflow/src/ops/pm.rs
@@ -16,7 +16,7 @@ use crate::lfdb::open_store;
 use crate::ops::error::{OpsError, OpsResult};
 use crate::ops::progress::Progress;
 use crate::ops::util::resolve_wave_name;
-use crate::provider_auth::{refresh_pm_oauth_token, resolve_linear_api_key, Provider};
+use crate::provider_auth::{refresh_pm_oauth_token, Provider};
 
 // ── Options and results ─────────────────────────────────────────────
 
@@ -226,34 +226,26 @@ async fn resolve_context(repo: &Path, wave: &str) -> OpsResult<PmContext> {
     })
 }
 
+/// Both Asana and Linear authenticate via OAuth: the access token lives in the
+/// lfdb credential store (keyed by provider), and an expired token is refreshed
+/// in place when it carries a refresh token and the OAuth client creds resolve.
 async fn resolve_pm_token(provider: PmProviderKind) -> OpsResult<String> {
-    match provider {
-        PmProviderKind::Asana => resolve_asana_token().await,
-        PmProviderKind::Linear => resolve_linear_token().await,
-    }
-}
+    let auth_provider = match provider {
+        PmProviderKind::Asana => Provider::Asana,
+        PmProviderKind::Linear => Provider::Linear,
+    };
 
-/// Linear authenticates with a static personal API key resolved from the
-/// environment (then Doppler); there is no OAuth exchange or refresh.
-async fn resolve_linear_token() -> OpsResult<String> {
-    resolve_linear_api_key().await.ok_or_else(|| {
-        OpsError::Message(
-            "No Linear API key found. Set LINEAR_API_KEY in the environment or Doppler."
-                .to_string(),
-        )
-    })
-}
-
-async fn resolve_asana_token() -> OpsResult<String> {
     let store = open_store(&storage_config_from_env()?)
         .await
         .map_err(|err| OpsError::Message(format!("failed to open lfd credential store: {err}")))?;
     let token = store
-        .get_provider_token("asana")
+        .get_provider_token(provider.as_str())
         .await
-        .map_err(|err| OpsError::Message(format!("failed to load asana token: {err}")))?
+        .map_err(|err| OpsError::Message(format!("failed to load {provider} token: {err}")))?
         .ok_or_else(|| {
-            OpsError::Message("No asana credential found. Run `lf op auth asana`.".to_string())
+            OpsError::Message(format!(
+                "No {provider} credential found. Run `lf op auth {provider}`."
+            ))
         })?;
 
     let expired = token
@@ -264,14 +256,14 @@ async fn resolve_asana_token() -> OpsResult<String> {
     }
 
     // The stored token is expired but may be refreshable: if it carries a refresh
-    // token and the OAuth client creds are in the env, refresh in place rather than
+    // token and the OAuth client creds resolve, refresh in place rather than
     // forcing the user to re-authenticate.
     let refresh_token = token
         .refresh_token
         .as_deref()
         .filter(|value| !value.trim().is_empty());
     if let Some(refresh_token) = refresh_token {
-        if let Ok(mut refreshed) = refresh_pm_oauth_token(Provider::Asana, refresh_token).await {
+        if let Ok(mut refreshed) = refresh_pm_oauth_token(auth_provider, refresh_token).await {
             if refreshed.refresh_token.is_none() {
                 refreshed.refresh_token = token.refresh_token.clone();
             }
@@ -283,15 +275,17 @@ async fn resolve_asana_token() -> OpsResult<String> {
                 .upsert_provider_token(&refreshed)
                 .await
                 .map_err(|err| {
-                    OpsError::Message(format!("failed to persist refreshed asana token: {err}"))
+                    OpsError::Message(format!(
+                        "failed to persist refreshed {provider} token: {err}"
+                    ))
                 })?;
             return Ok(access_token);
         }
     }
 
-    Err(OpsError::Message(
-        "Stored asana token has expired. Run `lf op auth asana` again.".to_string(),
-    ))
+    Err(OpsError::Message(format!(
+        "Stored {provider} token has expired. Run `lf op auth {provider}` again."
+    )))
 }
 
 fn storage_config_from_env() -> OpsResult<crate::lfdb::StorageConfig> {

--- a/rust/loopflow/src/ops/pm.rs
+++ b/rust/loopflow/src/ops/pm.rs
@@ -1,16 +1,17 @@
-//! `lf op pm` — read and write a wave's roadmap directly in Asana.
+//! `lf op pm` — read and write a wave's roadmap directly in a PM provider.
 //!
-//! Asana is the single source of truth for a wave's roadmap. There is no local
-//! mirror: every command here talks to the Asana project pinned by
-//! `pm.asana_project` in `wave/<name>/GOAL.md`.
+//! The PM provider is the single source of truth for a wave's roadmap. There is
+//! no local mirror: every command here talks to the project pinned by the wave's
+//! `pm.*_project` frontmatter.
 
 use std::future::Future;
 use std::path::Path;
 
 use crate::engine::config::load_config_or_default;
-use crate::engine::wave_config::{read_wave_config, update_wave_goal_config};
+use crate::engine::wave_config::{read_wave_config, update_wave_goal_config, WavePmConfig};
 use crate::lfd::pm::asana::AsanaClient;
-use crate::lfd::pm::{PmError, PmItem, PmItemCreate, PmItemUpdate};
+use crate::lfd::pm::linear::LinearClient;
+use crate::lfd::pm::{PmError, PmItem, PmItemCreate, PmItemUpdate, PmProviderKind};
 use crate::lfdb::open_store;
 use crate::ops::error::{OpsError, OpsResult};
 use crate::ops::progress::Progress;
@@ -39,6 +40,7 @@ pub struct PmShowOptions {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PmShowResult {
     pub wave: String,
+    pub provider: PmProviderKind,
     pub project: String,
     pub items: Vec<PmItem>,
 }
@@ -71,6 +73,7 @@ pub struct PmStatusOptions {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PmWaveStatus {
     pub wave: String,
+    pub provider: PmProviderKind,
     pub project: String,
     pub open: usize,
     pub total: usize,
@@ -83,47 +86,147 @@ pub struct PmStatusResult {
 
 // ── Client + project resolution ─────────────────────────────────────
 
-/// A wave's Asana client bound to its roadmap project.
+/// A wave's PM client bound to its roadmap project.
 pub(crate) struct PmContext {
-    pub client: AsanaClient,
+    pub client: PmClient,
+    pub provider: PmProviderKind,
     pub project: String,
 }
 
-/// The `pm.asana_project` handle from `wave/<name>/GOAL.md`, if set.
-fn read_asana_project(repo: &Path, wave: &str) -> Option<String> {
-    read_wave_config(repo, wave)
-        .and_then(|config| config.pm)
-        .and_then(|pm| pm.asana_project)
-        .filter(|project| !project.trim().is_empty())
+pub(crate) enum PmClient {
+    Asana(AsanaClient),
+    Linear(LinearClient),
 }
 
-async fn build_asana_client(repo: &Path) -> OpsResult<AsanaClient> {
+impl PmClient {
+    async fn create_project(&self, name: &str, description: &str) -> PmResult<String> {
+        match self {
+            Self::Asana(client) => client.create_project(name, description).await,
+            Self::Linear(client) => client.create_project(name, description).await,
+        }
+    }
+
+    async fn list_items(&self, project_id: &str) -> PmResult<Vec<PmItem>> {
+        match self {
+            Self::Asana(client) => client.list_items(project_id).await,
+            Self::Linear(client) => client.list_items(project_id).await,
+        }
+    }
+
+    async fn create_item(&self, project_id: &str, item: &PmItemCreate) -> PmResult<String> {
+        match self {
+            Self::Asana(client) => client.create_item(project_id, item).await,
+            Self::Linear(client) => client.create_item(project_id, item).await,
+        }
+    }
+
+    async fn update_item(&self, item_id: &str, update: &PmItemUpdate) -> PmResult<()> {
+        match self {
+            Self::Asana(client) => client.update_item(item_id, update).await,
+            Self::Linear(client) => client.update_item(item_id, update).await,
+        }
+    }
+
+    async fn complete_item(&self, item_id: &str) -> PmResult<()> {
+        match self {
+            Self::Asana(client) => client.complete_item(item_id).await,
+            Self::Linear(client) => client.complete_item(item_id).await,
+        }
+    }
+
+    async fn comment(&self, item_id: &str, body: &str) -> PmResult<()> {
+        match self {
+            Self::Asana(client) => client.comment(item_id, body).await,
+            Self::Linear(client) => client.comment(item_id, body).await,
+        }
+    }
+}
+
+fn read_wave_pm_config(repo: &Path, wave: &str) -> Option<WavePmConfig> {
+    read_wave_config(repo, wave).and_then(|config| config.pm)
+}
+
+fn parse_provider(value: &str) -> OpsResult<PmProviderKind> {
+    value.parse::<PmProviderKind>().map_err(pm_to_ops)
+}
+
+fn resolve_provider(repo: &Path, wave: &str) -> OpsResult<PmProviderKind> {
     let config = load_config_or_default(Some(repo));
-    let token = resolve_asana_token().await?;
-    Ok(AsanaClient::new(token, config.asana.clone()))
+    let wave_pm = read_wave_pm_config(repo, wave);
+    if let Some(provider) = wave_pm
+        .as_ref()
+        .and_then(|pm| pm.provider.as_deref())
+        .filter(|provider| !provider.trim().is_empty())
+    {
+        return parse_provider(provider);
+    }
+    if let Some(provider) = config
+        .pm
+        .as_ref()
+        .and_then(|pm| pm.provider.as_deref())
+        .filter(|provider| !provider.trim().is_empty())
+    {
+        return parse_provider(provider);
+    }
+    if wave_pm.as_ref().and_then(|pm| pm.linear_project.as_ref()).is_some() {
+        return Ok(PmProviderKind::Linear);
+    }
+    Ok(PmProviderKind::Asana)
+}
+
+fn read_project(repo: &Path, wave: &str, provider: PmProviderKind) -> Option<String> {
+    let pm = read_wave_pm_config(repo, wave)?;
+    let project = match provider {
+        PmProviderKind::Asana => pm.asana_project,
+        PmProviderKind::Linear => pm.linear_project,
+    }?;
+    Some(project).filter(|project| !project.trim().is_empty())
+}
+
+async fn build_client(repo: &Path, provider: PmProviderKind) -> OpsResult<PmClient> {
+    let config = load_config_or_default(Some(repo));
+    let token = resolve_pm_token(provider).await?;
+    match provider {
+        PmProviderKind::Asana => Ok(PmClient::Asana(AsanaClient::new(
+            token,
+            config.asana.clone(),
+        ))),
+        PmProviderKind::Linear => Ok(PmClient::Linear(LinearClient::new(
+            token,
+            config.linear.team.clone(),
+        ))),
+    }
 }
 
 async fn resolve_context(repo: &Path, wave: &str) -> OpsResult<PmContext> {
-    let project = read_asana_project(repo, wave).ok_or_else(|| {
+    let provider = resolve_provider(repo, wave)?;
+    let project = read_project(repo, wave, provider).ok_or_else(|| {
         OpsError::Message(format!(
-            "wave/{wave}/GOAL.md has no `pm.asana_project`. \
-             Run `lf op pm init --wave {wave}` to connect its roadmap."
+            "wave/{wave}/GOAL.md has no `pm.{}`. \
+             Run `lf op pm init --wave {wave}` to connect its roadmap.",
+            provider.project_key()
         ))
     })?;
-    let client = build_asana_client(repo).await?;
-    Ok(PmContext { client, project })
+    let client = build_client(repo, provider).await?;
+    Ok(PmContext {
+        client,
+        provider,
+        project,
+    })
 }
 
-async fn resolve_asana_token() -> OpsResult<String> {
+async fn resolve_pm_token(provider: PmProviderKind) -> OpsResult<String> {
     let store = open_store(&storage_config_from_env()?)
         .await
         .map_err(|err| OpsError::Message(format!("failed to open lfd credential store: {err}")))?;
     let token = store
-        .get_provider_token("asana")
+        .get_provider_token(provider.as_str())
         .await
-        .map_err(|err| OpsError::Message(format!("failed to load asana token: {err}")))?
+        .map_err(|err| OpsError::Message(format!("failed to load {provider} token: {err}")))?
         .ok_or_else(|| {
-            OpsError::Message("No asana credential found. Run `lf op auth asana`.".to_string())
+            OpsError::Message(format!(
+                "No {provider} credential found. Run `lf op auth {provider}`."
+            ))
         })?;
 
     let expired = token
@@ -133,15 +236,16 @@ async fn resolve_asana_token() -> OpsResult<String> {
         return Ok(token.access_token);
     }
 
-    // The stored token is expired but may be refreshable: if it carries a refresh
-    // token and the OAuth client creds are in the env, refresh in place rather than
-    // forcing the user to re-authenticate.
     let refresh_token = token
         .refresh_token
         .as_deref()
         .filter(|value| !value.trim().is_empty());
     if let Some(refresh_token) = refresh_token {
-        if let Ok(mut refreshed) = refresh_pm_oauth_token(Provider::Asana, refresh_token).await {
+        let auth_provider = match provider {
+            PmProviderKind::Asana => Provider::Asana,
+            PmProviderKind::Linear => Provider::Linear,
+        };
+        if let Ok(mut refreshed) = refresh_pm_oauth_token(auth_provider, refresh_token).await {
             if refreshed.refresh_token.is_none() {
                 refreshed.refresh_token = token.refresh_token.clone();
             }
@@ -153,15 +257,15 @@ async fn resolve_asana_token() -> OpsResult<String> {
                 .upsert_provider_token(&refreshed)
                 .await
                 .map_err(|err| {
-                    OpsError::Message(format!("failed to persist refreshed asana token: {err}"))
+                    OpsError::Message(format!("failed to persist refreshed {provider} token: {err}"))
                 })?;
             return Ok(access_token);
         }
     }
 
-    Err(OpsError::Message(
-        "Stored asana token has expired. Run `lf op auth asana` again.".to_string(),
-    ))
+    Err(OpsError::Message(format!(
+        "Stored {provider} token has expired. Run `lf op auth {provider}` again."
+    )))
 }
 
 fn storage_config_from_env() -> OpsResult<crate::lfdb::StorageConfig> {

--- a/rust/loopflow/src/provider_auth/mod.rs
+++ b/rust/loopflow/src/provider_auth/mod.rs
@@ -55,6 +55,7 @@ const ASANA_CLIENT_ID_ENV: &str = "ASANA_CLIENT_ID";
 const ASANA_CLIENT_SECRET_ENV: &str = "ASANA_CLIENT_SECRET";
 const ASANA_OAUTH_SCOPE_ENV: &str = "ASANA_OAUTH_SCOPE";
 const ASANA_OAUTH_DEFAULT_SCOPE: &str = "default";
+const LINEAR_API_KEY_ENV: &str = "LINEAR_API_KEY";
 const TOKEN_REFRESH_LEAD_SECONDS: i64 = 20 * 60;
 
 static USER_CODE_RE: Lazy<Regex> =
@@ -1927,6 +1928,16 @@ where
         return Some(value);
     }
     fetch_secret(name).await
+}
+
+/// Resolve a Linear personal API key: environment first, then Doppler.
+///
+/// A Linear API key is a static bearer token used directly as the GraphQL
+/// Authorization header, so there is no OAuth exchange or refresh — this just
+/// locates the secret. The value is never printed; Doppler is consumed inline.
+pub async fn resolve_linear_api_key() -> Option<String> {
+    let mut fetch_secret = fetch_doppler_secret;
+    read_oauth_client_credential(LINEAR_API_KEY_ENV, &mut fetch_secret).await
 }
 
 async fn fetch_doppler_secret(name: &'static str) -> Option<String> {

--- a/rust/loopflow/src/provider_auth/mod.rs
+++ b/rust/loopflow/src/provider_auth/mod.rs
@@ -55,7 +55,13 @@ const ASANA_CLIENT_ID_ENV: &str = "ASANA_CLIENT_ID";
 const ASANA_CLIENT_SECRET_ENV: &str = "ASANA_CLIENT_SECRET";
 const ASANA_OAUTH_SCOPE_ENV: &str = "ASANA_OAUTH_SCOPE";
 const ASANA_OAUTH_DEFAULT_SCOPE: &str = "default";
-const LINEAR_API_KEY_ENV: &str = "LINEAR_API_KEY";
+const LINEAR_OAUTH_AUTHORIZE_URL: &str = "https://linear.app/oauth/authorize";
+const LINEAR_OAUTH_TOKEN_URL: &str = "https://api.linear.app/oauth/token";
+const LINEAR_OAUTH_REDIRECT_URI: &str = "http://localhost:19222/oauth/callback";
+const LINEAR_OAUTH_CALLBACK_ADDR: &str = "127.0.0.1:19222";
+const LINEAR_CLIENT_ID_ENV: &str = "LINEAR_CLIENT_ID";
+const LINEAR_CLIENT_SECRET_ENV: &str = "LINEAR_CLIENT_SECRET";
+const LINEAR_OAUTH_DEFAULT_SCOPE: &str = "read,write";
 const TOKEN_REFRESH_LEAD_SECONDS: i64 = 20 * 60;
 
 static USER_CODE_RE: Lazy<Regex> =
@@ -77,6 +83,7 @@ pub enum Provider {
     Codex,
     OpenCodeZen,
     Asana,
+    Linear,
     Doppler,
 }
 
@@ -88,17 +95,19 @@ impl Provider {
             Self::Codex => "codex",
             Self::OpenCodeZen => "opencodezen",
             Self::Asana => "asana",
+            Self::Linear => "linear",
             Self::Doppler => "doppler",
         }
     }
 
-    pub fn all() -> [Self; 6] {
+    pub fn all() -> [Self; 7] {
         [
             Self::GitHub,
             Self::Claude,
             Self::Codex,
             Self::OpenCodeZen,
             Self::Asana,
+            Self::Linear,
             Self::Doppler,
         ]
     }
@@ -110,6 +119,7 @@ impl Provider {
             Self::Codex => "Codex",
             Self::OpenCodeZen => "OpenCode Zen",
             Self::Asana => "Asana",
+            Self::Linear => "Linear",
             Self::Doppler => "Doppler",
         }
     }
@@ -119,7 +129,7 @@ impl Provider {
             Self::Claude => Some("ANTHROPIC_API_KEY"),
             Self::Codex => Some("OPENAI_API_KEY"),
             Self::OpenCodeZen => Some("OPENCODE_API_KEY"),
-            Self::GitHub | Self::Asana | Self::Doppler => None,
+            Self::GitHub | Self::Asana | Self::Linear | Self::Doppler => None,
         }
     }
 
@@ -130,6 +140,7 @@ impl Provider {
     pub fn api_key_configure_error(self) -> Option<&'static str> {
         match self {
             Self::Asana => Some("Asana requires OAuth. Run 'lf op auth asana' to connect."),
+            Self::Linear => Some("Linear requires OAuth. Run 'lf op auth linear' to connect."),
             _ => None,
         }
     }
@@ -159,6 +170,7 @@ impl FromStr for Provider {
             "codex" => Ok(Self::Codex),
             "opencodezen" | "opencode" | "zen" | "oc" => Ok(Self::OpenCodeZen),
             "asana" => Ok(Self::Asana),
+            "linear" | "lin" => Ok(Self::Linear),
             "doppler" => Ok(Self::Doppler),
             _ => Err(ParseProviderError {
                 input: value.trim().to_string(),
@@ -624,6 +636,210 @@ impl AuthBroker for AsanaOAuthBroker {
     }
 }
 
+// ── Linear OAuth ────────────────────────────────────────────────────
+
+/// Linear OAuth uses a loopback redirect (`http://localhost:19222/oauth/callback`)
+/// rather than Asana's OOB paste: consent is a single click and the code arrives
+/// on a short-lived local listener. Refresh mirrors Asana — once Linear returns a
+/// refresh token, `refresh_pm_oauth_token` renews headlessly via the client creds.
+#[derive(Debug, Clone)]
+struct LinearOAuthBroker {
+    completed_token: Arc<Mutex<Option<ProviderToken>>>,
+}
+
+#[derive(Debug, Clone)]
+struct LinearOAuthApp {
+    client_id: String,
+    client_secret: String,
+    scope: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct LinearOAuthTokenResponse {
+    access_token: String,
+    refresh_token: Option<String>,
+    expires_in: Option<i64>,
+}
+
+impl LinearOAuthBroker {
+    fn new() -> Self {
+        Self {
+            completed_token: Arc::new(Mutex::new(None)),
+        }
+    }
+
+    async fn oauth_app() -> Result<LinearOAuthApp, AuthError> {
+        let (client_id, client_secret) = oauth_client_credentials(
+            Provider::Linear,
+            LINEAR_CLIENT_ID_ENV,
+            LINEAR_CLIENT_SECRET_ENV,
+        )
+        .await?;
+
+        Ok(LinearOAuthApp {
+            client_id,
+            client_secret,
+            scope: LINEAR_OAUTH_DEFAULT_SCOPE.to_string(),
+        })
+    }
+
+    fn build_authorization_url(app: &LinearOAuthApp, code_verifier: &str, state: &str) -> String {
+        let code_challenge = URL_SAFE_NO_PAD.encode(Sha256::digest(code_verifier.as_bytes()));
+        let mut url = Url::parse(LINEAR_OAUTH_AUTHORIZE_URL)
+            .expect("linear oauth authorize URL should parse");
+        {
+            let mut pairs = url.query_pairs_mut();
+            pairs.append_pair("client_id", &app.client_id);
+            pairs.append_pair("redirect_uri", LINEAR_OAUTH_REDIRECT_URI);
+            pairs.append_pair("response_type", "code");
+            pairs.append_pair("state", state);
+            pairs.append_pair("scope", &app.scope);
+            pairs.append_pair("code_challenge", &code_challenge);
+            pairs.append_pair("code_challenge_method", "S256");
+            pairs.append_pair("prompt", "consent");
+        }
+        url.to_string()
+    }
+
+    async fn exchange_code(
+        app: &LinearOAuthApp,
+        code_verifier: &str,
+        code: &str,
+    ) -> Result<ProviderToken, AuthError> {
+        let body = serde_urlencoded::to_string([
+            ("grant_type", "authorization_code"),
+            ("client_id", app.client_id.as_str()),
+            ("client_secret", app.client_secret.as_str()),
+            ("redirect_uri", LINEAR_OAUTH_REDIRECT_URI),
+            ("code", code),
+            ("code_verifier", code_verifier),
+        ])
+        .map_err(|err| AuthError::OAuthRequest {
+            provider: Provider::Linear,
+            message: format!("failed to encode token request: {err}"),
+        })?;
+        let response = reqwest::Client::new()
+            .post(LINEAR_OAUTH_TOKEN_URL)
+            .header("content-type", "application/x-www-form-urlencoded")
+            .body(body)
+            .send()
+            .await
+            .map_err(|err| AuthError::OAuthRequest {
+                provider: Provider::Linear,
+                message: err.to_string(),
+            })?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response
+                .bytes()
+                .await
+                .map_err(|err| AuthError::OAuthRequest {
+                    provider: Provider::Linear,
+                    message: err.to_string(),
+                })?;
+            let message = oauth_error_message(body.as_ref())
+                .unwrap_or_else(|| String::from_utf8_lossy(&body).trim().to_string());
+            if status == reqwest::StatusCode::BAD_REQUEST
+                || status == reqwest::StatusCode::UNAUTHORIZED
+            {
+                return Err(AuthError::CodeExchangeRejected {
+                    provider: Provider::Linear,
+                    message,
+                });
+            }
+            return Err(AuthError::OAuthRequest {
+                provider: Provider::Linear,
+                message: format!("HTTP {status}: {message}"),
+            });
+        }
+
+        let payload = response
+            .json::<LinearOAuthTokenResponse>()
+            .await
+            .map_err(|err| AuthError::OAuthRequest {
+                provider: Provider::Linear,
+                message: format!("failed to decode token response: {err}"),
+            })?;
+
+        let expires_at = payload
+            .expires_in
+            .filter(|seconds| *seconds > 0)
+            .map(|seconds| now_unix() + seconds);
+
+        Ok(ProviderToken {
+            provider: Provider::Linear.as_str().to_string(),
+            access_token: payload.access_token,
+            refresh_token: payload.refresh_token,
+            expires_at,
+            login: None,
+            updated_at: now_unix(),
+            credential_type: CredentialType::OAuth,
+        })
+    }
+}
+
+#[async_trait]
+impl AuthBroker for LinearOAuthBroker {
+    fn provider(&self) -> Provider {
+        Provider::Linear
+    }
+
+    async fn start_auth(&self) -> Result<AuthFlowHandle, AuthError> {
+        let app = Self::oauth_app().await?;
+        let code_verifier = format!("{}{}", Uuid::new_v4().simple(), Uuid::new_v4().simple());
+        let state = Uuid::new_v4().to_string();
+        let verification_uri = Self::build_authorization_url(&app, &code_verifier, &state);
+        let listener = oauth_callback_listener(Provider::Linear, LINEAR_OAUTH_CALLBACK_ADDR)?;
+        let completed_token = self.completed_token.clone();
+        let monitor = tokio::spawn(monitor_oauth_callback(
+            Provider::Linear,
+            listener,
+            Duration::from_secs(15 * 60),
+            "linear OAuth timed out",
+            completed_token,
+            move |code| {
+                let app = app.clone();
+                let code_verifier = code_verifier.clone();
+                async move { LinearOAuthBroker::exchange_code(&app, &code_verifier, &code).await }
+            },
+        ));
+
+        let response = AuthFlowResponse {
+            provider: Provider::Linear,
+            verification_uri_complete: Some(verification_uri.clone()),
+            verification_uri,
+            user_code: None,
+            expires_in: Some(15 * 60),
+        };
+
+        Ok(AuthFlowHandle::new(response, monitor))
+    }
+
+    async fn check_status(&self) -> Result<AuthStatus, AuthError> {
+        let token = self.completed_token.lock().await;
+        let Some(token) = token.as_ref() else {
+            return Ok(AuthStatus::None);
+        };
+        if token
+            .expires_at
+            .is_some_and(|expires_at| expires_at <= now_unix())
+        {
+            return Ok(AuthStatus::Expired);
+        }
+        Ok(AuthStatus::Active { login: None })
+    }
+
+    async fn disconnect(&self) -> Result<(), AuthError> {
+        *self.completed_token.lock().await = None;
+        Ok(())
+    }
+
+    async fn extract_token(&self) -> Option<ProviderToken> {
+        self.completed_token.lock().await.clone()
+    }
+}
+
 impl SocketAuthBroker {
     pub fn new(provider: Provider, client: Arc<CredentialSocketClient>) -> Self {
         Self {
@@ -1017,8 +1233,11 @@ fn default_brokers(client: Option<Arc<CredentialSocketClient>>) -> Vec<Arc<dyn A
     brokers
 }
 
-fn pm_auth_brokers() -> [Arc<dyn AuthBroker>; 1] {
-    [Arc::new(AsanaOAuthBroker::new()) as Arc<dyn AuthBroker>]
+fn pm_auth_brokers() -> [Arc<dyn AuthBroker>; 2] {
+    [
+        Arc::new(AsanaOAuthBroker::new()) as Arc<dyn AuthBroker>,
+        Arc::new(LinearOAuthBroker::new()) as Arc<dyn AuthBroker>,
+    ]
 }
 
 fn socket_auth_flow_handle(
@@ -1930,16 +2149,6 @@ where
     fetch_secret(name).await
 }
 
-/// Resolve a Linear personal API key: environment first, then Doppler.
-///
-/// A Linear API key is a static bearer token used directly as the GraphQL
-/// Authorization header, so there is no OAuth exchange or refresh — this just
-/// locates the secret. The value is never printed; Doppler is consumed inline.
-pub async fn resolve_linear_api_key() -> Option<String> {
-    let mut fetch_secret = fetch_doppler_secret;
-    read_oauth_client_credential(LINEAR_API_KEY_ENV, &mut fetch_secret).await
-}
-
 async fn fetch_doppler_secret(name: &'static str) -> Option<String> {
     let output = Command::new("doppler")
         .args(["secrets", "get", name, "--plain"])
@@ -2145,7 +2354,9 @@ async fn refresh_provider_token_with_runner(
                 provider: Provider::OpenCodeZen,
             })
         }
-        Provider::Asana | Provider::Doppler => Err(TokenRefreshError::MissingToken { provider }),
+        Provider::Asana | Provider::Linear | Provider::Doppler => {
+            Err(TokenRefreshError::MissingToken { provider })
+        }
     }
 }
 
@@ -2163,8 +2374,113 @@ fn pm_oauth_endpoint(provider: Provider) -> Option<PmOAuthEndpoint> {
             client_id_env: ASANA_CLIENT_ID_ENV,
             client_secret_env: ASANA_CLIENT_SECRET_ENV,
         }),
+        Provider::Linear => Some(PmOAuthEndpoint {
+            token_url: LINEAR_OAUTH_TOKEN_URL,
+            client_id_env: LINEAR_CLIENT_ID_ENV,
+            client_secret_env: LINEAR_CLIENT_SECRET_ENV,
+        }),
         _ => None,
     }
+}
+
+/// Bind a short-lived loopback listener for an OAuth redirect callback.
+fn oauth_callback_listener(
+    provider: Provider,
+    address: &str,
+) -> Result<tokio::net::TcpListener, AuthError> {
+    let listener = std::net::TcpListener::bind(address).map_err(|err| AuthError::OAuthRequest {
+        provider,
+        message: format!("failed to bind {address} for OAuth callback: {err}"),
+    })?;
+    listener.set_nonblocking(true).ok();
+    tokio::net::TcpListener::from_std(listener).map_err(|err| AuthError::OAuthRequest {
+        provider,
+        message: format!("failed to create async listener: {err}"),
+    })
+}
+
+/// Wait for the browser to hit the loopback redirect, exchange the returned code
+/// for a token, and stash it for the broker's `extract_token`.
+async fn monitor_oauth_callback<F, Fut>(
+    provider: Provider,
+    listener: tokio::net::TcpListener,
+    timeout: Duration,
+    timeout_message: &'static str,
+    completed_token: Arc<Mutex<Option<ProviderToken>>>,
+    exchange_code: F,
+) -> Result<(), AuthError>
+where
+    F: Fn(String) -> Fut + Send + 'static,
+    Fut: Future<Output = Result<ProviderToken, AuthError>> + Send,
+{
+    let deadline = Instant::now() + timeout;
+    loop {
+        if Instant::now() >= deadline {
+            return Err(AuthError::CommandFailed {
+                provider,
+                message: timeout_message.to_string(),
+            });
+        }
+
+        let accept = tokio::time::timeout(Duration::from_secs(1), listener.accept()).await;
+        let (stream, _) = match accept {
+            Ok(Ok(conn)) => conn,
+            Ok(Err(_)) | Err(_) => continue,
+        };
+        let Some(code) = read_oauth_callback_code(stream).await else {
+            continue;
+        };
+
+        match exchange_code(code).await {
+            Ok(token) => {
+                *completed_token.lock().await = Some(token);
+                return Ok(());
+            }
+            Err(err) => {
+                return Err(AuthError::CommandFailed {
+                    provider,
+                    message: err.to_string(),
+                });
+            }
+        }
+    }
+}
+
+async fn read_oauth_callback_code(stream: tokio::net::TcpStream) -> Option<String> {
+    let (mut reader, mut writer) = stream.into_split();
+    let mut buf = vec![0u8; 4096];
+    let n = tokio::io::AsyncReadExt::read(&mut reader, &mut buf)
+        .await
+        .ok()?;
+    let request = String::from_utf8_lossy(&buf[..n]);
+    let code = extract_oauth_code_from_request(&request);
+
+    let response_body = if code.is_some() {
+        "Authenticated! You can close this tab."
+    } else {
+        "Authentication failed — no code found."
+    };
+    let http_response = format!(
+        "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nConnection: close\r\n\r\n<html><body><h2>{response_body}</h2></body></html>"
+    );
+    let _ = tokio::io::AsyncWriteExt::write_all(&mut writer, http_response.as_bytes()).await;
+    let _ = tokio::io::AsyncWriteExt::shutdown(&mut writer).await;
+    code
+}
+
+fn extract_oauth_code_from_request(request: &str) -> Option<String> {
+    let first_line = request.lines().next()?;
+    let path = first_line.split_whitespace().nth(1)?;
+    let query = path.split_once('?')?.1;
+    for pair in query.split('&') {
+        if let Some(value) = pair.strip_prefix("code=") {
+            let value = value.trim();
+            if !value.is_empty() {
+                return Some(value.to_string());
+            }
+        }
+    }
+    None
 }
 
 #[derive(Debug, Deserialize)]
@@ -2175,7 +2491,7 @@ struct OAuthRefreshResponse {
 }
 
 /// Exchange a stored refresh token for a fresh access token via the PM provider's
-/// OAuth `grant_type=refresh_token` endpoint. Only Asana is supported;
+/// OAuth `grant_type=refresh_token` endpoint. Asana and Linear are supported;
 /// client credentials are read from the provider's `*_CLIENT_ID`/`*_CLIENT_SECRET` env vars.
 ///
 /// The returned token carries `login: None`; callers should preserve the prior login.
@@ -3121,6 +3437,65 @@ mod tests {
                 .map(|value| value.as_ref()),
             Some("S256")
         );
+    }
+
+    #[test]
+    fn linear_oauth_authorization_url_uses_loopback_redirect_and_pkce() {
+        let app = LinearOAuthApp {
+            client_id: "client-123".to_string(),
+            client_secret: "secret-456".to_string(),
+            scope: LINEAR_OAUTH_DEFAULT_SCOPE.to_string(),
+        };
+
+        let url = LinearOAuthBroker::build_authorization_url(&app, "verifier-123", "state-abc");
+        let parsed = Url::parse(&url).expect("linear oauth url should parse");
+        let query = parsed.query_pairs().collect::<HashMap<_, _>>();
+
+        assert_eq!(
+            parsed.as_str().split('?').next(),
+            Some(LINEAR_OAUTH_AUTHORIZE_URL)
+        );
+        assert_eq!(
+            query.get("client_id").map(|value| value.as_ref()),
+            Some("client-123")
+        );
+        assert_eq!(
+            query.get("redirect_uri").map(|value| value.as_ref()),
+            Some(LINEAR_OAUTH_REDIRECT_URI)
+        );
+        assert_eq!(
+            query.get("scope").map(|value| value.as_ref()),
+            Some("read,write")
+        );
+        assert!(query.contains_key("code_challenge"));
+        assert_eq!(
+            query
+                .get("code_challenge_method")
+                .map(|value| value.as_ref()),
+            Some("S256")
+        );
+    }
+
+    #[test]
+    fn linear_provider_parses_and_supports_oauth_refresh() {
+        assert_eq!("linear".parse::<Provider>(), Ok(Provider::Linear));
+        assert_eq!("lin".parse::<Provider>(), Ok(Provider::Linear));
+        assert_eq!(Provider::Linear.as_str(), "linear");
+        assert!(!Provider::Linear.api_key_bills_per_token());
+        assert_eq!(
+            Provider::Linear.api_key_configure_error(),
+            Some("Linear requires OAuth. Run 'lf op auth linear' to connect.")
+        );
+        // Refresh is wired: Linear resolves a PM OAuth endpoint like Asana.
+        assert!(pm_oauth_endpoint(Provider::Linear).is_some());
+    }
+
+    #[test]
+    fn linear_broker_registered_in_default_brokers() {
+        let has_linear = default_brokers(None)
+            .iter()
+            .any(|broker| broker.provider() == Provider::Linear);
+        assert!(has_linear, "`lf op auth linear` needs a registered broker");
     }
 
     #[tokio::test(flavor = "current_thread")]


### PR DESCRIPTION
## Usage

```toml
# .lf/config.toml
[pm]
provider = "linear"

[linear]
team = "Loopflow"
```

```markdown
---
pm:
  provider: linear
  linear_project: "lin-123"
---
```

```bash
lf op pm sync   # now routes to Linear when the provider is set
```

## Summary

Adds Linear alongside Asana as a project-management backend for `lf op pm`, plumbed through config, wave GOAL.md frontmatter, and OAuth. The provider is dormant by default — Asana remains the fallback — and only activates when `pm.provider = "linear"` (or a wave's `pm:` block) selects it. Linear authenticates via OAuth rather than a static API key, matching how the other providers resolve credentials.

## Changes

- New `lfd/pm/linear.rs`: a GraphQL client for Linear covering team/project/issue create, list, update, complete, and comment, with rate-limit retries and paginated issue listing ranked by priority/sort order.
- `PmConfig`/`LinearConfig` in engine config and a `provider`/`linear_project` block in `WavePmConfig`, so provider selection lives in both `.lf/config.toml` and GOAL.md frontmatter.
- `ops/pm.rs` dispatches to the selected provider instead of assuming Asana.
- `provider_auth` resolves Linear OAuth client credentials (with Doppler fallback), consistent with the Asana path.