### PR TITLE
wave: collapse the wave model from multi-repo to single-repo

### DIFF
--- a/python/loopflow/models.py
+++ b/python/loopflow/models.py
@@ -60,28 +60,12 @@ class FlowStep(BaseModel):
         raise TypeError(f"Unsupported flow step value: {value!r}")
 
 
-class RepoWork(BaseModel):
-    """Per-repo execution surface for a wave. Wire type — no defaults on the
-    fields the server always emits; optional fields mirror Rust's
-    skip_serializing_if (absent → None)."""
-
-    repo: str
-    status: str
-    iteration: int
-    commits: list[CommitEntry]
-    open_pr_count: int
-    stack_count: int
-    local_worktree: Optional[str] = None
-    remote_branch: Optional[str] = None
-    diff_stat: Optional[str] = None
-    active_run: Optional[Run] = None
-    pr: Optional[PullRequest] = None
-
-
 class Wave(BaseModel):
-    """Wave wire type. No field defaults — every field the server always emits
-    is required, mirroring Rust's `WaveDto` (absent → parse error). Optional
-    fields carry `None` for absent, never a value default."""
+    """Wave wire type. A wave targets exactly one repo, so its execution surface
+    (repo/iteration plus the git + PR snapshot) is carried inline. No field
+    defaults — every field the server always emits is required, mirroring Rust's
+    `WaveDto` (absent → parse error). Optional fields carry `None` for absent,
+    never a value default."""
 
     id: str
     name: str
@@ -92,9 +76,18 @@ class Wave(BaseModel):
     direction: list[str]
     area: list[str]
     status: str
-    repos: list[RepoWork]
+    repo: str
+    iteration: int
+    commits: list[CommitEntry]
+    open_pr_count: int
+    stack_count: int
     flow_steps: list[FlowStep]
     parent_wave_id: Optional[str]
+    local_worktree: Optional[str] = None
+    remote_branch: Optional[str] = None
+    diff_stat: Optional[str] = None
+    active_run: Optional[Run] = None
+    pr: Optional[PullRequest] = None
     created_at: Optional[datetime] = None
 
     @field_validator("flow_steps", mode="before")

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -14,59 +14,47 @@ WAVE_MINIMAL = {
     "status": "running",
     "flow_steps": [],
     "parent_wave_id": None,
-    "repos": [
-        {
-            "repo": "/tmp/repo",
-            "status": "running",
-            "iteration": 0,
-            "commits": [],
-            "open_pr_count": 0,
-            "stack_count": 0,
-        }
-    ],
+    "repo": "/tmp/repo",
+    "iteration": 0,
+    "commits": [],
+    "open_pr_count": 0,
+    "stack_count": 0,
 }
 
 WAVE_FULL = {
     **WAVE_MINIMAL,
     "created_at": "2026-02-08T01:56:54Z",
     "flow_steps": ["review", "iterate", "build", "gate"],
-    "repos": [
-        {
-            "repo": "/tmp/repo",
-            "status": "running",
-            "iteration": 0,
-            "local_worktree": "/tmp/wt",
-            "remote_branch": "wave/architecture",
-            "commits": [
-                {"sha": "a1b2c3d", "message": "implement: add retry logic"},
-                {"sha": "e4f5g6h", "message": "design: initial sketch"},
-            ],
-            "diff_stat": " 3 files changed, 42 insertions(+), 7 deletions(-)",
-            "open_pr_count": 1,
-            "stack_count": 1,
-            "active_run": {
-                "id": "run-1",
-                "wave_id": "abc-123",
-                "iteration": 0,
-                "step_index": 0,
-                "status": "running",
-                "local_worktree": "/tmp/wt",
-                "remote_branch": "wave/architecture",
-                "pr": {
-                    "url": "https://github.com/org/repo/pull/1",
-                    "number": 1,
-                    "state": "open",
-                },
-                "started_at": "2026-02-08T02:00:00Z",
-                "flow_parents": ["parent-1"],
-            },
-            "pr": {
-                "url": "https://github.com/org/repo/pull/1",
-                "number": 1,
-                "state": "open",
-            },
-        }
+    "local_worktree": "/tmp/wt",
+    "remote_branch": "wave/architecture",
+    "commits": [
+        {"sha": "a1b2c3d", "message": "implement: add retry logic"},
+        {"sha": "e4f5g6h", "message": "design: initial sketch"},
     ],
+    "diff_stat": " 3 files changed, 42 insertions(+), 7 deletions(-)",
+    "open_pr_count": 1,
+    "stack_count": 1,
+    "active_run": {
+        "id": "run-1",
+        "wave_id": "abc-123",
+        "iteration": 0,
+        "step_index": 0,
+        "status": "running",
+        "local_worktree": "/tmp/wt",
+        "remote_branch": "wave/architecture",
+        "pr": {
+            "url": "https://github.com/org/repo/pull/1",
+            "number": 1,
+            "state": "open",
+        },
+        "started_at": "2026-02-08T02:00:00Z",
+        "flow_parents": ["parent-1"],
+    },
+    "pr": {
+        "url": "https://github.com/org/repo/pull/1",
+        "number": 1,
+        "state": "open",
+    },
 }
 
 WAVE_RUN_MINIMAL = {

--- a/python/tests/test_contract.py
+++ b/python/tests/test_contract.py
@@ -28,13 +28,10 @@ def test_wave_fixture_parses():
     assert wave.area == ["src/"]
     assert wave.parent_wave_id == "wave_parent999"
 
-    assert len(wave.repos) == 1
-    repo = wave.repos[0]
-    assert repo.repo == "/home/user/project"
-    assert repo.status == "running"
-    assert repo.iteration == 3
-    assert repo.open_pr_count == 1
-    assert repo.local_worktree == "/home/user/project/.claude/worktrees/engbot"
-    assert repo.remote_branch == "engbot/build-3"
-    assert len(repo.commits) == 1
-    assert repo.commits[0].sha == "abc1234"
+    assert wave.repo == "/home/user/project"
+    assert wave.iteration == 3
+    assert wave.open_pr_count == 1
+    assert wave.local_worktree == "/home/user/project/.claude/worktrees/engbot"
+    assert wave.remote_branch == "engbot/build-3"
+    assert len(wave.commits) == 1
+    assert wave.commits[0].sha == "abc1234"

--- a/python/tests/test_models.py
+++ b/python/tests/test_models.py
@@ -34,26 +34,23 @@ class TestWaveModel:
         assert wave.created_at is None
         assert wave.flow_steps == []
         assert wave.workers == 1
-        assert len(wave.repos) == 1
-        repo = wave.repos[0]
-        assert repo.repo == "/tmp/repo"
-        assert repo.iteration == 0
-        assert repo.active_run is None
-        assert repo.commits == []
-        assert repo.diff_stat is None
+        assert wave.repo == "/tmp/repo"
+        assert wave.iteration == 0
+        assert wave.active_run is None
+        assert wave.commits == []
+        assert wave.diff_stat is None
 
     def test_full_payload(self):
         wave = Wave.model_validate(WAVE_FULL)
         assert wave.created_at is not None
-        repo = wave.repos[0]
-        assert repo.active_run.status == "running"
-        assert repo.active_run.pr.number == 1
-        assert repo.remote_branch == "wave/architecture"
-        assert repo.pr.number == 1
-        assert len(repo.commits) == 2
-        assert repo.commits[0].sha == "a1b2c3d"
-        assert repo.commits[0].message == "implement: add retry logic"
-        assert repo.diff_stat == " 3 files changed, 42 insertions(+), 7 deletions(-)"
+        assert wave.active_run.status == "running"
+        assert wave.active_run.pr.number == 1
+        assert wave.remote_branch == "wave/architecture"
+        assert wave.pr.number == 1
+        assert len(wave.commits) == 2
+        assert wave.commits[0].sha == "a1b2c3d"
+        assert wave.commits[0].message == "implement: add retry logic"
+        assert wave.diff_stat == " 3 files changed, 42 insertions(+), 7 deletions(-)"
         assert [step.type for step in wave.flow_steps] == ["step", "step", "step", "step"]
         assert [step.name for step in wave.flow_steps] == [
             "review",
@@ -67,9 +64,9 @@ class TestWaveModel:
         dumped = wave.model_dump(mode="json")
         reparsed = Wave.model_validate(dumped)
         assert reparsed.id == wave.id
-        assert reparsed.repos[0].active_run.pr.url == wave.repos[0].active_run.pr.url
-        assert reparsed.repos[0].commits == wave.repos[0].commits
-        assert reparsed.repos[0].diff_stat == wave.repos[0].diff_stat
+        assert reparsed.active_run.pr.url == wave.active_run.pr.url
+        assert reparsed.commits == wave.commits
+        assert reparsed.diff_stat == wave.diff_stat
         assert reparsed.flow_steps == wave.flow_steps
 
     def test_unknown_fields_ignored(self):

--- a/rust/loopflow/src/lf/commands/chat.rs
+++ b/rust/loopflow/src/lf/commands/chat.rs
@@ -368,7 +368,7 @@ mod tests {
 
     use crate::lfd::id::LfdId;
     use crate::lfd::types::{
-        RepoWork, Session, SessionStatus, SessionUse, WaveStatus, WAVE_SERVER_ENDPOINT_ENV,
+        Session, SessionStatus, SessionUse, WaveStatus, WAVE_SERVER_ENDPOINT_ENV,
         WAVE_SERVER_PID_ENV, WAVE_SERVER_SOURCE,
     };
     use crate::lfdb::{open_store, StorageConfig};
@@ -391,15 +391,12 @@ mod tests {
             primary_flow: "ship-roadmap".to_string(),
             goal: "ship-roadmap".to_string(),
             metrics: Vec::new(),
-            repos: vec![RepoWork {
-                repo: repo.display().to_string(),
-                worktree: String::new(),
-                branch: String::new(),
-                status: WaveStatus::Idle,
-                iteration: 0,
-                cycle_start_iteration: 0,
-                position: 0,
-            }],
+            repo: repo.display().to_string(),
+            worktree: String::new(),
+            branch: String::new(),
+            status: WaveStatus::Idle,
+            iteration: 0,
+            cycle_start_iteration: 0,
             direction: Vec::new(),
             area: Vec::new(),
             paused: false,

--- a/rust/loopflow/src/lf/session.rs
+++ b/rust/loopflow/src/lf/session.rs
@@ -365,9 +365,7 @@ mod tests {
     use time::OffsetDateTime;
 
     use crate::lfd::id::LfdId;
-    use crate::lfd::types::{
-        RepoWork, Session, SessionStatus, Wave, WaveStatus, TMUX_TERMINAL_SOURCE,
-    };
+    use crate::lfd::types::{Session, SessionStatus, Wave, WaveStatus, TMUX_TERMINAL_SOURCE};
     use crate::lfdb::{open_store, StorageConfig};
 
     use crate::engine::wave_context::AmbientWaveRef;
@@ -443,15 +441,12 @@ mod tests {
             primary_flow: "ship-roadmap".to_string(),
             goal: "ship-roadmap".to_string(),
             metrics: Vec::new(),
-            repos: vec![RepoWork {
-                repo: repo.to_string(),
-                worktree: String::new(),
-                branch: String::new(),
-                status: WaveStatus::Idle,
-                iteration: 0,
-                cycle_start_iteration: 0,
-                position: 0,
-            }],
+            repo: repo.to_string(),
+            worktree: String::new(),
+            branch: String::new(),
+            status: WaveStatus::Idle,
+            iteration: 0,
+            cycle_start_iteration: 0,
             direction: Vec::new(),
             area: Vec::new(),
             paused: false,

--- a/rust/loopflow/src/lfd/bridge.rs
+++ b/rust/loopflow/src/lfd/bridge.rs
@@ -302,8 +302,8 @@ mod tests {
 
     use crate::lfd::id::LfdId;
     use crate::lfd::types::{
-        AttentionKind, RepoWork, Run, RunStackStatus, RunStatus, Session, SessionStatus,
-        SessionUse, Wave, WaveStatus,
+        AttentionKind, Run, RunStackStatus, RunStatus, Session, SessionStatus, SessionUse, Wave,
+        WaveStatus,
     };
     use crate::lfdb::{open_store, StorageConfig};
 
@@ -322,15 +322,12 @@ mod tests {
             primary_flow: "ship-roadmap".to_string(),
             goal: "ship-roadmap".to_string(),
             metrics: Vec::new(),
-            repos: vec![RepoWork {
-                repo: "/tmp/repo".to_string(),
-                worktree: String::new(),
-                branch: String::new(),
-                status: WaveStatus::Idle,
-                iteration: 0,
-                cycle_start_iteration: 0,
-                position: 0,
-            }],
+            repo: "/tmp/repo".to_string(),
+            worktree: String::new(),
+            branch: String::new(),
+            status: WaveStatus::Idle,
+            iteration: 0,
+            cycle_start_iteration: 0,
             direction: Vec::new(),
             area: Vec::new(),
             paused: false,

--- a/rust/loopflow/src/lfd/executor/helpers.rs
+++ b/rust/loopflow/src/lfd/executor/helpers.rs
@@ -75,11 +75,7 @@ pub async fn create_run_for_placement(
         .map(|run| run.stack_group_id.clone())
         .unwrap_or_else(|| wave.id().to_string());
 
-    let repo_work = wave
-        .repos
-        .first()
-        .expect("wave always has at least one RepoWork");
-    let main_repo = Path::new(&repo_work.repo);
+    let main_repo = Path::new(&wave.repo);
 
     let ((wt_path, branch), run_target_branch) = match placement {
         Placement::Fresh => (
@@ -105,7 +101,7 @@ pub async fn create_run_for_placement(
     let run = Run {
         id: run_id.clone(),
         wave_id: wave.id().clone(),
-        repo: repo_work.repo.clone(),
+        repo: wave.repo.clone(),
         flow: wave.primary_flow().clone(),
         task: None,
         direction: wave.direction().clone(),
@@ -132,14 +128,12 @@ pub async fn create_run_for_placement(
     };
     store.create_run(&run).await?;
     if let Ok(Some(mut wave)) = store.get_wave(wave.id()).await {
-        if let Some(rw) = wave.repo_work_mut(&run.repo) {
-            // New cycle: record the starting iteration for max_iterations safety valve.
-            if rw.status == WaveStatus::Idle || rw.status == WaveStatus::Paused {
-                rw.cycle_start_iteration = iteration;
-            }
-            rw.status = WaveStatus::Running;
-            rw.iteration = iteration;
+        // New cycle: record the starting iteration for max_iterations safety valve.
+        if wave.status == WaveStatus::Idle || wave.status == WaveStatus::Paused {
+            wave.cycle_start_iteration = iteration;
         }
+        wave.status = WaveStatus::Running;
+        wave.iteration = iteration;
         if let Err(err) = store.update_wave(&wave).await {
             warn!(wave_id = %wave.id(), error = %err, "failed to set wave status to running");
         }

--- a/rust/loopflow/src/lfd/http/dto.rs
+++ b/rust/loopflow/src/lfd/http/dto.rs
@@ -86,19 +86,10 @@ pub struct WaveDto {
     pub flow_steps: Vec<String>,
     pub has_stale_pr_state: bool,
     pub workers: u32,
-    /// Per-repo execution state, one entry per repo the wave runs in.
-    pub repos: Vec<RepoWorkDto>,
-    /// Parent wave in the chord tree. `null` for a root wave. Always emitted
-    /// (no `skip_serializing_if`) so the Python/Swift mirrors stay in lockstep.
-    pub parent_wave_id: Option<String>,
-}
-
-/// Per-repo execution surface for a wave: status/iteration plus the live git
-/// (worktree/branch) and PR snapshot derived at DTO-build time for one repo.
-#[derive(Debug, Serialize, Deserialize)]
-pub struct RepoWorkDto {
+    /// The single repo this wave targets (wave = 1 repo). The remaining
+    /// execution fields below describe that repo's live git + PR state, inferred
+    /// at DTO-build time.
     pub repo: String,
-    pub status: String,
     pub iteration: u32,
     /// Live worktree path inferred from git at build time.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -115,6 +106,9 @@ pub struct RepoWorkDto {
     pub active_run: Option<RunDto>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub pr: Option<PullRequestDto>,
+    /// Parent wave in the chord tree. `null` for a root wave. Always emitted
+    /// (no `skip_serializing_if`) so the Python/Swift mirrors stay in lockstep.
+    pub parent_wave_id: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -539,14 +533,23 @@ mod contract_tests {
             created_at: None,
             flow_steps: Vec::new(),
             has_stale_pr_state: false,
-            repos: Vec::new(),
+            repo: "/home/user/project".to_string(),
+            iteration: 0,
+            local_worktree: None,
+            remote_branch: None,
+            commits: Vec::new(),
+            diff_stat: None,
+            open_pr_count: 0,
+            stack_count: 0,
+            active_run: None,
+            pr: None,
             parent_wave_id: None,
         };
 
         let json = serde_json::to_value(&wave).unwrap();
         assert_eq!(json["goal"], "ship-roadmap");
         assert_eq!(json["metrics"], serde_json::json!([]));
-        assert_eq!(json["repos"], serde_json::json!([]));
+        assert_eq!(json["repo"], "/home/user/project");
     }
 
     #[test]
@@ -572,13 +575,13 @@ mod contract_tests {
     }
 
     #[test]
-    fn wave_repos_is_required() {
+    fn wave_repo_is_required() {
         let mut json = wave_fixture();
         json.as_object_mut()
             .expect("wave payload should be an object")
-            .remove("repos");
+            .remove("repo");
 
         let err = serde_json::from_value::<WaveDto>(json).unwrap_err();
-        assert!(err.to_string().contains("missing field `repos`"));
+        assert!(err.to_string().contains("missing field `repo`"));
     }
 }

--- a/rust/loopflow/src/lfd/http/routes/attention.rs
+++ b/rust/loopflow/src/lfd/http/routes/attention.rs
@@ -132,7 +132,7 @@ async fn filter_items_for_repo(
         else {
             continue;
         };
-        if wave.repos.iter().any(|rw| rw.repo == repo) {
+        if wave.repo == repo {
             filtered.push(item);
         }
     }

--- a/rust/loopflow/src/lfd/http/routes/hooks.rs
+++ b/rust/loopflow/src/lfd/http/routes/hooks.rs
@@ -514,7 +514,7 @@ fn wave_ci_target(wave_id: &LfdId, run: &Run) -> Option<WaveCiTarget> {
 mod tests {
     use super::*;
     use crate::lfd::github::{CheckRun, CheckRunPR, CheckRunRef, GitHubRepository};
-    use crate::lfd::types::{PullRequest, RepoWork, RunStackStatus, RunStatus, WaveStatus};
+    use crate::lfd::types::{PullRequest, RunStackStatus, RunStatus, WaveStatus};
     use crate::lfdb::{open_store, StorageConfig};
     use std::sync::Arc;
     use tempfile::tempdir;
@@ -560,15 +560,12 @@ mod tests {
             primary_flow: "ship-roadmap".to_string(),
             goal: "ship-roadmap".to_string(),
             metrics: Vec::new(),
-            repos: vec![RepoWork {
-                repo: repo.to_string_lossy().to_string(),
-                worktree: String::new(),
-                branch: String::new(),
-                status: WaveStatus::Idle,
-                iteration: 0,
-                cycle_start_iteration: 0,
-                position: 0,
-            }],
+            repo: repo.to_string_lossy().to_string(),
+            worktree: String::new(),
+            branch: String::new(),
+            status: WaveStatus::Idle,
+            iteration: 0,
+            cycle_start_iteration: 0,
             direction: Vec::new(),
             area: Vec::new(),
             paused: false,

--- a/rust/loopflow/src/lfd/http/routes/mod.rs
+++ b/rust/loopflow/src/lfd/http/routes/mod.rs
@@ -18,7 +18,7 @@ pub(crate) mod test_helpers;
 
 use crate::lfd::config::GitHubConfig;
 use crate::lfd::http::dto::{
-    format_datetime, run_dto, CommitEntryDto, ErrorResponse, PullRequestDto, RepoWorkDto, WaveDto,
+    format_datetime, run_dto, CommitEntryDto, ErrorResponse, PullRequestDto, WaveDto,
 };
 use crate::lfd::id::LfdId;
 use crate::lfd::live_pr::{build_live_pr_snapshot, LivePrSnapshot};
@@ -89,74 +89,59 @@ pub async fn build_wave_dto(
     .await
     .unwrap_or_default();
 
-    // Per-repo execution surface: infer git state + live-PR snapshot per repo.
-    let mut repos = Vec::with_capacity(wave.repos.len());
-    let mut has_stale_pr_state = false;
-    for repo_work in &wave.repos {
-        let repo_runs: Vec<Run> = stack_runs
-            .iter()
-            .filter(|run| run.repo == repo_work.repo)
-            .cloned()
-            .collect();
-        let snapshot = build_live_pr_snapshot(store, github_config, &repo_runs).await?;
-        has_stale_pr_state |= snapshot.has_stale_pr_state();
-        let queue_views = project_queue_views(
-            &repo_runs,
-            |run| snapshot.state_for_run(run).cloned(),
-            &blocks_by_run,
-        );
+    // Execution surface for the wave's single repo: infer git state + live-PR
+    // snapshot for the runs that touched it.
+    let repo_runs: Vec<Run> = stack_runs
+        .iter()
+        .filter(|run| run.repo == wave.repo)
+        .cloned()
+        .collect();
+    let snapshot = build_live_pr_snapshot(store, github_config, &repo_runs).await?;
+    let has_stale_pr_state = snapshot.has_stale_pr_state();
+    let queue_views = project_queue_views(
+        &repo_runs,
+        |run| snapshot.state_for_run(run).cloned(),
+        &blocks_by_run,
+    );
 
-        let repo = repo_work.repo.clone();
-        let name = wave.name().clone();
-        let git_state = tokio::task::spawn_blocking(move || infer_wave_git_state(&repo, &name))
-            .await
-            .ok()
-            .flatten();
-        let (local_worktree, remote_branch, commits, diff_stat) = match git_state {
-            Some(state) => (
-                Some(state.worktree),
-                state.branch,
-                state.commits,
-                state.diff_stat,
-            ),
-            None => (None, None, Vec::new(), None),
-        };
+    let repo = wave.repo.clone();
+    let name = wave.name().clone();
+    let git_state = tokio::task::spawn_blocking(move || infer_wave_git_state(&repo, &name))
+        .await
+        .ok()
+        .flatten();
+    let (local_worktree, remote_branch, commits, diff_stat) = match git_state {
+        Some(state) => (
+            Some(state.worktree),
+            state.branch,
+            state.commits,
+            state.diff_stat,
+        ),
+        None => (None, None, Vec::new(), None),
+    };
 
-        let latest_for_repo = repo_runs.iter().max_by_key(|run| run.started_at);
-        let pr = latest_for_repo.and_then(|run| {
-            run.pr.as_ref().map(|pr| PullRequestDto {
-                url: pr.url.clone(),
-                number: pr.number,
-                state: pr.state.clone(),
-                title: pr.title.clone(),
-                branch: pr.branch.clone(),
-            })
-        });
-        let active_run = if include_active_run {
-            latest_for_repo.map(|run| {
-                let live_pr_state = snapshot.state_for_run(run);
-                let pr_state_stale = snapshot.stale_for_run(run);
-                let queue_view = queue_views.get(&run.id);
-                run_dto(run.clone(), live_pr_state, pr_state_stale, queue_view)
-            })
-        } else {
-            None
-        };
-
-        repos.push(RepoWorkDto {
-            repo: repo_work.repo.clone(),
-            status: repo_work.status.as_str().to_string(),
-            iteration: repo_work.iteration,
-            local_worktree,
-            remote_branch,
-            commits,
-            diff_stat,
-            open_pr_count: snapshot.open_pr_count(),
-            stack_count: repo_runs.len() as u32,
-            active_run,
-            pr,
-        });
-    }
+    let latest_for_repo = repo_runs.iter().max_by_key(|run| run.started_at);
+    let pr = latest_for_repo.and_then(|run| {
+        run.pr.as_ref().map(|pr| PullRequestDto {
+            url: pr.url.clone(),
+            number: pr.number,
+            state: pr.state.clone(),
+            title: pr.title.clone(),
+            branch: pr.branch.clone(),
+        })
+    });
+    let active_run = if include_active_run {
+        latest_for_repo.map(|run| {
+            let live_pr_state = snapshot.state_for_run(run);
+            let pr_state_stale = snapshot.stale_for_run(run);
+            let queue_view = queue_views.get(&run.id);
+            run_dto(run.clone(), live_pr_state, pr_state_stale, queue_view)
+        })
+    } else {
+        None
+    };
+    let open_pr_count = snapshot.open_pr_count();
+    let stack_count = repo_runs.len() as u32;
 
     let wave_config = crate::engine::wave_config::read_wave_config(
         std::path::Path::new(wave.repo()),
@@ -179,7 +164,16 @@ pub async fn build_wave_dto(
         flow_steps,
         has_stale_pr_state,
         workers: wave.workers(),
-        repos,
+        repo: wave.repo.clone(),
+        iteration: wave.iteration(),
+        local_worktree,
+        remote_branch,
+        commits,
+        diff_stat,
+        open_pr_count,
+        stack_count,
+        active_run,
+        pr,
         parent_wave_id: wave.parent_wave_id().map(|id| id.to_string()),
     })
 }
@@ -432,8 +426,8 @@ mod tests {
     use super::*;
     use crate::lfd::id::LfdId;
     use crate::lfd::types::{
-        LivePrState, LivePullRequestState, PullRequest, RepoWork, Run, RunStackStatus, RunStatus,
-        Wave, WaveStatus,
+        LivePrState, LivePullRequestState, PullRequest, Run, RunStackStatus, RunStatus, Wave,
+        WaveStatus,
     };
     use crate::lfdb::SharedStore;
     use std::collections::{HashMap, HashSet};
@@ -494,15 +488,12 @@ mod tests {
             primary_flow: "ship-roadmap".to_string(),
             goal: "ship-roadmap".to_string(),
             metrics: Vec::new(),
-            repos: vec![RepoWork {
-                repo: repo.to_string(),
-                worktree: String::new(),
-                branch: String::new(),
-                status: WaveStatus::Idle,
-                iteration: 0,
-                cycle_start_iteration: 0,
-                position: 0,
-            }],
+            repo: repo.to_string(),
+            worktree: String::new(),
+            branch: String::new(),
+            status: WaveStatus::Idle,
+            iteration: 0,
+            cycle_start_iteration: 0,
             direction: vec![],
             area: vec![],
             paused: false,
@@ -655,53 +646,41 @@ mod tests {
         .await
         .expect("wave dto should be built");
 
-        assert_eq!(dto.repos.len(), 1);
         assert_eq!(
-            dto.repos[0].open_pr_count, 0,
+            dto.open_pr_count, 0,
             "closed live PRs should not count as open even if snapshot says open"
         );
-        assert_eq!(dto.repos[0].stack_count, 1);
+        assert_eq!(dto.stack_count, 1);
         assert!(dto.has_stale_pr_state);
     }
 
     #[tokio::test]
-    async fn build_wave_dto_selects_latest_run_per_repo() {
+    async fn build_wave_dto_selects_latest_run_for_repo() {
         let store = sqlite_store().await;
-        let repo_a = tempfile::tempdir().expect("repo a");
-        let repo_b = tempfile::tempdir().expect("repo b");
-        let repo_a_path = repo_a.path().to_str().expect("repo a path").to_string();
-        let repo_b_path = repo_b.path().to_str().expect("repo b path").to_string();
+        let repo = tempfile::tempdir().expect("repo");
+        let repo_path = repo.path().to_str().expect("repo path").to_string();
         let started = OffsetDateTime::now_utc();
 
-        let mut wave = make_wave(&repo_a_path);
-        wave.repos.push(RepoWork {
-            repo: repo_b_path.clone(),
-            worktree: String::new(),
-            branch: String::new(),
-            status: WaveStatus::Idle,
-            iteration: 0,
-            cycle_start_iteration: 0,
-            position: 1,
-        });
+        let wave = make_wave(&repo_path);
         store
             .create_wave(&wave)
             .await
             .expect("wave should be created in store");
 
-        let mut run_a = make_run(&wave, 11);
-        run_a.repo = repo_a_path.clone();
-        run_a.started_at = Some(started);
-        let mut run_b = make_run(&wave, 22);
-        run_b.repo = repo_b_path;
-        run_b.started_at = Some(started + time::Duration::seconds(1));
+        let mut run_old = make_run(&wave, 11);
+        run_old.repo = repo_path.clone();
+        run_old.started_at = Some(started);
+        let mut run_new = make_run(&wave, 22);
+        run_new.repo = repo_path;
+        run_new.started_at = Some(started + time::Duration::seconds(1));
         store
-            .create_run(&run_a)
+            .create_run(&run_old)
             .await
-            .expect("repo a run should be created");
+            .expect("old run should be created");
         store
-            .create_run(&run_b)
+            .create_run(&run_new)
             .await
-            .expect("repo b run should be created");
+            .expect("new run should be created");
 
         let dto = build_wave_dto(
             &store,
@@ -712,22 +691,13 @@ mod tests {
         .await
         .expect("wave dto should be built");
 
-        assert_eq!(dto.repos.len(), 2);
         assert_eq!(
-            dto.repos[0]
-                .active_run
+            dto.active_run
                 .as_ref()
                 .and_then(|run| run.pr.as_ref())
                 .and_then(|pr| pr.number),
-            Some(11)
-        );
-        assert_eq!(
-            dto.repos[1]
-                .active_run
-                .as_ref()
-                .and_then(|run| run.pr.as_ref())
-                .and_then(|pr| pr.number),
-            Some(22)
+            Some(22),
+            "the latest run by start time wins"
         );
     }
 

--- a/rust/loopflow/src/lfd/http/routes/repos.rs
+++ b/rust/loopflow/src/lfd/http/routes/repos.rs
@@ -410,7 +410,7 @@ mod tests {
     use crate::lfd::executor::WaveExecutor;
     use crate::lfd::id::LfdId;
     use crate::lfd::output::OutputHub;
-    use crate::lfd::types::{RepoId, RepoWork, WaveStatus};
+    use crate::lfd::types::{RepoId, WaveStatus};
     use crate::lfdb::{open_store, SharedStore, StorageConfig};
     use crate::provider_auth::ProviderAuthService;
     use std::process::Command;
@@ -456,15 +456,12 @@ mod tests {
             primary_flow: "ship-roadmap".to_string(),
             goal: "ship-roadmap".to_string(),
             metrics: Vec::new(),
-            repos: vec![RepoWork {
-                repo,
-                worktree: String::new(),
-                branch: String::new(),
-                status: WaveStatus::Idle,
-                iteration: 0,
-                cycle_start_iteration: 0,
-                position: 0,
-            }],
+            repo,
+            worktree: String::new(),
+            branch: String::new(),
+            status: WaveStatus::Idle,
+            iteration: 0,
+            cycle_start_iteration: 0,
             direction: Vec::new(),
             area: Vec::new(),
             paused: false,

--- a/rust/loopflow/src/lfd/http/routes/session_controls.rs
+++ b/rust/loopflow/src/lfd/http/routes/session_controls.rs
@@ -111,7 +111,7 @@ pub async fn list_sessions_handler(
             else {
                 continue;
             };
-            if wave.repos.iter().any(|rw| rw.repo == repo) {
+            if wave.repo == repo {
                 filtered.push(session);
             }
         }
@@ -336,8 +336,8 @@ mod tests {
     use crate::lfd::http::routes::test_helpers::test_http_state;
     use crate::lfd::id::LfdId;
     use crate::lfd::types::{
-        tmux_session_name, RepoWork, SessionStatus, SessionUse, Wave, WaveStatus,
-        PALETTE_TERMINAL_SOURCE, TMUX_TERMINAL_SOURCE,
+        tmux_session_name, SessionStatus, SessionUse, Wave, WaveStatus, PALETTE_TERMINAL_SOURCE,
+        TMUX_TERMINAL_SOURCE,
     };
     use axum::extract::{Path, Query, State};
     use axum::http::{header::HOST, HeaderValue};
@@ -350,15 +350,12 @@ mod tests {
             primary_flow: "build".to_string(),
             goal: "ship-roadmap".to_string(),
             metrics: Vec::new(),
-            repos: vec![RepoWork {
-                repo: repo.to_string(),
-                worktree: String::new(),
-                branch: String::new(),
-                status: WaveStatus::Idle,
-                iteration: 0,
-                cycle_start_iteration: 0,
-                position: 0,
-            }],
+            repo: repo.to_string(),
+            worktree: String::new(),
+            branch: String::new(),
+            status: WaveStatus::Idle,
+            iteration: 0,
+            cycle_start_iteration: 0,
             direction: Vec::new(),
             area: Vec::new(),
             paused: false,

--- a/rust/loopflow/src/lfd/http/routes/waves.rs
+++ b/rust/loopflow/src/lfd/http/routes/waves.rs
@@ -807,7 +807,7 @@ fn rename_wave_worktree(
 mod tests {
     use super::*;
     use crate::lfd::http::routes::test_helpers::{init_git_repo, test_http_state};
-    use crate::lfd::types::{RepoWork, Session, SessionStatus, SessionUse, Wave};
+    use crate::lfd::types::{Session, SessionStatus, SessionUse, Wave};
     use std::path::Path;
     use tempfile::tempdir;
     use time::OffsetDateTime;
@@ -819,15 +819,12 @@ mod tests {
             primary_flow: "ship-roadmap".to_string(),
             goal: "ship-roadmap".to_string(),
             metrics: Vec::new(),
-            repos: vec![RepoWork {
-                repo: repo.to_string(),
-                worktree: String::new(),
-                branch: String::new(),
-                status: WaveStatus::Idle,
-                iteration: 0,
-                cycle_start_iteration: 0,
-                position: 0,
-            }],
+            repo: repo.to_string(),
+            worktree: String::new(),
+            branch: String::new(),
+            status: WaveStatus::Idle,
+            iteration: 0,
+            cycle_start_iteration: 0,
             direction: Vec::new(),
             area: Vec::new(),
             paused: false,
@@ -959,7 +956,7 @@ mod tests {
         let repos: Vec<&str> = response
             .child_waves
             .iter()
-            .flat_map(|w| w.repos.iter().map(|r| r.repo.as_str()))
+            .map(|w| w.repo.as_str())
             .collect();
         assert!(repos.contains(&repo_a.path().to_string_lossy().as_ref()));
         assert!(repos.contains(&repo_b.path().to_string_lossy().as_ref()));
@@ -1085,7 +1082,7 @@ mod tests {
         .expect("list waves");
 
         assert_eq!(listed.data.len(), 1);
-        assert_eq!(listed.data[0].repos[0].repo, repo_a);
+        assert_eq!(listed.data[0].repo, repo_a);
         assert_eq!(listed.data[0].name, "wave-a");
     }
 

--- a/rust/loopflow/src/lfd/queue.rs
+++ b/rust/loopflow/src/lfd/queue.rs
@@ -552,9 +552,7 @@ mod tests {
 
     use crate::lfd::events::EventHub;
     use crate::lfd::id::LfdId;
-    use crate::lfd::types::{
-        PullRequest, QueueBlockReason, RepoWork, Run, RunStatus, Wave, WaveStatus,
-    };
+    use crate::lfd::types::{PullRequest, QueueBlockReason, Run, RunStatus, Wave, WaveStatus};
 
     #[derive(Debug, Default)]
     struct MockOps {
@@ -619,15 +617,12 @@ mod tests {
             primary_flow: "ship-roadmap".to_string(),
             goal: "ship-roadmap".to_string(),
             metrics: Vec::new(),
-            repos: vec![RepoWork {
-                repo: repo.to_string(),
-                worktree: String::new(),
-                branch: String::new(),
-                status: WaveStatus::Idle,
-                iteration: 0,
-                cycle_start_iteration: 0,
-                position: 0,
-            }],
+            repo: repo.to_string(),
+            worktree: String::new(),
+            branch: String::new(),
+            status: WaveStatus::Idle,
+            iteration: 0,
+            cycle_start_iteration: 0,
             direction: Vec::new(),
             area: Vec::new(),
             paused: false,

--- a/rust/loopflow/src/lfd/types/mod.rs
+++ b/rust/loopflow/src/lfd/types/mod.rs
@@ -27,6 +27,6 @@ pub use session::{
 };
 pub use summary::Summary;
 pub use wave::{
-    LivePrState, LivePullRequestState, PullRequest, QueueBlock, QueueBlockReason, RepoWork, Run,
+    LivePrState, LivePullRequestState, PullRequest, QueueBlock, QueueBlockReason, Run,
     RunStackStatus, RunStatus, Wave, WaveStatus,
 };

--- a/rust/loopflow/src/lfd/types/wave.rs
+++ b/rust/loopflow/src/lfd/types/wave.rs
@@ -192,15 +192,21 @@ pub struct Wave {
     pub primary_flow: String,
     pub goal: String,
     pub metrics: Vec<String>,
-    /// Per-repo execution state (worktree/branch/status/iteration), stitched from
-    /// `wave_repos` on read. Execution state lives here; the wave carries only
-    /// identity plus the wave-level `paused` flag.
-    #[serde(default)]
-    pub repos: Vec<RepoWork>,
+    /// The single repo this wave targets. A wave = exactly one repo.
+    pub repo: String,
+    /// Worktree path for the wave's repo, `""` when none.
+    pub worktree: String,
+    /// Branch name for the wave's repo, `""` when none.
+    pub branch: String,
+    /// Execution status of the wave's repo. Rolled into `status()` together with
+    /// the wave-level `paused` flag.
+    pub status: WaveStatus,
+    pub iteration: u32,
+    pub cycle_start_iteration: u32,
     pub direction: Vec<String>,
     pub area: Vec<String>,
     /// Wave-level pause flag. Rolled into `status()` (a paused wave reports
-    /// `Paused` regardless of per-repo state).
+    /// `Paused` regardless of the repo's execution state).
     pub paused: bool,
     #[serde(with = "time::serde::rfc3339::option")]
     pub created_at: Option<OffsetDateTime>,
@@ -222,15 +228,12 @@ impl Wave {
             primary_flow: "ship-roadmap".to_string(),
             goal: "ship-roadmap".to_string(),
             metrics: Vec::new(),
-            repos: vec![RepoWork {
-                repo,
-                worktree: String::new(),
-                branch: String::new(),
-                status: WaveStatus::Idle,
-                iteration: 0,
-                cycle_start_iteration: 0,
-                position: 0,
-            }],
+            repo,
+            worktree: String::new(),
+            branch: String::new(),
+            status: WaveStatus::Idle,
+            iteration: 0,
+            cycle_start_iteration: 0,
             direction: Vec::new(),
             area: Vec::new(),
             paused: false,
@@ -259,10 +262,9 @@ impl Wave {
         &self.name
     }
 
-    /// Primary repo path — the first `RepoWork`'s repo, `""` when a wave carries
-    /// no repos (shouldn't happen outside construction).
+    /// The repo this wave targets.
     pub fn repo(&self) -> &str {
-        self.repos.first().map(|r| r.repo.as_str()).unwrap_or("")
+        &self.repo
     }
 
     pub fn primary_flow(&self) -> &String {
@@ -285,55 +287,28 @@ impl Wave {
         &self.area
     }
 
-    /// Wave-level status, rolled up over `repos`. `Paused` is a wave-level flag;
-    /// otherwise the status is derived from the per-repo execution state: any
-    /// running wins, then failed, then waiting, else idle.
+    /// Wave-level status. `Paused` is a wave-level flag; otherwise the status is
+    /// the repo's execution status.
     pub fn status(&self) -> WaveStatus {
         if self.paused {
             return WaveStatus::Paused;
         }
-        if self.repos.iter().any(|r| r.status == WaveStatus::Running) {
-            WaveStatus::Running
-        } else if self.repos.iter().any(|r| r.status == WaveStatus::Failed) {
-            WaveStatus::Failed
-        } else if self.repos.iter().any(|r| r.status == WaveStatus::Waiting) {
-            WaveStatus::Waiting
-        } else {
-            WaveStatus::Idle
-        }
+        self.status
     }
 
-    /// Max iteration across `repos`.
     pub fn iteration(&self) -> u32 {
-        self.repos.iter().map(|r| r.iteration).max().unwrap_or(0)
+        self.iteration
     }
 
     pub fn cycle_start_iteration(&self) -> u32 {
-        self.repos
-            .iter()
-            .map(|r| r.cycle_start_iteration)
-            .max()
-            .unwrap_or(0)
+        self.cycle_start_iteration
     }
 
     /// Set the wave's execution status. Toggles the wave-level `paused` flag and
-    /// writes the status onto every `RepoWork`, so reads through `status()` and
-    /// per-repo readers agree.
+    /// writes the execution status, so reads through `status()` agree.
     pub fn set_status(&mut self, status: WaveStatus) {
         self.paused = status == WaveStatus::Paused;
-        for repo in &mut self.repos {
-            repo.status = status;
-        }
-    }
-
-    /// Mutable access to the `RepoWork` for `repo`, falling back to the primary
-    /// repo when there's no exact match. Used by the executor to record per-repo
-    /// status/iteration after dispatching a run.
-    pub fn repo_work_mut(&mut self, repo: &str) -> Option<&mut RepoWork> {
-        if let Some(pos) = self.repos.iter().position(|r| r.repo == repo) {
-            return self.repos.get_mut(pos);
-        }
-        self.repos.first_mut()
+        self.status = status;
     }
 
     pub fn created_at(&self) -> Option<OffsetDateTime> {
@@ -343,21 +318,6 @@ impl Wave {
     pub fn workers(&self) -> u32 {
         self.workers
     }
-}
-
-/// Per-repo execution state for a wave. Waves own identity; each `RepoWork`
-/// carries the worktree/branch/status/iteration for one repo the wave runs in.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct RepoWork {
-    pub repo: String,
-    /// Worktree path, `""` when none.
-    pub worktree: String,
-    /// Branch name, `""` when none.
-    pub branch: String,
-    pub status: WaveStatus,
-    pub iteration: u32,
-    pub cycle_start_iteration: u32,
-    pub position: u32,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/rust/loopflow/src/lfdb/catalog.rs
+++ b/rust/loopflow/src/lfdb/catalog.rs
@@ -37,10 +37,7 @@ pub(crate) enum Query {
     ListChatMemoryBlocks,
     UpsertChatMemoryBlock,
     DeleteChatMemoryBlock,
-    ListWaveRepos,
-    UpsertWaveRepo,
-    DeleteWaveReposByWave,
-    ResetStaleActiveRepos,
+    ResetStaleActiveWaves,
     ListChildWaves,
     RecordRunTokenUsage,
     AggregateTokenUsageByWaveProvider,
@@ -79,10 +76,7 @@ impl Query {
         Self::ListChatMemoryBlocks,
         Self::UpsertChatMemoryBlock,
         Self::DeleteChatMemoryBlock,
-        Self::ListWaveRepos,
-        Self::UpsertWaveRepo,
-        Self::DeleteWaveReposByWave,
-        Self::ResetStaleActiveRepos,
+        Self::ResetStaleActiveWaves,
         Self::ListChildWaves,
         Self::RecordRunTokenUsage,
         Self::AggregateTokenUsageByWaveProvider,
@@ -105,23 +99,23 @@ const QUERY_DEFS: [QueryDef; QUERY_COUNT] = [
         sqlite_override: None,
     },
     QueryDef {
-        template: "SELECT id, name, direction, area, paused, created_at, workers,\n                    primary_flow, goal, metrics, parent_wave_id\n             FROM waves\n             ORDER BY created_at DESC",
+        template: "SELECT id, name, direction, area, paused, created_at, workers,\n                    primary_flow, goal, metrics, parent_wave_id,\n                    repo, worktree, branch, status, iteration, cycle_start_iteration\n             FROM waves\n             ORDER BY created_at DESC",
         sqlite_override: None,
     },
     QueryDef {
-        template: "SELECT id, name, direction, area, paused, created_at, workers,\n                    primary_flow, goal, metrics, parent_wave_id\n             FROM waves\n             WHERE EXISTS (SELECT 1 FROM wave_repos wr WHERE wr.wave_id = waves.id AND wr.repo = {p1})\n             ORDER BY created_at DESC",
+        template: "SELECT id, name, direction, area, paused, created_at, workers,\n                    primary_flow, goal, metrics, parent_wave_id,\n                    repo, worktree, branch, status, iteration, cycle_start_iteration\n             FROM waves\n             WHERE repo = {p1}\n             ORDER BY created_at DESC",
         sqlite_override: None,
     },
     QueryDef {
-        template: "INSERT INTO waves (\n                id, name, direction, area, paused, created_at, workers, primary_flow, goal, metrics, parent_wave_id\n            ) VALUES ({p1}, {p2}, {p3}, {p4}, {p5}, {p6}, {p7}, {p8}, {p9}, {p10}, {p11})\n            ON CONFLICT(id) DO UPDATE SET\n                name = excluded.name,\n                direction = excluded.direction,\n                area = excluded.area,\n                paused = excluded.paused,\n                created_at = excluded.created_at,\n                workers = excluded.workers,\n                primary_flow = excluded.primary_flow,\n                goal = excluded.goal,\n                metrics = excluded.metrics,\n                parent_wave_id = excluded.parent_wave_id",
+        template: "INSERT INTO waves (\n                id, name, direction, area, paused, created_at, workers, primary_flow, goal, metrics, parent_wave_id,\n                repo, worktree, branch, status, iteration, cycle_start_iteration\n            ) VALUES ({p1}, {p2}, {p3}, {p4}, {p5}, {p6}, {p7}, {p8}, {p9}, {p10}, {p11}, {p12}, {p13}, {p14}, {p15}, {p16}, {p17})\n            ON CONFLICT(id) DO UPDATE SET\n                name = excluded.name,\n                direction = excluded.direction,\n                area = excluded.area,\n                paused = excluded.paused,\n                created_at = excluded.created_at,\n                workers = excluded.workers,\n                primary_flow = excluded.primary_flow,\n                goal = excluded.goal,\n                metrics = excluded.metrics,\n                parent_wave_id = excluded.parent_wave_id,\n                repo = excluded.repo,\n                worktree = excluded.worktree,\n                branch = excluded.branch,\n                status = excluded.status,\n                iteration = excluded.iteration,\n                cycle_start_iteration = excluded.cycle_start_iteration",
         sqlite_override: None,
     },
     QueryDef {
-        template: "SELECT id, name, direction, area, paused, created_at, workers,\n                    primary_flow, goal, metrics, parent_wave_id\n             FROM waves WHERE id = {p1}",
+        template: "SELECT id, name, direction, area, paused, created_at, workers,\n                    primary_flow, goal, metrics, parent_wave_id,\n                    repo, worktree, branch, status, iteration, cycle_start_iteration\n             FROM waves WHERE id = {p1}",
         sqlite_override: None,
     },
     QueryDef {
-        template: "SELECT id, name, direction, area, paused, created_at, workers,\n                    primary_flow, goal, metrics, parent_wave_id\n             FROM waves\n             WHERE name = {p1}",
+        template: "SELECT id, name, direction, area, paused, created_at, workers,\n                    primary_flow, goal, metrics, parent_wave_id,\n                    repo, worktree, branch, status, iteration, cycle_start_iteration\n             FROM waves\n             WHERE name = {p1}",
         sqlite_override: None,
     },
     QueryDef {
@@ -217,30 +211,15 @@ const QUERY_DEFS: [QueryDef; QUERY_COUNT] = [
         template: "DELETE FROM chat_memory_blocks WHERE wave_id = {p1} AND name = {p2}",
         sqlite_override: None,
     },
-    // ListWaveRepos
+    // ResetStaleActiveWaves — after an lfd restart, waves stuck in Running/Waiting
+    // (their runs failed as orphans) get reset to Idle so their buttons re-enable.
     QueryDef {
-        template: "SELECT wave_id, repo, worktree, branch, status, iteration, cycle_start_iteration, position\n             FROM wave_repos WHERE wave_id = {p1}\n             ORDER BY position ASC",
-        sqlite_override: None,
-    },
-    // UpsertWaveRepo
-    QueryDef {
-        template: "INSERT INTO wave_repos (wave_id, repo, worktree, branch, status, iteration, cycle_start_iteration, position)\n             VALUES ({p1}, {p2}, {p3}, {p4}, {p5}, {p6}, {p7}, {p8})\n             ON CONFLICT(wave_id, repo) DO UPDATE SET\n                 worktree = excluded.worktree,\n                 branch = excluded.branch,\n                 status = excluded.status,\n                 iteration = excluded.iteration,\n                 cycle_start_iteration = excluded.cycle_start_iteration,\n                 position = excluded.position",
-        sqlite_override: None,
-    },
-    // DeleteWaveReposByWave
-    QueryDef {
-        template: "DELETE FROM wave_repos WHERE wave_id = {p1}",
-        sqlite_override: None,
-    },
-    // ResetStaleActiveRepos — mirror ResetStaleActiveWaves onto per-repo rows so
-    // the rolled-up wave status un-sticks after an lfd restart.
-    QueryDef {
-        template: "UPDATE wave_repos SET status = {p1}\n             WHERE status IN ({p2}, {p3})",
+        template: "UPDATE waves SET status = {p1}\n             WHERE status IN ({p2}, {p3})",
         sqlite_override: None,
     },
     // ListChildWaves — a chord's contents are its children, ordered by creation.
     QueryDef {
-        template: "SELECT id, name, direction, area, paused, created_at, workers,\n                    primary_flow, goal, metrics, parent_wave_id\n             FROM waves\n             WHERE parent_wave_id = {p1}\n             ORDER BY created_at ASC",
+        template: "SELECT id, name, direction, area, paused, created_at, workers,\n                    primary_flow, goal, metrics, parent_wave_id,\n                    repo, worktree, branch, status, iteration, cycle_start_iteration\n             FROM waves\n             WHERE parent_wave_id = {p1}\n             ORDER BY created_at ASC",
         sqlite_override: None,
     },
     // RecordRunTokenUsage — one row per run, replaced if re-recorded.

--- a/rust/loopflow/src/lfdb/migrations.rs
+++ b/rust/loopflow/src/lfdb/migrations.rs
@@ -214,6 +214,10 @@ const ALL_MIGRATIONS: &[Migration] = &[
         version: "051_drop_dead_tables",
         sql: include_str!("migrations/051_drop_dead_tables.sql"),
     },
+    Migration {
+        version: "052_wave_single_repo",
+        sql: include_str!("migrations/052_wave_single_repo.sql"),
+    },
 ];
 
 /// Migrations that rename or drop schema objects some dbs never had (the
@@ -385,6 +389,8 @@ mod tests {
             "activation_log",
             "agents",
             "wave_crons",
+            // Collapsed back onto `waves` in migration 052 (wave = 1 repo).
+            "wave_repos",
         ] {
             assert!(
                 tables.iter().all(|t| t != unexpected),

--- a/rust/loopflow/src/lfdb/migrations/052_wave_single_repo.sql
+++ b/rust/loopflow/src/lfdb/migrations/052_wave_single_repo.sql
@@ -1,0 +1,39 @@
+-- Collapse the multi-repo wave model to single-repo: a wave targets exactly
+-- one repo. The per-wave, per-repo execution state that lived in `wave_repos`
+-- (migration 042) moves back onto `waves` as plain columns, and the table is
+-- dropped. Multi-repo waves are deprioritized to a nice-to-have; nothing in the
+-- codebase writes more than one `wave_repos` row per wave today.
+--
+-- Additive ADD COLUMNs (re-run tolerated as "duplicate column name"), then a
+-- backfill from `wave_repos`, then the drop.
+ALTER TABLE waves ADD COLUMN repo TEXT NOT NULL DEFAULT '';
+ALTER TABLE waves ADD COLUMN worktree TEXT NOT NULL DEFAULT '';
+ALTER TABLE waves ADD COLUMN branch TEXT NOT NULL DEFAULT '';
+ALTER TABLE waves ADD COLUMN status INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE waves ADD COLUMN iteration INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE waves ADD COLUMN cycle_start_iteration INTEGER NOT NULL DEFAULT 0;
+
+-- Backfill from the primary repo. A wave should only ever have one row, but if
+-- history left several, the lowest `position` (then lowest `repo`) wins — the
+-- same "primary repo" the old code read via `repos.first()`.
+UPDATE waves SET
+    repo = COALESCE((
+        SELECT wr.repo FROM wave_repos wr WHERE wr.wave_id = waves.id
+        ORDER BY wr.position ASC, wr.repo ASC LIMIT 1), ''),
+    worktree = COALESCE((
+        SELECT wr.worktree FROM wave_repos wr WHERE wr.wave_id = waves.id
+        ORDER BY wr.position ASC, wr.repo ASC LIMIT 1), ''),
+    branch = COALESCE((
+        SELECT wr.branch FROM wave_repos wr WHERE wr.wave_id = waves.id
+        ORDER BY wr.position ASC, wr.repo ASC LIMIT 1), ''),
+    status = COALESCE((
+        SELECT wr.status FROM wave_repos wr WHERE wr.wave_id = waves.id
+        ORDER BY wr.position ASC, wr.repo ASC LIMIT 1), 0),
+    iteration = COALESCE((
+        SELECT wr.iteration FROM wave_repos wr WHERE wr.wave_id = waves.id
+        ORDER BY wr.position ASC, wr.repo ASC LIMIT 1), 0),
+    cycle_start_iteration = COALESCE((
+        SELECT wr.cycle_start_iteration FROM wave_repos wr WHERE wr.wave_id = waves.id
+        ORDER BY wr.position ASC, wr.repo ASC LIMIT 1), 0);
+
+DROP TABLE IF EXISTS wave_repos;

--- a/rust/loopflow/src/lfdb/mod.rs
+++ b/rust/loopflow/src/lfdb/mod.rs
@@ -13,8 +13,8 @@ use std::sync::Arc;
 use crate::lfd::id::LfdId;
 use crate::lfd::types::{
     AttentionItem, AttentionKind, AttentionStatus, ChatMemoryBlock, ChatMessage, LivePrState,
-    LivePullRequestState, QueueBlock, Repo, RepoEdge, RepoId, RepoWork, Run, RunStackStatus,
-    Session, SessionStatus, Summary, Wave,
+    LivePullRequestState, QueueBlock, Repo, RepoEdge, RepoId, Run, RunStackStatus, Session,
+    SessionStatus, Summary, Wave,
 };
 
 pub mod catalog;
@@ -236,47 +236,8 @@ impl Store {
         WaveStateStore::list_waves(self, repo).await
     }
 
-    pub async fn list_wave_repos(&self, wave_id: &LfdId) -> StoreResult<Vec<RepoWork>> {
-        WaveStateStore::list_wave_repos(self, wave_id).await
-    }
-
-    pub async fn replace_wave_repos(&self, wave_id: &LfdId, repos: &[RepoWork]) -> StoreResult<()> {
-        WaveStateStore::delete_wave_repos(self, wave_id).await?;
-        for repo in repos {
-            WaveStateStore::upsert_wave_repo(self, wave_id, repo).await?;
-        }
-        Ok(())
-    }
-
-    /// Stitch `repos` from the `wave_repos` table onto each wave. The store read
-    /// path fills `repos: Vec::new()` in `map_wave_row`; the actual load happens
-    /// here, in the layer that owns the store handle.
-    async fn attach_repos_vec(&self, mut waves: Vec<Wave>) -> StoreResult<Vec<Wave>> {
-        for wave in &mut waves {
-            wave.repos = WaveStateStore::list_wave_repos(self, wave.id()).await?;
-        }
-        Ok(waves)
-    }
-
-    async fn attach_repos_opt(&self, wave: Option<Wave>) -> StoreResult<Option<Wave>> {
-        match wave {
-            Some(mut wave) => {
-                wave.repos = WaveStateStore::list_wave_repos(self, wave.id()).await?;
-                Ok(Some(wave))
-            }
-            None => Ok(None),
-        }
-    }
-
-    /// Persist the wave's `repos` as the source of truth for per-repo execution
-    /// state (worktree/branch/status/iteration). The wave-level `paused` column
-    /// is written in `upsert_wave`.
-    async fn persist_wave_repos(&self, wave: &Wave) -> StoreResult<()> {
-        self.replace_wave_repos(wave.id(), &wave.repos).await
-    }
-
     /// A chord's contents: the waves whose `parent_wave_id` is `parent`,
-    /// ordered by creation, each stitched with its `repos`.
+    /// ordered by creation.
     pub async fn list_child_waves(&self, parent: &LfdId) -> StoreResult<Vec<Wave>> {
         WaveStateStore::children_of(self, parent).await
     }
@@ -290,13 +251,11 @@ impl Store {
     }
 
     pub async fn create_wave(&self, wave: &Wave) -> StoreResult<()> {
-        WaveStateStore::create_wave(self, wave).await?;
-        self.persist_wave_repos(wave).await
+        WaveStateStore::create_wave(self, wave).await
     }
 
     pub async fn update_wave(&self, wave: &Wave) -> StoreResult<()> {
-        WaveStateStore::update_wave(self, wave).await?;
-        self.persist_wave_repos(wave).await
+        WaveStateStore::update_wave(self, wave).await
     }
 
     pub async fn delete_wave(&self, wave_id: &LfdId) -> StoreResult<()> {
@@ -627,9 +586,6 @@ pub trait WaveStateStore: Send + Sync {
     async fn create_wave(&self, wave: &Wave) -> StoreResult<()>;
     async fn update_wave(&self, wave: &Wave) -> StoreResult<()>;
     async fn delete_wave(&self, wave_id: &LfdId) -> StoreResult<()>;
-    async fn list_wave_repos(&self, wave_id: &LfdId) -> StoreResult<Vec<RepoWork>>;
-    async fn upsert_wave_repo(&self, wave_id: &LfdId, repo: &RepoWork) -> StoreResult<()>;
-    async fn delete_wave_repos(&self, wave_id: &LfdId) -> StoreResult<()>;
 
     async fn list_runs(&self, wave_id: Option<&LfdId>, limit: Option<u32>)
         -> StoreResult<Vec<Run>>;
@@ -789,31 +745,22 @@ impl WaveStateStore for Store {
             let repo = repo.map(str::to_string);
             run_sqlite(&self.sqlite, move |store| store.list_waves(repo.as_deref())).await
         }?;
-        self.attach_repos_vec(waves).await
+        Ok(waves)
     }
 
     async fn children_of(&self, parent: &LfdId) -> StoreResult<Vec<Wave>> {
-        let waves = {
-            let parent = parent.clone();
-            run_sqlite(&self.sqlite, move |store| store.list_child_waves(&parent)).await
-        }?;
-        self.attach_repos_vec(waves).await
+        let parent = parent.clone();
+        run_sqlite(&self.sqlite, move |store| store.list_child_waves(&parent)).await
     }
 
     async fn get_wave(&self, wave_id: &LfdId) -> StoreResult<Option<Wave>> {
-        let wave = {
-            let wave_id = wave_id.clone();
-            run_sqlite(&self.sqlite, move |store| store.get_wave(&wave_id)).await
-        }?;
-        self.attach_repos_opt(wave).await
+        let wave_id = wave_id.clone();
+        run_sqlite(&self.sqlite, move |store| store.get_wave(&wave_id)).await
     }
 
     async fn get_wave_by_name(&self, name: &str) -> StoreResult<Option<Wave>> {
-        let wave = {
-            let name = name.to_string();
-            run_sqlite(&self.sqlite, move |store| store.get_wave_by_name(&name)).await
-        }?;
-        self.attach_repos_opt(wave).await
+        let name = name.to_string();
+        run_sqlite(&self.sqlite, move |store| store.get_wave_by_name(&name)).await
     }
 
     async fn create_wave(&self, wave: &Wave) -> StoreResult<()> {
@@ -834,31 +781,6 @@ impl WaveStateStore for Store {
         {
             let wave_id = wave_id.clone();
             run_sqlite(&self.sqlite, move |store| store.delete_wave(&wave_id)).await
-        }
-    }
-
-    async fn list_wave_repos(&self, wave_id: &LfdId) -> StoreResult<Vec<RepoWork>> {
-        {
-            let wave_id = wave_id.clone();
-            run_sqlite(&self.sqlite, move |store| store.list_wave_repos(&wave_id)).await
-        }
-    }
-
-    async fn upsert_wave_repo(&self, wave_id: &LfdId, repo: &RepoWork) -> StoreResult<()> {
-        {
-            let wave_id = wave_id.clone();
-            let repo = repo.clone();
-            run_sqlite(&self.sqlite, move |store| {
-                store.upsert_wave_repo(&wave_id, &repo)
-            })
-            .await
-        }
-    }
-
-    async fn delete_wave_repos(&self, wave_id: &LfdId) -> StoreResult<()> {
-        {
-            let wave_id = wave_id.clone();
-            run_sqlite(&self.sqlite, move |store| store.delete_wave_repos(&wave_id)).await
         }
     }
 
@@ -1459,8 +1381,8 @@ mod tests {
     use crate::lfd::id::LfdId;
     use crate::lfd::types::{
         ChatMemoryBlock, LivePrState, LivePullRequestState, PullRequest, QueueBlock,
-        QueueBlockReason, Repo, RepoEdge, RepoId, RepoWork, Run, RunStackStatus, RunStatus,
-        Summary, Wave, WaveStatus,
+        QueueBlockReason, Repo, RepoEdge, RepoId, Run, RunStackStatus, RunStatus, Summary, Wave,
+        WaveStatus,
     };
     use std::env;
     use time::OffsetDateTime;
@@ -1473,15 +1395,12 @@ mod tests {
             primary_flow: "ship-roadmap".to_string(),
             goal: "ship-roadmap".to_string(),
             metrics: Vec::new(),
-            repos: vec![RepoWork {
-                repo: repo.to_string(),
-                worktree: String::new(),
-                branch: String::new(),
-                status: WaveStatus::Idle,
-                iteration: 0,
-                cycle_start_iteration: 0,
-                position: 0,
-            }],
+            repo: repo.to_string(),
+            worktree: String::new(),
+            branch: String::new(),
+            status: WaveStatus::Idle,
+            iteration: 0,
+            cycle_start_iteration: 0,
             direction: vec!["focus".to_string()],
             area: vec!["src".to_string()],
             paused: false,
@@ -1535,9 +1454,8 @@ mod tests {
             .expect("get wave")
             .expect("wave exists");
         assert_eq!(loaded.status(), WaveStatus::Paused);
-        assert_eq!(loaded.repos.len(), 1);
-        assert_eq!(loaded.repos[0].repo, "/repo");
-        assert_eq!(loaded.repos[0].status, WaveStatus::Paused);
+        assert_eq!(loaded.repo(), "/repo");
+        assert_eq!(loaded.status, WaveStatus::Paused);
 
         let repo = Repo {
             path: "/tmp/repo".to_string(),

--- a/rust/loopflow/src/lfdb/rows.rs
+++ b/rust/loopflow/src/lfdb/rows.rs
@@ -1,7 +1,7 @@
 use crate::lfd::id::LfdId;
 use crate::lfd::types::{
     ChatMemoryBlock, ChatMessage, LivePrState, LivePullRequestState, PullRequest, Repo, RepoEdge,
-    RepoId, RepoWork, Run, RunStackStatus, RunStatus, Summary, Wave, WaveStatus,
+    RepoId, Run, RunStackStatus, RunStatus, Summary, Wave, WaveStatus,
 };
 use crate::lfdb::{
     ForkRun, ForkRunStatus, RepoProviderUsage, StoreError, StoreResult, WaveProviderUsage,
@@ -62,7 +62,8 @@ pub fn parse_pr(value: Option<String>) -> StoreResult<Option<PullRequest>> {
 // -- Shared row mappers ------------------------------------------------------
 
 /// SELECT id, name, direction, area, paused, created_at, workers,
-///        primary_flow, goal, metrics, parent_wave_id
+///        primary_flow, goal, metrics, parent_wave_id,
+///        repo, worktree, branch, status, iteration, cycle_start_iteration
 pub fn map_wave_row(row: &rusqlite::Row<'_>) -> StoreResult<Wave> {
     let direction = parse_json_vec(&text(row, 2)?)?;
     let area = parse_json_vec(&text(row, 3)?)?;
@@ -80,27 +81,18 @@ pub fn map_wave_row(row: &rusqlite::Row<'_>) -> StoreResult<Wave> {
         primary_flow,
         goal,
         metrics,
-        repos: Vec::new(),
+        repo: text(row, 11)?,
+        worktree: text(row, 12)?,
+        branch: text(row, 13)?,
+        status: WaveStatus::from_i32(int(row, 14)?),
+        iteration: int(row, 15)? as u32,
+        cycle_start_iteration: int(row, 16)? as u32,
         direction,
         area,
         paused,
         created_at: Some(created_at),
         workers,
         parent_wave_id,
-    })
-}
-
-/// SELECT wave_id, repo, worktree, branch, status, iteration,
-///        cycle_start_iteration, position
-pub fn map_wave_repo_row(row: &rusqlite::Row<'_>) -> StoreResult<RepoWork> {
-    Ok(RepoWork {
-        repo: text(row, 1)?,
-        worktree: text(row, 2)?,
-        branch: text(row, 3)?,
-        status: WaveStatus::from_i32(int(row, 4)?),
-        iteration: int(row, 5)? as u32,
-        cycle_start_iteration: int(row, 6)? as u32,
-        position: int(row, 7)? as u32,
     })
 }
 

--- a/rust/loopflow/src/lfdb/sqlite.rs
+++ b/rust/loopflow/src/lfdb/sqlite.rs
@@ -7,14 +7,14 @@ use crate::lfd::attention::{queue_block_attention_item, queue_block_from_attenti
 use crate::lfd::id::LfdId;
 use crate::lfd::types::{
     AttentionItem, AttentionKind, AttentionStatus, ChatMemoryBlock, ChatMessage,
-    LivePullRequestState, QueueBlock, Repo, RepoEdge, RepoId, RepoWork, Run, RunStatus, Session,
+    LivePullRequestState, QueueBlock, Repo, RepoEdge, RepoId, Run, RunStatus, Session,
     SessionStatus, SessionUse, Summary, Wave, WaveStatus,
 };
 use crate::lfdb::catalog::{list_runs_query, list_waves_query, sql, Query, SqlDialect};
 use crate::lfdb::rows::{
     map_chat_memory_block_row, map_chat_message_row, map_fork_run_row, map_live_pr_state_row,
     map_repo_edge_row, map_repo_provider_usage_row, map_repo_row, map_run_row, map_summary_row,
-    map_wave_provider_usage_row, map_wave_repo_row, map_wave_row, now_unix, serialize_pr,
+    map_wave_provider_usage_row, map_wave_row, now_unix, serialize_pr,
 };
 use crate::lfdb::token_crypto;
 use crate::lfdb::{
@@ -174,20 +174,6 @@ impl SqliteStore {
         Ok(waves)
     }
 
-    fn read_wave_repos<P>(&self, query: Query, params: P) -> StoreResult<Vec<RepoWork>>
-    where
-        P: rusqlite::Params,
-    {
-        let conn = self.conn.lock().expect("store mutex poisoned");
-        let mut stmt = conn.prepare(Self::sql(query))?;
-        let rows = stmt.query_map(params, |row| Ok(map_wave_repo_row(row)))?;
-        let mut repos = Vec::new();
-        for repo in rows {
-            repos.push(repo??);
-        }
-        Ok(repos)
-    }
-
     fn upsert_wave(&self, wave: &Wave) -> StoreResult<()> {
         let conn = self.conn.lock().expect("store mutex poisoned");
         let direction_json = serde_json::to_string(wave.direction())?;
@@ -216,6 +202,12 @@ impl SqliteStore {
                 wave.goal(),
                 metrics_json,
                 wave.parent_wave_id(),
+                wave.repo,
+                wave.worktree,
+                wave.branch,
+                wave.status.as_i32() as i64,
+                wave.iteration as i64,
+                wave.cycle_start_iteration as i64,
             ],
         )?;
         Ok(())
@@ -731,34 +723,6 @@ impl SqliteStore {
         Ok(())
     }
 
-    pub fn list_wave_repos(&self, wave_id: &LfdId) -> StoreResult<Vec<RepoWork>> {
-        self.read_wave_repos(Query::ListWaveRepos, params![wave_id])
-    }
-
-    pub fn upsert_wave_repo(&self, wave_id: &LfdId, repo: &RepoWork) -> StoreResult<()> {
-        let conn = self.conn.lock().expect("store mutex poisoned");
-        conn.execute(
-            Self::sql(Query::UpsertWaveRepo),
-            params![
-                wave_id.as_str(),
-                repo.repo,
-                repo.worktree,
-                repo.branch,
-                repo.status.as_i32(),
-                repo.iteration as i64,
-                repo.cycle_start_iteration as i64,
-                repo.position as i64,
-            ],
-        )?;
-        Ok(())
-    }
-
-    pub fn delete_wave_repos(&self, wave_id: &LfdId) -> StoreResult<()> {
-        let conn = self.conn.lock().expect("store mutex poisoned");
-        conn.execute(Self::sql(Query::DeleteWaveReposByWave), params![wave_id])?;
-        Ok(())
-    }
-
     pub fn list_runs(&self, wave_id: Option<&LfdId>, limit: Option<u32>) -> StoreResult<Vec<Run>> {
         let conn = self.conn.lock().expect("store mutex poisoned");
         let query = Self::sql(list_runs_query(wave_id.is_some(), limit.is_some()));
@@ -1175,11 +1139,11 @@ impl SqliteStore {
                 RunStatus::Waiting.as_i32() as i64,
             ],
         )?;
-        // Runs that were in flight are now Failed; the repos that owned them
-        // would otherwise stay stuck in Running/Waiting and the rolled-up wave
-        // status would keep their action buttons disabled. Reset them to Idle.
+        // Runs that were in flight are now Failed; the waves that owned them
+        // would otherwise stay stuck in Running/Waiting and keep their action
+        // buttons disabled. Reset them to Idle.
         conn.execute(
-            Self::sql(Query::ResetStaleActiveRepos),
+            Self::sql(Query::ResetStaleActiveWaves),
             params![
                 WaveStatus::Idle.as_i32() as i64,
                 WaveStatus::Running.as_i32() as i64,

--- a/rust/loopflow/src/ops/queue.rs
+++ b/rust/loopflow/src/ops/queue.rs
@@ -180,8 +180,8 @@ mod tests {
     use crate::lfd::id::LfdId;
     use crate::lfd::queue::{QueueOps, QueueRebaseConflict};
     use crate::lfd::types::{
-        LivePrState, LivePullRequestState, PullRequest, QueueBlockReason, RepoWork, Run,
-        RunStackStatus, RunStatus, Wave, WaveStatus,
+        LivePrState, LivePullRequestState, PullRequest, QueueBlockReason, Run, RunStackStatus,
+        RunStatus, Wave, WaveStatus,
     };
     use crate::lfdb::SharedStore;
 
@@ -235,15 +235,12 @@ mod tests {
             primary_flow: "ship-roadmap".to_string(),
             goal: "ship-roadmap".to_string(),
             metrics: Vec::new(),
-            repos: vec![RepoWork {
-                repo: ".".to_string(),
-                worktree: String::new(),
-                branch: String::new(),
-                status: WaveStatus::Idle,
-                iteration: 0,
-                cycle_start_iteration: 0,
-                position: 0,
-            }],
+            repo: ".".to_string(),
+            worktree: String::new(),
+            branch: String::new(),
+            status: WaveStatus::Idle,
+            iteration: 0,
+            cycle_start_iteration: 0,
             direction: Vec::new(),
             area: Vec::new(),
             paused: false,

--- a/rust/loopflow/src/wave/mod.rs
+++ b/rust/loopflow/src/wave/mod.rs
@@ -1620,22 +1620,19 @@ mod tests {
     }
 
     fn make_wave_row(name: &str) -> crate::lfd::types::Wave {
-        use crate::lfd::types::{RepoWork, WaveStatus};
+        use crate::lfd::types::WaveStatus;
         crate::lfd::types::Wave {
             id: crate::lfd::id::LfdId::new(),
             name: name.to_string(),
             primary_flow: "ship-roadmap".to_string(),
             goal: "ship-roadmap".to_string(),
             metrics: Vec::new(),
-            repos: vec![RepoWork {
-                repo: "/tmp/repo".to_string(),
-                worktree: String::new(),
-                branch: String::new(),
-                status: WaveStatus::Idle,
-                iteration: 0,
-                cycle_start_iteration: 0,
-                position: 0,
-            }],
+            repo: "/tmp/repo".to_string(),
+            worktree: String::new(),
+            branch: String::new(),
+            status: WaveStatus::Idle,
+            iteration: 0,
+            cycle_start_iteration: 0,
             direction: Vec::new(),
             area: Vec::new(),
             paused: false,

--- a/rust/loopflow/src/wave/registry.rs
+++ b/rust/loopflow/src/wave/registry.rs
@@ -651,11 +651,11 @@ impl StoreObserver {
                 return;
             }
         }
-        // No active runs → the wave is idle again. Reset every repo still
-        // stamped Running (the status create_run_for_placement set on
-        // dispatch); leave Paused and already-Idle repos alone.
+        // No active runs → the wave is idle again. Reset it if still stamped
+        // Running (the status create_run_for_placement set on dispatch); leave
+        // Paused and already-Idle waves alone.
         match self.store.count_active_runs(&self.wave_id).await {
-            Ok(0) => self.reset_wave_repos_to_idle().await,
+            Ok(0) => self.reset_wave_to_idle().await,
             Ok(_) => {}
             Err(err) => {
                 tracing::debug!(error = %err, "active-run count failed; wave status unchanged");
@@ -663,20 +663,14 @@ impl StoreObserver {
         }
     }
 
-    async fn reset_wave_repos_to_idle(&self) {
+    async fn reset_wave_to_idle(&self) {
         let Ok(Some(mut wave)) = self.store.get_wave(&self.wave_id).await else {
             return;
         };
-        let mut changed = false;
-        for repo in &mut wave.repos {
-            if repo.status == WaveStatus::Running {
-                repo.status = WaveStatus::Idle;
-                changed = true;
-            }
-        }
-        if !changed {
+        if wave.status != WaveStatus::Running {
             return;
         }
+        wave.status = WaveStatus::Idle;
         if let Err(err) = self.store.update_wave(&wave).await {
             tracing::debug!(wave_id = %self.wave_id, error = %err, "failed to reset wave status to idle");
         }
@@ -689,7 +683,7 @@ mod tests {
     use std::collections::BTreeMap;
 
     use crate::lfd::types::{
-        PullRequest, RepoWork, RunStackStatus, RunStatus, WaveStatus, TMUX_TERMINAL_SOURCE,
+        PullRequest, RunStackStatus, RunStatus, WaveStatus, TMUX_TERMINAL_SOURCE,
     };
     use crate::lfdb::{open_store, StorageConfig};
     use crate::wave::journal::{journal_path, EventKind, Journal};
@@ -709,15 +703,12 @@ mod tests {
             primary_flow: "ship-roadmap".to_string(),
             goal: "ship-roadmap".to_string(),
             metrics: Vec::new(),
-            repos: vec![RepoWork {
-                repo: "/tmp/repo".to_string(),
-                worktree: String::new(),
-                branch: String::new(),
-                status: WaveStatus::Idle,
-                iteration: 0,
-                cycle_start_iteration: 0,
-                position: 0,
-            }],
+            repo: "/tmp/repo".to_string(),
+            worktree: String::new(),
+            branch: String::new(),
+            status: WaveStatus::Idle,
+            iteration: 0,
+            cycle_start_iteration: 0,
             direction: Vec::new(),
             area: Vec::new(),
             paused: false,

--- a/rust/loopflow/tests/dto_fixtures.rs
+++ b/rust/loopflow/tests/dto_fixtures.rs
@@ -36,7 +36,7 @@ fn load_top_fixture(name: &str) -> Value {
 }
 
 #[test]
-fn wave_fixture_nests_repo_work() {
+fn wave_fixture_carries_single_repo() {
     let wave: WaveDto =
         serde_json::from_value(load_top_fixture("wave.json")).expect("wave fixture should parse");
 
@@ -46,19 +46,16 @@ fn wave_fixture_nests_repo_work() {
     assert_eq!(wave.status, "running");
     assert_eq!(wave.parent_wave_id.as_deref(), Some("wave_parent999"));
 
-    assert_eq!(wave.repos.len(), 1);
-    let repo = &wave.repos[0];
-    assert_eq!(repo.repo, "/home/user/project");
-    assert_eq!(repo.status, "running");
-    assert_eq!(repo.iteration, 3);
+    assert_eq!(wave.repo, "/home/user/project");
+    assert_eq!(wave.iteration, 3);
     assert_eq!(
-        repo.local_worktree.as_deref(),
+        wave.local_worktree.as_deref(),
         Some("/home/user/project/.claude/worktrees/engbot")
     );
-    assert_eq!(repo.remote_branch.as_deref(), Some("engbot/build-3"));
-    assert_eq!(repo.open_pr_count, 1);
-    assert_eq!(repo.commits.len(), 1);
-    assert_eq!(repo.commits[0].sha, "abc1234");
+    assert_eq!(wave.remote_branch.as_deref(), Some("engbot/build-3"));
+    assert_eq!(wave.open_pr_count, 1);
+    assert_eq!(wave.commits.len(), 1);
+    assert_eq!(wave.commits[0].sha, "abc1234");
 }
 
 #[test]

--- a/rust/loopflow/tests/wave_worktree_tests.rs
+++ b/rust/loopflow/tests/wave_worktree_tests.rs
@@ -10,7 +10,7 @@ use loopflow::engine::worktrees::{
 };
 use loopflow::lfd::executor::{create_run_for_placement, ensure_wave_worktree, Placement};
 use loopflow::lfd::id::LfdId;
-use loopflow::lfd::types::{RepoWork, Wave, WaveStatus};
+use loopflow::lfd::types::{Wave, WaveStatus};
 use loopflow::lfdb::{open_store, SharedStore, StorageConfig};
 use loopflow_test_support::TestRepo;
 
@@ -33,15 +33,12 @@ fn make_wave(repo: &str, name: &str) -> Wave {
         primary_flow: "ship-roadmap".to_string(),
         goal: "ship-roadmap".to_string(),
         metrics: Vec::new(),
-        repos: vec![RepoWork {
-            repo: repo.to_string(),
-            worktree: String::new(),
-            branch: String::new(),
-            status: WaveStatus::Idle,
-            iteration: 0,
-            cycle_start_iteration: 0,
-            position: 0,
-        }],
+        repo: repo.to_string(),
+        worktree: String::new(),
+        branch: String::new(),
+        status: WaveStatus::Idle,
+        iteration: 0,
+        cycle_start_iteration: 0,
         direction: vec![],
         area: vec![],
         paused: false,

--- a/swift/Concerto/State/PortfolioRepoState.swift
+++ b/swift/Concerto/State/PortfolioRepoState.swift
@@ -70,7 +70,7 @@ final class PortfolioRepoState {
 
     func applyConnectedWaves(_ connectedWaves: [Wave]) {
         let filtered = connectedWaves
-            .filter { wave in wave.repos.contains { $0.repo.normalizedFilePath == repoPath } }
+            .filter { $0.repo.normalizedFilePath == repoPath }
             .map { WaveViewModel(api: $0) }
         waves = Self.sortWaves(filtered)
     }
@@ -79,13 +79,13 @@ final class PortfolioRepoState {
         switch event.type {
         case .deleted:
             if let wave = event.wave,
-               !wave.repos.contains(where: { $0.repo.normalizedFilePath == repoPath }) {
+               wave.repo.normalizedFilePath != repoPath {
                 return
             }
             waves.removeAll { $0.id == event.waveId }
         case .created, .updated, .started, .stopped, .waiting:
             guard let wave = event.wave,
-                  wave.repos.contains(where: { $0.repo.normalizedFilePath == repoPath }) else {
+                  wave.repo.normalizedFilePath == repoPath else {
                 return
             }
             upsertWave(WaveViewModel(api: wave))

--- a/swift/ConcertoTests/ContractTests.swift
+++ b/swift/ConcertoTests/ContractTests.swift
@@ -39,14 +39,12 @@ struct ContractTests {
         #expect(wave.area == ["src/"])
         #expect(wave.parentWaveId == "wave_parent999")
 
-        #expect(wave.repos.count == 1)
-        #expect(wave.repos.first?.repo == "/home/user/project")
-        #expect(wave.repos.first?.status == .running)
-        #expect(wave.repos.first?.iteration == 3)
-        #expect(wave.repos.first?.openPRCount == 1)
-        #expect(wave.repos.first?.localWorktree == "/home/user/project/.claude/worktrees/engbot")
-        #expect(wave.repos.first?.remoteBranch == "engbot/build-3")
-        #expect(wave.repos.first?.commits.count == 1)
+        #expect(wave.repo == "/home/user/project")
+        #expect(wave.iteration == 3)
+        #expect(wave.openPRCount == 1)
+        #expect(wave.localWorktree == "/home/user/project/.claude/worktrees/engbot")
+        #expect(wave.remoteBranch == "engbot/build-3")
+        #expect(wave.commits.count == 1)
 
         // Triggers and crons left the wire in the collapse's organ cut:
         // absent keys parse as empty.

--- a/swift/ConcertoTests/PortfolioRepoStateTests.swift
+++ b/swift/ConcertoTests/PortfolioRepoStateTests.swift
@@ -93,29 +93,6 @@ struct PortfolioRepoStateTests {
         #expect(state.waves[0].id == localWave.id)
     }
 
-    @Test("multi-repo waves match non-primary repo state")
-    func multiRepoWaveMatchesNonPrimaryRepoState() {
-        let repoURL = URL(fileURLWithPath: "/tmp/portfolio-secondary")
-        let repo = PortfolioRepo(path: repoURL.normalizedFilePath, lastOpened: Date())
-        let state = PortfolioRepoState(repo: repo, connection: .local, token: nil)
-        let wave = Wave(
-            id: "multi",
-            name: "multi",
-            repos: [
-                RepoWork(repo: "/tmp/portfolio-primary", status: .running),
-                RepoWork(repo: repo.path, status: .waiting),
-            ],
-            flow: "build",
-            direction: [],
-            area: ["."],
-            status: .running
-        )
-
-        state.applyConnectedWaves([wave])
-
-        #expect(state.waves.map(\.id) == ["multi"])
-    }
-
     @Test("wave agent session name mirrors lf tmux handle")
     func waveAgentSessionNameMirrorsLfTmuxHandle() {
         let name = PortfolioRepoState.waveAgentSessionName(

--- a/swift/ConcertoTests/WaveTests.swift
+++ b/swift/ConcertoTests/WaveTests.swift
@@ -599,36 +599,31 @@ struct ParseWaveFromJSONTests {
             "area": ["."],
             "status": "running",
             "flow_steps": ["ingest", "kickoff"],
-            "repos": [
-                [
-                    "repo": "/tmp/repo",
-                    "status": "running",
-                    "iteration": 0,
-                    "open_pr_count": 3,
-                    "commits": [],
-                    "stack_count": 0,
-                    "active_run": [
-                        "id": "run-1",
-                        "wave_id": "wave-1",
-                        "flow": "start",
-                        "repo": "/tmp/repo",
-                        "direction": ["ux"],
-                        "area": ["."],
-                        "iteration": 0,
-                        "step_index": 1,
-                        "status": "running",
-                        "local_worktree": "/tmp/wt",
-                        "remote_branch": "jack/ux"
-                    ] as [String: Any]
-                ] as [String: Any]
-            ]
+            "repo": "/tmp/repo",
+            "iteration": 0,
+            "open_pr_count": 3,
+            "commits": [],
+            "stack_count": 0,
+            "active_run": [
+                "id": "run-1",
+                "wave_id": "wave-1",
+                "flow": "start",
+                "repo": "/tmp/repo",
+                "direction": ["ux"],
+                "area": ["."],
+                "iteration": 0,
+                "step_index": 1,
+                "status": "running",
+                "local_worktree": "/tmp/wt",
+                "remote_branch": "jack/ux"
+            ] as [String: Any]
         ]
 
         let wave = WaveService.parseWaveFromJSON(json)
 
         #expect(wave.flowSteps == ["ingest", "kickoff"])
-        #expect(wave.repos.first?.openPRCount == 3)
-        #expect(wave.repos.first?.activeRun?.stepIndex == 1)
+        #expect(wave.openPRCount == 3)
+        #expect(wave.activeRun?.stepIndex == 1)
 
         let vm = WaveViewModel(api: wave)
         #expect(vm.stepIndex == 1)
@@ -644,23 +639,18 @@ struct ParseWaveFromJSONTests {
             "metrics": [],
             "status": "idle",
             "flow_steps": ["ingest", "kickoff"],
-            "repos": [
-                [
-                    "repo": "/tmp/repo",
-                    "status": "idle",
-                    "iteration": 0,
-                    "open_pr_count": 0,
-                    "commits": [],
-                    "stack_count": 0
-                ] as [String: Any]
-            ]
+            "repo": "/tmp/repo",
+            "iteration": 0,
+            "open_pr_count": 0,
+            "commits": [],
+            "stack_count": 0
         ]
 
         let wave = WaveService.parseWaveFromJSON(json)
         let vm = WaveViewModel(api: wave)
 
         #expect(vm.stepIndex == 0)
-        #expect(wave.repos.first?.activeRun == nil)
+        #expect(wave.activeRun == nil)
     }
 }
 

--- a/swift/LoopflowCore/Models/Wave.swift
+++ b/swift/LoopflowCore/Models/Wave.swift
@@ -195,49 +195,9 @@ public struct WaveCron: Sendable, Hashable, Codable, Identifiable {
     }
 }
 
-/// Per-repo execution surface for a wave, mirroring `RepoWorkDto`. One entry
-/// per repo the wave runs in. `localWorktree`/`remoteBranch` are git-inferred at
-/// build time; `worktree`/`branch` persisted duplicates were dropped from the wire.
-public struct RepoWork: Sendable, Hashable {
-    public var repo: String
-    public var status: WaveStatus
-    public var iteration: Int
-    public var localWorktree: String?
-    public var remoteBranch: String?
-    public var commits: [CommitEntry]
-    public var diffStat: String?
-    public var openPRCount: Int
-    public var stackCount: Int
-    public var activeRun: Run?
-    public var pr: PullRequest?
-
-    public init(
-        repo: String,
-        status: WaveStatus = .idle,
-        iteration: Int = 0,
-        localWorktree: String? = nil,
-        remoteBranch: String? = nil,
-        commits: [CommitEntry] = [],
-        diffStat: String? = nil,
-        openPRCount: Int = 0,
-        stackCount: Int = 0,
-        activeRun: Run? = nil,
-        pr: PullRequest? = nil
-    ) {
-        self.repo = repo
-        self.status = status
-        self.iteration = iteration
-        self.localWorktree = localWorktree
-        self.remoteBranch = remoteBranch
-        self.commits = commits
-        self.diffStat = diffStat
-        self.openPRCount = openPRCount
-        self.stackCount = stackCount
-        self.activeRun = activeRun
-        self.pr = pr
-    }
-}
-
+/// A wave targets exactly one repo, so its execution surface is carried inline,
+/// mirroring `WaveDto`. `localWorktree`/`remoteBranch` are git-inferred at build
+/// time; the persisted `worktree`/`branch` duplicates were dropped from the wire.
 public struct Wave: Sendable, Identifiable, Hashable {
     public let id: String
     public var name: String
@@ -250,53 +210,23 @@ public struct Wave: Sendable, Identifiable, Hashable {
     public var stepAgents: [String: String]?
     public var triggers: [Trigger]
     public var crons: [WaveCron]
-    /// Wave-level status rolled up over `repos`.
     public var status: WaveStatus
-    public var repos: [RepoWork]
+    /// The single repo this wave targets, plus its live execution state.
+    public var repo: String
+    public var iteration: Int
+    public var localWorktree: String?
+    public var remoteBranch: String?
+    public var commits: [CommitEntry]
+    public var diffStat: String?
+    public var openPRCount: Int
+    public var stackCount: Int
+    public var activeRun: Run?
+    public var pr: PullRequest?
     public var flowSteps: [String]
     public var createdAt: Date?
     /// Parent wave in the chord tree. `nil` for a root wave.
     public var parentWaveId: String?
 
-    public init(
-        id: String,
-        name: String = "",
-        repos: [RepoWork],
-        flow: String = "",
-        goal: String = "ship-roadmap",
-        metrics: [String] = [],
-        direction: [String] = [],
-        area: [String] = [],
-        agent: String? = nil,
-        stepAgents: [String: String]? = nil,
-        triggers: [Trigger] = [],
-        crons: [WaveCron] = [],
-        status: WaveStatus = .idle,
-        flowSteps: [String] = [],
-        createdAt: Date? = nil,
-        parentWaveId: String? = nil
-    ) {
-        self.id = id
-        self.name = name
-        self.repos = repos
-        self.flow = flow
-        self.goal = goal
-        self.metrics = metrics
-        self.direction = direction
-        self.area = area
-        self.agent = agent
-        self.stepAgents = stepAgents
-        self.triggers = triggers
-        self.crons = crons
-        self.status = status
-        self.flowSteps = flowSteps
-        self.createdAt = createdAt
-        self.parentWaveId = parentWaveId
-    }
-
-    /// Single-repo convenience mirroring the old flat shape: packs the per-repo
-    /// execution fields into one `RepoWork`. Keeps existing call sites (views,
-    /// tests, placeholders) compiling unchanged.
     public init(
         id: String,
         name: String = "",
@@ -318,38 +248,36 @@ public struct Wave: Sendable, Identifiable, Hashable {
         diffStat: String? = nil,
         flowSteps: [String] = [],
         openPRCount: Int = 0,
+        stackCount: Int = 0,
         activeRun: Run? = nil,
-        createdAt: Date? = nil
+        pr: PullRequest? = nil,
+        createdAt: Date? = nil,
+        parentWaveId: String? = nil
     ) {
-        self.init(
-            id: id,
-            name: name,
-            repos: [
-                RepoWork(
-                    repo: repo,
-                    status: status,
-                    iteration: iteration,
-                    localWorktree: localWorktree,
-                    remoteBranch: remoteBranch,
-                    commits: commits,
-                    diffStat: diffStat,
-                    openPRCount: openPRCount,
-                    activeRun: activeRun
-                )
-            ],
-            flow: flow,
-            goal: goal,
-            metrics: metrics,
-            direction: direction,
-            area: area,
-            agent: agent,
-            stepAgents: stepAgents,
-            triggers: triggers,
-            crons: crons,
-            status: status,
-            flowSteps: flowSteps,
-            createdAt: createdAt,
-            parentWaveId: nil
-        )
+        self.id = id
+        self.name = name
+        self.repo = repo
+        self.flow = flow
+        self.goal = goal
+        self.metrics = metrics
+        self.direction = direction
+        self.area = area
+        self.agent = agent
+        self.stepAgents = stepAgents
+        self.triggers = triggers
+        self.crons = crons
+        self.status = status
+        self.iteration = iteration
+        self.localWorktree = localWorktree
+        self.remoteBranch = remoteBranch
+        self.commits = commits
+        self.diffStat = diffStat
+        self.openPRCount = openPRCount
+        self.stackCount = stackCount
+        self.activeRun = activeRun
+        self.pr = pr
+        self.flowSteps = flowSteps
+        self.createdAt = createdAt
+        self.parentWaveId = parentWaveId
     }
 }

--- a/swift/LoopflowCore/Models/WaveViewModel.swift
+++ b/swift/LoopflowCore/Models/WaveViewModel.swift
@@ -49,12 +49,11 @@ public struct WaveViewModel: Sendable, Identifiable, Hashable {
         waitingReason: WaitingReason? = nil,
         runStartedAt: Date? = nil
     ) {
-        let primary = api.repos.first
-        let activeRun = primary?.activeRun
+        let activeRun = api.activeRun
         self.api = api
         self.content = content
-        self.worktreePath = worktreePath ?? activeRun?.worktree ?? primary?.localWorktree
-        self.branch = branch ?? activeRun?.branch ?? primary?.remoteBranch
+        self.worktreePath = worktreePath ?? activeRun?.worktree ?? api.localWorktree
+        self.branch = branch ?? activeRun?.branch ?? api.remoteBranch
         self.isDirty = isDirty
         self.isRebasing = isRebasing
         self.isMerging = isMerging
@@ -77,28 +76,14 @@ public struct WaveViewModel: Sendable, Identifiable, Hashable {
 
     public var id: String { api.id }
 
-    /// The wave's first/primary repo — backs the flat per-repo accessors below.
-    private var primaryRepo: RepoWork? { api.repos.first }
-
-    /// Mutate the primary repo in place, creating one if the wave has none.
-    private mutating func withPrimaryRepo(_ mutate: (inout RepoWork) -> Void) {
-        if api.repos.isEmpty {
-            var work = RepoWork(repo: "")
-            mutate(&work)
-            api.repos = [work]
-        } else {
-            mutate(&api.repos[0])
-        }
-    }
-
     public var name: String {
         get { api.name }
         set { api.name = newValue }
     }
 
     public var repo: String {
-        get { primaryRepo?.repo ?? "" }
-        set { withPrimaryRepo { $0.repo = newValue } }
+        get { api.repo }
+        set { api.repo = newValue }
     }
 
     public var flow: String {
@@ -140,13 +125,13 @@ public struct WaveViewModel: Sendable, Identifiable, Hashable {
     }
 
     public var iteration: Int {
-        get { primaryRepo?.iteration ?? 0 }
-        set { withPrimaryRepo { $0.iteration = newValue } }
+        get { api.iteration }
+        set { api.iteration = newValue }
     }
 
     public var activeRun: Run? {
-        get { primaryRepo?.activeRun }
-        set { withPrimaryRepo { $0.activeRun = newValue } }
+        get { api.activeRun }
+        set { api.activeRun = newValue }
     }
 
     public var createdAt: Date? {
@@ -202,8 +187,8 @@ public struct WaveViewModel: Sendable, Identifiable, Hashable {
         direction.isEmpty ? "" : direction.joined(separator: ", ")
     }
 
-    public var commits: [CommitEntry] { primaryRepo?.commits ?? [] }
-    public var diffStat: String? { primaryRepo?.diffStat }
+    public var commits: [CommitEntry] { api.commits }
+    public var diffStat: String? { api.diffStat }
     public var flowSteps: [String] { api.flowSteps }
     private var diffCounts: (additions: Int, deletions: Int)? {
         guard let diffStat else { return nil }
@@ -252,7 +237,7 @@ public struct WaveViewModel: Sendable, Identifiable, Hashable {
         return displayFlow.isEmpty ? [] : [displayFlow]
     }
 
-    public var openPRCount: Int { primaryRepo?.openPRCount ?? 0 }
+    public var openPRCount: Int { api.openPRCount }
     public var effectiveOpenPRCount: Int { max(openPRCount, pendingPR == nil ? 0 : 1) }
     public var hasOpenPRs: Bool { effectiveOpenPRCount > 0 }
 

--- a/swift/LoopflowCore/Services/LocalWaveService.swift
+++ b/swift/LoopflowCore/Services/LocalWaveService.swift
@@ -789,52 +789,6 @@ public struct WaveService: WaveServiceProtocol, @unchecked Sendable {
         }
         let status = WaveStatus(rawValue: normalizedStatus) ?? .idle
 
-        let repos: [RepoWork]
-        if let reposData = json["repos"] as? [[String: Any]] {
-            repos = reposData.map { Self.parseRepoWorkFromJSON($0) }
-        } else {
-            repos = []
-        }
-
-        let flowSteps = json["flow_steps"] as? [String] ?? []
-        let stepAgents = (json["step_agents"] as? [String: Any])?.reduce(into: [String: String]()) { partial, entry in
-            if let value = entry.value as? String {
-                partial[entry.key] = value
-            }
-        }
-
-        return Wave(
-            id: json["id"] as? String ?? UUID().uuidString,
-            name: json["name"] as? String ?? "",
-            repos: repos,
-            flow: json["primary_flow"] as? String ?? "",
-            goal: json["goal"] as! String,
-            metrics: json["metrics"] as! [String],
-            direction: normalizeStringList(json["direction"]),
-            area: normalizeStringList(json["area"]),
-            agent: json["agent"] as? String,
-            stepAgents: stepAgents,
-            triggers: triggers,
-            crons: crons,
-            status: status,
-            flowSteps: flowSteps,
-            createdAt: createdAt,
-            parentWaveId: json["parent_wave_id"] as? String
-        )
-    }
-
-    /// Parse one entry of a wave's nested `repos` array into a `RepoWork`,
-    /// mirroring `RepoWorkDto`.
-    static func parseRepoWorkFromJSON(_ json: [String: Any]) -> RepoWork {
-        let statusValue = json["status"] as? String ?? "idle"
-        let normalizedStatus: String
-        switch statusValue {
-        case "error": normalizedStatus = "failed"
-        case "completed": normalizedStatus = "idle"
-        default: normalizedStatus = statusValue
-        }
-        let status = WaveStatus(rawValue: normalizedStatus) ?? .idle
-
         let commits: [CommitEntry]
         if let commitsData = json["commits"] as? [[String: Any]] {
             commits = commitsData.compactMap { entry in
@@ -865,18 +819,39 @@ public struct WaveService: WaveServiceProtocol, @unchecked Sendable {
             pr = nil
         }
 
-        return RepoWork(
+        let flowSteps = json["flow_steps"] as? [String] ?? []
+        let stepAgents = (json["step_agents"] as? [String: Any])?.reduce(into: [String: String]()) { partial, entry in
+            if let value = entry.value as? String {
+                partial[entry.key] = value
+            }
+        }
+
+        return Wave(
+            id: json["id"] as? String ?? UUID().uuidString,
+            name: json["name"] as? String ?? "",
             repo: json["repo"] as? String ?? "",
+            flow: json["primary_flow"] as? String ?? "",
+            goal: json["goal"] as! String,
+            metrics: json["metrics"] as! [String],
+            direction: normalizeStringList(json["direction"]),
+            area: normalizeStringList(json["area"]),
+            agent: json["agent"] as? String,
+            stepAgents: stepAgents,
+            triggers: triggers,
+            crons: crons,
             status: status,
             iteration: normalizeInt(json["iteration"]),
             localWorktree: json["local_worktree"] as? String,
             remoteBranch: json["remote_branch"] as? String,
             commits: commits,
             diffStat: json["diff_stat"] as? String,
+            flowSteps: flowSteps,
             openPRCount: normalizeInt(json["open_pr_count"]),
             stackCount: normalizeInt(json["stack_count"]),
             activeRun: activeRun,
-            pr: pr
+            pr: pr,
+            createdAt: createdAt,
+            parentWaveId: json["parent_wave_id"] as? String
         )
     }
 

--- a/swift/LoopflowCore/State/RepoState.swift
+++ b/swift/LoopflowCore/State/RepoState.swift
@@ -547,7 +547,7 @@ public final class RepoState {
 
         if let currentRepoPath,
            let wave = event.wave,
-           !wave.repos.contains(where: { $0.repo.normalizedFilePath == currentRepoPath }) {
+           wave.repo.normalizedFilePath != currentRepoPath {
             return
         }
 
@@ -560,7 +560,7 @@ public final class RepoState {
                 refreshedWave = wave
             } else if let wave = try? await waveService.getWave(event.waveId) {
                 if let currentRepoPath,
-                   !wave.repos.contains(where: { $0.repo.normalizedFilePath == currentRepoPath }) {
+                   wave.repo.normalizedFilePath != currentRepoPath {
                     return
                 }
                 waveStore.set(makeWaveViewModel(api: wave))
@@ -1380,7 +1380,7 @@ public final class RepoState {
     func applyConnectedSnapshot(_ waves: [Wave]) {
         let currentRepoPath = repoTarget?.path.normalizedFilePath
         let scoped = waves.filter { wave in
-            wave.repos.contains { $0.repo.normalizedFilePath == currentRepoPath }
+            wave.repo.normalizedFilePath == currentRepoPath
         }
         waveStore.setAll(scoped.map(makeWaveViewModel))
     }

--- a/tests/fixtures/wave.json
+++ b/tests/fixtures/wave.json
@@ -13,19 +13,14 @@
   "has_stale_pr_state": false,
   "workers": 1,
   "parent_wave_id": "wave_parent999",
-  "repos": [
-    {
-      "repo": "/home/user/project",
-      "status": "running",
-      "iteration": 3,
-      "local_worktree": "/home/user/project/.claude/worktrees/engbot",
-      "remote_branch": "engbot/build-3",
-      "commits": [
-        {"sha": "abc1234", "message": "implement: add user auth"}
-      ],
-      "diff_stat": " 3 files changed, 42 insertions(+), 7 deletions(-)",
-      "open_pr_count": 1,
-      "stack_count": 0
-    }
-  ]
+  "repo": "/home/user/project",
+  "iteration": 3,
+  "local_worktree": "/home/user/project/.claude/worktrees/engbot",
+  "remote_branch": "engbot/build-3",
+  "commits": [
+    {"sha": "abc1234", "message": "implement: add user auth"}
+  ],
+  "diff_stat": " 3 files changed, 42 insertions(+), 7 deletions(-)",
+  "open_pr_count": 1,
+  "stack_count": 0
 }


### PR DESCRIPTION
## Usage

```bash
uv run pytest python/tests/
cargo test
```

## Summary

A wave now targets exactly one repo, so the multi-repo indirection is gone. The old `RepoWork`/`RepoWorkDto` wrapper (a `Vec` of per-repo execution surfaces) is removed and its fields — repo, iteration, status, worktree/branch, commits, PR + git snapshot — are carried inline on the `Wave`/`WaveDto` across all three wire mirrors (Rust, Python, Swift). This kills the split-brain of a "list of repos" that in practice always held one element, and simplifies every consumer that used to reach through `wave.repos.first()` or iterate the vec.

## Changes

- Rust: flatten `RepoWork` into `Wave` and `RepoWorkDto` into `WaveDto`; update executor, bridge, queue, catalog, sqlite, and route handlers (attention/hooks/repos/waves) to read the inline fields directly.
- SQLite migration `052_wave_single_repo.sql` collapses per-repo rows onto the wave row.
- Python: merge `RepoWork` into the `Wave` pydantic model; update fixtures and contract/model tests.
- Swift: inline the repo execution fields on `Wave` and update `WaveViewModel`, `LocalWaveService`, and Concerto state/tests.
- DTO fixtures and contract tests updated; `repo` is now the required field (previously `repos`).
