### PR TITLE
pm/linear: teamId is ID! not String! in workflow-state filters

### DIFF
--- a/rust/loopflow/src/lfd/pm/linear.rs
+++ b/rust/loopflow/src/lfd/pm/linear.rs
@@ -87,7 +87,7 @@ const COMPLETE_ITEM_MUTATION: &str = r#"mutation CompleteIssue($id: String!, $st
   }
 }"#;
 
-const LIST_COMPLETED_WORKFLOW_STATES_QUERY: &str = r#"query CompletedWorkflowStates($teamId: String!) {
+const LIST_COMPLETED_WORKFLOW_STATES_QUERY: &str = r#"query CompletedWorkflowStates($teamId: ID!) {
   workflowStates(filter: { team: { id: { eq: $teamId } }, type: { eq: "completed" } }) {
     nodes {
       id
@@ -95,7 +95,7 @@ const LIST_COMPLETED_WORKFLOW_STATES_QUERY: &str = r#"query CompletedWorkflowSta
   }
 }"#;
 
-const LIST_UNSTARTED_WORKFLOW_STATES_QUERY: &str = r#"query UnstartedWorkflowStates($teamId: String!) {
+const LIST_UNSTARTED_WORKFLOW_STATES_QUERY: &str = r#"query UnstartedWorkflowStates($teamId: ID!) {
   workflowStates(filter: { team: { id: { eq: $teamId } }, type: { eq: "unstarted" } }) {
     nodes {
       id


### PR DESCRIPTION
## Usage

```bash
lf op pm --status done
```

The Linear GraphQL queries that list completed and unstarted workflow states declared `$teamId` as `String!`, but Linear's schema types `team.id` filters as `ID!`. Linear rejects the type mismatch, so the queries fail and status transitions (e.g. marking an item done) never resolve their target state. This changes both query variable declarations to `ID!` to match the schema.

## Changes

- `LIST_COMPLETED_WORKFLOW_STATES_QUERY`: `$teamId: String!` → `$teamId: ID!`
- `LIST_UNSTARTED_WORKFLOW_STATES_QUERY`: `$teamId: String!` → `$teamId: ID!`