### PR TITLE
lf ssh: forward local credentials to a remote host (ssh_with_credits)

### DIFF
--- a/rust/loopflow/src/bin/lf.rs
+++ b/rust/loopflow/src/bin/lf.rs
@@ -531,6 +531,15 @@ fn main() -> anyhow::Result<()> {
             Some(Commands::Memory { cmd, target }) => {
                 loopflow::lf::commands::memory::run(cmd.as_ref(), target)
             }
+            Some(Commands::Ssh {
+                host,
+                repo,
+                secret,
+                forward_agent,
+                cmd,
+            }) => {
+                loopflow::lf::commands::ssh::run(host, repo.as_deref(), secret, *forward_agent, cmd)
+            }
             Some(Commands::External(external_args)) => {
                 match loopflow::lf::commands::run::split_step_args(external_args) {
                     Ok((name, step_args)) => {
@@ -577,7 +586,8 @@ fn run_label(cli: &Cli) -> Option<String> {
         | Some(Commands::Trace { .. })
         | Some(Commands::Chat { .. })
         | Some(Commands::Sub { .. })
-        | Some(Commands::Memory { .. }) => None,
+        | Some(Commands::Memory { .. })
+        | Some(Commands::Ssh { .. }) => None,
     }
 }
 

--- a/rust/loopflow/src/lf/commands/mod.rs
+++ b/rust/loopflow/src/lf/commands/mod.rs
@@ -6,6 +6,7 @@ pub mod memory;
 pub mod ops;
 pub mod run;
 pub mod runs;
+pub mod ssh;
 pub mod sub;
 pub mod usage;
 pub mod util;

--- a/rust/loopflow/src/lf/commands/ssh.rs
+++ b/rust/loopflow/src/lf/commands/ssh.rs
@@ -1,0 +1,370 @@
+//! `lf ssh <host> -- <cmd...>` — run a command on a remote home carrying the
+//! caller's *local* credentials, resolved per invocation.
+//!
+//! The "bring your auth with you" model: credentials are resolved on this
+//! machine, forwarded into the remote process environment as a stdin preamble
+//! (never in argv, `ps`, or logs), and are NOT persisted on the remote — they
+//! die with the process. The remote host stays a stateless compute surface.
+//!
+//! Forwarded bundle: GitHub (`gh`), Claude/agent OAuth, and — the capability
+//! beyond the shell prototype — the PM/Linear token, which lives in lfdb rather
+//! than the environment. The remote `resolve_pm_token` reads
+//! `LF_FORWARDED_PM_TOKEN` before its (empty) store, so remote `lf op pm` works.
+//!
+//! Secrets policy: `lf ssh` forwards specific resolved secrets, never the
+//! Doppler token that could fetch them all. The Doppler login/CLI token is a
+//! master key to the whole secret estate and never leaves this machine. When a
+//! remote command needs a Doppler-backed secret, name it with `--secret NAME`:
+//! the value is resolved *locally* via Doppler and only that value is forwarded.
+//! Agent forwarding (`ssh -A`) is off by default — git pushes ride the
+//! forwarded `GH_TOKEN` over HTTPS, so the caller's SSH identity stays home.
+
+use std::io::Write;
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+
+use anyhow::{anyhow, Context};
+
+use crate::lfd::pm::PmProviderKind;
+use crate::provider_auth::extract_claude_token;
+
+/// Default repository path (relative to `$HOME`) the remote command runs in.
+pub const DEFAULT_REPO: &str = "src/loopflow";
+
+/// The local credential bundle forwarded to the remote. Absent credentials are
+/// simply not exported — the remote falls back to whatever it can resolve.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct Credentials {
+    pub gh_token: Option<String>,
+    pub claude_token: Option<String>,
+    pub pm_token: Option<String>,
+    /// PM provider the token belongs to (e.g. `linear`).
+    pub pm_provider: Option<String>,
+    /// Doppler-backed secrets resolved locally, forwarded as `export NAME=value`.
+    pub secrets: Vec<(String, String)>,
+}
+
+/// Run `cmd` on `host` in `$HOME/<repo>` with the local credential bundle
+/// forwarded. Propagates the remote exit code.
+///
+/// `secret_names` are resolved locally via Doppler and forwarded as env vars —
+/// the sanctioned way a remote command receives a Doppler-backed secret without
+/// the remote ever holding a Doppler credential.
+///
+/// `forward_agent` opts into `ssh -A`. It is off by default: git pushes ride
+/// the forwarded `GH_TOKEN` over HTTPS, so agent forwarding is dead weight that
+/// would hand the caller's whole SSH identity to the remote.
+pub fn run(
+    host: &str,
+    repo: Option<&str>,
+    secret_names: &[String],
+    forward_agent: bool,
+    cmd: &[String],
+) -> anyhow::Result<()> {
+    if cmd.is_empty() {
+        return Err(anyhow!(
+            "lf ssh needs a command after `--`, e.g. `lf ssh {host} -- lf op pr`"
+        ));
+    }
+    let repo = repo.unwrap_or(DEFAULT_REPO);
+    let runtime = tokio::runtime::Runtime::new().context("failed to create async runtime")?;
+    let credentials = runtime.block_on(resolve_credentials(secret_names))?;
+    let preamble = build_preamble(&credentials, host, repo, cmd);
+    run_ssh(host, forward_agent, &preamble)
+}
+
+/// Resolve the credential bundle from local sources. Auth tokens that aren't
+/// present resolve to `None`; a `--secret` that can't be resolved is a hard
+/// error (the caller explicitly asked for it). Nothing here prints a value.
+async fn resolve_credentials(secret_names: &[String]) -> anyhow::Result<Credentials> {
+    let home = dirs::home_dir().unwrap_or_else(|| PathBuf::from("."));
+    let mut secrets = Vec::with_capacity(secret_names.len());
+    for name in secret_names {
+        secrets.push((name.clone(), resolve_doppler_secret(name)?));
+    }
+    Ok(Credentials {
+        gh_token: resolve_gh_token(),
+        claude_token: extract_claude_token(&home).map(|token| token.access_token),
+        pm_token: resolve_pm_token().await,
+        pm_provider: Some(PmProviderKind::Linear.as_str().to_string()),
+        secrets,
+    })
+}
+
+/// GitHub token via the `gh` CLI (honors `GH_TOKEN`, refreshes when needed).
+fn resolve_gh_token() -> Option<String> {
+    let output = Command::new("gh").args(["auth", "token"]).output().ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let token = String::from_utf8(output.stdout).ok()?.trim().to_string();
+    (!token.is_empty()).then_some(token)
+}
+
+/// Resolve one secret from Doppler on the local machine. The Doppler token never
+/// leaves this process; only the resolved value is forwarded.
+fn resolve_doppler_secret(name: &str) -> anyhow::Result<String> {
+    if !is_valid_env_name(name) {
+        return Err(anyhow!(
+            "invalid --secret name '{name}': expected an environment variable identifier"
+        ));
+    }
+    let output = Command::new("doppler")
+        .args(["secrets", "get", name, "--plain"])
+        .output()
+        .with_context(|| format!("failed to run doppler for secret '{name}'"))?;
+    if !output.status.success() {
+        return Err(anyhow!(
+            "doppler could not resolve secret '{name}' (is it set in the active config?)"
+        ));
+    }
+    // Strip only the trailing newline doppler appends; keep the value otherwise.
+    let value = String::from_utf8(output.stdout)
+        .with_context(|| format!("doppler returned non-UTF8 value for '{name}'"))?
+        .trim_end_matches(['\n', '\r'])
+        .to_string();
+    if value.is_empty() {
+        return Err(anyhow!(
+            "doppler returned an empty value for secret '{name}'"
+        ));
+    }
+    Ok(value)
+}
+
+/// PM/Linear access token from the local lfdb credential store. Absent when no
+/// store exists or no Linear credential is stored.
+async fn resolve_pm_token() -> Option<String> {
+    let cfg = crate::lfd::storage_config_from_env().ok()?;
+    let store = crate::lfdb::open_store(&cfg).await.ok()?;
+    let token = store
+        .get_provider_token(PmProviderKind::Linear.as_str())
+        .await
+        .ok()??;
+    Some(token.access_token)
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+}
+
+/// A valid POSIX environment variable name: `[A-Za-z_][A-Za-z0-9_]*`.
+fn is_valid_env_name(name: &str) -> bool {
+    let mut chars = name.chars();
+    match chars.next() {
+        Some(first) if first.is_ascii_alphabetic() || first == '_' => {}
+        _ => return false,
+    }
+    chars.all(|ch| ch.is_ascii_alphanumeric() || ch == '_')
+}
+
+/// Assemble the bash preamble piped to the remote over stdin. Every secret value
+/// is single-quote escaped so it can never break out of the assignment; the
+/// values travel only through this channel, never through argv.
+fn build_preamble(credentials: &Credentials, host: &str, repo: &str, cmd: &[String]) -> String {
+    let mut lines: Vec<String> = Vec::new();
+
+    // Give the remote a sane PATH so `lf`, `gh` resolve under a
+    // non-interactive `bash -s`.
+    lines.push(
+        "export PATH=\"$HOME/.cargo/bin:$HOME/.local/bin:/opt/homebrew/bin:/usr/local/bin:$PATH\""
+            .to_string(),
+    );
+
+    if let Some(token) = nonempty(&credentials.gh_token) {
+        lines.push(format!("export GH_TOKEN={}", sh_quote(token)));
+        // Route HTTPS git pushes through the forwarded token via env-only config
+        // (nothing written to the remote ~/.gitconfig). Two entries:
+        //  - reset `credential.helper` to empty first, so any ambient global
+        //    helper on the remote (store/cache/osxkeychain) can't fire and
+        //    persist the token to disk — preserving "nothing persisted".
+        //  - then install our in-memory helper. The `$GH_TOKEN` inside it is
+        //    evaluated on the remote when git invokes it; the single quotes keep
+        //    it literal here, exactly as intended.
+        lines.push("export GIT_CONFIG_COUNT=2".to_string());
+        lines.push(format!(
+            "export GIT_CONFIG_KEY_0={}",
+            sh_quote("credential.helper")
+        ));
+        lines.push("export GIT_CONFIG_VALUE_0=''".to_string());
+        lines.push(format!(
+            "export GIT_CONFIG_KEY_1={}",
+            sh_quote("credential.https://github.com.helper")
+        ));
+        lines.push(format!(
+            "export GIT_CONFIG_VALUE_1={}",
+            sh_quote("!f(){ echo username=x-access-token; echo \"password=$GH_TOKEN\"; };f")
+        ));
+    }
+    if let Some(token) = nonempty(&credentials.claude_token) {
+        lines.push(format!(
+            "export CLAUDE_CODE_OAUTH_TOKEN={}",
+            sh_quote(token)
+        ));
+    }
+    if let Some(token) = nonempty(&credentials.pm_token) {
+        lines.push(format!("export LF_FORWARDED_PM_TOKEN={}", sh_quote(token)));
+        if let Some(provider) = nonempty(&credentials.pm_provider) {
+            lines.push(format!(
+                "export LF_FORWARDED_PM_PROVIDER={}",
+                sh_quote(provider)
+            ));
+        }
+    }
+    // Doppler-backed secrets resolved locally: only the value crosses the wire.
+    for (name, value) in &credentials.secrets {
+        lines.push(format!("export {name}={}", sh_quote(value)));
+    }
+
+    // cd into the repo; `$HOME` expands on the remote, the path stays quoted.
+    lines.push(format!(
+        "cd \"$HOME\"/{} || {{ echo {} >&2; exit 1; }}",
+        sh_quote(repo),
+        sh_quote(&format!("no repo ~/{repo} on {host}"))
+    ));
+
+    let remote_cmd = cmd
+        .iter()
+        .map(|arg| sh_quote(arg))
+        .collect::<Vec<_>>()
+        .join(" ");
+    lines.push(format!("exec {remote_cmd}"));
+
+    let mut preamble = lines.join("\n");
+    preamble.push('\n');
+    preamble
+}
+
+fn nonempty(value: &Option<String>) -> Option<&str> {
+    value.as_deref().filter(|value| !value.trim().is_empty())
+}
+
+/// POSIX single-quote escaping: wrap in `'…'`, and render any embedded single
+/// quote as `'\''`. Safe for arbitrary bytes including secrets.
+fn sh_quote(value: &str) -> String {
+    let mut quoted = String::with_capacity(value.len() + 2);
+    quoted.push('\'');
+    for ch in value.chars() {
+        if ch == '\'' {
+            quoted.push_str("'\\''");
+        } else {
+            quoted.push(ch);
+        }
+    }
+    quoted.push('\'');
+    quoted
+}
+
+/// Pipe the preamble into `ssh [-A] <host> bash -s`, streaming stdout/stderr and
+/// propagating the remote exit code. Agent forwarding (`-A`) is opt-in.
+fn run_ssh(host: &str, forward_agent: bool, preamble: &str) -> anyhow::Result<()> {
+    let mut command = Command::new("ssh");
+    if forward_agent {
+        command.arg("-A");
+    }
+    let mut child = command
+        .args([host, "bash -s"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit())
+        .spawn()
+        .context("failed to spawn ssh")?;
+
+    child
+        .stdin
+        .take()
+        .ok_or_else(|| anyhow!("ssh stdin unavailable"))?
+        .write_all(preamble.as_bytes())
+        .context("failed to write preamble to ssh")?;
+
+    let status = child.wait().context("ssh did not complete")?;
+    if status.success() {
+        Ok(())
+    } else {
+        std::process::exit(status.code().unwrap_or(1));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn full_bundle() -> Credentials {
+        Credentials {
+            gh_token: Some("gh-secret".to_string()),
+            claude_token: Some("claude-secret".to_string()),
+            pm_token: Some("linear-secret".to_string()),
+            pm_provider: Some("linear".to_string()),
+            secrets: vec![("STRIPE_KEY".to_string(), "sk-live-123".to_string())],
+        }
+    }
+
+    #[test]
+    fn preamble_exports_every_credential_and_execs_command() {
+        let cmd = vec!["lf".to_string(), "op".to_string(), "pr".to_string()];
+        let preamble = build_preamble(&full_bundle(), "mini-heart", "src/loopflow", &cmd);
+
+        assert!(preamble.contains("export GH_TOKEN='gh-secret'"));
+        assert!(preamble.contains("export CLAUDE_CODE_OAUTH_TOKEN='claude-secret'"));
+        assert!(preamble.contains("export LF_FORWARDED_PM_TOKEN='linear-secret'"));
+        assert!(preamble.contains("export LF_FORWARDED_PM_PROVIDER='linear'"));
+        // Locally-resolved Doppler secret, forwarded by value; no Doppler token.
+        assert!(preamble.contains("export STRIPE_KEY='sk-live-123'"));
+        assert!(!preamble.contains("DOPPLER_TOKEN"));
+        // git HTTPS credential helper wired to the forwarded token, with the
+        // ambient helper list reset first so nothing persists to remote disk.
+        assert!(preamble.contains("export GIT_CONFIG_COUNT=2"));
+        assert!(preamble.contains("export GIT_CONFIG_KEY_0='credential.helper'"));
+        assert!(preamble.contains("export GIT_CONFIG_VALUE_0=''"));
+        assert!(preamble.contains("export GIT_CONFIG_KEY_1='credential.https://github.com.helper'"));
+        assert!(preamble.contains("password=$GH_TOKEN"));
+        // cd into the repo and exec the command
+        assert!(preamble.contains("cd \"$HOME\"/'src/loopflow'"));
+        assert!(preamble.trim_end().ends_with("exec 'lf' 'op' 'pr'"));
+    }
+
+    #[test]
+    fn preamble_omits_absent_credentials() {
+        let creds = Credentials {
+            claude_token: Some("only-claude".to_string()),
+            ..Credentials::default()
+        };
+        let cmd = vec!["lf".to_string(), "runs".to_string()];
+        let preamble = build_preamble(&creds, "host", "src/loopflow", &cmd);
+
+        assert!(preamble.contains("export CLAUDE_CODE_OAUTH_TOKEN='only-claude'"));
+        assert!(!preamble.contains("GH_TOKEN"));
+        assert!(!preamble.contains("LF_FORWARDED_PM_TOKEN"));
+        assert!(!preamble.contains("GIT_CONFIG_COUNT"));
+        assert!(!preamble.contains("credential.helper"));
+    }
+
+    #[test]
+    fn preamble_never_leaks_a_secret_to_argv_form() {
+        // A secret containing shell metacharacters stays inside single quotes,
+        // so it can neither break the assignment nor reach a command position.
+        let creds = Credentials {
+            gh_token: Some("a'b; rm -rf ~ #".to_string()),
+            ..Credentials::default()
+        };
+        let cmd = vec!["lf".to_string()];
+        let preamble = build_preamble(&creds, "host", "src/loopflow", &cmd);
+
+        assert!(preamble.contains(r#"export GH_TOKEN='a'\''b; rm -rf ~ #'"#));
+        // The dangerous substring never appears unquoted at a statement start.
+        assert!(!preamble.contains("\nrm -rf"));
+    }
+
+    #[test]
+    fn sh_quote_escapes_embedded_single_quotes() {
+        assert_eq!(sh_quote("plain"), "'plain'");
+        assert_eq!(sh_quote("a'b"), r#"'a'\''b'"#);
+    }
+
+    #[test]
+    fn env_name_validation_rejects_injection() {
+        assert!(is_valid_env_name("STRIPE_KEY"));
+        assert!(is_valid_env_name("_x1"));
+        assert!(!is_valid_env_name("1BAD"));
+        assert!(!is_valid_env_name("A B"));
+        assert!(!is_valid_env_name("A=B; rm -rf ~"));
+        assert!(!is_valid_env_name(""));
+    }
+}

--- a/rust/loopflow/src/lf/mod.rs
+++ b/rust/loopflow/src/lf/mod.rs
@@ -204,6 +204,30 @@ pub enum Commands {
         #[command(flatten)]
         target: WaveTargetArgs,
     },
+    /// Run a command on a remote host carrying your local credentials.
+    ///
+    /// Resolves the local credential bundle (GitHub, Claude, PM) and forwards it
+    /// over the ssh channel per-invocation; nothing persists on the remote. The
+    /// Doppler token is never forwarded — name specific secrets with `--secret`
+    /// to resolve them locally. Example: `lf ssh mini-heart -- lf op pr`.
+    Ssh {
+        /// Remote host (ssh alias or user@host)
+        host: String,
+        /// Repository path on the remote, relative to $HOME
+        #[arg(long = "repo")]
+        repo: Option<String>,
+        /// Doppler secret to resolve locally and forward as an env var
+        /// (repeatable). The Doppler token itself is never forwarded.
+        #[arg(long = "secret")]
+        secret: Vec<String>,
+        /// Forward the ssh-agent (`ssh -A`). Off by default: git pushes use the
+        /// forwarded GH_TOKEN over HTTPS, so agent forwarding is unneeded risk.
+        #[arg(long = "forward-agent")]
+        forward_agent: bool,
+        /// Command to run on the remote (after `--`)
+        #[arg(last = true)]
+        cmd: Vec<String>,
+    },
     /// External: step/flow name (when no subcommand matches)
     #[command(external_subcommand)]
     External(Vec<String>),

--- a/rust/loopflow/src/ops/pm.rs
+++ b/rust/loopflow/src/ops/pm.rs
@@ -210,6 +210,14 @@ async fn resolve_context(repo: &Path, wave: &str) -> OpsResult<PmContext> {
 /// store (keyed by provider), and an expired token is refreshed in place when it
 /// carries a refresh token and the OAuth client creds resolve.
 async fn resolve_pm_token(provider: PmProviderKind) -> OpsResult<String> {
+    // A forwarded token wins over the local store: `lf ssh` resolves the PM
+    // credential on the caller's machine (where lfdb lives) and hands it to the
+    // remote through the environment. The remote lfdb holds no PM credential, so
+    // without this hook remote `lf op pm` could never authenticate.
+    if let Some(token) = forwarded_pm_token(provider) {
+        return Ok(token);
+    }
+
     let auth_provider = match provider {
         PmProviderKind::Linear => Provider::Linear,
     };
@@ -265,6 +273,27 @@ async fn resolve_pm_token(provider: PmProviderKind) -> OpsResult<String> {
     Err(OpsError::Message(format!(
         "Stored {provider} token has expired. Run `lf op auth {provider}` again."
     )))
+}
+
+/// Env var carrying a PM access token forwarded by `lf ssh`.
+pub(crate) const FORWARDED_PM_TOKEN_ENV: &str = "LF_FORWARDED_PM_TOKEN";
+/// Env var naming the provider the forwarded token belongs to (e.g. `linear`).
+pub(crate) const FORWARDED_PM_PROVIDER_ENV: &str = "LF_FORWARDED_PM_PROVIDER";
+
+/// A forwarded PM token from the environment, if present and matching `provider`.
+/// When `LF_FORWARDED_PM_PROVIDER` is set it must name `provider`; when it is
+/// absent the token is accepted for whatever provider the wave resolves to.
+fn forwarded_pm_token(provider: PmProviderKind) -> Option<String> {
+    let token = std::env::var(FORWARDED_PM_TOKEN_ENV)
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())?;
+    match std::env::var(FORWARDED_PM_PROVIDER_ENV) {
+        Ok(name) if !name.trim().is_empty() => {
+            (name.trim().eq_ignore_ascii_case(provider.as_str())).then_some(token)
+        }
+        _ => Some(token),
+    }
 }
 
 fn storage_config_from_env() -> OpsResult<crate::lfdb::StorageConfig> {
@@ -866,5 +895,46 @@ mod tests {
             .expect("PR link is posted as a comment");
         assert!(comment.body.contains("Shipped:"));
         assert!(comment.body.contains("pull/42"));
+    }
+
+    // Env vars are process-global; serialize the forwarded-token tests so a
+    // concurrent test never observes a half-set environment.
+    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    #[test]
+    fn resolve_pm_token_prefers_forwarded_env() {
+        let _guard = ENV_LOCK.lock().expect("env lock");
+        std::env::set_var(FORWARDED_PM_TOKEN_ENV, "forwarded-secret");
+        std::env::remove_var(FORWARDED_PM_PROVIDER_ENV);
+
+        // Returns the forwarded token without ever opening the lfdb store.
+        let token = block_on_pm(resolve_pm_token(PmProviderKind::Linear)).expect("token");
+        assert_eq!(token, "forwarded-secret");
+
+        std::env::remove_var(FORWARDED_PM_TOKEN_ENV);
+    }
+
+    #[test]
+    fn forwarded_pm_token_matches_provider_and_skips_blank() {
+        let _guard = ENV_LOCK.lock().expect("env lock");
+
+        std::env::set_var(FORWARDED_PM_TOKEN_ENV, "tok");
+        std::env::set_var(FORWARDED_PM_PROVIDER_ENV, "linear");
+        assert_eq!(
+            forwarded_pm_token(PmProviderKind::Linear).as_deref(),
+            Some("tok")
+        );
+
+        // A provider that doesn't match falls through to the store.
+        std::env::set_var(FORWARDED_PM_PROVIDER_ENV, "github");
+        assert_eq!(forwarded_pm_token(PmProviderKind::Linear), None);
+
+        // A blank token is treated as absent.
+        std::env::set_var(FORWARDED_PM_TOKEN_ENV, "   ");
+        std::env::remove_var(FORWARDED_PM_PROVIDER_ENV);
+        assert_eq!(forwarded_pm_token(PmProviderKind::Linear), None);
+
+        std::env::remove_var(FORWARDED_PM_TOKEN_ENV);
+        std::env::remove_var(FORWARDED_PM_PROVIDER_ENV);
     }
 }

--- a/rust/loopflow/src/provider_auth/mod.rs
+++ b/rust/loopflow/src/provider_auth/mod.rs
@@ -1744,13 +1744,28 @@ fn extract_github_token(home_dir: &Path) -> Option<ProviderToken> {
     })
 }
 
-fn extract_claude_token(home_dir: &Path) -> Option<ProviderToken> {
+pub(crate) fn extract_claude_token(home_dir: &Path) -> Option<ProviderToken> {
     let cred_path = home_dir.join(".claude/.credentials.json");
-    let content = fs::read_to_string(cred_path).ok()?;
-    let json: serde_json::Value = serde_json::from_str(&content).ok()?;
-    let token = json.get("accessToken")?.as_str()?;
+    if let Ok(content) = fs::read_to_string(cred_path) {
+        if let Some(token) = claude_token_from_credentials_json(&content) {
+            return Some(token);
+        }
+    }
+    // The file is absent on machines where Claude Code stashed its OAuth blob in
+    // the macOS keychain (service "Claude Code-credentials", JSON under
+    // `.claudeAiOauth`). Fall back to reading it there.
+    read_claude_keychain_token()
+}
+
+/// Parse a `.claude/.credentials.json` payload. The access token sits at the top
+/// level (`accessToken`); the keychain blob nests it under `claudeAiOauth`, so
+/// accept either shape.
+fn claude_token_from_credentials_json(content: &str) -> Option<ProviderToken> {
+    let json: serde_json::Value = serde_json::from_str(content).ok()?;
+    let node = json.get("claudeAiOauth").unwrap_or(&json);
+    let token = node.get("accessToken")?.as_str()?;
     let expires_at = read_json_expires_at(
-        &json,
+        node,
         &[
             "expiresAt",
             "expires_at",
@@ -1767,6 +1782,29 @@ fn extract_claude_token(home_dir: &Path) -> Option<ProviderToken> {
         updated_at: now_unix(),
         credential_type: CredentialType::OAuth,
     })
+}
+
+#[cfg(target_os = "macos")]
+fn read_claude_keychain_token() -> Option<ProviderToken> {
+    let output = std::process::Command::new("security")
+        .args([
+            "find-generic-password",
+            "-s",
+            "Claude Code-credentials",
+            "-w",
+        ])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let blob = String::from_utf8(output.stdout).ok()?;
+    claude_token_from_credentials_json(blob.trim())
+}
+
+#[cfg(not(target_os = "macos"))]
+fn read_claude_keychain_token() -> Option<ProviderToken> {
+    None
 }
 
 fn extract_codex_token(home_dir: &Path) -> Option<ProviderToken> {


### PR DESCRIPTION
## What

`lf ssh <host> [--repo <rel>] [--secret <NAME>]... [--forward-agent] -- <cmd...>` — an ssh transport that carries the caller's *local* credentials into a remote command, per invocation. This is not "lf running a remote command"; it's ssh gaining credential-forwarding so a stateless remote home can run `lf op …` authenticated as the user while storing nothing.

Concerto (and the CLI) switch `ssh mini-heart lf op …` → `lf ssh mini-heart -- lf op …`.

## Credential resolution (all local)

| Credential | Source | Forwarded as |
|---|---|---|
| GitHub | `gh auth token` | `GH_TOKEN` (+ HTTPS git credential helper) |
| Claude/agent | `extract_claude_token` — `~/.claude/.credentials.json`, falling back to the macOS keychain blob `Claude Code-credentials` (`.claudeAiOauth.accessToken`) when the file is absent | `CLAUDE_CODE_OAUTH_TOKEN` |
| PM/Linear | lfdb credential store (`get_provider_token("linear")`) | `LF_FORWARDED_PM_TOKEN` + `LF_FORWARDED_PM_PROVIDER` |
| Doppler-backed secrets | `--secret NAME` → `doppler secrets get NAME --plain` **locally** | `export NAME=<value>` |

The forwarding preamble is piped into `ssh <host> bash -s` over stdin; `cd "$HOME/<repo>"`; `exec <cmd>`. Every value is single-quote escaped — secrets never touch argv, ps, or logs. Nothing is written to the remote disk.

## PM env override (the new capability)

PM auth is lfdb-resident, not env, so raw ssh could never forward it. `resolve_pm_token` in `ops/pm.rs` now checks `LF_FORWARDED_PM_TOKEN` **before** the store (honoring `LF_FORWARDED_PM_PROVIDER` when set). Forwarded token wins; the remote's empty store is never consulted.

## Security posture (deliberately diverges from the ssh-lf.sh prototype)

- **No `ssh -A` by default.** Agent forwarding hands the user's whole SSH identity to remote root. Git pushes ride the forwarded `GH_TOKEN` over HTTPS, so `-A` is dead weight. Opt-in `--forward-agent` preserves an escape hatch.
- **Ambient git credential caching neutralized.** The forwarded `GIT_CONFIG` resets `credential.helper` to empty *before* installing the in-memory token helper, so a global store/cache/osxkeychain helper on the remote can't fire and persist the token to disk.
- **Doppler token never forwarded.** The Doppler login/CLI token is a master key to the whole secret estate. `lf ssh` forwards specific resolved secrets, never the token that could fetch them all — resolve locally with `--secret`, forward only the value.

## Tests

- `build_preamble` assembles the exports + `cd` + `exec` from a stubbed bundle; asserts the git-helper reset, the forwarded secret by value, that absent credentials are omitted, and that a secret with shell metacharacters can't escape its single-quoted assignment.
- `resolve_pm_token` returns the forwarded env token without opening the store; provider match/mismatch/blank handled.
- env-name validation rejects injection via `--secret`.

No live ssh or API calls in tests.

## Documented follow-ups (need provisioning decisions — NOT in this PR)

The security review flagged two residual credential-provisioning risks, out of scope here but captured for direction:

1. **Doppler:** even with `--secret`, the *local* resolution uses the Doppler CLI login token = master key to the whole secret estate. Direction: move to a scoped read-only service token, or keep resolving locally and forwarding only what's needed (this PR does the latter for the remote; the local token is still broad).
2. **GitHub:** the forwarded `gh` token is a broad, non-expiring classic OAuth token. Direction: switch to a fine-grained, expiring PAT scoped to the loopflow repos.