### PR TITLE
release: retire the central DECISIONS.md ledger

### DIFF
--- a/rust/loopflow/src/engine/builtins/ops/prompt/release_notes.md
+++ b/rust/loopflow/src/engine/builtins/ops/prompt/release_notes.md
@@ -31,10 +31,10 @@ When target context is provided (target name, tag prefix, area scope), include o
 
 Lead with outcomes, not mechanisms.
 
-Good: “`lf op release run` now turns release decisions into versioned notes and archives the ledger for audit.”
+Good: “`lf op release run` now generates versioned notes from the merged PRs and archives them for audit.”
 Bad: “Updated release.rs and release_notes.md.”
 
-Do not paste `DECISIONS.md` wholesale. Do not dump PR titles verbatim. The release notes are the synthesis; the ledger remains archived separately.
+Do not dump PR titles verbatim. The release notes are the synthesis of what shipped and why, drawn from the PRs themselves.
 
 Skip internal refactors unless they affect what users experience or how operators run the system.
 

--- a/rust/loopflow/src/engine/builtins/ops/step/release-notes.md
+++ b/rust/loopflow/src/engine/builtins/ops/step/release-notes.md
@@ -46,8 +46,8 @@ Structure:
 - Be specific and factual. No marketing filler.
 - Prefer a few strong themes over many headings.
 - Write for the person deciding whether to upgrade and the operator debugging the release six weeks later.
-- Keep the decision ledger archived under `release/v<version>/DECISIONS.md`; `RELEASE_NOTES.md` should be the interpreted story.
+- Synthesize from the merged PRs and their intent; `RELEASE_NOTES.md` is the interpreted story, not a changelog.
 
 ## Quality bar
 
-A good release note could not be generated from PR titles alone. It carries the intent from `DECISIONS.md`, proves it against shipped changes, and leaves a concise operational record.
+A good release note could not be generated from PR titles alone. It reads the intent from the merged PRs (their descriptions, not just titles), proves it against shipped changes, and leaves a concise operational record. Per-decision context lives in each wave's `MEMORY.md`, not a central ledger.

--- a/rust/loopflow/src/engine/builtins/ops/step/release.md
+++ b/rust/loopflow/src/engine/builtins/ops/step/release.md
@@ -25,7 +25,7 @@ lf op release run <version>
 That command is responsible for:
 - checking there are merged PRs since the previous tag
 - bumping manifests and generating release notes
-- promoting `release/unreleased/` to `release/v<version>/` when a decisions ledger exists
+- promoting any staged `release/unreleased/` artifacts to `release/v<version>/`
 - archiving the generated root `RELEASE_NOTES.md` to `release/v<version>/NOTES.md`
 - creating and landing the release PR
 - waiting for merge queue completion

--- a/rust/loopflow/src/ops/release.rs
+++ b/rust/loopflow/src/ops/release.rs
@@ -433,7 +433,6 @@ struct ReleaseNotesContext {
     area_scope: Vec<String>,
     merged_prs: Vec<MergedPr>,
     previous_release_notes: Option<String>,
-    decisions: Option<String>,
 }
 
 fn run_release_notes_step(
@@ -444,7 +443,6 @@ fn run_release_notes_step(
     target: &ReleaseTarget,
 ) -> OpsResult<()> {
     let previous_notes = fs::read_to_string(repo.join("RELEASE_NOTES.md")).ok();
-    let decisions = load_unreleased_decisions(repo);
     promote_unreleased_dir(repo, version)?;
 
     let context = ReleaseNotesContext {
@@ -455,7 +453,6 @@ fn run_release_notes_step(
         area_scope: target.area.clone(),
         merged_prs: merged_prs.to_vec(),
         previous_release_notes: previous_notes,
-        decisions,
     };
 
     let mut context_file = tempfile::NamedTempFile::new_in(repo)?;
@@ -474,13 +471,7 @@ fn run_release_notes_step(
             eprintln!(
                 "release-notes agent unavailable; writing deterministic fallback release notes"
             );
-            let notes = generate_release_notes(
-                merged_prs,
-                version,
-                prev_tag,
-                target,
-                context.decisions.as_deref(),
-            )?;
+            let notes = generate_release_notes(merged_prs, version, prev_tag, target)?;
             write_release_notes(repo, &notes, version)?;
         }
         Err(err) => {
@@ -516,14 +507,6 @@ fn is_missing_release_notes_agent_cli(err: &CommandError) -> bool {
         || combined.contains("failed to spawn");
 
     mentions_agent_cli && missing_binary
-}
-
-/// Read `release/unreleased/DECISIONS.md` if it exists.
-fn load_unreleased_decisions(repo: &Path) -> Option<String> {
-    let path = repo.join("release").join("unreleased").join("DECISIONS.md");
-    fs::read_to_string(path)
-        .ok()
-        .filter(|s| !s.trim().is_empty())
 }
 
 /// Rename `release/unreleased/` to `release/v<version>/` at tag time.
@@ -729,7 +712,7 @@ fn generate_release_with_target(
     let prs = merged_prs_since(repo, &prev_tag, target)?;
 
     progress.status("Generating release notes...");
-    let notes = generate_release_notes(&prs, &version, &prev_tag, target, None)?;
+    let notes = generate_release_notes(&prs, &version, &prev_tag, target)?;
 
     progress.status("Writing RELEASE_NOTES.md...");
     write_release_notes(repo, &notes, &version)?;
@@ -1197,7 +1180,6 @@ fn generate_release_notes(
     version: &str,
     prev_tag: &str,
     target: &ReleaseTarget,
-    decisions: Option<&str>,
 ) -> OpsResult<String> {
     let mut lines = vec![
         format!("## Changes since {prev_tag}"),
@@ -1207,13 +1189,6 @@ fn generate_release_notes(
         format!("- Area scope: {}", display_area_scope(target)),
         String::new(),
     ];
-
-    if let Some(decisions) = decisions.map(str::trim).filter(|d| !d.is_empty()) {
-        lines.push("## Release decisions".to_string());
-        lines.push(String::new());
-        lines.push(decisions.to_string());
-        lines.push(String::new());
-    }
 
     lines.push("## Merged PRs".to_string());
     lines.push(String::new());
@@ -1974,33 +1949,6 @@ version = "2.0.0"
     // ======================================================================
 
     #[test]
-    fn load_unreleased_decisions_returns_none_when_missing() {
-        let tmp = tempfile::tempdir().unwrap();
-        assert!(load_unreleased_decisions(tmp.path()).is_none());
-    }
-
-    #[test]
-    fn load_unreleased_decisions_ignores_blank_file() {
-        let tmp = tempfile::tempdir().unwrap();
-        let dir = tmp.path().join("release").join("unreleased");
-        fs::create_dir_all(&dir).unwrap();
-        fs::write(dir.join("DECISIONS.md"), "   \n\n").unwrap();
-        assert!(load_unreleased_decisions(tmp.path()).is_none());
-    }
-
-    #[test]
-    fn load_unreleased_decisions_returns_content() {
-        let tmp = tempfile::tempdir().unwrap();
-        let dir = tmp.path().join("release").join("unreleased");
-        fs::create_dir_all(&dir).unwrap();
-        fs::write(dir.join("DECISIONS.md"), "# Decisions\n\nentry").unwrap();
-        assert_eq!(
-            load_unreleased_decisions(tmp.path()).as_deref(),
-            Some("# Decisions\n\nentry"),
-        );
-    }
-
-    #[test]
     fn promote_unreleased_is_noop_without_dir() {
         let tmp = tempfile::tempdir().unwrap();
         promote_unreleased_dir(tmp.path(), "0.9.10").unwrap();
@@ -2012,14 +1960,14 @@ version = "2.0.0"
         let tmp = tempfile::tempdir().unwrap();
         let unreleased = tmp.path().join("release").join("unreleased");
         fs::create_dir_all(&unreleased).unwrap();
-        fs::write(unreleased.join("DECISIONS.md"), "ledger").unwrap();
+        fs::write(unreleased.join("CHANGES.md"), "ledger").unwrap();
 
         promote_unreleased_dir(tmp.path(), "0.9.10").unwrap();
 
         assert!(!unreleased.exists());
         let promoted = tmp.path().join("release").join("v0.9.10");
         assert_eq!(
-            fs::read_to_string(promoted.join("DECISIONS.md")).unwrap(),
+            fs::read_to_string(promoted.join("CHANGES.md")).unwrap(),
             "ledger",
         );
     }
@@ -2029,7 +1977,7 @@ version = "2.0.0"
         let tmp = tempfile::tempdir().unwrap();
         let unreleased = tmp.path().join("release").join("unreleased");
         fs::create_dir_all(&unreleased).unwrap();
-        fs::write(unreleased.join("DECISIONS.md"), "ledger").unwrap();
+        fs::write(unreleased.join("CHANGES.md"), "ledger").unwrap();
 
         let version_dir = tmp.path().join("release").join("v0.9.10");
         fs::create_dir_all(&version_dir).unwrap();
@@ -2039,7 +1987,7 @@ version = "2.0.0"
 
         assert!(!unreleased.exists());
         assert_eq!(
-            fs::read_to_string(version_dir.join("DECISIONS.md")).unwrap(),
+            fs::read_to_string(version_dir.join("CHANGES.md")).unwrap(),
             "ledger",
         );
         assert_eq!(
@@ -2053,11 +2001,11 @@ version = "2.0.0"
         let tmp = tempfile::tempdir().unwrap();
         let unreleased = tmp.path().join("release").join("unreleased");
         fs::create_dir_all(&unreleased).unwrap();
-        fs::write(unreleased.join("DECISIONS.md"), "new").unwrap();
+        fs::write(unreleased.join("CHANGES.md"), "new").unwrap();
 
         let version_dir = tmp.path().join("release").join("v0.9.10");
         fs::create_dir_all(&version_dir).unwrap();
-        fs::write(version_dir.join("DECISIONS.md"), "old").unwrap();
+        fs::write(version_dir.join("CHANGES.md"), "old").unwrap();
 
         assert!(promote_unreleased_dir(tmp.path(), "0.9.10").is_err());
     }

--- a/rust/loopflow/tests/release_tests.rs
+++ b/rust/loopflow/tests/release_tests.rs
@@ -120,10 +120,12 @@ fn release_notes_falls_back_when_agent_cli_is_missing() {
 
     let repo = TestRepo::new();
     git(&repo, &["tag", "v0.9.0"]);
+    // A staged unreleased artifact still gets promoted; it is no longer a
+    // decisions ledger and no longer injected into the notes.
     fs::create_dir_all(repo.path().join("release/unreleased")).unwrap();
     fs::write(
-        repo.path().join("release/unreleased/DECISIONS.md"),
-        "# Decisions\n\nUse deterministic notes in CI when the agent CLI is unavailable.\n",
+        repo.path().join("release/unreleased/CHANGES.md"),
+        "staged artifact\n",
     )
     .unwrap();
 
@@ -132,14 +134,16 @@ fn release_notes_falls_back_when_agent_cli_is_missing() {
 
     assert!(notes.starts_with("# v0.9.1\n\n"));
     assert!(notes.contains("_Generated mechanically for v0.9.1._"));
-    assert!(notes.contains("## Release decisions"));
+    // Notes synthesize from the merged PRs, not a central ledger.
     assert!(notes.contains("Make weekly release self-contained"));
-    assert!(notes.contains("Use deterministic notes in CI"));
+    assert!(!notes.contains("## Release decisions"));
     assert_eq!(
         fs::read_to_string(repo.path().join("release/v0.9.1/NOTES.md")).unwrap(),
         notes,
     );
+    // The unreleased dir was promoted to the version dir.
     assert!(!repo.path().join("release/unreleased").exists());
+    assert!(repo.path().join("release/v0.9.1/CHANGES.md").exists());
 }
 
 #[test]


### PR DESCRIPTION
## Usage

```bash
lf op release run <version>
```

Release notes are now synthesized from the merged PRs and their descriptions instead of a central `DECISIONS.md` ledger. Per-decision context lives in each wave's `MEMORY.md`, so the release pipeline no longer reads, injects, or archives a decisions ledger. The `release/unreleased/` → `release/v<version>/` promotion still happens for any staged artifacts.

## Changes

- Drop `load_unreleased_decisions` and the `decisions` field on `ReleaseNotesContext`; `generate_release_notes` no longer takes a decisions argument or emits a `## Release decisions` section.
- Update the `release-notes` and `release` builtin prompts/steps to draw intent from merged PRs rather than pasting `DECISIONS.md`, pointing per-decision context at each wave's `MEMORY.md`.
- Rework tests: promotion tests use a generic `CHANGES.md` staged artifact, and the fallback test asserts notes come from PRs (no `## Release decisions`) while the unreleased dir is still promoted.