### PR TITLE
install.py: drop stale --global from lf op sync-skills

### DIFF
--- a/python/tests/test_install_script.py
+++ b/python/tests/test_install_script.py
@@ -187,7 +187,7 @@ def test_stage_binaries_errors_on_missing_cargo_output(
         install._stage_binaries(tmp_path / "local-bin")
 
 
-def test_sync_skills_runs_fresh_lf_with_global_yes(tmp_path: Path) -> None:
+def test_sync_skills_runs_fresh_lf_with_yes(tmp_path: Path) -> None:
     log = tmp_path / "sync.log"
     lf = tmp_path / "lf"
     lf.write_text(f"#!/usr/bin/env bash\nprintf '%s\\n' \"$*\" > {log}\nprintf 'synced\\n'\n")
@@ -195,7 +195,7 @@ def test_sync_skills_runs_fresh_lf_with_global_yes(tmp_path: Path) -> None:
 
     install._sync_skills(lf)
 
-    assert log.read_text() == "op sync-skills --global --yes\n"
+    assert log.read_text() == "op sync-skills --yes\n"
 
 
 def test_sync_skills_warns_without_failing_when_lf_cannot_run(

--- a/scripts/install.py
+++ b/scripts/install.py
@@ -322,7 +322,7 @@ def _sync_skills(lf_bin: Path) -> None:
     typer.echo("Syncing skills into ~/.claude and ~/.agents...")
     try:
         code = _stream_process(
-            [str(lf_bin), "op", "sync-skills", "--global", "--yes"], "skills", cwd=ROOT
+            [str(lf_bin), "op", "sync-skills", "--yes"], "skills", cwd=ROOT
         )
     except OSError as exc:
         typer.echo(f"skill sync failed ({exc}); binaries installed, skills unchanged", err=True)


### PR DESCRIPTION
## Usage

```bash
python scripts/install.py
```

## Summary

`lf op sync-skills` no longer accepts a `--global` flag, so the installer's skill-sync step was passing a dead argument. This drops `--global` from the `_sync_skills` invocation, leaving just `op sync-skills --yes`, and updates the corresponding test to match.

## Changes

- `scripts/install.py`: `_sync_skills` now runs `lf op sync-skills --yes`
- `python/tests/test_install_script.py`: renamed and updated the sync-skills test to assert the new argument list