### PR TITLE
lf op submit: a human-gated finish between pr and land

### DIFF
--- a/rust/loopflow/src/engine/builtins/LOOPFLOW.md
+++ b/rust/loopflow/src/engine/builtins/LOOPFLOW.md
@@ -33,9 +33,11 @@ lands it:
   only if behind, writes title/body, leaves the PR up for review. Use it to make
   work visible mid-stream; nothing is finalized.
 - **`lf op submit`** — the work is done and a **human** lands it. Rebases onto
-  main, clears `scratch/`, marks the PR ready, and assigns it to the reviewer.
-  Stops there: no auto-merge. The reviewer's merge click is the one required
-  gate. Use this as the default finish for anything a person should approve.
+  main, clears `scratch/`, marks the PR ready, and assigns it to you. Stops
+  there: no auto-merge. Your merge click on GitHub is the one required gate —
+  the button unlocks once checks pass. (GitHub blocks approving your own PR, so
+  the gate is the merge click, not a review approval.) Use this as the default
+  finish for anything a person should land by hand.
 - **`lf op land`** — the work is done and **loopflow** lands it hands-off. Does
   everything `submit` does, then arms auto-merge and rotates the worktree onto
   the next wave item. Use it in headless/auto runs where no human is gating.

--- a/rust/loopflow/src/engine/builtins/LOOPFLOW.md
+++ b/rust/loopflow/src/engine/builtins/LOOPFLOW.md
@@ -12,7 +12,8 @@ Use `lf op` for mechanical git and GitHub operations.
 ```bash
 lf op commit -m "message" -p     # commit and push
 lf op pr --title "..."           # create/update PR
-lf op land                       # submit to merge queue
+lf op submit                     # prep + mark ready + assign to you; you click merge
+lf op land                       # hands-off: arm auto-merge + rotate worktree
 lf op rebase --plan              # show reset/rebase strategy
 lf op rebase                     # apply the planned update
 lf op next                       # preserve worktree, fresh branch
@@ -22,6 +23,22 @@ lf op wt create --stack parent child # stack child under parent
 lf op wt switch my-feature       # cd to existing worktree
 lf op wt prune                   # clean up merged worktrees
 ```
+
+### `pr` vs `submit` vs `land`
+
+Three commands, three commitment levels — pick by how done the work is and who
+lands it:
+
+- **`lf op pr`** — open or refresh the PR while work is still in flight. Rebases
+  only if behind, writes title/body, leaves the PR up for review. Use it to make
+  work visible mid-stream; nothing is finalized.
+- **`lf op submit`** — the work is done and a **human** lands it. Rebases onto
+  main, clears `scratch/`, marks the PR ready, and assigns it to the reviewer.
+  Stops there: no auto-merge. The reviewer's merge click is the one required
+  gate. Use this as the default finish for anything a person should approve.
+- **`lf op land`** — the work is done and **loopflow** lands it hands-off. Does
+  everything `submit` does, then arms auto-merge and rotates the worktree onto
+  the next wave item. Use it in headless/auto runs where no human is gating.
 
 The sibling naming convention (`<repo>.<name>`) is load-bearing. Worktrees
 created elsewhere will not be recognized and may be corrupted during land

--- a/rust/loopflow/src/engine/builtins/ops/step/submit.md
+++ b/rust/loopflow/src/engine/builtins/ops/step/submit.md
@@ -1,0 +1,87 @@
+---
+requires: code on branch
+produces: PR ready for review, assigned to a human to merge
+---
+Submit the current branch for a human to land. Rebase, clear scratch, create/update the PR, mark it ready, and assign it — then stop. Nothing merges until the reviewer clicks merge.
+
+Use `submit` (not `land`) whenever a person should approve the work. `land` is for headless/auto runs where loopflow merges hands-off; `submit` leaves the one required merge click to a human.
+
+## Orientation
+
+Before starting, orient yourself in this branch:
+
+- Read `scratch/` — design docs and notes for the current work live here
+  (`scratch/<branch>.md` is this PR's design; `scratch/questions.md` holds open
+  questions and assumptions).
+- If a `wave/<name>/` directory matches this work, skim its roadmap and items.
+- Read the repo's agent doc (`CLAUDE.md` / `AGENTS.md`) for conventions.
+
+Write design artifacts, notes, and open questions under `scratch/`. Don't
+re-derive what these already record.
+
+## API
+
+`lf op submit` handles the entire mechanical workflow: staging uncommitted changes, rebasing, creating or updating the PR, marking it ready, and assigning it for review. It does **not** arm auto-merge or rotate the worktree.
+
+```
+lf op submit [--create-pr] [-m "commit message"] [--title "..."] [--body "..."]
+```
+
+**Do not run git commit, git push, gh pr create, or gh pr ready directly.** `lf op submit` does all of this. Running those commands manually skips the assignment and leaves the PR in an inconsistent state.
+
+## Workflow
+
+### 1. Understand the branch
+
+```bash
+git log origin/main..HEAD --oneline
+git diff origin/main...HEAD --stat
+```
+
+Check `scratch/` for context. If `scratch/<branch>-review.md` exists (from gate), use it to understand the change and inform the PR body.
+
+Stage and include all changes — committed and uncommitted — in the PR. If the working tree is dirty, compose a commit message for the uncommitted changes (pass it as `-m` in step 3). Never ask which files to include; everything on the branch ships together.
+
+### 2. Prepare PR copy
+
+If `scratch/pr-title.txt`, `scratch/pr-body.md`, and `scratch/.pr-copy-ref` exist (from `lf gate`), `lf op submit` reuses them automatically.
+
+If those files are missing or stale, write title/body manually and pass `--title` + `--body`.
+
+**Title guidelines:** lowercase, concise, area prefix when focused.
+
+Examples:
+- `mobile: quote replies on iOS`
+- `cost: add analytics dashboard with timeseries API`
+- `fix worktree cleanup on branch delete`
+
+**Body:** markdown. Structure:
+
+1. **Usage** — code block showing how to try it or see it in action
+2. **Summary** — one paragraph on what changed and why
+3. **Changes** — optional bullet list for larger PRs
+
+### 3. Submit
+
+```bash
+lf op submit --create-pr
+```
+
+If you wrote title/body manually, include them:
+
+```bash
+lf op submit --create-pr --title "<title>" --body "<body>"
+```
+
+Include `-m "<message>"` if the working tree was dirty in step 1.
+
+If `lf op submit` fails due to rebase conflicts, launch a sub-agent to run the `rebase` step, then retry `lf op submit`.
+
+## Notes
+
+- The PR is left ready and assigned — the reviewer's merge click lands it. Don't enable auto-merge or merge on their behalf.
+- If the PR already has a good title and body, run `lf op submit` without `--title`/`--body` to keep existing content.
+
+## Adaptation
+
+If you discovered repo-specific submit conventions — reviewer assignment, branch protection rules, CI wait behavior — encode them. Most belong in repo docs where all steps benefit. Copy this step to `.lf/steps/submit.md` when the repo needs submit to work differently.

--- a/rust/loopflow/src/engine/builtins/ops/step/submit.md
+++ b/rust/loopflow/src/engine/builtins/ops/step/submit.md
@@ -1,10 +1,10 @@
 ---
 requires: code on branch
-produces: PR ready for review, assigned to a human to merge
+produces: PR ready, assigned to a human to merge
 ---
-Submit the current branch for a human to land. Rebase, clear scratch, create/update the PR, mark it ready, and assign it — then stop. Nothing merges until the reviewer clicks merge.
+Submit the current branch for a human to land. Rebase, clear scratch, create/update the PR, mark it ready, and assign it — then stop. Nothing merges until a human clicks merge.
 
-Use `submit` (not `land`) whenever a person should approve the work. `land` is for headless/auto runs where loopflow merges hands-off; `submit` leaves the one required merge click to a human.
+Use `submit` (not `land`) whenever a person should land the work by hand. `land` is for headless/auto runs where loopflow merges hands-off; `submit` leaves the one required merge click to a human. (GitHub blocks approving your own PR, so the gate is the merge click, not a review approval — the button unlocks once checks pass.)
 
 ## Orientation
 
@@ -21,7 +21,7 @@ re-derive what these already record.
 
 ## API
 
-`lf op submit` handles the entire mechanical workflow: staging uncommitted changes, rebasing, creating or updating the PR, marking it ready, and assigning it for review. It does **not** arm auto-merge or rotate the worktree.
+`lf op submit` handles the entire mechanical workflow: staging uncommitted changes, rebasing, creating or updating the PR, marking it ready, and assigning it to the human who will merge. It does **not** arm auto-merge or rotate the worktree.
 
 ```
 lf op submit [--create-pr] [-m "commit message"] [--title "..."] [--body "..."]
@@ -79,9 +79,9 @@ If `lf op submit` fails due to rebase conflicts, launch a sub-agent to run the `
 
 ## Notes
 
-- The PR is left ready and assigned — the reviewer's merge click lands it. Don't enable auto-merge or merge on their behalf.
+- The PR is left ready and assigned — the assignee's merge click lands it. Don't enable auto-merge or merge on their behalf.
 - If the PR already has a good title and body, run `lf op submit` without `--title`/`--body` to keep existing content.
 
 ## Adaptation
 
-If you discovered repo-specific submit conventions — reviewer assignment, branch protection rules, CI wait behavior — encode them. Most belong in repo docs where all steps benefit. Copy this step to `.lf/steps/submit.md` when the repo needs submit to work differently.
+If you discovered repo-specific submit conventions — assignee, branch protection rules, CI wait behavior — encode them. Most belong in repo docs where all steps benefit. Copy this step to `.lf/steps/submit.md` when the repo needs submit to work differently.

--- a/rust/loopflow/src/lf/commands/ops/mod.rs
+++ b/rust/loopflow/src/lf/commands/ops/mod.rs
@@ -263,7 +263,7 @@ fn submit_current(options: &LandOptions, progress: &impl Progress) -> Result<()>
     let repo_root = find_repo_root()?;
     match submit(&repo_root, options, progress) {
         Ok(_) => {
-            progress.status("Ready to land — approve the PR on GitHub to merge.");
+            progress.status("Ready to land — click merge on the PR once checks pass.");
             Ok(())
         }
         Err(OpsError::RebaseConflict { onto, detail }) => {
@@ -274,7 +274,7 @@ fn submit_current(options: &LandOptions, progress: &impl Progress) -> Result<()>
             launch_step_agent(&repo_root, "rebase", Some(&context))?;
             progress.status("Retrying submit after rebase...");
             submit(&repo_root, options, progress)?;
-            progress.status("Ready to land — approve the PR on GitHub to merge.");
+            progress.status("Ready to land — click merge on the PR once checks pass.");
             Ok(())
         }
         Err(err) => Err(err.into()),

--- a/rust/loopflow/src/lf/commands/ops/mod.rs
+++ b/rust/loopflow/src/lf/commands/ops/mod.rs
@@ -22,8 +22,9 @@ use crate::ops::{
     abandon_branch, commit_workflow, create_or_update_pr, land, list_branch_candidates,
     next_branch, plan_rebase, prune_branches, rebase_class_name, rebase_strategy_name,
     rebase_with_recovery, release_bump, release_check, release_notes, release_run, release_status,
-    release_tag, AbandonOptions, BranchFilterOptions, BranchListOptions, BranchPruneOptions,
-    CommitOptions, LandOptions, NextOptions, PrOptions, Progress, RebaseOptions, RotationResult,
+    release_tag, submit, AbandonOptions, BranchFilterOptions, BranchListOptions,
+    BranchPruneOptions, CommitOptions, LandOptions, NextOptions, PrOptions, Progress,
+    RebaseOptions, RotationResult,
 };
 use anyhow::{anyhow, Result};
 use std::io::{self, IsTerminal, Write};
@@ -50,6 +51,26 @@ pub fn run(op: &OpsCommand, cli_model: Option<&str>) -> Result<()> {
             &LandOptions {
                 strict: *strict,
                 local: *local,
+                create_pr: *create_pr,
+                worktree: worktree.clone(),
+                commit_message: message.clone(),
+                pr_title: title.clone(),
+                pr_body: body.clone(),
+                agent: cli_model.map(str::to_string),
+            },
+            &progress,
+        ),
+        OpsCommand::Submit {
+            strict,
+            create_pr,
+            worktree,
+            message,
+            title,
+            body,
+        } => submit_current(
+            &LandOptions {
+                strict: *strict,
+                local: false,
                 create_pr: *create_pr,
                 worktree: worktree.clone(),
                 commit_message: message.clone(),
@@ -236,6 +257,28 @@ fn land_current(options: &LandOptions, progress: &impl Progress) -> Result<()> {
     }
 
     Ok(())
+}
+
+fn submit_current(options: &LandOptions, progress: &impl Progress) -> Result<()> {
+    let repo_root = find_repo_root()?;
+    match submit(&repo_root, options, progress) {
+        Ok(_) => {
+            progress.status("Ready to land — approve the PR on GitHub to merge.");
+            Ok(())
+        }
+        Err(OpsError::RebaseConflict { onto, detail }) => {
+            let context = format!(
+                "<lf:rebase-conflict>\nRebase onto: {onto}\n{detail}\n</lf:rebase-conflict>"
+            );
+            progress.status("Launching rebase agent to resolve conflicts...");
+            launch_step_agent(&repo_root, "rebase", Some(&context))?;
+            progress.status("Retrying submit after rebase...");
+            submit(&repo_root, options, progress)?;
+            progress.status("Ready to land — approve the PR on GitHub to merge.");
+            Ok(())
+        }
+        Err(err) => Err(err.into()),
+    }
 }
 
 fn open_pr(

--- a/rust/loopflow/src/lf/mod.rs
+++ b/rust/loopflow/src/lf/mod.rs
@@ -274,12 +274,30 @@ pub enum OpsCommand {
         #[arg(long)]
         force: bool,
     },
-    /// Submit PR to merge queue
+    /// Land a PR hands-off: rebase, clear scratch, arm auto-merge, and rotate
+    /// the worktree. For a human-gated merge instead, use `lf op submit`.
     Land {
         #[arg(long)]
         strict: bool,
         #[arg(long)]
         local: bool,
+        #[arg(short = 'c', long = "create-pr")]
+        create_pr: bool,
+        #[arg(short = 'w', long = "worktree")]
+        worktree: Option<String>,
+        #[arg(short = 'm', long = "message")]
+        message: Option<String>,
+        #[arg(long = "title")]
+        title: Option<String>,
+        #[arg(long = "body")]
+        body: Option<String>,
+    },
+    /// Prepare a PR to land: rebase, clear scratch, mark ready, and assign it
+    /// to you. Nothing merges until you click merge on GitHub — the one
+    /// required gate. Does not arm auto-merge or rotate the worktree.
+    Submit {
+        #[arg(long)]
+        strict: bool,
         #[arg(short = 'c', long = "create-pr")]
         create_pr: bool,
         #[arg(short = 'w', long = "worktree")]

--- a/rust/loopflow/src/ops/flow.rs
+++ b/rust/loopflow/src/ops/flow.rs
@@ -10,7 +10,7 @@ use crate::ops::error::{OpsError, OpsResult};
 use crate::ops::progress::Progress;
 use crate::ops::{
     abandon_branch, commit_workflow, create_or_update_pr, land, next_branch, rebase_with_recovery,
-    release_bump, release_check, release_notes, release_run, release_status, release_tag,
+    release_bump, release_check, release_notes, release_run, release_status, release_tag, submit,
     AbandonOptions, CommitOptions, LandOptions, NextOptions, PrOptions, RebaseOptions,
 };
 
@@ -48,6 +48,30 @@ fn execute_parsed_ops(repo: &Path, op: &OpsCommand, progress: &impl Progress) ->
                 &LandOptions {
                     strict: *strict,
                     local: *local,
+                    create_pr: *create_pr,
+                    worktree: worktree.clone(),
+                    commit_message: message.clone(),
+                    pr_title: title.clone(),
+                    pr_body: body.clone(),
+                    agent: None,
+                },
+                progress,
+            )?;
+            Ok(())
+        }
+        OpsCommand::Submit {
+            strict,
+            create_pr,
+            worktree,
+            message,
+            title,
+            body,
+        } => {
+            submit(
+                repo,
+                &LandOptions {
+                    strict: *strict,
+                    local: false,
                     create_pr: *create_pr,
                     worktree: worktree.clone(),
                     commit_message: message.clone(),

--- a/rust/loopflow/src/ops/land.rs
+++ b/rust/loopflow/src/ops/land.rs
@@ -363,7 +363,7 @@ fn finalize_remote(
             enable_auto_merge(repo_root, pr_title, pr_body)?;
         }
         Finalize::AssignForReview => {
-            progress.status("Assigning PR for review...");
+            progress.status("Assigning PR for you to merge...");
             assign_to_me(repo_root)?;
         }
     }

--- a/rust/loopflow/src/ops/land.rs
+++ b/rust/loopflow/src/ops/land.rs
@@ -48,7 +48,37 @@ pub enum RotationResult {
     Complete { preserved: PathBuf },
 }
 
-pub fn land(repo: &Path, options: &LandOptions, progress: &impl Progress) -> OpsResult<LandResult> {
+/// How a prepared PR is handed off once it is rebased, scratch-cleared, and
+/// marked ready.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Finalize {
+    /// Arm GitHub auto-merge so the PR merges itself once checks pass. Used by
+    /// `land` — the walk-away path.
+    AutoMerge,
+    /// Assign the PR to the current user and leave it for a required, manual
+    /// merge click. Used by `submit` — nothing merges without that one click.
+    AssignForReview,
+}
+
+/// Result of preparing a PR up to (but not including) worktree rotation:
+/// committed, rebased onto main, scratch cleared, PR ready and either
+/// auto-merge armed or assigned for review (or merged locally when
+/// `options.local`).
+struct PreparedPr {
+    repo_root: PathBuf,
+    main_repo: PathBuf,
+    feature_branch: String,
+    pr: Option<PrInfo>,
+}
+
+/// Run every land step except worktree rotation. `land` follows this with a
+/// rotation; `submit` stops here and leaves the PR for a human to merge.
+fn prepare_pr(
+    repo: &Path,
+    options: &LandOptions,
+    finalize: Finalize,
+    progress: &impl Progress,
+) -> OpsResult<PreparedPr> {
     let (repo_root, main_repo) = resolve_repos(repo, options.worktree.as_deref())?;
     let feature_branch = current_branch(&repo_root)?
         .ok_or_else(|| OpsError::Message("not on a branch".to_string()))?;
@@ -85,17 +115,50 @@ pub fn land(repo: &Path, options: &LandOptions, progress: &impl Progress) -> Ops
             &repo_root,
             pr_title.as_deref(),
             pr_body.as_deref(),
+            finalize,
             progress,
         )?;
         // Capture PR info before worktree rotation may invalidate the path.
         crate::ops::pr::current_pr(&repo_root).ok().flatten()
     };
 
-    let rotation = rotate_worktree(&repo_root, &main_repo, &feature_branch, progress)?;
+    Ok(PreparedPr {
+        repo_root,
+        main_repo,
+        feature_branch,
+        pr,
+    })
+}
+
+pub fn land(repo: &Path, options: &LandOptions, progress: &impl Progress) -> OpsResult<LandResult> {
+    let prepared = prepare_pr(repo, options, Finalize::AutoMerge, progress)?;
+    let rotation = rotate_worktree(
+        &prepared.repo_root,
+        &prepared.main_repo,
+        &prepared.feature_branch,
+        progress,
+    )?;
     Ok(LandResult {
         merged: true,
         rotation,
-        pr,
+        pr: prepared.pr,
+    })
+}
+
+/// Prepare a PR to land without rotating the worktree or arming auto-merge:
+/// commit, rebase onto main, clear scratch, mark the PR ready, and assign it to
+/// the current user. Nothing merges until that user clicks merge on GitHub —
+/// that one click is the required gate.
+pub fn submit(
+    repo: &Path,
+    options: &LandOptions,
+    progress: &impl Progress,
+) -> OpsResult<LandResult> {
+    let prepared = prepare_pr(repo, options, Finalize::AssignForReview, progress)?;
+    Ok(LandResult {
+        merged: false,
+        rotation: None,
+        pr: prepared.pr,
     })
 }
 
@@ -284,23 +347,50 @@ fn finalize_remote(
     repo_root: &Path,
     pr_title: Option<&str>,
     pr_body: Option<&str>,
+    finalize: Finalize,
     progress: &impl Progress,
 ) -> OpsResult<()> {
     if let Some(title) = pr_title {
         let body = pr_body.unwrap_or("");
         progress.status("Updating PR...");
         update_pr_message(repo_root, title, body)?;
-    } else {
-        progress.status("Enabling auto-merge...");
     }
     mark_ready(repo_root)?;
-    enable_auto_merge(repo_root, pr_title, pr_body)?;
+
+    match finalize {
+        Finalize::AutoMerge => {
+            progress.status("Enabling auto-merge...");
+            enable_auto_merge(repo_root, pr_title, pr_body)?;
+        }
+        Finalize::AssignForReview => {
+            progress.status("Assigning PR for review...");
+            assign_to_me(repo_root)?;
+        }
+    }
 
     if let Some(url) = current_pr_url(repo_root)? {
         progress.status(&format!("\n{url}\n"));
         open_url(&url);
     }
 
+    Ok(())
+}
+
+/// Assign the open PR to the authenticated user so it lands in their review
+/// queue. Nothing merges until they click merge — the required gate.
+fn assign_to_me(repo: &Path) -> OpsResult<()> {
+    let mut cmd = Command::new("gh");
+    cmd.arg("pr")
+        .arg("edit")
+        .arg("--add-assignee")
+        .arg("@me")
+        .current_dir(repo);
+    if let Err(err) = run_command(&mut cmd) {
+        return Err(OpsError::CommandFailed {
+            command: err.command_line(),
+            stderr: err.stderr,
+        });
+    }
     Ok(())
 }
 

--- a/rust/loopflow/src/ops/mod.rs
+++ b/rust/loopflow/src/ops/mod.rs
@@ -24,7 +24,7 @@ pub use combine::{combine_prs, CombineOptions, CombineResult};
 pub use commit::{commit_workflow, commit_workflow_traced, CommitOptions};
 pub use error::{OpsError, OpsResult};
 pub use flow::execute_flow_ops;
-pub use land::{land, mark_ready, LandOptions, LandResult, RotationResult};
+pub use land::{land, mark_ready, submit, LandOptions, LandResult, RotationResult};
 pub use next::{advance_branch, next_branch, NextOptions, NextResult};
 pub use pr::{create_or_update_pr, current_pr, update_pr, PrInfo, PrOptions, PrResult};
 pub use progress::{NullProgress, Progress};

--- a/rust/loopflow/tests/land_tests.rs
+++ b/rust/loopflow/tests/land_tests.rs
@@ -4,7 +4,7 @@ use std::fs;
 use std::process::{Command, Stdio};
 
 use loopflow::engine::worktrees::create_with_schema;
-use loopflow::ops::{land, LandOptions, NullProgress, OpsError};
+use loopflow::ops::{land, submit, LandOptions, NullProgress, OpsError};
 use loopflow_test_support::TestRepo;
 use support::EnvGuard;
 
@@ -332,6 +332,91 @@ fn land_uses_cached_pr_copy_when_available() {
     let log = fs::read_to_string(log_path).expect("read gh log");
     assert!(log.contains("--title cached title"));
     assert!(log.contains("--body cached body"));
+}
+
+#[test]
+fn submit_assigns_reviewer_and_skips_auto_merge() {
+    let repo = TestRepo::new();
+    repo.create_branch("feature");
+    repo.create_file("feature.txt", "feature");
+    repo.stage_all();
+    repo.commit("feature work");
+    push_branch(&repo, "feature");
+
+    let log_path = repo.path().join("gh.log");
+    let script = gh_land_script(log_path.to_string_lossy().as_ref());
+    let _env = EnvGuard::new(&[("gh", script.as_str()), ("open", noop_open_script())]);
+
+    let result = submit(
+        repo.path(),
+        &LandOptions {
+            strict: true,
+            local: false,
+            create_pr: true,
+            worktree: None,
+            commit_message: None,
+            pr_title: Some("test title".to_string()),
+            pr_body: Some("test body".to_string()),
+            agent: None,
+        },
+        &NullProgress,
+    )
+    .expect("submit");
+
+    // submit prepares but never merges — that click is the human's.
+    assert!(!result.merged);
+    assert!(result.rotation.is_none());
+
+    let log = fs::read_to_string(log_path).expect("read gh log");
+    // Assigns the PR to the current user for a required, manual merge.
+    assert!(log.contains("pr edit --add-assignee @me"));
+    // Marks the PR ready, but does NOT arm auto-merge.
+    assert!(log.contains("pr ready"));
+    assert!(!log.contains("merge --auto"));
+}
+
+#[test]
+fn submit_does_not_rotate_worktree() {
+    let repo = TestRepo::new();
+    let log_path = repo.path().join("gh.log");
+    let script = gh_land_script(log_path.to_string_lossy().as_ref());
+    let _env = EnvGuard::new(&[("gh", script.as_str()), ("open", noop_open_script())]);
+
+    let worktree = create_with_schema(repo.path(), "sub", None, None).expect("create worktree");
+    fs::write(worktree.path.join("feature.txt"), "feature").expect("write feature file");
+    let status = Command::new("git")
+        .args(["add", "."])
+        .current_dir(&worktree.path)
+        .status()
+        .expect("git add");
+    assert!(status.success(), "git add should succeed");
+    let status = Command::new("git")
+        .args(["commit", "-m", "feature work"])
+        .current_dir(&worktree.path)
+        .status()
+        .expect("git commit");
+    assert!(status.success(), "git commit should succeed");
+    push_branch(&repo, &worktree.branch);
+
+    let result = submit(
+        &worktree.path,
+        &LandOptions {
+            strict: true,
+            local: false,
+            create_pr: true,
+            worktree: None,
+            commit_message: None,
+            pr_title: Some("test title".to_string()),
+            pr_body: Some("test body".to_string()),
+            agent: None,
+        },
+        &NullProgress,
+    )
+    .expect("submit from worktree");
+
+    // The worktree stays put — no preserve, no next-item rotation.
+    assert!(result.rotation.is_none());
+    assert!(worktree.path.exists());
 }
 
 #[test]

--- a/tests/goldens/basic.md
+++ b/tests/goldens/basic.md
@@ -13,7 +13,8 @@ Use `lf op` for mechanical git and GitHub operations.
 ```bash
 lf op commit -m "message" -p     # commit and push
 lf op pr --title "..."           # create/update PR
-lf op land                       # submit to merge queue
+lf op submit                     # prep + mark ready + assign to you; you click merge
+lf op land                       # hands-off: arm auto-merge + rotate worktree
 lf op rebase --plan              # show reset/rebase strategy
 lf op rebase                     # apply the planned update
 lf op next                       # preserve worktree, fresh branch
@@ -23,6 +24,24 @@ lf op wt create --stack parent child # stack child under parent
 lf op wt switch my-feature       # cd to existing worktree
 lf op wt prune                   # clean up merged worktrees
 ```
+
+### `pr` vs `submit` vs `land`
+
+Three commands, three commitment levels — pick by how done the work is and who
+lands it:
+
+- **`lf op pr`** — open or refresh the PR while work is still in flight. Rebases
+  only if behind, writes title/body, leaves the PR up for review. Use it to make
+  work visible mid-stream; nothing is finalized.
+- **`lf op submit`** — the work is done and a **human** lands it. Rebases onto
+  main, clears `scratch/`, marks the PR ready, and assigns it to you. Stops
+  there: no auto-merge. Your merge click on GitHub is the one required gate —
+  the button unlocks once checks pass. (GitHub blocks approving your own PR, so
+  the gate is the merge click, not a review approval.) Use this as the default
+  finish for anything a person should land by hand.
+- **`lf op land`** — the work is done and **loopflow** lands it hands-off. Does
+  everything `submit` does, then arms auto-merge and rotates the worktree onto
+  the next wave item. Use it in headless/auto runs where no human is gating.
 
 The sibling naming convention (`<repo>.<name>`) is load-bearing. Worktrees
 created elsewhere will not be recognized and may be corrupted during land

--- a/tests/goldens/builtin_code_review.md
+++ b/tests/goldens/builtin_code_review.md
@@ -13,7 +13,8 @@ Use `lf op` for mechanical git and GitHub operations.
 ```bash
 lf op commit -m "message" -p     # commit and push
 lf op pr --title "..."           # create/update PR
-lf op land                       # submit to merge queue
+lf op submit                     # prep + mark ready + assign to you; you click merge
+lf op land                       # hands-off: arm auto-merge + rotate worktree
 lf op rebase --plan              # show reset/rebase strategy
 lf op rebase                     # apply the planned update
 lf op next                       # preserve worktree, fresh branch
@@ -23,6 +24,24 @@ lf op wt create --stack parent child # stack child under parent
 lf op wt switch my-feature       # cd to existing worktree
 lf op wt prune                   # clean up merged worktrees
 ```
+
+### `pr` vs `submit` vs `land`
+
+Three commands, three commitment levels — pick by how done the work is and who
+lands it:
+
+- **`lf op pr`** — open or refresh the PR while work is still in flight. Rebases
+  only if behind, writes title/body, leaves the PR up for review. Use it to make
+  work visible mid-stream; nothing is finalized.
+- **`lf op submit`** — the work is done and a **human** lands it. Rebases onto
+  main, clears `scratch/`, marks the PR ready, and assigns it to you. Stops
+  there: no auto-merge. Your merge click on GitHub is the one required gate —
+  the button unlocks once checks pass. (GitHub blocks approving your own PR, so
+  the gate is the merge click, not a review approval.) Use this as the default
+  finish for anything a person should land by hand.
+- **`lf op land`** — the work is done and **loopflow** lands it hands-off. Does
+  everything `submit` does, then arms auto-merge and rotates the worktree onto
+  the next wave item. Use it in headless/auto runs where no human is gating.
 
 The sibling naming convention (`<repo>.<name>`) is load-bearing. Worktrees
 created elsewhere will not be recognized and may be corrupted during land

--- a/tests/goldens/builtin_debug.md
+++ b/tests/goldens/builtin_debug.md
@@ -13,7 +13,8 @@ Use `lf op` for mechanical git and GitHub operations.
 ```bash
 lf op commit -m "message" -p     # commit and push
 lf op pr --title "..."           # create/update PR
-lf op land                       # submit to merge queue
+lf op submit                     # prep + mark ready + assign to you; you click merge
+lf op land                       # hands-off: arm auto-merge + rotate worktree
 lf op rebase --plan              # show reset/rebase strategy
 lf op rebase                     # apply the planned update
 lf op next                       # preserve worktree, fresh branch
@@ -23,6 +24,24 @@ lf op wt create --stack parent child # stack child under parent
 lf op wt switch my-feature       # cd to existing worktree
 lf op wt prune                   # clean up merged worktrees
 ```
+
+### `pr` vs `submit` vs `land`
+
+Three commands, three commitment levels — pick by how done the work is and who
+lands it:
+
+- **`lf op pr`** — open or refresh the PR while work is still in flight. Rebases
+  only if behind, writes title/body, leaves the PR up for review. Use it to make
+  work visible mid-stream; nothing is finalized.
+- **`lf op submit`** — the work is done and a **human** lands it. Rebases onto
+  main, clears `scratch/`, marks the PR ready, and assigns it to you. Stops
+  there: no auto-merge. Your merge click on GitHub is the one required gate —
+  the button unlocks once checks pass. (GitHub blocks approving your own PR, so
+  the gate is the merge click, not a review approval.) Use this as the default
+  finish for anything a person should land by hand.
+- **`lf op land`** — the work is done and **loopflow** lands it hands-off. Does
+  everything `submit` does, then arms auto-merge and rotates the worktree onto
+  the next wave item. Use it in headless/auto runs where no human is gating.
 
 The sibling naming convention (`<repo>.<name>`) is load-bearing. Worktrees
 created elsewhere will not be recognized and may be corrupted during land

--- a/tests/goldens/builtin_demo.md
+++ b/tests/goldens/builtin_demo.md
@@ -13,7 +13,8 @@ Use `lf op` for mechanical git and GitHub operations.
 ```bash
 lf op commit -m "message" -p     # commit and push
 lf op pr --title "..."           # create/update PR
-lf op land                       # submit to merge queue
+lf op submit                     # prep + mark ready + assign to you; you click merge
+lf op land                       # hands-off: arm auto-merge + rotate worktree
 lf op rebase --plan              # show reset/rebase strategy
 lf op rebase                     # apply the planned update
 lf op next                       # preserve worktree, fresh branch
@@ -23,6 +24,24 @@ lf op wt create --stack parent child # stack child under parent
 lf op wt switch my-feature       # cd to existing worktree
 lf op wt prune                   # clean up merged worktrees
 ```
+
+### `pr` vs `submit` vs `land`
+
+Three commands, three commitment levels — pick by how done the work is and who
+lands it:
+
+- **`lf op pr`** — open or refresh the PR while work is still in flight. Rebases
+  only if behind, writes title/body, leaves the PR up for review. Use it to make
+  work visible mid-stream; nothing is finalized.
+- **`lf op submit`** — the work is done and a **human** lands it. Rebases onto
+  main, clears `scratch/`, marks the PR ready, and assigns it to you. Stops
+  there: no auto-merge. Your merge click on GitHub is the one required gate —
+  the button unlocks once checks pass. (GitHub blocks approving your own PR, so
+  the gate is the merge click, not a review approval.) Use this as the default
+  finish for anything a person should land by hand.
+- **`lf op land`** — the work is done and **loopflow** lands it hands-off. Does
+  everything `submit` does, then arms auto-merge and rotates the worktree onto
+  the next wave item. Use it in headless/auto runs where no human is gating.
 
 The sibling naming convention (`<repo>.<name>`) is load-bearing. Worktrees
 created elsewhere will not be recognized and may be corrupted during land

--- a/tests/goldens/builtin_implement.md
+++ b/tests/goldens/builtin_implement.md
@@ -13,7 +13,8 @@ Use `lf op` for mechanical git and GitHub operations.
 ```bash
 lf op commit -m "message" -p     # commit and push
 lf op pr --title "..."           # create/update PR
-lf op land                       # submit to merge queue
+lf op submit                     # prep + mark ready + assign to you; you click merge
+lf op land                       # hands-off: arm auto-merge + rotate worktree
 lf op rebase --plan              # show reset/rebase strategy
 lf op rebase                     # apply the planned update
 lf op next                       # preserve worktree, fresh branch
@@ -23,6 +24,24 @@ lf op wt create --stack parent child # stack child under parent
 lf op wt switch my-feature       # cd to existing worktree
 lf op wt prune                   # clean up merged worktrees
 ```
+
+### `pr` vs `submit` vs `land`
+
+Three commands, three commitment levels — pick by how done the work is and who
+lands it:
+
+- **`lf op pr`** — open or refresh the PR while work is still in flight. Rebases
+  only if behind, writes title/body, leaves the PR up for review. Use it to make
+  work visible mid-stream; nothing is finalized.
+- **`lf op submit`** — the work is done and a **human** lands it. Rebases onto
+  main, clears `scratch/`, marks the PR ready, and assigns it to you. Stops
+  there: no auto-merge. Your merge click on GitHub is the one required gate —
+  the button unlocks once checks pass. (GitHub blocks approving your own PR, so
+  the gate is the merge click, not a review approval.) Use this as the default
+  finish for anything a person should land by hand.
+- **`lf op land`** — the work is done and **loopflow** lands it hands-off. Does
+  everything `submit` does, then arms auto-merge and rotates the worktree onto
+  the next wave item. Use it in headless/auto runs where no human is gating.
 
 The sibling naming convention (`<repo>.<name>`) is load-bearing. Worktrees
 created elsewhere will not be recognized and may be corrupted during land

--- a/tests/goldens/with_direction.md
+++ b/tests/goldens/with_direction.md
@@ -13,7 +13,8 @@ Use `lf op` for mechanical git and GitHub operations.
 ```bash
 lf op commit -m "message" -p     # commit and push
 lf op pr --title "..."           # create/update PR
-lf op land                       # submit to merge queue
+lf op submit                     # prep + mark ready + assign to you; you click merge
+lf op land                       # hands-off: arm auto-merge + rotate worktree
 lf op rebase --plan              # show reset/rebase strategy
 lf op rebase                     # apply the planned update
 lf op next                       # preserve worktree, fresh branch
@@ -23,6 +24,24 @@ lf op wt create --stack parent child # stack child under parent
 lf op wt switch my-feature       # cd to existing worktree
 lf op wt prune                   # clean up merged worktrees
 ```
+
+### `pr` vs `submit` vs `land`
+
+Three commands, three commitment levels — pick by how done the work is and who
+lands it:
+
+- **`lf op pr`** — open or refresh the PR while work is still in flight. Rebases
+  only if behind, writes title/body, leaves the PR up for review. Use it to make
+  work visible mid-stream; nothing is finalized.
+- **`lf op submit`** — the work is done and a **human** lands it. Rebases onto
+  main, clears `scratch/`, marks the PR ready, and assigns it to you. Stops
+  there: no auto-merge. Your merge click on GitHub is the one required gate —
+  the button unlocks once checks pass. (GitHub blocks approving your own PR, so
+  the gate is the merge click, not a review approval.) Use this as the default
+  finish for anything a person should land by hand.
+- **`lf op land`** — the work is done and **loopflow** lands it hands-off. Does
+  everything `submit` does, then arms auto-merge and rotates the worktree onto
+  the next wave item. Use it in headless/auto runs where no human is gating.
 
 The sibling naming convention (`<repo>.<name>`) is load-bearing. Worktrees
 created elsewhere will not be recognized and may be corrupted during land

--- a/tests/goldens/with_direction_group.md
+++ b/tests/goldens/with_direction_group.md
@@ -13,7 +13,8 @@ Use `lf op` for mechanical git and GitHub operations.
 ```bash
 lf op commit -m "message" -p     # commit and push
 lf op pr --title "..."           # create/update PR
-lf op land                       # submit to merge queue
+lf op submit                     # prep + mark ready + assign to you; you click merge
+lf op land                       # hands-off: arm auto-merge + rotate worktree
 lf op rebase --plan              # show reset/rebase strategy
 lf op rebase                     # apply the planned update
 lf op next                       # preserve worktree, fresh branch
@@ -23,6 +24,24 @@ lf op wt create --stack parent child # stack child under parent
 lf op wt switch my-feature       # cd to existing worktree
 lf op wt prune                   # clean up merged worktrees
 ```
+
+### `pr` vs `submit` vs `land`
+
+Three commands, three commitment levels — pick by how done the work is and who
+lands it:
+
+- **`lf op pr`** — open or refresh the PR while work is still in flight. Rebases
+  only if behind, writes title/body, leaves the PR up for review. Use it to make
+  work visible mid-stream; nothing is finalized.
+- **`lf op submit`** — the work is done and a **human** lands it. Rebases onto
+  main, clears `scratch/`, marks the PR ready, and assigns it to you. Stops
+  there: no auto-merge. Your merge click on GitHub is the one required gate —
+  the button unlocks once checks pass. (GitHub blocks approving your own PR, so
+  the gate is the merge click, not a review approval.) Use this as the default
+  finish for anything a person should land by hand.
+- **`lf op land`** — the work is done and **loopflow** lands it hands-off. Does
+  everything `submit` does, then arms auto-merge and rotates the worktree onto
+  the next wave item. Use it in headless/auto runs where no human is gating.
 
 The sibling naming convention (`<repo>.<name>`) is load-bearing. Worktrees
 created elsewhere will not be recognized and may be corrupted during land

--- a/tests/goldens/with_docs.md
+++ b/tests/goldens/with_docs.md
@@ -13,7 +13,8 @@ Use `lf op` for mechanical git and GitHub operations.
 ```bash
 lf op commit -m "message" -p     # commit and push
 lf op pr --title "..."           # create/update PR
-lf op land                       # submit to merge queue
+lf op submit                     # prep + mark ready + assign to you; you click merge
+lf op land                       # hands-off: arm auto-merge + rotate worktree
 lf op rebase --plan              # show reset/rebase strategy
 lf op rebase                     # apply the planned update
 lf op next                       # preserve worktree, fresh branch
@@ -23,6 +24,24 @@ lf op wt create --stack parent child # stack child under parent
 lf op wt switch my-feature       # cd to existing worktree
 lf op wt prune                   # clean up merged worktrees
 ```
+
+### `pr` vs `submit` vs `land`
+
+Three commands, three commitment levels — pick by how done the work is and who
+lands it:
+
+- **`lf op pr`** — open or refresh the PR while work is still in flight. Rebases
+  only if behind, writes title/body, leaves the PR up for review. Use it to make
+  work visible mid-stream; nothing is finalized.
+- **`lf op submit`** — the work is done and a **human** lands it. Rebases onto
+  main, clears `scratch/`, marks the PR ready, and assigns it to you. Stops
+  there: no auto-merge. Your merge click on GitHub is the one required gate —
+  the button unlocks once checks pass. (GitHub blocks approving your own PR, so
+  the gate is the merge click, not a review approval.) Use this as the default
+  finish for anything a person should land by hand.
+- **`lf op land`** — the work is done and **loopflow** lands it hands-off. Does
+  everything `submit` does, then arms auto-merge and rotates the worktree onto
+  the next wave item. Use it in headless/auto runs where no human is gating.
 
 The sibling naming convention (`<repo>.<name>`) is load-bearing. Worktrees
 created elsewhere will not be recognized and may be corrupted during land


### PR DESCRIPTION
## Usage

```bash
lf op submit    # prep to land, mark ready, assign to you — you click merge
lf op land      # hands-off: same prep, then arm auto-merge + rotate worktree
```

## Summary

Adds `lf op submit`, a middle gear between `lf op pr` and `lf op land`. It rebases onto main, clears `scratch/`, marks the PR ready, and assigns it to you — then stops. Nothing merges until you click merge on GitHub; that one click is the required gate. No auto-merge, no worktree rotation.

`land` and `submit` share a single `prepare_pr()` and diverge only at the finalize step — `land` arms auto-merge and rotates the worktree, `submit` assigns the PR for review. `land`'s behavior is unchanged.

## Changes

- `lf op submit` command + `submit()` op, sharing `prepare_pr()` with `land()`
- `submit.md` step builtin (agents can be dispatched to submit)
- `pr` vs `submit` vs `land` guide in LOOPFLOW.md
- Tests: submit assigns the reviewer, skips auto-merge, and doesn't rotate