### PR TITLE
pm: flip default provider to Linear

### DIFF
--- a/.lf/config.yaml
+++ b/.lf/config.yaml
@@ -5,7 +5,10 @@ branch_names:
   schema: "{user}.{name}.{ts}"
 
 pm:
-  provider: asana
+  provider: linear
+
+linear:
+  team: "60558c53-2169-49f8-a76a-1f4586705aa9"
 
 internal:
   use_rust: true

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ commands for long-term coordination.
 
 ```bash
 lf debug -c    # paste an error, watch it fix
-lf op pm show --wave designer   # print the wave's live Asana roadmap
+lf op pm show --wave designer   # print the wave's live Linear roadmap
 lf design      # interactive design session
 lf gstack/office-hours   # run a built-in gstack workstyle step
 lf office-hours          # same thing — bare name works when unambiguous
@@ -338,34 +338,34 @@ watch it in Concerto. To remove a wave, delete `wave/engbot/` and its worktree
 (`lf op wt remove engbot`).
 
 ```bash
-lf op auth status    # provider auth status (GitHub / Claude / Codex / OpenCode Zen / Asana)
+lf op auth status    # provider auth status (GitHub / Claude / Codex / OpenCode Zen / Linear)
 lf op auth github    # connect GitHub in your browser
 lf op auth claude    # connect Claude in your browser
 lf op auth codex     # connect Codex in your browser
 lf op auth zen       # connect OpenCode Zen in your browser
-lf op auth asana     # connect Asana with OAuth
+lf op auth linear     # connect Linear with OAuth
 lf op auth disconnect github
 ```
 
-The roadmap lives in Asana. Pin a wave to its Asana project in `wave/<name>/GOAL.md` frontmatter — `lf op pm init` writes this for you:
+The roadmap lives in Linear. Pin a wave to its Linear project in `wave/<name>/GOAL.md` frontmatter — `lf op pm init` writes this for you:
 
 ```yaml
 # wave/designer/GOAL.md frontmatter
 pm:
-  asana_project: 1207xxxxxxxxxxxx
+  linear_project: 8c4ba3f9-cf23-4136-87ed-37847aa7dc82
 ```
 
 ```bash
 lf op branches list --user @me --stale 60d   # preview stale remote branches
 lf op branches prune --user @me --stale 60d  # delete after confirmation
-lf op pm init --wave designer                # connect/create the Asana project, write asana_project into GOAL.md
-lf op pm show --wave designer                # print the wave's live Asana roadmap
+lf op pm init --wave designer                # connect/create the Linear project, write linear_project into GOAL.md
+lf op pm show --wave designer                # print the wave's live Linear roadmap
 lf op pm update --wave designer --title "Add dark mode" --notes "..."   # create a task
 lf op pm update --wave designer --id 1207... --title "..." --status done # update or close a task
 lf op pm status                              # show linked waves
 ```
 
-`lf op pm` reads and edits the roadmap directly in Asana — there is no local mirror and nothing to sync. Task notes preserve basic markdown formatting: Loopflow writes rich text through `html_notes` and falls back to plaintext `notes` when a task has none yet.
+`lf op pm` reads and edits the roadmap directly in Linear — there is no local mirror and nothing to sync. Issue descriptions and comments are Markdown, which Linear renders natively.
 
 The `loopflow` Python package is a library only (wire models).
 Use the install script or cargo to install `lf` and `lfd`.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -52,7 +52,7 @@ Git/PR/PM ops             Clients
 | Direction | `.lf/directions/` | `engine` prompt assembly |
 | Wave goal | `wave/<name>/GOAL.md` | `lf wave` server + resident mind |
 | Wave memory | `wave/<name>/MEMORY.md` | wave agent |
-| Roadmap item | Asana | `lf op pm` and wave flows |
+| Roadmap item | Linear | `lf op pm` and wave flows |
 | Session | lfdb | `lf` runs and placement flags |
 | Run/event | lfdb | lfd HTTP/event stream |
 | Attention | lfdb | lfd + Concerto |
@@ -149,7 +149,7 @@ Loopflow integrates with:
 
 - Git and worktrees for branch isolation.
 - GitHub for PRs, webhook ingress translated to `lf` execs, and release workflows.
-- Asana, Linear, and Notion for PM-backed wave roadmaps.
+- Linear, Asana, and Notion for PM-backed wave roadmaps.
 - tmux and local processes for interactive sessions.
 - Swift/macOS services for Concerto and native host behavior.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -204,7 +204,7 @@ Auth connects your providers:
 ```bash
 lf op auth github    # connect GitHub
 lf op auth claude    # connect Claude
-lf op auth asana     # connect Asana with OAuth
+lf op auth linear     # connect Linear with OAuth
 lf op auth status    # check connections
 ```
 

--- a/docs/lfop.md
+++ b/docs/lfop.md
@@ -135,38 +135,38 @@ Keep release-cycle rationale in `release/unreleased/DECISIONS.md` when you want 
 
 ## lf op pm
 
-Read and edit a wave's roadmap. The roadmap lives in Asana — `lf op pm` talks to it directly, so there is no local mirror and nothing to sync.
+Read and edit a wave's roadmap. The roadmap lives in Linear — `lf op pm` talks to it directly, so there is no local mirror and nothing to sync.
 
 ```bash
-lf op pm show --wave designer                              # print the wave's live Asana roadmap
+lf op pm show --wave designer                              # print the wave's live Linear roadmap
 lf op pm update --wave designer --title "Add dark mode"    # create a task
 lf op pm update --wave designer --id 1207... --title "..." # update a task
 lf op pm update --wave designer --id 1207... --status done # close a task
-lf op pm init --wave designer                              # connect/create the Asana project, write asana_project into GOAL.md
+lf op pm init --wave designer                              # connect/create the Linear project, write linear_project into GOAL.md
 lf op pm status                                            # show linked waves
 ```
 
 | Command | What it does |
 |---------|--------------|
-| `show` | Print the wave's live roadmap from Asana |
+| `show` | Print the wave's live roadmap from Linear |
 | `update` | Create a task (no `--id`), or update/close one (`--id`; `--status done` closes it) |
-| `init` | Connect or create the wave's Asana project and write `asana_project` into `wave/<name>/GOAL.md` |
-| `status` | Show which waves are linked to an Asana project |
+| `init` | Connect or create the wave's Linear project and write `linear_project` into `wave/<name>/GOAL.md` |
+| `status` | Show which waves are linked to a Linear project |
 
 | Flag | Description |
 |------|-------------|
 | `--wave NAME` | Target wave (defaults to the current branch's wave) |
-| `--id TASK-ID` | Existing Asana task to update or close |
+| `--id TASK-ID` | Existing Linear issue to update or close |
 | `--title` | Task title (required when creating) |
 | `--notes` | Task notes/description |
 | `--status done` | Close the task |
 
-Connect Asana first with `lf op auth asana`. `lf op pm init` pins the project into `GOAL.md`:
+Connect Linear first with `lf op auth linear`. `lf op pm init` pins the project into `GOAL.md`:
 
 ```yaml
 # wave/designer/GOAL.md frontmatter
 pm:
-  asana_project: 1207xxxxxxxxxxxx
+  linear_project: 8c4ba3f9-cf23-4136-87ed-37847aa7dc82
 ```
 
 ---

--- a/docs/wave-authoring.md
+++ b/docs/wave-authoring.md
@@ -29,7 +29,7 @@ wave/infra/
 └── MEMORY.md  # What the agent remembers between loops
 ```
 
-`GOAL.md` and `MEMORY.md` are the two files a wave authors. The roadmap itself lives in Asana, not in the repo — read and edit it with `lf op pm` (see [Roadmap](#the-roadmap)).
+`GOAL.md` and `MEMORY.md` are the two files a wave authors. The roadmap itself lives in Linear, not in the repo — read and edit it with `lf op pm` (see [Roadmap](#the-roadmap)).
 
 ### The Goal
 
@@ -61,20 +61,20 @@ lf wave s3           # the s3 (control) charter
 
 ### The Roadmap
 
-The roadmap lives in Asana. There are no local roadmap files and nothing to sync — `lf op pm` reads and edits the wave's Asana project directly.
+The roadmap lives in Linear. There are no local roadmap files and nothing to sync — `lf op pm` reads and edits the wave's Linear project directly.
 
-Connect a wave to Asana once. `lf op pm init` creates (or links) the project and writes its id into `GOAL.md` frontmatter:
+Connect a wave to Linear once. `lf op pm init` creates (or links) the project and writes its id into `GOAL.md` frontmatter:
 
 ```yaml
 # wave/infra/GOAL.md frontmatter
 pm:
-  asana_project: 1207xxxxxxxxxxxx
+  linear_project: 8c4ba3f9-cf23-4136-87ed-37847aa7dc82
 ```
 
 Then read and edit the roadmap:
 
 ```bash
-lf op pm init --wave infra                              # connect/create the Asana project
+lf op pm init --wave infra                              # connect/create the Linear project
 lf op pm show --wave infra                              # print the live roadmap
 lf op pm update --wave infra --title "Daemon data integrity" --notes "..."   # add a task
 lf op pm update --wave infra --id 1207... --status done # close a task
@@ -92,7 +92,7 @@ Keep each task to one PR's worth of work — roughly 1000 LOC. If a task feels l
 | `metrics` | Criteria the loop re-judges each iteration |
 | `agent` | Preferred agent harness/model |
 | `crons` | Supplementary flow schedules (`flow:` + `schedule:`), fired by the wave's resident mind |
-| `pm.asana_project` | Asana project id backing the wave's roadmap (written by `lf op pm init`) |
+| `pm.linear_project` | Linear project id backing the wave's roadmap (written by `lf op pm init`) |
 
 The resident mind reads `crons:` directly from this frontmatter and opens a system turn when a schedule comes due; edits land without a restart. See [Crons](waves.md#crons).
 
@@ -172,7 +172,7 @@ A `wave/billing/` directory for a billing rewrite. **`GOAL.md`** sets the intent
 - Invoices generate correctly for all plan types
 - Legacy endpoints return the same responses during migration
 
-The **Asana roadmap** holds the tasks, each scoped to one PR:
+The **Linear roadmap** holds the tasks, each scoped to one PR:
 
 ```
 Usage events       → Event capture and storage

--- a/rust/loopflow/src/engine/builtins.rs
+++ b/rust/loopflow/src/engine/builtins.rs
@@ -217,7 +217,7 @@ mod tests {
         let scan_waves = get_builtin_step("scan").expect("scan prompt");
         let split_wave = get_builtin_step("split-wave").expect("split-wave prompt");
 
-        // The roadmap lives in Asana, reached via `lf op pm` — no local N-*.md files.
+        // The roadmap lives in Linear, reached via `lf op pm` — no local N-*.md files.
         assert!(update_wave.contains("lf op pm"));
         assert!(update_wave.contains("MEMORY.md"));
         assert!(!update_wave.contains("1-fix-broken-build.md"));
@@ -227,7 +227,7 @@ mod tests {
         assert!(scan_waves.contains("lf op pm show"));
         assert!(split_wave.contains("lf op pm"));
         assert!(WAVE_AUTHORING_DOC.contains("GOAL.md"));
-        assert!(WAVE_AUTHORING_DOC.contains("Asana"));
+        assert!(WAVE_AUTHORING_DOC.contains("Linear"));
         assert!(!WAVE_AUTHORING_DOC.contains("1-fix-crash-loop.md"));
 
         // The ingest step is gone; workers are handed their task at dispatch.

--- a/rust/loopflow/src/engine/builtins/LOOPFLOW.md
+++ b/rust/loopflow/src/engine/builtins/LOOPFLOW.md
@@ -72,11 +72,11 @@ Use these unconditionally. Outside any wave they drop silently (exit 0) -
 publish-to-no-subscriber is correct pubsub, never a blocker. A wave whose
 server is down errors instead; note it and move on.
 
-## The Roadmap Lives in Asana
+## The Roadmap Lives in Linear
 
-A wave's roadmap is not in the repo — it lives in Asana, and `lf op pm` is the
+A wave's roadmap is not in the repo — it lives in Linear, and `lf op pm` is the
 only way to read or change it. There is no local roadmap file to edit and no
-sync step; Asana is the source of truth.
+sync step; Linear is the source of truth.
 
 ```bash
 lf op pm show                                          # the wave's live roadmap
@@ -97,7 +97,7 @@ roadmap files or a roadmap table in `GOAL.md` — that mirror is gone.
 - `scratch/<branch>.md` - design doc for the current work
 - `scratch/questions.md` - open questions, blockers, assumptions
 - `lf memory add "<fact>"` - durable wave learnings; `wave/<name>/MEMORY.md` is
-  server-owned, never edited directly (roadmap goes to Asana, above)
+  server-owned, never edited directly (roadmap goes to Linear, above)
 - Code - the actual work
 
 ## Checkpoint And Proceed

--- a/rust/loopflow/src/engine/builtins/build/step/design.md
+++ b/rust/loopflow/src/engine/builtins/build/step/design.md
@@ -84,19 +84,19 @@ This is the natural session exit point. The user's answer determines what to run
 1. Choose a wave name and create `wave/<name>/`.
 2. Write `wave/<name>/GOAL.md` — the wave's identity and anchor:
    - frontmatter: `primary_flow` (default `ship` unless the user asks for
-     something else) and, once connected, `pm.asana_project`
+     something else) and, once connected, `pm.linear_project`
    - body (the loop prompt): what this wave is and why it exists (scope
      boundaries as natural qualifiers), how it judges progress (numeric metrics
      where possible), and the shape of the work ahead
    - **No roadmap table, no status indicators, no item lists** — the roadmap
-     lives in Asana.
+     lives in Linear.
 3. Write `wave/<name>/MEMORY.md` — seed it with the load-bearing context from the
    Detail phase (key decisions, constraints, what's known). Short is fine.
-4. Connect and seed the roadmap in Asana:
-   - `lf op pm init --wave <name>` creates/links the Asana project and writes
-     `asana_project` into `GOAL.md`.
+4. Connect and seed the roadmap in Linear:
+   - `lf op pm init --wave <name>` creates/links the Linear project and writes
+     `linear_project` into `GOAL.md`.
    - File the opening items with `lf op pm update --title "…" --notes "…"` — the
-     urgent and next-step work, one task each. The roadmap starts in Asana, not
+     urgent and next-step work, one task each. The roadmap starts in Linear, not
      on disk.
 5. The first item you expect to build now becomes the design doc for this branch
    (`scratch/<branch>.md`).

--- a/rust/loopflow/src/engine/builtins/govern/step/scan.md
+++ b/rust/loopflow/src/engine/builtins/govern/step/scan.md
@@ -30,9 +30,9 @@ contains `wave/chord-model/` and `wave/signals/`, the wave names are
 ## Workflow
 
 1. **Read wave configs.** For each member wave directory in the area:
-   - `GOAL.md` — intent, metrics, primary flow, and the Asana handle
+   - `GOAL.md` — intent, metrics, primary flow, and the Linear handle
    - `MEMORY.md` — what the wave has learned and decided
-   - The live roadmap — `lf op pm show --wave <wave-name>` (Asana is the source of truth; there are no local roadmap files)
+   - The live roadmap — `lf op pm show --wave <wave-name>` (Linear is the source of truth; there are no local roadmap files)
 
 2. **Read runtime state.** For each member wave:
    - `wave/<wave-name>/.wave-endpoint` — a live wave server publishes its

--- a/rust/loopflow/src/engine/builtins/ops/step/split-wave.md
+++ b/rust/loopflow/src/engine/builtins/ops/step/split-wave.md
@@ -24,7 +24,7 @@ Wave mitosis. The parent wave ceases to exist — its identity and roadmap are d
 
 The numeric argument controls how many children to create (default 2).
 
-Roadmap items (Asana tasks) move as-is — each one lands in exactly one child. But `GOAL.md` needs rewriting, not slicing:
+Roadmap items (Linear issues) move as-is — each one lands in exactly one child. But `GOAL.md` needs rewriting, not slicing:
 
 - **Intent**: written fresh for each child. Must be internally coherent, not a fragment of the parent's.
 - **Metrics**: preserved and distributed. A metric can appear in multiple children if it spans both.
@@ -42,12 +42,12 @@ Roadmap items (Asana tasks) move as-is — each one lands in exactly one child. 
    - Each resulting wave should stand alone
 
 3. Allocate roadmap items
-   - Assign each Asana task to exactly one child — no orphans
+   - Assign each Linear issue to exactly one child — no orphans
 
 4. Create the new waves
    - `wave/<child>/GOAL.md` — fresh intent and metrics for each child; carry forward the primary flow; draw scope boundaries between siblings
    - `wave/<child>/MEMORY.md` — the decisions and context this child inherits
-   - `lf op pm init --wave <child>` — connect each child's Asana project
+   - `lf op pm init --wave <child>` — connect each child's Linear project
    - Recreate the allocated items on each child's roadmap with `lf op pm update`, and close them on the parent (`lf op pm update --id <task> --status done` is for shipped work; for a move, recreate on the child and delete/close on the parent)
 
 5. Remove the parent
@@ -55,7 +55,7 @@ Roadmap items (Asana tasks) move as-is — each one lands in exactly one child. 
    - Commit: `split-wave: <parent> → <child-a>, <child-b>`
 
 6. Verify
-   - Each child has a `GOAL.md`, a `MEMORY.md`, and a connected Asana project
+   - Each child has a `GOAL.md`, a `MEMORY.md`, and a connected Linear project
    - No content from the parent is unaccounted for
 
 ## Guardrails

--- a/rust/loopflow/src/engine/builtins/ops/step/update-wave.md
+++ b/rust/loopflow/src/engine/builtins/ops/step/update-wave.md
@@ -1,6 +1,6 @@
 ---
 requires: diff vs main | scratch/ analysis | both
-produces: wave/<wave>/ (GOAL.md, MEMORY.md), roadmap updates in Asana, scratch/ cleanup
+produces: wave/<wave>/ (GOAL.md, MEMORY.md), roadmap updates in Linear, scratch/ cleanup
 ---
 Single owner of `wave/<wave>/`. Keeps the wave's identity current and folds what the branch learned into memory.
 
@@ -10,10 +10,10 @@ A wave is two local files plus a remote roadmap:
 
 - **`wave/<wave>/GOAL.md`** — the wave's identity: what it's for, how it judges
   progress, the loop prompt it runs. Frontmatter carries `primary_flow` and the
-  Asana handle (`pm.asana_project`). This is the anchor; it changes rarely.
+  Linear handle (`pm.linear_project`). This is the anchor; it changes rarely.
 - **`wave/<wave>/MEMORY.md`** — what the wave remembers between loops. Durable
   observations, decisions, and context. This is where branch learnings land.
-- **The roadmap lives in Asana**, not in the repo. Read it with `lf op pm show`;
+- **The roadmap lives in Linear**, not in the repo. Read it with `lf op pm show`;
   change it with `lf op pm update`. There is no local roadmap mirror — never
   write `N-*.md` item files or a roadmap table.
 
@@ -35,7 +35,7 @@ Whether you're cleaning up after a build, reconciling scratch analysis, or both:
 - Durable learnings from `scratch/` are folded into `MEMORY.md`.
 - `GOAL.md` still describes the wave truthfully — if the branch changed the
   wave's intent, flow, or metrics, update it. Otherwise leave it.
-- The roadmap in Asana reflects reality: shipped work is closed, new work is
+- The roadmap in Linear reflects reality: shipped work is closed, new work is
   filed, stale items are corrected — all through `lf op pm update`.
 - `scratch/` is trimmed to what a reviewer needs (see below).
 
@@ -63,7 +63,7 @@ fold it. If it only describes what was already built, let it go.
 1. Read the diff (if any) to understand what this branch built.
 2. Read `GOAL.md`, `MEMORY.md`, and the live roadmap (`lf op pm show`).
 3. Read `scratch/` — every file, completely.
-4. **Reconcile the roadmap against reality.** For each item on the Asana
+4. **Reconcile the roadmap against reality.** For each item on the Linear
    roadmap, ask:
    - **Shipped?** If this branch (or main) crossed its finish line, close it:
      `lf op pm update --id <task-id> --status done`.
@@ -94,9 +94,9 @@ When `scratch/` holds a proposal and no wave exists yet, create one:
 2. Create `wave/<wave>/MEMORY.md` — seed it with the load-bearing context from
    the proposal (key decisions, constraints, what's known). It can be short.
 3. Connect the roadmap: `lf op pm init --wave <name>` creates/links the wave's
-   Asana project and writes `asana_project` into `GOAL.md`.
-4. File the opening roadmap items in Asana with `lf op pm update` — the urgent
-   and next-step work, one task each. The roadmap starts in Asana, not on disk.
+   Linear project and writes `linear_project` into `GOAL.md`.
+4. File the opening roadmap items in Linear with `lf op pm update` — the urgent
+   and next-step work, one task each. The roadmap starts in Linear, not on disk.
 
 ### GOAL.md
 
@@ -108,7 +108,7 @@ When `scratch/` holds a proposal and no wave exists yet, create one:
 ---
 primary_flow: build            # the flow this wave loops
 pm:
-  asana_project: "1201234567890"   # written by `lf op pm init`
+  linear_project: "8c4ba3f9-cf23-4136-87ed-37847aa7dc82"   # written by `lf op pm init`
 ---
 ```
 
@@ -119,7 +119,7 @@ pm:
 - The milestones or shape of the work ahead.
 
 **GOAL.md must not contain:** a roadmap table, status indicators
-(shipped/in-progress/planned), or item lists. The roadmap is in Asana.
+(shipped/in-progress/planned), or item lists. The roadmap is in Linear.
 
 ## Coherence
 
@@ -153,7 +153,7 @@ human explicitly closes it.
 ## Output
 
 Updated `wave/<wave>/MEMORY.md` (and `GOAL.md` if intent moved), a roadmap in
-Asana that reflects reality, and a trimmed `scratch/`.
+Linear that reflects reality, and a trimmed `scratch/`.
 
 **"No changes needed" is only valid when scratch/ is empty and the roadmap
 already matches reality.** If scratch has files, something must move into

--- a/rust/loopflow/src/lf/mod.rs
+++ b/rust/loopflow/src/lf/mod.rs
@@ -360,7 +360,7 @@ pub enum OpsCommand {
         #[command(subcommand)]
         cmd: ReleaseCommand,
     },
-    /// Roadmap in Asana (show, update, init, status)
+    /// Roadmap in Linear (show, update, init, status)
     Pm {
         #[command(subcommand)]
         cmd: PmCommand,
@@ -432,7 +432,7 @@ pub struct BranchFilterArgs {
 
 #[derive(Subcommand, Debug)]
 pub enum PmCommand {
-    /// Connect (or create) the wave's Asana project; write asana_project to GOAL.md
+    /// Connect (or create) the wave's Linear project; write linear_project to GOAL.md
     Init {
         /// Wave name (auto-detected if omitted)
         wave: Option<String>,
@@ -443,13 +443,13 @@ pub enum PmCommand {
         #[arg(long, conflicts_with_all = ["wave", "wave_flag"])]
         all: bool,
     },
-    /// Print the wave's live Asana roadmap
+    /// Print the wave's live Linear roadmap
     Show {
         /// Wave name (auto-detected if omitted)
         #[arg(short = 'w', long = "wave")]
         wave: Option<String>,
     },
-    /// Create, edit, or close a roadmap task in Asana
+    /// Create, edit, or close a roadmap task in Linear
     Update {
         /// Wave name (auto-detected if omitted)
         #[arg(short = 'w', long = "wave")]
@@ -500,7 +500,7 @@ pub enum AuthCommand {
         /// Provider name
         provider: String,
     },
-    /// External: provider name (so `lf op auth asana` works)
+    /// External: provider name (so `lf op auth linear` works)
     #[command(external_subcommand)]
     External(Vec<String>),
 }

--- a/rust/loopflow/src/ops/pm.rs
+++ b/rust/loopflow/src/ops/pm.rs
@@ -175,7 +175,14 @@ fn resolve_provider(repo: &Path, wave: &str) -> OpsResult<PmProviderKind> {
     {
         return Ok(PmProviderKind::Linear);
     }
-    Ok(PmProviderKind::Asana)
+    if wave_pm
+        .as_ref()
+        .and_then(|pm| pm.asana_project.as_ref())
+        .is_some()
+    {
+        return Ok(PmProviderKind::Asana);
+    }
+    Ok(PmProviderKind::Linear)
 }
 
 fn read_project(repo: &Path, wave: &str, provider: PmProviderKind) -> Option<String> {
@@ -687,12 +694,22 @@ mod tests {
     }
 
     #[test]
-    fn resolve_provider_defaults_to_asana() {
+    fn resolve_provider_infers_asana_from_project_key() {
         let repo = tempfile::tempdir().expect("temp dir");
         write_goal(repo.path(), "goals", "pm:\n  asana_project: \"123\"\n");
         assert_eq!(
             resolve_provider(repo.path(), "goals").unwrap(),
             PmProviderKind::Asana
+        );
+    }
+
+    #[test]
+    fn resolve_provider_defaults_to_linear() {
+        let repo = tempfile::tempdir().expect("temp dir");
+        write_goal(repo.path(), "goals", "pm:\n  provider: \"\"\n");
+        assert_eq!(
+            resolve_provider(repo.path(), "goals").unwrap(),
+            PmProviderKind::Linear
         );
     }
 

--- a/tests/goldens/basic.md
+++ b/tests/goldens/basic.md
@@ -73,11 +73,11 @@ Use these unconditionally. Outside any wave they drop silently (exit 0) -
 publish-to-no-subscriber is correct pubsub, never a blocker. A wave whose
 server is down errors instead; note it and move on.
 
-## The Roadmap Lives in Asana
+## The Roadmap Lives in Linear
 
-A wave's roadmap is not in the repo — it lives in Asana, and `lf op pm` is the
+A wave's roadmap is not in the repo — it lives in Linear, and `lf op pm` is the
 only way to read or change it. There is no local roadmap file to edit and no
-sync step; Asana is the source of truth.
+sync step; Linear is the source of truth.
 
 ```bash
 lf op pm show                                          # the wave's live roadmap
@@ -98,7 +98,7 @@ roadmap files or a roadmap table in `GOAL.md` — that mirror is gone.
 - `scratch/<branch>.md` - design doc for the current work
 - `scratch/questions.md` - open questions, blockers, assumptions
 - `lf memory add "<fact>"` - durable wave learnings; `wave/<name>/MEMORY.md` is
-  server-owned, never edited directly (roadmap goes to Asana, above)
+  server-owned, never edited directly (roadmap goes to Linear, above)
 - Code - the actual work
 
 ## Checkpoint And Proceed

--- a/tests/goldens/builtin_code_review.md
+++ b/tests/goldens/builtin_code_review.md
@@ -73,11 +73,11 @@ Use these unconditionally. Outside any wave they drop silently (exit 0) -
 publish-to-no-subscriber is correct pubsub, never a blocker. A wave whose
 server is down errors instead; note it and move on.
 
-## The Roadmap Lives in Asana
+## The Roadmap Lives in Linear
 
-A wave's roadmap is not in the repo — it lives in Asana, and `lf op pm` is the
+A wave's roadmap is not in the repo — it lives in Linear, and `lf op pm` is the
 only way to read or change it. There is no local roadmap file to edit and no
-sync step; Asana is the source of truth.
+sync step; Linear is the source of truth.
 
 ```bash
 lf op pm show                                          # the wave's live roadmap
@@ -98,7 +98,7 @@ roadmap files or a roadmap table in `GOAL.md` — that mirror is gone.
 - `scratch/<branch>.md` - design doc for the current work
 - `scratch/questions.md` - open questions, blockers, assumptions
 - `lf memory add "<fact>"` - durable wave learnings; `wave/<name>/MEMORY.md` is
-  server-owned, never edited directly (roadmap goes to Asana, above)
+  server-owned, never edited directly (roadmap goes to Linear, above)
 - Code - the actual work
 
 ## Checkpoint And Proceed

--- a/tests/goldens/builtin_debug.md
+++ b/tests/goldens/builtin_debug.md
@@ -73,11 +73,11 @@ Use these unconditionally. Outside any wave they drop silently (exit 0) -
 publish-to-no-subscriber is correct pubsub, never a blocker. A wave whose
 server is down errors instead; note it and move on.
 
-## The Roadmap Lives in Asana
+## The Roadmap Lives in Linear
 
-A wave's roadmap is not in the repo — it lives in Asana, and `lf op pm` is the
+A wave's roadmap is not in the repo — it lives in Linear, and `lf op pm` is the
 only way to read or change it. There is no local roadmap file to edit and no
-sync step; Asana is the source of truth.
+sync step; Linear is the source of truth.
 
 ```bash
 lf op pm show                                          # the wave's live roadmap
@@ -98,7 +98,7 @@ roadmap files or a roadmap table in `GOAL.md` — that mirror is gone.
 - `scratch/<branch>.md` - design doc for the current work
 - `scratch/questions.md` - open questions, blockers, assumptions
 - `lf memory add "<fact>"` - durable wave learnings; `wave/<name>/MEMORY.md` is
-  server-owned, never edited directly (roadmap goes to Asana, above)
+  server-owned, never edited directly (roadmap goes to Linear, above)
 - Code - the actual work
 
 ## Checkpoint And Proceed

--- a/tests/goldens/builtin_demo.md
+++ b/tests/goldens/builtin_demo.md
@@ -73,11 +73,11 @@ Use these unconditionally. Outside any wave they drop silently (exit 0) -
 publish-to-no-subscriber is correct pubsub, never a blocker. A wave whose
 server is down errors instead; note it and move on.
 
-## The Roadmap Lives in Asana
+## The Roadmap Lives in Linear
 
-A wave's roadmap is not in the repo — it lives in Asana, and `lf op pm` is the
+A wave's roadmap is not in the repo — it lives in Linear, and `lf op pm` is the
 only way to read or change it. There is no local roadmap file to edit and no
-sync step; Asana is the source of truth.
+sync step; Linear is the source of truth.
 
 ```bash
 lf op pm show                                          # the wave's live roadmap
@@ -98,7 +98,7 @@ roadmap files or a roadmap table in `GOAL.md` — that mirror is gone.
 - `scratch/<branch>.md` - design doc for the current work
 - `scratch/questions.md` - open questions, blockers, assumptions
 - `lf memory add "<fact>"` - durable wave learnings; `wave/<name>/MEMORY.md` is
-  server-owned, never edited directly (roadmap goes to Asana, above)
+  server-owned, never edited directly (roadmap goes to Linear, above)
 - Code - the actual work
 
 ## Checkpoint And Proceed

--- a/tests/goldens/builtin_implement.md
+++ b/tests/goldens/builtin_implement.md
@@ -73,11 +73,11 @@ Use these unconditionally. Outside any wave they drop silently (exit 0) -
 publish-to-no-subscriber is correct pubsub, never a blocker. A wave whose
 server is down errors instead; note it and move on.
 
-## The Roadmap Lives in Asana
+## The Roadmap Lives in Linear
 
-A wave's roadmap is not in the repo — it lives in Asana, and `lf op pm` is the
+A wave's roadmap is not in the repo — it lives in Linear, and `lf op pm` is the
 only way to read or change it. There is no local roadmap file to edit and no
-sync step; Asana is the source of truth.
+sync step; Linear is the source of truth.
 
 ```bash
 lf op pm show                                          # the wave's live roadmap
@@ -98,7 +98,7 @@ roadmap files or a roadmap table in `GOAL.md` — that mirror is gone.
 - `scratch/<branch>.md` - design doc for the current work
 - `scratch/questions.md` - open questions, blockers, assumptions
 - `lf memory add "<fact>"` - durable wave learnings; `wave/<name>/MEMORY.md` is
-  server-owned, never edited directly (roadmap goes to Asana, above)
+  server-owned, never edited directly (roadmap goes to Linear, above)
 - Code - the actual work
 
 ## Checkpoint And Proceed

--- a/tests/goldens/with_direction.md
+++ b/tests/goldens/with_direction.md
@@ -73,11 +73,11 @@ Use these unconditionally. Outside any wave they drop silently (exit 0) -
 publish-to-no-subscriber is correct pubsub, never a blocker. A wave whose
 server is down errors instead; note it and move on.
 
-## The Roadmap Lives in Asana
+## The Roadmap Lives in Linear
 
-A wave's roadmap is not in the repo — it lives in Asana, and `lf op pm` is the
+A wave's roadmap is not in the repo — it lives in Linear, and `lf op pm` is the
 only way to read or change it. There is no local roadmap file to edit and no
-sync step; Asana is the source of truth.
+sync step; Linear is the source of truth.
 
 ```bash
 lf op pm show                                          # the wave's live roadmap
@@ -98,7 +98,7 @@ roadmap files or a roadmap table in `GOAL.md` — that mirror is gone.
 - `scratch/<branch>.md` - design doc for the current work
 - `scratch/questions.md` - open questions, blockers, assumptions
 - `lf memory add "<fact>"` - durable wave learnings; `wave/<name>/MEMORY.md` is
-  server-owned, never edited directly (roadmap goes to Asana, above)
+  server-owned, never edited directly (roadmap goes to Linear, above)
 - Code - the actual work
 
 ## Checkpoint And Proceed

--- a/tests/goldens/with_direction_group.md
+++ b/tests/goldens/with_direction_group.md
@@ -73,11 +73,11 @@ Use these unconditionally. Outside any wave they drop silently (exit 0) -
 publish-to-no-subscriber is correct pubsub, never a blocker. A wave whose
 server is down errors instead; note it and move on.
 
-## The Roadmap Lives in Asana
+## The Roadmap Lives in Linear
 
-A wave's roadmap is not in the repo — it lives in Asana, and `lf op pm` is the
+A wave's roadmap is not in the repo — it lives in Linear, and `lf op pm` is the
 only way to read or change it. There is no local roadmap file to edit and no
-sync step; Asana is the source of truth.
+sync step; Linear is the source of truth.
 
 ```bash
 lf op pm show                                          # the wave's live roadmap
@@ -98,7 +98,7 @@ roadmap files or a roadmap table in `GOAL.md` — that mirror is gone.
 - `scratch/<branch>.md` - design doc for the current work
 - `scratch/questions.md` - open questions, blockers, assumptions
 - `lf memory add "<fact>"` - durable wave learnings; `wave/<name>/MEMORY.md` is
-  server-owned, never edited directly (roadmap goes to Asana, above)
+  server-owned, never edited directly (roadmap goes to Linear, above)
 - Code - the actual work
 
 ## Checkpoint And Proceed

--- a/tests/goldens/with_docs.md
+++ b/tests/goldens/with_docs.md
@@ -73,11 +73,11 @@ Use these unconditionally. Outside any wave they drop silently (exit 0) -
 publish-to-no-subscriber is correct pubsub, never a blocker. A wave whose
 server is down errors instead; note it and move on.
 
-## The Roadmap Lives in Asana
+## The Roadmap Lives in Linear
 
-A wave's roadmap is not in the repo — it lives in Asana, and `lf op pm` is the
+A wave's roadmap is not in the repo — it lives in Linear, and `lf op pm` is the
 only way to read or change it. There is no local roadmap file to edit and no
-sync step; Asana is the source of truth.
+sync step; Linear is the source of truth.
 
 ```bash
 lf op pm show                                          # the wave's live roadmap
@@ -98,7 +98,7 @@ roadmap files or a roadmap table in `GOAL.md` — that mirror is gone.
 - `scratch/<branch>.md` - design doc for the current work
 - `scratch/questions.md` - open questions, blockers, assumptions
 - `lf memory add "<fact>"` - durable wave learnings; `wave/<name>/MEMORY.md` is
-  server-owned, never edited directly (roadmap goes to Asana, above)
+  server-owned, never edited directly (roadmap goes to Linear, above)
 - Code - the actual work
 
 ## Checkpoint And Proceed

--- a/wave/architecture/GOAL.md
+++ b/wave/architecture/GOAL.md
@@ -1,8 +1,8 @@
 ---
 primary_flow: build
 pm:
-  provider: asana
-  asana_project: '1216271408546327'
+  provider: linear
+  linear_project: '8c4ba3f9-cf23-4136-87ed-37847aa7dc82'
 ---
 
 Collapse the three binaries — `lf`, `lfd`, `lfq` — toward **one workhorse plus one

--- a/wave/goals/GOAL.md
+++ b/wave/goals/GOAL.md
@@ -1,12 +1,12 @@
 ---
 primary_flow: ship-roadmap
 pm:
-  provider: asana
-  asana_project: '1216257471889000'
+  provider: linear
+  linear_project: 'fbdd6124-6114-4427-b6ac-5788dead4f87'
 ---
 
 Turn a Wave from a ticker spawning cold, stateless runs into a persistent Looping
-Agent running against a Goal, steered by a live Asana roadmap — until writing goals
+Agent running against a Goal, steered by a live Linear roadmap — until writing goals
 is a good way to compute, with clients and servers built from goals and zero step
 authoring.
 
@@ -14,11 +14,11 @@ authoring.
 - Reference builds from goals, zero step authoring: 3 (mobile client, CLI client, server) reaching demoable. Target 3/3.
 - Product-dev step-authoring rate on those builds. Target 0.
 - Unattended loop iterations without human intervention. Target ≥ 20 consecutive.
-- Asana round-trip: items the loop both reads and writes status back to. Target 100%.
+- Linear round-trip: items the loop both reads and writes status back to. Target 100%.
 - Concerto can launch and show looping sessions per repo.
 
 **Milestones**
 - Goal primitive superseding `direction`, with the `.lf/` override model.
-- Asana as the live roadmap; Looping Agent on codex/claude cloud (backend a); first-class wave spend budget.
+- Linear as the live roadmap; Looping Agent on codex/claude cloud (backend a); first-class wave spend budget.
 - Concerto per-repo looping sessions; vocabulary completeness; simplified wave-tree data model (parent/child waves; no separate "chord" concept).
 - Looping Agent on hosted lfd + Ghostty (backend b).

--- a/wave/meta/GOAL.md
+++ b/wave/meta/GOAL.md
@@ -10,7 +10,8 @@ metrics:
 - Every builtin step and flow is legible — declared shape visible before a run, hotness and real duration empirical from the ledger; redundant or dead ones get merged or deleted
 - The general/taste split is clean — universal lessons live in builtins, personal taste in the repo's agent file, proven on both loopflow and cadenza
 pm:
-  asana_project: '1216277277718272'
+  provider: linear
+  linear_project: '0e2c75ee-a287-467b-988c-2c83f0f3cbba'
 ---
 
 Run one loop iteration for the Meta wave.

--- a/wave/systems/GOAL.md
+++ b/wave/systems/GOAL.md
@@ -12,7 +12,8 @@ metrics:
 - Local and host lf/lfd/app stay fresh with one command; failures surface as work, not Actions-history noise
 - Agents run unattended — every human-in-the-loop step a CLI or API could do (credential fetch, discovery, setup, approval) is automated away
 pm:
-  asana_project: '1216278115228408'
+  provider: linear
+  linear_project: '7cf1518e-340e-4cfa-8426-63f06b7a5e1c'
 ---
 
 Run one loop iteration for the Systems wave.

--- a/website/main.py
+++ b/website/main.py
@@ -326,7 +326,7 @@ Worker: a scoped agent a wave dispatches to run a flow and open a PR; inherits
   the wave's GOAL.md and MEMORY.md.
 Step: a prompt that runs a coding agent. Flow: a sequence of steps.
 Direction: composable quality definitions that shape agent judgment.
-Roadmap: the wave's work queue, provider-backed (e.g. Asana).
+Roadmap: the wave's work queue, provider-backed (e.g. Linear).
 
 ## Docs
 /docs              Overview and quick start


### PR DESCRIPTION
## Usage

```bash
lf op auth linear                 # connect Linear with OAuth
lf op pm init --wave designer     # connect/create the Linear project, write linear_project into GOAL.md
lf op pm show --wave designer     # print the wave's live Linear roadmap
```

## Summary

Flips the default PM provider from Asana to Linear. `.lf/config.yaml` now sets `pm.provider: linear` with a `linear.team` id, and every user-facing surface that named Asana as the roadmap backend now points at Linear — README, docs, builtin wave prompts, and test goldens. The roadmap still lives entirely in the PM tool with no local mirror; the change is which tool that is.

## Changes

- `.lf/config.yaml`: default provider set to `linear`, adds `linear.team`
- Docs and README: Asana → Linear throughout (`lf op auth linear`, `linear_project` frontmatter, roadmap-source-of-truth prose); notes Linear issue descriptions/comments are native Markdown
- Builtin prompts (`LOOPFLOW.md`, build/design, govern/scan, ops/split-wave, ops/update-wave): roadmap-lives-in-Linear wording, `pm.linear_project` handle, Linear issue terminology
- `ops/pm.rs` and wave `GOAL.md` files updated to reference Linear
- Test goldens regenerated to match the new prompt text; builtins test now asserts on `Linear`