### PR TITLE
rebase/queue: re-parent stacked children onto main when their parent lands

### DIFF
--- a/rust/loopflow/src/engine/git.rs
+++ b/rust/loopflow/src/engine/git.rs
@@ -692,6 +692,19 @@ pub fn is_squash_merged(repo: &Path, branch: &str, target: &str) -> Result<bool,
     Ok(result_tree == target_tree)
 }
 
+/// Return true if `branch` is already merged into `target`.
+///
+/// Covers both shapes a merge can take: a fast-forwardable ancestor (its
+/// commits live in `target`) and a squash-merge (its *changes* live in
+/// `target` even though its commits do not). A stacked child must re-parent
+/// onto the default branch once its parent is merged either way.
+pub fn is_merged_into(repo: &Path, branch: &str, target: &str) -> Result<bool, GitError> {
+    if is_ancestor(repo, branch, target)? {
+        return Ok(true);
+    }
+    is_squash_merged(repo, branch, target)
+}
+
 /// Find the fork point for a stacked branch whose parent was squash-merged.
 ///
 /// When branch B is stacked on A, and A gets squash-merged into `target`,

--- a/rust/loopflow/src/lfd/queue.rs
+++ b/rust/loopflow/src/lfd/queue.rs
@@ -133,10 +133,26 @@ impl QueueOps for RealQueueOps {
         git::fetch(&main_repo, "origin", default_branch).map_err(|err| QueueRebaseConflict {
             files: vec![err.to_string()],
         })?;
-        let rebase_result = git::rebase(worktree, &format!("origin/{default_branch}"), None)
-            .map_err(|err| QueueRebaseConflict {
-                files: vec![err.to_string()],
-            })?;
+        // When this child's stack parent has already merged, drop the parent's
+        // commits by forking off its tip. Without this the lazy rebase replays
+        // the (now-merged) parent commits against the default branch and blocks
+        // the queue with a spurious RebaseConflict.
+        let branch = git::current_branch(worktree)
+            .ok()
+            .flatten()
+            .unwrap_or_default();
+        let merged_parent = crate::ops::merged_parent_fork_point(worktree, &branch, default_branch);
+        let fork_point = merged_parent
+            .as_ref()
+            .map(|(fork_point, _)| fork_point.clone());
+        let rebase_result = git::rebase(
+            worktree,
+            &format!("origin/{default_branch}"),
+            fork_point.as_deref(),
+        )
+        .map_err(|err| QueueRebaseConflict {
+            files: vec![err.to_string()],
+        })?;
         if !rebase_result.success {
             return Err(QueueRebaseConflict {
                 files: rebase_result
@@ -150,6 +166,11 @@ impl QueueOps for RealQueueOps {
         git::push(worktree, true).map_err(|err| QueueRebaseConflict {
             files: vec![err.to_string()],
         })?;
+        // The child re-parented onto the default branch; prune the merged
+        // parent's lingering local ref so it stops resolving as an open base.
+        if let Some((_, Some(local_parent))) = merged_parent {
+            let _ = git::delete_local_branch(worktree, &local_parent);
+        }
         Ok(())
     }
 
@@ -830,5 +851,68 @@ mod tests {
         drop(guard);
         waiter.await.expect("waiter task");
         assert!(*locked.lock().expect("mutex"));
+    }
+
+    fn git_out(repo: &Path, args: &[&str]) -> String {
+        let output = Command::new("git")
+            .args(args)
+            .current_dir(repo)
+            .output()
+            .expect("run git");
+        assert!(
+            output.status.success(),
+            "git {args:?} failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        String::from_utf8_lossy(&output.stdout).trim().to_string()
+    }
+
+    #[test]
+    fn queue_rebase_drops_squash_merged_parent_commits() {
+        use loopflow_test_support::TestRepo;
+
+        // Parent `a.b` builds shared.txt over two commits; child `a.b.c` extends
+        // it. A plain `git rebase origin/main` (fork-point None) would replay the
+        // parent's commits and conflict — the queue's old behavior, which
+        // surfaces as a spurious RebaseConflict block. The fork-point fix must
+        // drop the parent's commits and rebase cleanly.
+        let repo = TestRepo::new();
+
+        repo.create_branch("a.b");
+        repo.create_file("shared.txt", "a-line-1\na-line-2\n");
+        repo.stage_all();
+        repo.commit("p1");
+        repo.create_file("shared.txt", "a-line-1\na-line-2\na-line-3\n");
+        repo.stage_all();
+        repo.commit("p2");
+
+        repo.create_branch("a.b.c");
+        repo.create_file("shared.txt", "a-line-1\na-line-2\na-line-3\nb-line\n");
+        repo.stage_all();
+        repo.commit("child work");
+        repo.push_new_branch("a.b.c");
+
+        // Squash-merge the parent into main; leave the local `a.b` ref dangling.
+        repo.checkout("main");
+        git_out(repo.path(), &["merge", "--squash", "a.b"]);
+        git_out(repo.path(), &["commit", "-m", "squash merge a.b"]);
+        repo.push();
+
+        repo.checkout("a.b.c");
+        RealQueueOps
+            .rebase_onto_default(repo.path(), "main")
+            .expect("queue rebase should drop merged parent and succeed");
+
+        // The child carries only its own change relative to main.
+        let commits_beyond = git_out(repo.path(), &["rev-list", "--count", "origin/main..HEAD"]);
+        assert_eq!(
+            commits_beyond, "1",
+            "only the child's commit sits above main"
+        );
+        let diff = git_out(repo.path(), &["diff", "--name-only", "origin/main...HEAD"]);
+        assert_eq!(diff, "shared.txt");
+        // The merged parent's lingering local ref was pruned.
+        let branches = git_out(repo.path(), &["branch", "--list", "a.b"]);
+        assert!(branches.is_empty(), "merged local parent should be pruned");
     }
 }

--- a/rust/loopflow/src/lfd/queue.rs
+++ b/rust/loopflow/src/lfd/queue.rs
@@ -8,7 +8,7 @@ use time::OffsetDateTime;
 use tokio::sync::{Mutex, OwnedMutexGuard};
 
 use crate::engine::git;
-use crate::engine::worktrees::main_repo_root;
+use crate::engine::worktrees::{main_repo_root, StackBranch};
 use crate::lfd::attention::{
     attention_id_for_queue_block, queue_block_attention_item_from_existing,
 };
@@ -82,6 +82,7 @@ pub(crate) trait QueueOps: Send + Sync {
         &self,
         worktree: &Path,
         default_branch: &str,
+        parent_landed: bool,
     ) -> Result<(), QueueRebaseConflict>;
     fn scratch_clean(&self, worktree: &Path) -> Result<bool, String>;
 }
@@ -128,20 +129,24 @@ impl QueueOps for RealQueueOps {
         &self,
         worktree: &Path,
         default_branch: &str,
+        parent_landed: bool,
     ) -> Result<(), QueueRebaseConflict> {
         let main_repo = main_repo_root(worktree).unwrap_or_else(|_| worktree.to_path_buf());
         git::fetch(&main_repo, "origin", default_branch).map_err(|err| QueueRebaseConflict {
             files: vec![err.to_string()],
         })?;
-        // When this child's stack parent has already merged, drop the parent's
-        // commits by forking off its tip. Without this the lazy rebase replays
-        // the (now-merged) parent commits against the default branch and blocks
-        // the queue with a spurious RebaseConflict.
+        // When this child's stack parent has landed, drop the parent's commits
+        // by forking off its tip. `parent_landed` carries the daemon's lfdb
+        // signal (the parent PR merged, content-independent) so a *reworked*
+        // parent is handled too; without it the lazy rebase replays the parent's
+        // commits against the default branch and blocks the queue with a
+        // spurious RebaseConflict.
         let branch = git::current_branch(worktree)
             .ok()
             .flatten()
             .unwrap_or_default();
-        let merged_parent = crate::ops::merged_parent_fork_point(worktree, &branch, default_branch);
+        let merged_parent =
+            crate::ops::merged_parent_fork_point(worktree, &branch, default_branch, parent_landed);
         let fork_point = merged_parent
             .as_ref()
             .map(|(fork_point, _)| fork_point.clone());
@@ -330,10 +335,16 @@ pub(crate) async fn reconcile_wave_queue_with_ops(
         let main_repo = main_repo_root(worktree).unwrap_or_else(|_| worktree.to_path_buf());
         let default_branch =
             git::get_default_branch(&main_repo).unwrap_or_else(|_| "main".to_string());
+        // The head is the oldest unmerged run, so its stack parent has usually
+        // landed — but only re-parent onto main when that parent's PR is
+        // actually Merged (not merely closed/superseded, whose changes never
+        // reached main). This lfdb signal is content-independent, so a reworked
+        // parent is caught where a git content-check would miss it.
+        let parent_landed = head_stack_parent_merged(&runs, &head, &default_branch, &live_snapshot);
         if let Err(conflict) = ops
             .ensure_branch_checked_out(worktree, &head.branch)
             .map_err(|err| QueueRebaseConflict { files: vec![err] })
-            .and_then(|_| ops.rebase_onto_default(worktree, &default_branch))
+            .and_then(|_| ops.rebase_onto_default(worktree, &default_branch, parent_landed))
         {
             set_queue_block(
                 store,
@@ -440,6 +451,26 @@ fn queue_next_action(role: QueueRole, block: Option<&QueueBlock>, has_pr: bool) 
             _ => QueueNextAction::AwaitMerge,
         },
     }
+}
+
+/// True when the head's dotted stack parent has a run whose inferred status is
+/// `Merged` — the content-independent "parent PR merged" signal that tells the
+/// child to re-parent onto the default branch (even for a reworked parent).
+fn head_stack_parent_merged(
+    runs: &[Run],
+    head: &Run,
+    default_branch: &str,
+    live_snapshot: &LivePrSnapshot,
+) -> bool {
+    let Some(parent) = StackBranch::parse(&head.branch, default_branch).and_then(|s| s.parent())
+    else {
+        return false;
+    };
+    runs.iter().any(|run| {
+        run.branch == parent
+            && inferred_stack_status(run.stack_status, live_snapshot.state_for_run(run))
+                == RunStackStatus::Merged
+    })
 }
 
 fn find_queue_head_index(runs: &[Run], live_snapshot: &LivePrSnapshot) -> Option<usize> {
@@ -557,6 +588,7 @@ mod tests {
             &self,
             _worktree: &Path,
             default_branch: &str,
+            _parent_landed: bool,
         ) -> Result<(), QueueRebaseConflict> {
             if self
                 .rebase_fail_for_branch
@@ -900,7 +932,7 @@ mod tests {
 
         repo.checkout("a.b.c");
         RealQueueOps
-            .rebase_onto_default(repo.path(), "main")
+            .rebase_onto_default(repo.path(), "main", true)
             .expect("queue rebase should drop merged parent and succeed");
 
         // The child carries only its own change relative to main.
@@ -914,5 +946,43 @@ mod tests {
         // The merged parent's lingering local ref was pruned.
         let branches = git_out(repo.path(), &["branch", "--list", "a.b"]);
         assert!(branches.is_empty(), "merged local parent should be pruned");
+    }
+
+    #[test]
+    fn queue_rebase_surfaces_conflict_when_reworked_parent_overlaps() {
+        use loopflow_test_support::TestRepo;
+
+        // The parent landed REWORKED (lfdb says merged; main's content diverges)
+        // and the child's own commit overlaps the divergent lines. The queue
+        // must surface a RebaseConflict — not silently rebase onto the stale
+        // parent, not auto-heal.
+        let repo = TestRepo::new();
+
+        repo.create_branch("a.b");
+        repo.create_file("feature.txt", "v1\n");
+        repo.stage_all();
+        repo.commit("feature v1");
+        repo.push_new_branch("a.b");
+
+        repo.create_branch("a.b.c");
+        repo.create_file("feature.txt", "v1\nchild addition\n");
+        repo.stage_all();
+        repo.commit("child extends feature");
+        repo.push_new_branch("a.b.c");
+
+        repo.checkout("main");
+        repo.create_file("feature.txt", "v2 reworked\n");
+        repo.stage_all();
+        repo.commit("feature v2");
+        repo.push();
+        git_out(repo.path(), &["push", "origin", "--delete", "a.b"]);
+
+        repo.checkout("a.b.c");
+        // parent_landed = true: lfdb reports the parent PR merged.
+        let result = RealQueueOps.rebase_onto_default(repo.path(), "main", true);
+        assert!(
+            result.is_err(),
+            "reworked overlap must block the queue with a conflict"
+        );
     }
 }

--- a/rust/loopflow/src/ops/mod.rs
+++ b/rust/loopflow/src/ops/mod.rs
@@ -33,6 +33,7 @@ pub use land::{land, mark_ready, submit, LandOptions, LandResult, RotationResult
 pub use next::{advance_branch, next_branch, NextOptions, NextResult};
 pub use pr::{create_or_update_pr, current_pr, update_pr, PrInfo, PrOptions, PrResult};
 pub use progress::{NullProgress, Progress};
+pub(crate) use rebase::merged_parent_fork_point;
 pub use rebase::{
     plan_rebase, rebase_class_name, rebase_strategy_name, rebase_with_recovery, RebaseClass,
     RebaseOptions, RebasePlan, RebaseStrategy,

--- a/rust/loopflow/src/ops/queue.rs
+++ b/rust/loopflow/src/ops/queue.rs
@@ -200,6 +200,7 @@ mod tests {
             &self,
             _worktree: &Path,
             _default_branch: &str,
+            _parent_landed: bool,
         ) -> Result<(), QueueRebaseConflict> {
             Ok(())
         }

--- a/rust/loopflow/src/ops/rebase.rs
+++ b/rust/loopflow/src/ops/rebase.rs
@@ -2,7 +2,8 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use crate::engine::git::{
-    current_branch, fetch, get_default_branch, rebase, squash_merge_fork_point, sync_main,
+    current_branch, delete_local_branch, fetch, get_default_branch, is_merged_into, rebase,
+    rev_parse, squash_merge_fork_point, sync_main,
 };
 use crate::engine::worktrees::StackBranch;
 
@@ -45,6 +46,49 @@ pub struct RebasePlan {
     pub changed_files: Vec<PathBuf>,
     pub protected: bool,
     pub scratch_stashed: bool,
+    /// When the stack parent has already merged, the parent's tip commit. A
+    /// `rebase --onto <base_ref> <fork_point>` replays only the child's own
+    /// commits, dropping the parent's now-merged history.
+    pub fork_point: Option<String>,
+    /// A merged parent's local branch that is safe to prune once the child has
+    /// re-parented (present only when the lingering local ref still exists).
+    pub merged_parent: Option<String>,
+}
+
+/// Resolve a dotted stack parent to a usable ref: the local branch if it
+/// survives (a squash-merge deletes `origin/P` but leaves the local `P`),
+/// otherwise the remote-tracking ref.
+fn resolve_parent_ref(repo: &Path, parent: &str) -> Option<String> {
+    if ref_exists(repo, parent) {
+        return Some(parent.to_string());
+    }
+    let remote_parent = format!("origin/{parent}");
+    ref_exists(repo, &remote_parent).then_some(remote_parent)
+}
+
+/// The fork point for re-parenting a stacked child onto the default branch when
+/// its parent has merged, plus the parent's local branch name if it lingers.
+///
+/// Returns `None` when the branch has no stack parent or the parent is still
+/// open — the child keeps stacking on it, unchanged. When the parent is merged
+/// (fast-forward ancestor or squash-merge), the fork point is the parent's tip,
+/// which is exact even for a multi-commit parent that `squash_merge_fork_point`
+/// (patch-id based) cannot detect.
+pub(crate) fn merged_parent_fork_point(
+    repo: &Path,
+    branch: &str,
+    default_branch: &str,
+) -> Option<(String, Option<String>)> {
+    let stack = StackBranch::parse(branch, default_branch)?;
+    let parent = stack.parent()?;
+    let parent_ref = resolve_parent_ref(repo, &parent)?;
+    let default_ref = format!("origin/{default_branch}");
+    if !is_merged_into(repo, &parent_ref, &default_ref).unwrap_or(false) {
+        return None;
+    }
+    let fork_point = rev_parse(repo, &parent_ref).ok()?;
+    let local_branch = ref_exists(repo, &parent).then_some(parent);
+    Some((fork_point, local_branch))
 }
 
 pub fn plan_rebase(repo: &Path, onto: Option<&str>) -> OpsResult<RebasePlan> {
@@ -52,14 +96,20 @@ pub fn plan_rebase(repo: &Path, onto: Option<&str>) -> OpsResult<RebasePlan> {
     let branch = current_branch(repo)?.unwrap_or_else(|| "HEAD".to_string());
     let stack = StackBranch::parse(&branch, &default_branch);
     let stack_parent = stack.as_ref().and_then(StackBranch::parent);
-    let parent_base_ref = stack_parent.as_deref().and_then(|parent| {
-        if ref_exists(repo, parent) {
-            Some(parent.to_string())
-        } else {
-            let remote_parent = format!("origin/{parent}");
-            ref_exists(repo, &remote_parent).then_some(remote_parent)
-        }
-    });
+    // A surviving parent ref is only a valid base while the parent is still
+    // open. Once the parent merges into the default branch, its ref is a dead
+    // tip: rebasing onto it drags the parent's already-merged commits back into
+    // the child. Detect the merge and re-parent onto the default branch instead.
+    let (fork_point, merged_parent) = merged_parent_fork_point(repo, &branch, &default_branch)
+        .map(|(fork_point, local_branch)| (Some(fork_point), local_branch))
+        .unwrap_or((None, None));
+    let parent_base_ref = if fork_point.is_some() {
+        None
+    } else {
+        stack_parent
+            .as_deref()
+            .and_then(|parent| resolve_parent_ref(repo, parent))
+    };
     let base_ref = if let Some(onto) = onto {
         onto.to_string()
     } else if let Some(parent_base_ref) = parent_base_ref.as_ref() {
@@ -122,6 +172,8 @@ pub fn plan_rebase(repo: &Path, onto: Option<&str>) -> OpsResult<RebasePlan> {
         changed_files,
         protected,
         scratch_stashed,
+        fork_point,
+        merged_parent,
     })
 }
 
@@ -141,9 +193,11 @@ pub fn rebase_with_recovery(
         let _ = sync_main(repo, branch);
     }
 
-    // When a stacked branch's parent was squash-merged into the target,
-    // a plain rebase replays the parent's commits (already in target) and
-    // hits conflicts. Detect this and use --onto to skip them.
+    // When a stacked branch's parent has merged into the target, a plain rebase
+    // replays the parent's commits (already in target) and hits conflicts.
+    // Detect this and use --onto to skip them. Prefer the parent's tip as the
+    // fork point (exact, even for a multi-commit parent), falling back to the
+    // patch-id scan for non-stack squashes.
     //
     // TODO(stacking): this only covers a clean squash-merge. When the parent is
     // *reworked* during land (its merged content diverges from what the child
@@ -155,13 +209,23 @@ pub fn rebase_with_recovery(
     // policy: stacked worktrees just target main. Real fix (unresolved, systems
     // wave): identity-preserving land for parents that have children, OR detect
     // the rework and flag the stack for re-derivation instead of auto-rebasing.
-    let fork_point = squash_merge_fork_point(repo, &options.onto).unwrap_or(None);
+    let fork_point = plan
+        .fork_point
+        .clone()
+        .or_else(|| squash_merge_fork_point(repo, &options.onto).unwrap_or(None));
 
     progress.status(&format!("Rebasing onto {}...", options.onto));
     let result = rebase(repo, &options.onto, fork_point.as_deref())?;
     if result.success {
         if fork_point.is_some() {
-            progress.status("Skipped squash-merged parent commits");
+            progress.status("Skipped merged parent commits");
+        }
+        // The child has re-parented onto the default branch; the merged parent's
+        // lingering local ref is now a dead base — prune it so future rebases
+        // don't resolve it as an open parent. Best-effort: a ref still checked
+        // out in the parent's worktree can't be deleted, which is fine.
+        if let Some(parent) = plan.merged_parent.as_deref() {
+            let _ = delete_local_branch(repo, parent);
         }
         if options.push {
             crate::ops::commit::push_with_upstream_if_needed(repo)?;

--- a/rust/loopflow/src/ops/rebase.rs
+++ b/rust/loopflow/src/ops/rebase.rs
@@ -66,24 +66,48 @@ fn resolve_parent_ref(repo: &Path, parent: &str) -> Option<String> {
     ref_exists(repo, &remote_parent).then_some(remote_parent)
 }
 
+/// The classic "GitHub deleted the head branch on merge" state: the parent's
+/// remote branch is gone while its local ref lingers. In loopflow's model a
+/// genuinely-open stacked parent keeps its `origin/P` (it was pushed with a
+/// PR), so `origin/P`'s absence means the parent landed — in whatever form,
+/// including a rework whose content no longer matches what the child stacked on.
+fn parent_deleted_on_remote(repo: &Path, parent: &str) -> bool {
+    ref_exists(repo, parent) && !ref_exists(repo, &format!("origin/{parent}"))
+}
+
 /// The fork point for re-parenting a stacked child onto the default branch when
-/// its parent has merged, plus the parent's local branch name if it lingers.
+/// its parent has landed, plus the parent's local branch name if it lingers.
 ///
-/// Returns `None` when the branch has no stack parent or the parent is still
-/// open — the child keeps stacking on it, unchanged. When the parent is merged
-/// (fast-forward ancestor or squash-merge), the fork point is the parent's tip,
-/// which is exact even for a multi-commit parent that `squash_merge_fork_point`
-/// (patch-id based) cannot detect.
+/// The child owns only its own commits: once the parent lands in ANY form, we
+/// replay the child's commits onto the default branch. "Landed" is detected
+/// content-independently — a caller-supplied signal (the daemon's lfdb
+/// `stack_status == Merged`), a fast-forward ancestor or squash-merge into the
+/// default branch, or the parent's remote branch having been deleted. This is
+/// deliberately broader than a content match: a *reworked* parent (its merged
+/// content diverges from the child's base) still counts as landed, so the child
+/// re-parents onto the default branch and never falls back to the stale local
+/// `P`. If the rework diverges from lines the child also touched, the replay
+/// conflicts — the correct outcome, surfaced to the caller, not auto-healed.
+///
+/// The fork point is the parent's tip, exact even for a multi-commit parent
+/// that `squash_merge_fork_point` (patch-id based) cannot detect.
+///
+/// Returns `None` only when the branch has no stack parent, or the parent is
+/// genuinely open (not landed) — the child keeps stacking on it, unchanged.
 pub(crate) fn merged_parent_fork_point(
     repo: &Path,
     branch: &str,
     default_branch: &str,
+    parent_landed: bool,
 ) -> Option<(String, Option<String>)> {
     let stack = StackBranch::parse(branch, default_branch)?;
     let parent = stack.parent()?;
     let parent_ref = resolve_parent_ref(repo, &parent)?;
     let default_ref = format!("origin/{default_branch}");
-    if !is_merged_into(repo, &parent_ref, &default_ref).unwrap_or(false) {
+    let landed = parent_landed
+        || is_merged_into(repo, &parent_ref, &default_ref).unwrap_or(false)
+        || parent_deleted_on_remote(repo, &parent);
+    if !landed {
         return None;
     }
     let fork_point = rev_parse(repo, &parent_ref).ok()?;
@@ -100,9 +124,12 @@ pub fn plan_rebase(repo: &Path, onto: Option<&str>) -> OpsResult<RebasePlan> {
     // open. Once the parent merges into the default branch, its ref is a dead
     // tip: rebasing onto it drags the parent's already-merged commits back into
     // the child. Detect the merge and re-parent onto the default branch instead.
-    let (fork_point, merged_parent) = merged_parent_fork_point(repo, &branch, &default_branch)
-        .map(|(fork_point, local_branch)| (Some(fork_point), local_branch))
-        .unwrap_or((None, None));
+    // No daemon here: `parent_landed` is inferred from git alone (content merge
+    // or a deleted remote branch) inside merged_parent_fork_point.
+    let (fork_point, merged_parent) =
+        merged_parent_fork_point(repo, &branch, &default_branch, false)
+            .map(|(fork_point, local_branch)| (Some(fork_point), local_branch))
+            .unwrap_or((None, None));
     let parent_base_ref = if fork_point.is_some() {
         None
     } else {
@@ -193,22 +220,14 @@ pub fn rebase_with_recovery(
         let _ = sync_main(repo, branch);
     }
 
-    // When a stacked branch's parent has merged into the target, a plain rebase
-    // replays the parent's commits (already in target) and hits conflicts.
-    // Detect this and use --onto to skip them. Prefer the parent's tip as the
-    // fork point (exact, even for a multi-commit parent), falling back to the
-    // patch-id scan for non-stack squashes.
-    //
-    // TODO(stacking): this only covers a clean squash-merge. When the parent is
-    // *reworked* during land (its merged content diverges from what the child
-    // stacked on — a different design, CI fixups, edited squash), --onto still
-    // strands the child: mechanically the fork point may not match, and
-    // semantically the child's changes assume the pre-rework parent. A memory
-    // slice hit this — its parent merged as a redesigned version and the rebase
-    // replayed already-merged commits into GOAL.md/MEMORY.md conflicts. Interim
-    // policy: stacked worktrees just target main. Real fix (unresolved, systems
-    // wave): identity-preserving land for parents that have children, OR detect
-    // the rework and flag the stack for re-derivation instead of auto-rebasing.
+    // When a stacked branch's parent has landed, the child owns only its own
+    // commits: replay them onto the target via the parent's tip as the fork
+    // point (exact, even for a multi-commit parent). Fall back to the patch-id
+    // scan for non-stack squashes. A *reworked* parent (its merged content
+    // diverges from the child's base) is still landed — the child re-parents
+    // onto the target. If the rework diverges from lines the child also touched,
+    // the replay conflicts; that conflict propagates to the caller to resolve,
+    // rather than being swallowed or retried onto the stale parent.
     let fork_point = plan
         .fork_point
         .clone()

--- a/rust/loopflow/tests/rebase_tests.rs
+++ b/rust/loopflow/tests/rebase_tests.rs
@@ -158,6 +158,74 @@ fn rebase_stacked_branch_after_squash_merge() {
 }
 
 #[test]
+fn rebase_reparents_child_onto_main_when_parent_merged() {
+    // Parent `a.b` is squash-merged into main, but its local ref lingers at the
+    // pre-squash tip (a squash-merge deletes origin/a.b, not the local branch).
+    // The child `a.b.c` must re-parent onto main and carry ONLY its own change,
+    // not the parent's already-merged commits.
+    let repo = TestRepo::new();
+
+    repo.create_branch("a.b");
+    repo.create_file("p1.txt", "p1");
+    repo.stage_all();
+    repo.commit("p1");
+    repo.create_file("p2.txt", "p2");
+    repo.stage_all();
+    repo.commit("p2");
+
+    repo.create_branch("a.b.c");
+    repo.create_file("child.txt", "child");
+    repo.stage_all();
+    repo.commit("child work");
+
+    // Squash-merge the parent's two commits into main as a single commit.
+    repo.checkout("main");
+    git(repo.path(), &["merge", "--squash", "a.b"]);
+    git(repo.path(), &["commit", "-m", "squash merge a.b"]);
+    repo.push();
+    // Local `a.b` ref is left dangling at its pre-squash tip.
+
+    repo.checkout("a.b.c");
+    let plan = plan_rebase(repo.path(), None).expect("plan rebase");
+    // A merged parent is a dead base: re-parent onto the default branch.
+    assert_eq!(plan.base_ref, "origin/main");
+    assert!(
+        plan.fork_point.is_some(),
+        "should fork off the merged parent"
+    );
+    assert_eq!(plan.merged_parent.as_deref(), Some("a.b"));
+
+    rebase_with_recovery(
+        repo.path(),
+        &RebaseOptions {
+            onto: "origin/main".to_string(),
+            push: false,
+        },
+        &NullProgress,
+    )
+    .expect("re-parent onto main should succeed");
+
+    // The child's own change is present; the parent's merged content is present
+    // via main.
+    assert!(repo.path().join("child.txt").exists());
+    assert!(repo.path().join("p1.txt").exists());
+
+    // The child carries ONLY its own change relative to main — not the parent's
+    // now-merged commits.
+    let diff = git(repo.path(), &["diff", "--name-only", "origin/main...HEAD"]);
+    assert_eq!(diff, "child.txt", "child diff vs main is only its own file");
+    let commits_beyond = git(repo.path(), &["rev-list", "--count", "origin/main..HEAD"]);
+    assert_eq!(
+        commits_beyond, "1",
+        "only the child's commit sits above main"
+    );
+
+    // The merged parent's lingering local ref was pruned.
+    let branches = git(repo.path(), &["branch", "--list", "a.b"]);
+    assert!(branches.is_empty(), "merged local parent should be pruned");
+}
+
+#[test]
 fn plan_rebase_classifies_dirty_scratch_only_branch_as_reset() {
     let repo = TestRepo::new();
     repo.create_branch("feature");
@@ -256,4 +324,7 @@ fn plan_rebase_uses_open_stack_parent() {
     assert_eq!(plan.base_ref, "a");
     assert_eq!(plan.class, RebaseClass::StackParentOpen);
     assert_eq!(plan.strategy, RebaseStrategy::RebaseOntoParent);
+    // An open parent is not a merge: the child keeps stacking on it, unchanged.
+    assert!(plan.fork_point.is_none());
+    assert!(plan.merged_parent.is_none());
 }

--- a/rust/loopflow/tests/rebase_tests.rs
+++ b/rust/loopflow/tests/rebase_tests.rs
@@ -226,6 +226,104 @@ fn rebase_reparents_child_onto_main_when_parent_merged() {
 }
 
 #[test]
+fn rebase_reparents_child_when_reworked_parent_branch_deleted() {
+    // Parent `a.b` lands in a REWORKED form: main's content diverges from what
+    // the child stacked on, so no content-based merge check matches. The signal
+    // is purely "origin/a.b was deleted on merge" while local `a.b` lingers. The
+    // child (which touches unrelated files) must still re-parent onto main and
+    // carry ONLY its own change — never the stale parent's diverged content.
+    let repo = TestRepo::new();
+
+    repo.create_branch("a.b");
+    repo.create_file("feature.txt", "v1\n");
+    repo.stage_all();
+    repo.commit("feature v1");
+    repo.push_new_branch("a.b");
+
+    repo.create_branch("a.b.c");
+    repo.create_file("child.txt", "child\n");
+    repo.stage_all();
+    repo.commit("child work");
+
+    // Reworked land: main gets a divergent feature.txt = v2; origin/a.b deleted.
+    repo.checkout("main");
+    repo.create_file("feature.txt", "v2\n");
+    repo.stage_all();
+    repo.commit("feature v2 (reworked in review)");
+    repo.push();
+    git(repo.path(), &["push", "origin", "--delete", "a.b"]);
+
+    repo.checkout("a.b.c");
+    let plan = plan_rebase(repo.path(), None).expect("plan rebase");
+    assert_eq!(
+        plan.base_ref, "origin/main",
+        "reworked parent re-parents onto main, not the stale local a.b"
+    );
+    assert!(plan.fork_point.is_some());
+    assert_eq!(plan.merged_parent.as_deref(), Some("a.b"));
+
+    rebase_with_recovery(
+        repo.path(),
+        &RebaseOptions {
+            onto: "origin/main".to_string(),
+            push: false,
+        },
+        &NullProgress,
+    )
+    .expect("clean child re-parents cleanly onto reworked main");
+
+    let diff = git(repo.path(), &["diff", "--name-only", "origin/main...HEAD"]);
+    assert_eq!(diff, "child.txt", "child carries only its own change");
+    let feature = std::fs::read_to_string(repo.path().join("feature.txt")).expect("read feature");
+    assert_eq!(
+        feature, "v2\n",
+        "child inherits main's reworked content, not the stale parent's v1"
+    );
+    let branches = git(repo.path(), &["branch", "--list", "a.b"]);
+    assert!(branches.is_empty(), "stale local parent should be pruned");
+}
+
+#[test]
+fn rebase_surfaces_conflict_when_reworked_parent_overlaps_child() {
+    // Same reworked-parent land, but now the child's own commit touches the same
+    // lines the rework diverged on. Replaying the child onto main must SURFACE a
+    // conflict — the correct outcome — not silently rebase onto the dead parent.
+    let repo = TestRepo::new();
+
+    repo.create_branch("a.b");
+    repo.create_file("feature.txt", "v1\n");
+    repo.stage_all();
+    repo.commit("feature v1");
+    repo.push_new_branch("a.b");
+
+    repo.create_branch("a.b.c");
+    repo.create_file("feature.txt", "v1\nchild addition\n");
+    repo.stage_all();
+    repo.commit("child extends feature");
+
+    repo.checkout("main");
+    repo.create_file("feature.txt", "v2 reworked\n");
+    repo.stage_all();
+    repo.commit("feature v2");
+    repo.push();
+    git(repo.path(), &["push", "origin", "--delete", "a.b"]);
+
+    repo.checkout("a.b.c");
+    let result = rebase_with_recovery(
+        repo.path(),
+        &RebaseOptions {
+            onto: "origin/main".to_string(),
+            push: false,
+        },
+        &NullProgress,
+    );
+    assert!(
+        matches!(result, Err(OpsError::RebaseConflict { ref onto, .. }) if onto == "origin/main"),
+        "reworked parent overlapping the child must surface a conflict, got: {result:?}"
+    );
+}
+
+#[test]
 fn plan_rebase_classifies_dirty_scratch_only_branch_as_reset() {
     let repo = TestRepo::new();
     repo.create_branch("feature");
@@ -316,6 +414,8 @@ fn plan_rebase_uses_open_stack_parent() {
     repo.create_file("a.txt", "a");
     repo.stage_all();
     repo.commit("a");
+    // A genuinely-open parent keeps its branch on origin (pushed with a PR).
+    repo.push_new_branch("a");
     repo.create_branch("a.b");
 
     let plan = plan_rebase(repo.path(), None).expect("plan rebase");


### PR DESCRIPTION
## Usage

No new command — this changes how the wave queue and `lf`'s rebase recovery handle a stacked child once its parent has merged. It kicks in automatically:

```bash
# parent PR (a.b) merges — plain or reworked; child a.b.c is queue head
# the daemon reconciles the queue and re-parents a.b.c onto origin/main
```

## Summary

When a stacked child's parent lands, the child owns only its own commits and must re-parent onto the default branch. The old lazy rebase replayed the parent's already-merged commits against `origin/main` and blocked the queue with a spurious `RebaseConflict`. This detects the landed parent and rebases with `--onto <default> <parent-tip>`, dropping the parent's history exactly — even for a multi-commit parent that the patch-id `squash_merge_fork_point` scan can't catch.

"Landed" is detected content-independently, so a *reworked* parent (its merged content diverges from what the child stacked on) is handled too. The daemon passes its lfdb signal (`stack_status == Merged`) down through `rebase_onto_default`; where no daemon is present, the same logic infers landing from git alone (ancestor/squash-merge into the default branch, or a deleted `origin/P`). When a reworked parent diverges from lines the child also touched, the replay conflicts — that conflict surfaces to the caller rather than being auto-healed.

## Changes

- `git::is_merged_into` — covers both fast-forward ancestor and squash-merge shapes of a merge.
- `ops::merged_parent_fork_point` — resolves the fork point (parent tip) and the lingering local parent ref to prune, given a `parent_landed` signal plus git-only fallbacks.
- `plan_rebase`/`rebase_with_recovery` use the fork point to re-parent onto the default branch, replacing the old squash-only TODO path.
- `QueueOps::rebase_onto_default` takes `parent_landed`; the reconcile loop derives it via `head_stack_parent_merged` (dotted stack parent whose inferred status is `Merged`) and prunes the merged parent's local ref after re-parenting.
- Tests: squash-merged parent commits get dropped and the stale local ref pruned; a reworked parent overlapping the child's own lines surfaces a conflict.
