### PR TITLE
lfdb: sweep three pieces of confirmed-dead code

### DIFF
--- a/rust/loopflow/src/lfd/types/mod.rs
+++ b/rust/loopflow/src/lfd/types/mod.rs
@@ -27,6 +27,6 @@ pub use session::{
 };
 pub use summary::Summary;
 pub use wave::{
-    LivePrState, LivePullRequestState, PullRequest, QueueBlock, QueueBlockReason, QueueMergeEvent,
-    RepoWork, Run, RunStackStatus, RunStatus, Wave, WaveStatus,
+    LivePrState, LivePullRequestState, PullRequest, QueueBlock, QueueBlockReason, RepoWork, Run,
+    RunStackStatus, RunStatus, Wave, WaveStatus,
 };

--- a/rust/loopflow/src/lfd/types/wave.rs
+++ b/rust/loopflow/src/lfd/types/wave.rs
@@ -444,16 +444,6 @@ pub struct QueueBlock {
     pub error: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct QueueMergeEvent {
-    pub wave_id: LfdId,
-    pub pr_number: u32,
-    #[serde(with = "time::serde::rfc3339")]
-    pub merged_at: OffsetDateTime,
-    #[serde(with = "time::serde::rfc3339")]
-    pub processed_at: OffsetDateTime,
-}
-
 impl Run {
     pub fn new(id: LfdId, wave_id: LfdId) -> Self {
         let stack_group_id = wave_id.to_string();

--- a/rust/loopflow/src/lfdb/migrations.rs
+++ b/rust/loopflow/src/lfdb/migrations.rs
@@ -210,6 +210,10 @@ const ALL_MIGRATIONS: &[Migration] = &[
         version: "050_drop_trigger_organs",
         sql: include_str!("migrations/050_drop_trigger_organs.sql"),
     },
+    Migration {
+        version: "051_drop_dead_tables",
+        sql: include_str!("migrations/051_drop_dead_tables.sql"),
+    },
 ];
 
 /// Migrations that rename or drop schema objects some dbs never had (the

--- a/rust/loopflow/src/lfdb/migrations/051_drop_dead_tables.sql
+++ b/rust/loopflow/src/lfdb/migrations/051_drop_dead_tables.sql
@@ -1,0 +1,12 @@
+-- Two tables that never earned their keep:
+--
+-- secrets_provider_config (from 031) has zero references in all of src/ --
+-- nothing ever read or wrote it.
+--
+-- wave_pr_merge_events (from 009, recreated in 011) was insert-only via
+-- record_merge_event with no SELECT anywhere; the writer and its only callers
+-- lived in test code. That writer and the QueueMergeEvent type go with it.
+--
+-- IF EXISTS keeps the drops convergent on every history.
+DROP TABLE IF EXISTS secrets_provider_config;
+DROP TABLE IF EXISTS wave_pr_merge_events;

--- a/rust/loopflow/src/lfdb/mod.rs
+++ b/rust/loopflow/src/lfdb/mod.rs
@@ -13,8 +13,8 @@ use std::sync::Arc;
 use crate::lfd::id::LfdId;
 use crate::lfd::types::{
     AttentionItem, AttentionKind, AttentionStatus, ChatMemoryBlock, ChatMessage, LivePrState,
-    LivePullRequestState, QueueBlock, QueueMergeEvent, Repo, RepoEdge, RepoId, RepoWork, Run,
-    RunStackStatus, Session, SessionStatus, Summary, Wave,
+    LivePullRequestState, QueueBlock, Repo, RepoEdge, RepoId, RepoWork, Run, RunStackStatus,
+    Session, SessionStatus, Summary, Wave,
 };
 
 pub mod catalog;
@@ -409,10 +409,6 @@ impl Store {
         WaveStateStore::delete_queue_block(self, wave_id, run_id).await
     }
 
-    pub async fn record_merge_event(&self, event: &QueueMergeEvent) -> StoreResult<bool> {
-        WaveStateStore::record_merge_event(self, event).await
-    }
-
     pub async fn get_summary(&self, wave_id: &LfdId) -> StoreResult<Option<Summary>> {
         WaveStateStore::get_summary(self, wave_id).await
     }
@@ -675,7 +671,6 @@ pub trait WaveStateStore: Send + Sync {
     async fn list_queue_blocks(&self, wave_id: &LfdId) -> StoreResult<Vec<QueueBlock>>;
     async fn upsert_queue_block(&self, block: &QueueBlock) -> StoreResult<()>;
     async fn delete_queue_block(&self, wave_id: &LfdId, run_id: &LfdId) -> StoreResult<u32>;
-    async fn record_merge_event(&self, event: &QueueMergeEvent) -> StoreResult<bool>;
 
     async fn get_summary(&self, wave_id: &LfdId) -> StoreResult<Option<Summary>>;
     async fn upsert_summary(&self, summary: &Summary) -> StoreResult<()>;
@@ -1088,13 +1083,6 @@ impl WaveStateStore for Store {
         }
     }
 
-    async fn record_merge_event(&self, event: &QueueMergeEvent) -> StoreResult<bool> {
-        {
-            let event = event.clone();
-            run_sqlite(&self.sqlite, move |store| store.record_merge_event(&event)).await
-        }
-    }
-
     async fn get_summary(&self, wave_id: &LfdId) -> StoreResult<Option<Summary>> {
         {
             let wave_id = wave_id.clone();
@@ -1471,8 +1459,8 @@ mod tests {
     use crate::lfd::id::LfdId;
     use crate::lfd::types::{
         ChatMemoryBlock, LivePrState, LivePullRequestState, PullRequest, QueueBlock,
-        QueueBlockReason, QueueMergeEvent, Repo, RepoEdge, RepoId, RepoWork, Run, RunStackStatus,
-        RunStatus, Summary, Wave, WaveStatus,
+        QueueBlockReason, Repo, RepoEdge, RepoId, RepoWork, Run, RunStackStatus, RunStatus,
+        Summary, Wave, WaveStatus,
     };
     use std::env;
     use time::OffsetDateTime;
@@ -2508,23 +2496,6 @@ mod tests {
             .await
             .expect("delete block");
         assert_eq!(deleted, 1);
-
-        let merge_event = QueueMergeEvent {
-            wave_id: wave.id().clone(),
-            pr_number: 42,
-            merged_at: OffsetDateTime::now_utc(),
-            processed_at: OffsetDateTime::now_utc(),
-        };
-        let first = store
-            .record_merge_event(&merge_event)
-            .await
-            .expect("record first");
-        let second = store
-            .record_merge_event(&merge_event)
-            .await
-            .expect("record second");
-        assert!(first);
-        assert!(!second);
 
         store.delete_wave(wave.id()).await.expect("delete wave");
     }

--- a/rust/loopflow/src/lfdb/sqlite.rs
+++ b/rust/loopflow/src/lfdb/sqlite.rs
@@ -7,8 +7,8 @@ use crate::lfd::attention::{queue_block_attention_item, queue_block_from_attenti
 use crate::lfd::id::LfdId;
 use crate::lfd::types::{
     AttentionItem, AttentionKind, AttentionStatus, ChatMemoryBlock, ChatMessage,
-    LivePullRequestState, QueueBlock, QueueMergeEvent, Repo, RepoEdge, RepoId, RepoWork, Run,
-    RunStatus, Session, SessionStatus, SessionUse, Summary, Wave, WaveStatus,
+    LivePullRequestState, QueueBlock, Repo, RepoEdge, RepoId, RepoWork, Run, RunStatus, Session,
+    SessionStatus, SessionUse, Summary, Wave, WaveStatus,
 };
 use crate::lfdb::catalog::{list_runs_query, list_waves_query, sql, Query, SqlDialect};
 use crate::lfdb::rows::{
@@ -1160,22 +1160,6 @@ impl SqliteStore {
         item.resolved_at = Some(time::OffsetDateTime::now_utc());
         self.upsert_attention_item(&item)?;
         Ok(1)
-    }
-
-    pub fn record_merge_event(&self, event: &QueueMergeEvent) -> StoreResult<bool> {
-        let conn = self.conn.lock().expect("store mutex poisoned");
-        let inserted = conn.execute(
-            "INSERT INTO wave_pr_merge_events (wave_id, pr_number, merged_at, processed_at)
-             VALUES (?1, ?2, ?3, ?4)
-             ON CONFLICT(wave_id, pr_number, merged_at) DO NOTHING",
-            params![
-                event.wave_id,
-                event.pr_number as i64,
-                event.merged_at.unix_timestamp(),
-                event.processed_at.unix_timestamp(),
-            ],
-        )?;
-        Ok(inserted > 0)
     }
 
     pub fn fail_orphaned_runs(&self) -> StoreResult<u32> {

--- a/rust/loopflow/src/wave/journal.rs
+++ b/rust/loopflow/src/wave/journal.rs
@@ -227,17 +227,12 @@ pub enum EventKind {
         reason: String,
     },
     // -- orchestration (observations, not commands) --
-    // The serde aliases keep yesterday's journals replayable: these kinds
-    // were written as `worker_dispatched`/`worker_finished` before the
-    // rename. New writes always carry the new names.
-    #[serde(alias = "worker_dispatched")]
     RunObserved {
         run_id: String,
         session_id: String,
         flow: String,
         task: String,
     },
-    #[serde(alias = "worker_finished")]
     RunCompleted {
         run_id: String,
         outcome: WorkerOutcome,
@@ -1161,67 +1156,14 @@ mod tests {
         }
     }
 
-    /// Yesterday's journals carry the pre-rename kind names
-    /// (`worker_dispatched`/`worker_finished`); the serde aliases must keep
-    /// them decoding — and folding — exactly as the new names do, while new
-    /// writes always carry the new names.
+    /// New appends carry the post-rename kind names on disk — a run completion
+    /// serializes as `run_completed`, never the retired `worker_finished`.
     #[test]
-    fn old_worker_kind_names_still_replay_and_fold_identically() {
+    fn new_appends_carry_the_renamed_kind_names() {
         let (_tmp, path) = open_tmp();
         std::fs::create_dir_all(path.parent().unwrap()).unwrap();
-        let old_lines = concat!(
-            "{\"v\":1,\"seq\":1,\"at\":\"2026-07-03T00:00:00Z\",\"kind\":{\"type\":\"worker_dispatched\",\"run_id\":\"run-1\",\"session_id\":\"sess-1\",\"flow\":\"implement\",\"task\":\"wire it\"}}\n",
-            "{\"v\":1,\"seq\":2,\"at\":\"2026-07-03T00:01:00Z\",\"kind\":{\"type\":\"worker_dispatched\",\"run_id\":\"run-2\",\"session_id\":\"sess-2\",\"flow\":\"design\",\"task\":\"sketch it\"}}\n",
-            "{\"v\":1,\"seq\":3,\"at\":\"2026-07-03T00:02:00Z\",\"kind\":{\"type\":\"worker_finished\",\"run_id\":\"run-1\",\"outcome\":\"completed\",\"summary\":\"pr landed\"}}\n",
-        );
-        std::fs::write(&path, old_lines).unwrap();
+        let (mut journal, _events) = Journal::open(&path).expect("journal opens");
 
-        let (mut journal, old_events) = Journal::open(&path).expect("old journal replays");
-        assert_eq!(old_events.len(), 3, "every old line decoded");
-        let old_fold = fold_workers(&old_events);
-
-        // The same facts written by this build, under the new names.
-        let new_events = vec![
-            Event {
-                v: FORMAT_VERSION,
-                seq: 1,
-                at: OffsetDateTime::now_utc(),
-                kind: EventKind::RunObserved {
-                    run_id: "run-1".into(),
-                    session_id: "sess-1".into(),
-                    flow: "implement".into(),
-                    task: "wire it".into(),
-                },
-            },
-            Event {
-                v: FORMAT_VERSION,
-                seq: 2,
-                at: OffsetDateTime::now_utc(),
-                kind: EventKind::RunObserved {
-                    run_id: "run-2".into(),
-                    session_id: "sess-2".into(),
-                    flow: "design".into(),
-                    task: "sketch it".into(),
-                },
-            },
-            Event {
-                v: FORMAT_VERSION,
-                seq: 3,
-                at: OffsetDateTime::now_utc(),
-                kind: EventKind::RunCompleted {
-                    run_id: "run-1".into(),
-                    outcome: WorkerOutcome::Completed,
-                    summary: "pr landed".into(),
-                },
-            },
-        ];
-        assert_eq!(
-            old_fold,
-            fold_workers(&new_events),
-            "old names fold identically to new names"
-        );
-
-        // New appends carry the new names on disk, never the aliases.
         journal.append(|_| EventKind::RunCompleted {
             run_id: "run-2".into(),
             outcome: WorkerOutcome::Failed,


### PR DESCRIPTION
## What changed

Removes three confirmed-dead pieces of code and adds a migration to drop the tables behind them.

- **`secrets_provider_config` table** (from migration 031) had zero references anywhere in `src/` — nothing ever read or wrote it.
- **`wave_pr_merge_events` table** (from 009, recreated in 011) was insert-only via `record_merge_event`, with no `SELECT` anywhere; the writer and its only callers lived in test code. The writer, the `record_merge_event` methods on `Store`/`SqliteStore`/`WaveStateStore`, and the `QueueMergeEvent` DTO go with it.
- **`worker_dispatched`/`worker_finished` serde aliases** on the journal's `RunObserved`/`RunCompleted` event kinds — the pre-rename compatibility shim is no longer needed, so the aliases and the replay-equivalence test are dropped. The test is replaced by a leaner one asserting new appends serialize under the post-rename names.

## Migration

```sql
-- 051_drop_dead_tables.sql
DROP TABLE IF EXISTS secrets_provider_config;
DROP TABLE IF EXISTS wave_pr_merge_events;
```

`IF EXISTS` keeps the drops convergent across every db history.