### PR TITLE
wave docs: retarget PM references from asana to linear

### DIFF
--- a/wave/architecture/analysis/architecture-map.md
+++ b/wave/architecture/analysis/architecture-map.md
@@ -29,7 +29,7 @@ The runtime state lives outside that authored layer:
 
 - lfd store - waves, sessions, runs, events, triggers, auth, provider state.
 - tmux/processes/Docker - execution backends.
-- PM provider - Asana mirror and lifecycle state.
+- PM provider - Linear mirror and lifecycle state.
 - release artifacts - decision ledgers and archived notes.
 
 ## Main code boundaries
@@ -89,7 +89,7 @@ authored goal, recurring assessment, delegated execution, and visible state.
 | Wave intent | repo | `wave/<name>/GOAL.md`, `MEMORY.md` |
 | Wave runtime | lfd store | status, sessions, events, triggers |
 | Agent execution | engine/executor | local process, tmux, Docker |
-| PM truth | provider | Asana can arbitrate picks |
+| PM truth | provider | Linear can arbitrate picks |
 | UI state | Swift stores | derived from lfd and local preferences |
 
 ## Current architectural tension

--- a/wave/concerto/concerto.yaml
+++ b/wave/concerto/concerto.yaml
@@ -3,5 +3,5 @@ direction:
 - ux
 - clarity
 pm:
-  provider: asana
-  asana_project: '1214270017631632'
+  provider: linear
+  linear_project: '9ee88f2a-ef37-46c7-b201-d197db3ccae0'

--- a/wave/goals/MEMORY.md
+++ b/wave/goals/MEMORY.md
@@ -1,7 +1,7 @@
 # goals wave memory
 
 Steers Loopflow toward persistent Goal-driven Waves: goals as the authored loop
-prompt, Asana as the live roadmap, Concerto as the session surface. Standing
+prompt, Linear as the live roadmap, Concerto as the session surface. Standing
 campaign: writing goals becomes a way to compute — three reference builds from
 goals (mobile, CLI, server) with zero step authoring.
 
@@ -87,8 +87,8 @@ risks, a reading list for the merged code). Read those for detail. The spine:
 
 ## Landed research (2026-07-03, for the record)
 
-- **01 Asana live roadmap — shipped.** Loop reads Asana live each iteration; no
-  local mirror; `--pr` link on `lf op pm update` (#780 merged).
+- **01 Live roadmap — shipped.** Loop reads the PM provider live each
+  iteration; no local mirror; `--pr` link on `lf op pm update` (#780 merged).
 - **03 Wave ancestry — #781 merged.** `parent_wave_id` tree, `children_of()`
   query, DTO mirrored. Nothing constructs trees yet.
 - **04 Wave spend budget — designed, deferred to M4.** Core hard floor
@@ -96,14 +96,13 @@ risks, a reading list for the merged code). Read those for detail. The spine:
   ceiling. Needs a Money cents newtype.
 - **02 Cloud backend — recommend A2 (lfd scaffolds; vendor owns the loop);
   deferred to M3.** Claude Routines have no create API; Codex has no
-  server-side schedule. Net-new piece is a `.mcp.json` Asana emitter.
+  server-side schedule. Net-new piece is a `.mcp.json` Linear emitter.
 
 ## Next
 
-- **Reconcile the roadmap** (blocked 2026-07-05: Asana token expired): file the
-  M1 conversion work-list and the 10 decision questions from
-  wave-agent-follow-ups.md into Asana; close #780/#781/#796/#801 tasks; file
-  #803.
+- **Reconcile the roadmap:** file the M1 conversion work-list and the 10
+  decision questions from wave-agent-follow-ups.md into Linear; close
+  #780/#781/#796/#801 tasks; file #803.
 - **Prove-the-language:** CLI probe shipped (#799 open — GOAL.md-only Rust CLI
   built and gated `hello, Loopflow` with 0 authored `.lf/steps`); server and
   mobile reference builds remain.

--- a/wave/goals/architecture-direction.md
+++ b/wave/goals/architecture-direction.md
@@ -81,7 +81,7 @@ Claude coinages and were reshaped in the July 5 design walk.
 2. **C2 — Coordination uses durable facts and explicit commands [R]:**
    speech is a worker-output/reporting primitive, not the universal bus.
    Coordination state should be inspectable: sqlite for operational facts,
-   journals for conversation, git/GitHub for PR truth, Asana for roadmap truth,
+   journals for conversation, git/GitHub for PR truth, Linear for roadmap truth,
    and explicit `lf` commands for action. Private daemon control loops are
    suspect; commands at authority boundaries are real.
 3. **C3 — Execution converges on `lf` invocations [R]:** the ideal execution

--- a/wave/goals/wave-agent-follow-ups.md
+++ b/wave/goals/wave-agent-follow-ups.md
@@ -4,7 +4,7 @@ What the wave-agent branch deliberately did not resolve: the decision
 questions for a next branch, the risks we accepted with eyes open, and the
 reading list for walking the merged code. The branch's `scratch/` review
 artifacts die at land; this survives. When an item is picked up, file it in
-Asana (`lf op pm update`) — this doc is context, not the tracker.
+Linear (`lf op pm update`) — this doc is context, not the tracker.
 
 ## Decision questions
 
@@ -49,7 +49,7 @@ vestigial.
 5. **`roadmap_item` plumbing.** Dead end to end — every internal producer
    passes `None`; it terminates in a debug log ("no local ingest"). Rust
    side plus Swift `LocalWaveService` sender. Contradicts
-   Asana-is-the-roadmap.
+   Linear-is-the-roadmap.
 
 6. **Interrupt has no grace window.** The design's cooperative → grace →
    kill story is aspirational everywhere: codex is cooperative with a

--- a/wave/systems/MEMORY.md
+++ b/wave/systems/MEMORY.md
@@ -22,13 +22,13 @@ Steers Loopflow toward boring releases: nightly verification that never deploys,
 
 ## Next
 
-- **Drain current buffer** — keep local `lf`/`lfd`, release scripts, and CI aligned with the latest merged release-infra work. Known drift: `wave/*/items/*.md` and `wave/*/[0-9]-*.md` local roadmap mirrors survived the `asana-only` migration (c113ef04b) that was supposed to drop them — the roadmap now lives only in Asana (`lf op pm show`). Sweep these stale mirrors when a broader wave-hygiene pass runs; this update-wave run left them in place per the skill's "never delete local roadmap files" rule.
+- **Drain current buffer** — keep local `lf`/`lfd`, release scripts, and CI aligned with the latest merged release-infra work. Known drift: `wave/*/items/*.md` and `wave/*/[0-9]-*.md` local roadmap mirrors are stale — the roadmap now lives only in Linear (`lf op pm show`), not in local files. Sweep these stale mirrors when a broader wave-hygiene pass runs; this update-wave run left them in place per the skill's "never delete local roadmap files" rule.
 - **Cadenza release parity** (items/01) — same nightly/weekly cadence, one-command updater, tests, self-hosted assumptions; document any deliberate divergence.
 - **Cron host bootstrap** (items/02) — bring up the first maintained self-hosted `lfd` host (Mac mini + Tailscale default), Doppler configured, root/conductor wave with scheduled checks.
 - **Release feedback loop** (items/03) — failed nightly/weekly runs surface as attention items or focused fix PRs, distinguishing verification vs publish vs host vs stale-local drift.
 - **Replicate intentionally** — apply the skeleton to Manabot/Hootro only when they need it.
 
-### Rebase-efficiency follow-ups (file to Asana once auth restored)
+### Rebase-efficiency follow-ups (file to Linear)
 
 - **Config/naming-schema child** — redesign `branch_names.schema` so branch ancestry and root formatting stop fighting over dots; include migration, config docs, DTO/fixture updates if wire shapes change, and prompt guidance. The parent PR deliberately did *not* solve this; it opens as a stacked child.
 - **Normal `lf` placement flags** — `lf <flow-or-step> --stack|--fork|--dispatch` execution placement, calling the same `engine/worktrees` planner as `lf op wt create` (not a reimplementation). Parent landed only the shared engine + the `wt create` surface.


### PR DESCRIPTION
## Try it

```bash
git diff main -- wave/
```

## Summary

The PM provider flipped from Asana to Linear (Asana was removed entirely in `43a1f85c`). This branch scrubs the stale Asana references out of the wave documents so the authored roadmap, memory, and architecture notes match the live provider. The one functional change is `wave/concerto/concerto.yaml`, which now points at the Linear provider and project id instead of Asana; everything else is prose in `MEMORY.md`, analysis, and follow-up docs.

## Changes

- `wave/concerto/concerto.yaml` — set `provider: linear` with the Linear project uuid, replacing the Asana provider and numeric project id.
- `wave/goals/*` and `wave/systems/MEMORY.md` — rewrite "Asana is the roadmap" language to Linear; drop the resolved "Asana token expired" / "once auth restored" blockers now that the reconcile work targets Linear.
- `wave/architecture/analysis/architecture-map.md` — update PM-mirror and PM-truth rows to name Linear.
- `wave/goals/wave-agent-follow-ups.md` — point the `roadmap_item` and filing notes at Linear.