### PR TITLE
agents: respect sandbox configs in worktrees

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -290,14 +290,33 @@ Requires the [Chrome extension](https://chromewebstore.google.com/detail/claude-
 
 ### Yolo
 
-Skip permissions. Codex uses the danger-full-access sandbox.
+Skip vendor permission prompts and sandboxes.
 
 | | |
 |---|---|
 | **Config** | `yolo: true` |
 | **Default** | `false` |
 
-Claude: `--dangerously-skip-permissions`. Codex: `--sandbox danger-full-access` with `approval_policy="never"`. Gemini: `--yolo`. OpenCode: `permission: "allow"` via `OPENCODE_CONFIG_CONTENT`.
+Loopflow's normal floor is conservative automation: Codex gets
+`workspace-write` and non-interactive Codex runs get `approval_policy = "never"`;
+non-interactive Claude runs skip permission prompts. User and repo-level vendor
+configs that are already more permissive are not downgraded. For example, Codex
+`sandbox_mode = "danger-full-access"` or Claude
+`permissions.defaultMode = "bypassPermissions"` are left to the vendor config.
+If vendor config is less permissive, Loopflow warns and supplies its default.
+
+`yolo: true` is the explicit Loopflow bypass: Claude uses
+`--dangerously-skip-permissions`, Codex uses
+`--dangerously-bypass-approvals-and-sandbox`, Gemini uses `--yolo`, and OpenCode
+uses `permission: "allow"` via `OPENCODE_CONFIG_CONTENT`.
+
+### Worktree Sandboxes
+
+Claude and Codex CLI/TUI sessions launched from a Git worktree automatically add
+the main repo as an extra writable directory. This keeps normal agent
+permissions, but lets Git write the linked worktree index under
+`<main>/.git/worktrees/<worktree>/` when the agent stages, commits, rebases, or
+runs `lf op`.
 
 ### Autoprune
 

--- a/rust/loopflow/src/engine/agent.rs
+++ b/rust/loopflow/src/engine/agent.rs
@@ -4,7 +4,10 @@
 //! supported coding agent. Output can be captured or streamed.
 
 use std::collections::BTreeMap;
+use std::env;
+use std::fs;
 use std::io::{BufRead, BufReader, Read};
+use std::path::{Path, PathBuf};
 use std::process::{Child, Command, ExitStatus, Stdio};
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::{mpsc, Mutex, OnceLock};
@@ -167,6 +170,250 @@ pub struct AgentCapabilities {
     pub chrome: bool,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+enum CodexSandboxMode {
+    ReadOnly,
+    WorkspaceWrite,
+    DangerFullAccess,
+}
+
+impl CodexSandboxMode {
+    fn parse(value: &str) -> Option<Self> {
+        match value {
+            "read-only" => Some(Self::ReadOnly),
+            "workspace-write" => Some(Self::WorkspaceWrite),
+            "danger-full-access" => Some(Self::DangerFullAccess),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+enum CodexApprovalPolicy {
+    Untrusted,
+    OnRequest,
+    OnFailure,
+    Never,
+}
+
+impl CodexApprovalPolicy {
+    fn parse(value: &str) -> Option<Self> {
+        match value {
+            "untrusted" => Some(Self::Untrusted),
+            "on-request" => Some(Self::OnRequest),
+            "on-failure" => Some(Self::OnFailure),
+            "never" => Some(Self::Never),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+struct CodexPermissionConfig {
+    sandbox: Option<CodexSandboxMode>,
+    approval: Option<CodexApprovalPolicy>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ClaudePermissionMode {
+    AcceptEdits,
+    Auto,
+    BypassPermissions,
+    Manual,
+    DontAsk,
+    Plan,
+}
+
+impl ClaudePermissionMode {
+    fn parse(value: &str) -> Option<Self> {
+        match value {
+            "acceptEdits" => Some(Self::AcceptEdits),
+            "auto" => Some(Self::Auto),
+            "bypassPermissions" => Some(Self::BypassPermissions),
+            "manual" => Some(Self::Manual),
+            "dontAsk" => Some(Self::DontAsk),
+            "plan" => Some(Self::Plan),
+            _ => None,
+        }
+    }
+}
+
+fn read_codex_permission_config(cwd: Option<&Path>) -> CodexPermissionConfig {
+    let mut config = CodexPermissionConfig::default();
+    for path in codex_config_paths(cwd) {
+        let Ok(contents) = fs::read_to_string(&path) else {
+            continue;
+        };
+        config = merge_codex_permission_config(config, parse_codex_permission_config(&contents));
+    }
+    config
+}
+
+fn codex_config_paths(cwd: Option<&Path>) -> Vec<PathBuf> {
+    let mut paths = Vec::new();
+
+    if let Some(home) = env::var_os("CODEX_HOME")
+        .map(PathBuf::from)
+        .or_else(|| dirs::home_dir().map(|home| home.join(".codex")))
+    {
+        paths.push(home.join("config.toml"));
+    }
+
+    if let Some(cwd) = cwd {
+        let mut ancestors: Vec<PathBuf> = cwd.ancestors().map(Path::to_path_buf).collect();
+        ancestors.reverse();
+        for ancestor in ancestors {
+            paths.push(ancestor.join(".codex").join("config.toml"));
+        }
+    }
+
+    paths
+}
+
+fn parse_codex_permission_config(contents: &str) -> CodexPermissionConfig {
+    let mut config = CodexPermissionConfig::default();
+    for line in contents.lines() {
+        let line = line.trim();
+        if line.starts_with('[') {
+            break;
+        }
+        if let Some(value) = parse_toml_string_assignment(line, "sandbox_mode") {
+            config.sandbox = CodexSandboxMode::parse(&value);
+        } else if let Some(value) = parse_toml_string_assignment(line, "approval_policy") {
+            config.approval = CodexApprovalPolicy::parse(&value);
+        }
+    }
+    config
+}
+
+fn parse_toml_string_assignment(line: &str, key: &str) -> Option<String> {
+    let (left, right) = line.split_once('=')?;
+    if left.trim() != key {
+        return None;
+    }
+    let value = right.split('#').next()?.trim();
+    value
+        .strip_prefix('"')
+        .and_then(|value| value.strip_suffix('"'))
+        .map(str::to_string)
+}
+
+fn merge_codex_permission_config(
+    base: CodexPermissionConfig,
+    overlay: CodexPermissionConfig,
+) -> CodexPermissionConfig {
+    CodexPermissionConfig {
+        sandbox: overlay.sandbox.or(base.sandbox),
+        approval: overlay.approval.or(base.approval),
+    }
+}
+
+pub fn codex_permission_args(
+    cwd: Option<&Path>,
+    auto: bool,
+    skip_permissions: bool,
+) -> Vec<String> {
+    if skip_permissions {
+        return vec!["--dangerously-bypass-approvals-and-sandbox".to_string()];
+    }
+
+    let config = read_codex_permission_config(cwd);
+    codex_permission_args_for_config(config, auto, skip_permissions)
+}
+
+fn codex_permission_args_for_config(
+    config: CodexPermissionConfig,
+    auto: bool,
+    skip_permissions: bool,
+) -> Vec<String> {
+    if skip_permissions {
+        return vec!["--dangerously-bypass-approvals-and-sandbox".to_string()];
+    }
+
+    let mut args = Vec::new();
+    if config.sandbox < Some(CodexSandboxMode::WorkspaceWrite) {
+        if config.sandbox.is_some() {
+            eprintln!(
+                "warning: Codex config sandbox_mode is less permissive than Loopflow's workspace-write default; launching with --sandbox workspace-write"
+            );
+        }
+        args.push("--sandbox".to_string());
+        args.push("workspace-write".to_string());
+    }
+
+    if auto && config.approval < Some(CodexApprovalPolicy::Never) {
+        if config.approval.is_some() {
+            eprintln!(
+                "warning: Codex config approval_policy is less permissive than Loopflow's non-interactive default; launching with --ask-for-approval never"
+            );
+        }
+        args.push("--ask-for-approval".to_string());
+        args.push("never".to_string());
+    }
+
+    args
+}
+
+fn read_claude_permission_mode(cwd: Option<&Path>) -> Option<ClaudePermissionMode> {
+    let mut mode = None;
+    for path in claude_settings_paths(cwd) {
+        let Ok(contents) = fs::read_to_string(&path) else {
+            continue;
+        };
+        if let Some(next) = parse_claude_permission_mode(&contents) {
+            mode = Some(next);
+        }
+    }
+    mode
+}
+
+fn claude_settings_paths(cwd: Option<&Path>) -> Vec<PathBuf> {
+    let mut paths = Vec::new();
+
+    if let Some(home) = dirs::home_dir() {
+        paths.push(home.join(".claude").join("settings.json"));
+    }
+
+    if let Some(cwd) = cwd {
+        let mut ancestors: Vec<PathBuf> = cwd.ancestors().map(Path::to_path_buf).collect();
+        ancestors.reverse();
+        for ancestor in ancestors {
+            paths.push(ancestor.join(".claude").join("settings.json"));
+            paths.push(ancestor.join(".claude").join("settings.local.json"));
+        }
+    }
+
+    paths
+}
+
+fn parse_claude_permission_mode(contents: &str) -> Option<ClaudePermissionMode> {
+    let json: serde_json::Value = serde_json::from_str(contents).ok()?;
+    json.get("permissions")
+        .and_then(|permissions| permissions.get("defaultMode"))
+        .and_then(serde_json::Value::as_str)
+        .and_then(ClaudePermissionMode::parse)
+}
+
+fn claude_skip_permissions(cwd: Option<&Path>, auto: bool, skip_permissions: bool) -> bool {
+    if skip_permissions {
+        return true;
+    }
+    if !auto {
+        return false;
+    }
+
+    let mode = read_claude_permission_mode(cwd);
+    if mode == Some(ClaudePermissionMode::BypassPermissions) {
+        return false;
+    }
+    if mode.is_some() {
+        eprintln!(
+            "warning: Claude permissions.defaultMode is less permissive than Loopflow's non-interactive default; launching with --dangerously-skip-permissions"
+        );
+    }
+    true
+}
+
 /// Common Claude CLI arguments shared across engine and session paths.
 ///
 /// Both `build_claude_command` (engine one-shot) and the session harness
@@ -180,6 +427,8 @@ pub struct ClaudeArgs {
     pub system_prompt: Option<String>,
     /// System prompt file for `--append-system-prompt-file` (takes precedence over text).
     pub system_prompt_file: Option<std::path::PathBuf>,
+    /// Additional directories the harness may access.
+    pub add_dirs: Vec<PathBuf>,
     /// Skip permission prompts.
     pub skip_permissions: bool,
     /// Max turn budget.
@@ -229,6 +478,15 @@ impl ClaudeArgs {
             }
         }
 
+        if !self.add_dirs.is_empty() {
+            args.push("--add-dir".to_string());
+            args.extend(
+                self.add_dirs
+                    .iter()
+                    .map(|dir| dir.to_string_lossy().to_string()),
+            );
+        }
+
         if self.skip_permissions {
             args.push("--dangerously-skip-permissions".to_string());
         }
@@ -267,7 +525,16 @@ pub fn build_claude_session_turn_args(
         model: config.agent.as_deref().and_then(ClaudeArgs::resolve_model),
         system_prompt: Some(system_prompt_with_structured_replies(config)),
         system_prompt_file: None,
-        skip_permissions: config.skip_permissions,
+        add_dirs: config
+            .cwd
+            .as_deref()
+            .map(workspace_add_dirs)
+            .unwrap_or_default(),
+        skip_permissions: claude_skip_permissions(
+            config.cwd.as_deref(),
+            true,
+            config.skip_permissions,
+        ),
         max_turns: config.max_turns,
         stream: true,
         chrome: false,
@@ -310,7 +577,51 @@ pub fn build_codex_thread_start_params(
         );
     }
 
+    if launch.skip_permissions {
+        params.insert(
+            "approvalPolicy".to_string(),
+            serde_json::Value::String("never".to_string()),
+        );
+        params.insert(
+            "sandbox".to_string(),
+            serde_json::Value::String("danger-full-access".to_string()),
+        );
+    } else {
+        let config = read_codex_permission_config(launch.cwd.as_deref());
+        if config.sandbox < Some(CodexSandboxMode::WorkspaceWrite) {
+            params.insert(
+                "sandbox".to_string(),
+                serde_json::Value::String("workspace-write".to_string()),
+            );
+        }
+        if config.approval < Some(CodexApprovalPolicy::Never) {
+            params.insert(
+                "approvalPolicy".to_string(),
+                serde_json::Value::String("never".to_string()),
+            );
+        }
+    }
+
     params
+}
+
+/// Extra workspace roots agents need for Git worktree metadata.
+pub fn workspace_add_dirs(cwd: &Path) -> Vec<PathBuf> {
+    let Ok(main_repo) = crate::engine::worktrees::main_repo_root(cwd) else {
+        return Vec::new();
+    };
+    if paths_equal(cwd, &main_repo) {
+        Vec::new()
+    } else {
+        vec![main_repo]
+    }
+}
+
+fn paths_equal(left: &Path, right: &Path) -> bool {
+    match (left.canonicalize(), right.canonicalize()) {
+        (Ok(left), Ok(right)) => left == right,
+        _ => left == right,
+    }
 }
 
 /// Build Claude CLI command.
@@ -326,7 +637,16 @@ pub fn build_claude_command(
         model: model_variant.map(str::to_string),
         system_prompt: Some(system_prompt_with_structured_replies(launch)),
         system_prompt_file: process.context_file.clone(),
-        skip_permissions: process.auto || launch.skip_permissions,
+        add_dirs: launch
+            .cwd
+            .as_deref()
+            .map(workspace_add_dirs)
+            .unwrap_or_default(),
+        skip_permissions: claude_skip_permissions(
+            launch.cwd.as_deref(),
+            process.auto,
+            launch.skip_permissions,
+        ),
         max_turns: launch.max_turns,
         stream: process.auto && process.stream,
         chrome: capabilities.chrome,
@@ -373,19 +693,27 @@ pub fn build_codex_command(
         cmd.push(cwd.to_string_lossy().to_string());
     }
 
+    if !launch.skip_permissions {
+        for dir in launch
+            .cwd
+            .as_deref()
+            .map(workspace_add_dirs)
+            .unwrap_or_default()
+        {
+            cmd.push("--add-dir".to_string());
+            cmd.push(dir.to_string_lossy().to_string());
+        }
+    }
+
     if process.stream {
         cmd.push("--json".to_string());
     }
 
-    if launch.skip_permissions {
-        cmd.push("--dangerously-bypass-approvals-and-sandbox".to_string());
-    } else if process.auto {
-        // --full-auto = sandboxed workspace-write + auto-approve safe operations.
-        cmd.push("--full-auto".to_string());
-    } else {
-        cmd.push("--sandbox".to_string());
-        cmd.push("workspace-write".to_string());
-    }
+    cmd.extend(codex_permission_args(
+        launch.cwd.as_deref(),
+        process.auto,
+        launch.skip_permissions,
+    ));
 
     cmd
 }
@@ -934,11 +1262,124 @@ mod tests {
         }
     }
 
+    fn git_worktree_fixture() -> (tempfile::TempDir, PathBuf, PathBuf) {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let main = tmp.path().join("repo");
+        let worktree = tmp.path().join("repo.feature");
+        std::fs::create_dir(&main).expect("create repo dir");
+        std::fs::write(main.join("README.md"), "hello\n").expect("write file");
+
+        git(&main, &["init", "-b", "main"]);
+        git(&main, &["config", "user.email", "test@example.com"]);
+        git(&main, &["config", "user.name", "Test User"]);
+        git(&main, &["add", "."]);
+        git(&main, &["commit", "-m", "init"]);
+        git(
+            &main,
+            &[
+                "worktree",
+                "add",
+                "-b",
+                "feature",
+                worktree.to_str().expect("utf8 worktree"),
+            ],
+        );
+
+        (tmp, main, worktree)
+    }
+
+    fn git(repo: &Path, args: &[&str]) {
+        let output = std::process::Command::new("git")
+            .arg("-C")
+            .arg(repo)
+            .args(args)
+            .output()
+            .expect("run git");
+        assert!(
+            output.status.success(),
+            "git -C {} {} failed:\n{}",
+            repo.display(),
+            args.join(" "),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
     fn auto_process() -> ProcessConfig {
         ProcessConfig {
             auto: true,
             ..Default::default()
         }
+    }
+
+    fn assert_arg_pair(args: &[String], flag: &str, value: &str) {
+        let idx = args
+            .iter()
+            .position(|arg| arg == flag)
+            .unwrap_or_else(|| panic!("{flag} flag"));
+        assert_eq!(args[idx + 1], value);
+    }
+
+    #[test]
+    fn parse_codex_permission_config_reads_top_level_policy() {
+        let config = parse_codex_permission_config(
+            r#"
+model = "gpt-5.5"
+sandbox_mode = "danger-full-access"
+approval_policy = "never"
+
+[projects."/tmp/repo"]
+trust_level = "trusted"
+"#,
+        );
+
+        assert_eq!(config.sandbox, Some(CodexSandboxMode::DangerFullAccess));
+        assert_eq!(config.approval, Some(CodexApprovalPolicy::Never));
+    }
+
+    #[test]
+    fn codex_permission_args_supply_loopflow_floor_when_unset() {
+        let args = codex_permission_args_for_config(CodexPermissionConfig::default(), true, false);
+
+        assert_arg_pair(&args, "--sandbox", "workspace-write");
+        assert_arg_pair(&args, "--ask-for-approval", "never");
+    }
+
+    #[test]
+    fn codex_permission_args_do_not_downgrade_danger_full_access() {
+        let args = codex_permission_args_for_config(
+            CodexPermissionConfig {
+                sandbox: Some(CodexSandboxMode::DangerFullAccess),
+                approval: Some(CodexApprovalPolicy::Never),
+            },
+            true,
+            false,
+        );
+
+        assert!(!args.contains(&"--sandbox".to_string()));
+        assert!(!args.contains(&"--ask-for-approval".to_string()));
+    }
+
+    #[test]
+    fn codex_permission_args_raise_less_permissive_config_to_floor() {
+        let args = codex_permission_args_for_config(
+            CodexPermissionConfig {
+                sandbox: Some(CodexSandboxMode::ReadOnly),
+                approval: Some(CodexApprovalPolicy::OnRequest),
+            },
+            true,
+            false,
+        );
+
+        assert_arg_pair(&args, "--sandbox", "workspace-write");
+        assert_arg_pair(&args, "--ask-for-approval", "never");
+    }
+
+    #[test]
+    fn parse_claude_permission_mode_reads_default_mode() {
+        assert_eq!(
+            parse_claude_permission_mode(r#"{"permissions":{"defaultMode":"bypassPermissions"}}"#),
+            Some(ClaudePermissionMode::BypassPermissions)
+        );
     }
 
     #[test]
@@ -954,6 +1395,24 @@ mod tests {
         };
         let cmd = build_claude_command(&launch, &process, &AgentCapabilities::default(), None);
         assert!(cmd.contains(&"--print".to_string()));
+        assert_eq!(
+            cmd.contains(&"--dangerously-skip-permissions".to_string()),
+            claude_skip_permissions(None, true, false)
+        );
+    }
+
+    #[test]
+    fn build_claude_command_yolo() {
+        let launch = AgentConfig {
+            skip_permissions: true,
+            ..default_launch()
+        };
+        let process = ProcessConfig {
+            auto: true,
+            stream: false,
+            ..Default::default()
+        };
+        let cmd = build_claude_command(&launch, &process, &AgentCapabilities::default(), None);
         assert!(cmd.contains(&"--dangerously-skip-permissions".to_string()));
     }
 
@@ -994,6 +1453,39 @@ mod tests {
     }
 
     #[test]
+    fn build_claude_command_adds_main_repo_for_worktree_metadata() {
+        let (_tmp, main, worktree) = git_worktree_fixture();
+        let launch = AgentConfig {
+            cwd: Some(worktree),
+            ..default_launch()
+        };
+        let process = auto_process();
+
+        let cmd = build_claude_command(&launch, &process, &AgentCapabilities::default(), None);
+        let idx = cmd
+            .iter()
+            .position(|arg| arg == "--add-dir")
+            .expect("add-dir flag");
+        assert_eq!(
+            PathBuf::from(&cmd[idx + 1]).canonicalize().unwrap(),
+            main.canonicalize().unwrap()
+        );
+    }
+
+    #[test]
+    fn build_claude_command_omits_add_dir_for_main_repo() {
+        let (_tmp, main, _worktree) = git_worktree_fixture();
+        let launch = AgentConfig {
+            cwd: Some(main),
+            ..default_launch()
+        };
+        let process = auto_process();
+
+        let cmd = build_claude_command(&launch, &process, &AgentCapabilities::default(), None);
+        assert!(!cmd.contains(&"--add-dir".to_string()));
+    }
+
+    #[test]
     fn build_codex_command_auto() {
         let launch = AgentConfig {
             skip_permissions: false,
@@ -1005,10 +1497,17 @@ mod tests {
             ..Default::default()
         };
         let cmd = build_codex_command(&launch, &process, None);
+        let policy_args = codex_permission_args(None, true, false);
         assert!(cmd.contains(&"exec".to_string()));
-        assert!(cmd.contains(&"--full-auto".to_string()));
-        assert!(!cmd.contains(&"--sandbox".to_string()));
-        assert!(!cmd.contains(&"--ask-for-approval".to_string()));
+        assert!(!cmd.contains(&"--full-auto".to_string()));
+        assert_eq!(
+            cmd.contains(&"--sandbox".to_string()),
+            policy_args.contains(&"--sandbox".to_string())
+        );
+        assert_eq!(
+            cmd.contains(&"--ask-for-approval".to_string()),
+            policy_args.contains(&"--ask-for-approval".to_string())
+        );
         assert!(!cmd.contains(&"--dangerously-bypass-approvals-and-sandbox".to_string()));
     }
 
@@ -1029,6 +1528,45 @@ mod tests {
             "interactive mode should not use 'exec'"
         );
         assert!(!cmd.contains(&"--full-auto".to_string()));
+        assert_eq!(
+            cmd.contains(&"--sandbox".to_string()),
+            codex_permission_args(None, false, false).contains(&"--sandbox".to_string())
+        );
+    }
+
+    #[test]
+    fn build_codex_command_adds_main_repo_for_worktree_metadata() {
+        let (_tmp, main, worktree) = git_worktree_fixture();
+        let launch = AgentConfig {
+            cwd: Some(worktree),
+            skip_permissions: false,
+            ..default_launch()
+        };
+        let process = auto_process();
+
+        let cmd = build_codex_command(&launch, &process, None);
+        let idx = cmd
+            .iter()
+            .position(|arg| arg == "--add-dir")
+            .expect("add-dir flag");
+        assert_eq!(
+            PathBuf::from(&cmd[idx + 1]).canonicalize().unwrap(),
+            main.canonicalize().unwrap()
+        );
+    }
+
+    #[test]
+    fn build_codex_command_omits_add_dir_for_main_repo() {
+        let (_tmp, main, _worktree) = git_worktree_fixture();
+        let launch = AgentConfig {
+            cwd: Some(main),
+            skip_permissions: false,
+            ..default_launch()
+        };
+        let process = auto_process();
+
+        let cmd = build_codex_command(&launch, &process, None);
+        assert!(!cmd.contains(&"--add-dir".to_string()));
     }
 
     #[test]
@@ -1286,6 +1824,7 @@ mod tests {
             model: Some("sonnet".to_string()),
             system_prompt: Some("Be brief".to_string()),
             system_prompt_file: None,
+            add_dirs: vec!["/tmp/repo".into()],
             skip_permissions: true,
             max_turns: Some(10),
             stream: true,
@@ -1297,6 +1836,8 @@ mod tests {
         assert!(args.contains(&"--model".to_string()));
         assert!(args.contains(&"sonnet".to_string()));
         assert!(args.contains(&"--append-system-prompt".to_string()));
+        assert!(args.contains(&"--add-dir".to_string()));
+        assert!(args.contains(&"/tmp/repo".to_string()));
         assert!(args.contains(&"--dangerously-skip-permissions".to_string()));
         assert!(args.contains(&"--max-turns".to_string()));
         assert!(args.contains(&"10".to_string()));
@@ -1399,9 +1940,14 @@ mod tests {
             directive_relay: None,
         };
         let args = build_claude_session_turn_args("hello", &config, None);
+        assert_eq!(args[0], "-p");
+        assert_eq!(args[1], "hello");
+        assert!(args.contains(&"--output-format".to_string()));
+        assert!(args.contains(&"stream-json".to_string()));
+        assert!(args.contains(&"--verbose".to_string()));
         assert_eq!(
-            args,
-            vec!["-p", "hello", "--output-format", "stream-json", "--verbose"]
+            args.contains(&"--dangerously-skip-permissions".to_string()),
+            claude_skip_permissions(Some(Path::new("/tmp")), true, false)
         );
     }
 

--- a/rust/loopflow/src/engine/mod.rs
+++ b/rust/loopflow/src/engine/mod.rs
@@ -26,8 +26,9 @@ pub mod worktrees;
 
 pub use agent::{
     build_agent_command, build_claude_command, build_codex_command, build_gemini_command,
-    build_model_command, build_opencode_command, check_cli_available, launch_agent,
-    AgentCapabilities, AgentConfig, ClaudeArgs, DefaultRunner, LaunchResult, ProcessConfig, Runner,
+    build_model_command, build_opencode_command, check_cli_available, codex_permission_args,
+    launch_agent, workspace_add_dirs, AgentCapabilities, AgentConfig, ClaudeArgs, DefaultRunner,
+    LaunchResult, ProcessConfig, Runner,
 };
 pub use command::{run_command, CommandError};
 pub use config::{

--- a/rust/loopflow/src/harness/codex.rs
+++ b/rust/loopflow/src/harness/codex.rs
@@ -707,9 +707,8 @@ impl CodexHarness {
 
                 // Any server request (method + id) is an approval request
                 // (item/commandExecution/requestApproval and friends); answer
-                // it per the configured policy. With approvalPolicy "never"
-                // in thread/start these should not occur, but the belt goes
-                // with the suspenders.
+                // it per the configured Loopflow response policy. The user's
+                // Codex approval policy decides whether these requests occur.
                 if let Some(id) = value.get("id") {
                     let result = match approval {
                         ApprovalPolicy::AutoApprove => json!({ "decision": "accept" }),
@@ -763,18 +762,10 @@ impl CodexHarness {
             .map_err(|_| anyhow!("codex initialize channel closed"))?;
         self.send_notification("initialized").await?;
 
-        let mut thread_params = build_codex_thread_start_params(launch);
-        // Pass the approval intent explicitly instead of inheriting whatever
-        // ~/.codex/config.toml says. Probed live on 0.142.5: thread/start
-        // accepts `approvalPolicy` (AskForApproval: "never" | "on-request" |
-        // "on-failure" | "untrusted") and `sandbox` (SandboxMode: "read-only"
-        // | "workspace-write" | "danger-full-access") and echoes them back in
-        // its response.
-        let (approval_policy, sandbox) = match self.approval {
-            ApprovalPolicy::AutoApprove => ("never", "danger-full-access"),
-        };
-        thread_params.insert("approvalPolicy".to_string(), json!(approval_policy));
-        thread_params.insert("sandbox".to_string(), json!(sandbox));
+        let thread_params = build_codex_thread_start_params(launch);
+        // The thread params include Loopflow's conservative defaults only when
+        // Codex config is missing or less permissive. More permissive user or
+        // repo config, such as danger-full-access, is left alone.
         // Publish the request id before sending so the reader can match the
         // response even if it races the send.
         let request_id = self.next_request_id;

--- a/rust/loopflow/src/lf/commands/util.rs
+++ b/rust/loopflow/src/lf/commands/util.rs
@@ -2,7 +2,7 @@ use anyhow::{anyhow, Result};
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
-use crate::engine::{check_cli_available, LaunchTarget};
+use crate::engine::{check_cli_available, codex_permission_args, workspace_add_dirs, LaunchTarget};
 
 pub fn find_repo_root() -> Result<PathBuf> {
     crate::engine::repo::find_repo_root()
@@ -91,8 +91,11 @@ fn build_session_command(
                 args.push("-c".to_string());
                 args.push(format!("model=\"{model}\""));
             }
-            args.push("--sandbox".to_string());
-            args.push("workspace-write".to_string());
+            for dir in workspace_add_dirs(worktree) {
+                args.push("--add-dir".to_string());
+                args.push(dir.to_string_lossy().to_string());
+            }
+            args.extend(codex_permission_args(Some(worktree), false, false));
             args.push(prompt.to_string());
             Ok(SessionCommand {
                 program: "codex".to_string(),
@@ -105,6 +108,10 @@ fn build_session_command(
             if let Some(model) = model {
                 args.push("--model".to_string());
                 args.push(model.to_string());
+            }
+            for dir in workspace_add_dirs(worktree) {
+                args.push("--add-dir".to_string());
+                args.push(dir.to_string_lossy().to_string());
             }
             args.push(prompt.to_string());
             Ok(SessionCommand {
@@ -193,29 +200,93 @@ mod tests {
         values.iter().map(|value| value.to_string()).collect()
     }
 
+    fn git_worktree_fixture() -> (tempfile::TempDir, PathBuf, PathBuf) {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let main = tmp.path().join("repo");
+        let worktree = tmp.path().join("repo.feature");
+        std::fs::create_dir(&main).expect("create repo dir");
+        std::fs::write(main.join("README.md"), "hello\n").expect("write file");
+
+        git(&main, &["init", "-b", "main"]);
+        git(&main, &["config", "user.email", "test@example.com"]);
+        git(&main, &["config", "user.name", "Test User"]);
+        git(&main, &["add", "."]);
+        git(&main, &["commit", "-m", "init"]);
+        git(
+            &main,
+            &[
+                "worktree",
+                "add",
+                "-b",
+                "feature",
+                worktree.to_str().expect("utf8 worktree"),
+            ],
+        );
+
+        (tmp, main, worktree)
+    }
+
+    fn git(repo: &Path, args: &[&str]) {
+        let output = std::process::Command::new("git")
+            .arg("-C")
+            .arg(repo)
+            .args(args)
+            .output()
+            .expect("run git");
+        assert!(
+            output.status.success(),
+            "git -C {} {} failed:\n{}",
+            repo.display(),
+            args.join(" "),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
     #[test]
-    fn session_launch_tui_codex_sets_worktree_model_sandbox_and_prompt() {
+    fn session_launch_tui_codex_sets_worktree_model_and_prompt() {
         let launch =
             build_session_launch(LaunchTarget::Tui, "codex", Some("o3"), &path(), "fix it")
                 .expect("build launch");
 
+        assert_eq!(launch.command.program, "codex");
+        assert_eq!(launch.command.cwd, path());
+        assert!(launch.command.args.starts_with(&args(&[
+            "-C",
+            "/tmp/loop flow",
+            "-c",
+            "model=\"o3\""
+        ])));
         assert_eq!(
-            launch.command,
-            SessionCommand {
-                program: "codex".to_string(),
-                args: args(&[
-                    "-C",
-                    "/tmp/loop flow",
-                    "-c",
-                    "model=\"o3\"",
-                    "--sandbox",
-                    "workspace-write",
-                    "fix it",
-                ]),
-                cwd: path(),
-            }
+            launch.command.args.last().map(String::as_str),
+            Some("fix it")
+        );
+        assert_eq!(
+            launch.command.args.contains(&"--sandbox".to_string()),
+            crate::engine::codex_permission_args(Some(&path()), false, false)
+                .contains(&"--sandbox".to_string())
         );
         assert_eq!(launch.ide_url, None);
+    }
+
+    #[test]
+    fn session_launch_tui_codex_adds_main_repo_for_worktree_metadata() {
+        let (_tmp, main, worktree) = git_worktree_fixture();
+
+        let launch = build_session_launch(LaunchTarget::Tui, "codex", None, &worktree, "fix it")
+            .expect("build launch");
+
+        let idx = launch
+            .command
+            .args
+            .iter()
+            .position(|arg| arg == "--add-dir")
+            .expect("add-dir flag");
+        assert_eq!(
+            PathBuf::from(&launch.command.args[idx + 1])
+                .canonicalize()
+                .unwrap(),
+            main.canonicalize().unwrap()
+        );
     }
 
     #[test]
@@ -238,6 +309,33 @@ mod tests {
             }
         );
         assert_eq!(launch.ide_url, None);
+    }
+
+    #[test]
+    fn session_launch_tui_claude_adds_main_repo_for_worktree_metadata() {
+        let (_tmp, main, worktree) = git_worktree_fixture();
+
+        let launch = build_session_launch(
+            LaunchTarget::Tui,
+            "claude",
+            Some("sonnet"),
+            &worktree,
+            "fix it",
+        )
+        .expect("build launch");
+
+        let idx = launch
+            .command
+            .args
+            .iter()
+            .position(|arg| arg == "--add-dir")
+            .expect("add-dir flag");
+        assert_eq!(
+            PathBuf::from(&launch.command.args[idx + 1])
+                .canonicalize()
+                .unwrap(),
+            main.canonicalize().unwrap()
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Usage

```yaml
# loop.yaml — normal floor, no config needed; Loopflow supplies conservative defaults
# Codex: workspace-write + approval never (non-interactive); Claude: skip prompts (non-interactive)

yolo: true   # explicit bypass: Codex --dangerously-bypass-approvals-and-sandbox, Claude --dangerously-skip-permissions
```

Run any agent from a Git worktree and it just works — staging, commits, rebases, and `lf op` can now write the linked worktree index under the main repo.

## Summary

Loopflow used to hardcode Codex/Claude permission flags, which both clobbered a user's more-permissive vendor config and broke agents running inside Git worktrees (Git needs to write `<main>/.git/worktrees/<worktree>/` but that path lives outside the worktree cwd). This PR makes Loopflow treat its permissions as a *floor*: it reads the effective Codex `config.toml` and Claude `settings.json` for the launch directory, supplies its conservative default only when the vendor config is unset or less permissive, leaves already-permissive configs (e.g. `danger-full-access`, `bypassPermissions`) untouched, and warns when it has to raise a weaker config. Claude and Codex CLI/TUI sessions launched from a worktree automatically add the main repo as an extra writable directory so Git worktree metadata stays writable without loosening the sandbox.

## Changes

- Parse Codex `sandbox_mode`/`approval_policy` (home + repo `.codex/config.toml`) and Claude `permissions.defaultMode` (`~/.claude` + repo settings), ordered by permissiveness so Loopflow's floor only raises, never downgrades
- `codex_permission_args` / `claude_skip_permissions` replace the old hardcoded flag logic; both warn when raising a weaker vendor config to the Loopflow floor
- `yolo: true` now maps Codex to `--dangerously-bypass-approvals-and-sandbox` (was `--sandbox danger-full-access`)
- `workspace_add_dirs` adds the main repo via `--add-dir` (Claude/Codex) when cwd is a worktree; `ClaudeArgs` gains an `add_dirs` field
- docs/config.md rewrites the Yolo section and adds a Worktree Sandboxes section
- Tests cover config parsing, floor-vs-downgrade behavior, yolo bypass, and a real Git worktree fixture