### PR TITLE
mac: resolve GUI child PATH from the login shell without blocking startup

### DIFF
--- a/.lf/metrics/ops.jsonl
+++ b/.lf/metrics/ops.jsonl
@@ -5,3 +5,4 @@
 {"base_ref":"main","branch":"jack-heart/hmm","duration_ms":1943,"exit_status":"ok","op":"wt.create","stack_depth":1,"stack_parent":null,"strategy":"create_root","ts":"2026-07-07T19:25:01.651737+00:00"}
 {"base_ref":"main","branch":"jack-heart/lfapi","duration_ms":1810,"exit_status":"ok","op":"wt.create","stack_depth":1,"stack_parent":null,"strategy":"create_root","ts":"2026-07-09T02:55:35.078098+00:00"}
 {"base_ref":"main","branch":"jack-heart/tokencaching","duration_ms":1944,"exit_status":"ok","op":"wt.create","stack_depth":1,"stack_parent":null,"strategy":"create_root","ts":"2026-07-09T22:03:37.295811+00:00"}
+{"base_ref":"main","branch":"jack-heart/infra","duration_ms":1680,"exit_status":"ok","op":"wt.create","stack_depth":1,"stack_parent":null,"strategy":"use_existing_worktree","ts":"2026-07-10T17:48:57.744595+00:00"}

--- a/scratch/questions.md
+++ b/scratch/questions.md
@@ -1,0 +1,13 @@
+# Assumptions
+
+- Product performance had no existing latency thresholds. This clarification
+  sets user-visible p95 budgets at 1 second for state-bearing paths and 2
+  seconds for terminal attachment; dogfood data should tighten or correct the
+  thresholds rather than leaving the KR unnamed.
+
+# Blockers
+
+- The live Linear backlog could not be audited on 2026-07-10 because both
+  `lf pm show --wave product` and `lf pm sync --plan` fail against Linear's
+  current schema: their GraphQL variables use `ID!` where Linear expects
+  `String!`. This is product implementation work, not a charter edit.

--- a/wave/product/GOAL.md
+++ b/wave/product/GOAL.md
@@ -1,5 +1,7 @@
 ---
-crons: []
+crons:
+  - flow: wave
+    schedule: '0 0 8 * * * *'
 pm:
   provider: linear
   linear_project: '9ee88f2a-ef37-46c7-b201-d197db3ccae0'

--- a/wave/product/projects/auditability.md
+++ b/wave/product/projects/auditability.md
@@ -10,7 +10,7 @@ system's own planning record: every claim points back to its receipt.
   the product surfaces — each drop to raw transcripts or files is logged as
   a failure of this bet.
 - Drill-down holds end to end, every time: wave state -> run detail ->
-  attachable live session, N/N attempts across a week.
+  attachable live session, 5/5 attempts across a week.
 - Every visible state carries its reason (failed, waiting, running, idle,
   blocked, done) for the full lifetime of a wave, not just at steady state.
 - Curation always points back: for a month, every summary, retained fact,

--- a/wave/product/projects/distributed-computing.md
+++ b/wave/product/projects/distributed-computing.md
@@ -10,7 +10,7 @@ the user has to reconcile.
   identity, repo context, and audit trail intact throughout — the remote
   runs are indistinguishable in the record except for their host.
 - Reattach, interrupt, report, and recover succeed across local and remote
-  workers N/N trials over that week.
+  workers in 5/5 trials for each operation over that week.
 - Trust, credential, spend, and ownership boundaries are explicit and hold
   unattended — no remote run exceeds its authority or budget in the window.
 - One vocabulary survives the distribution: a month of mixed local/remote

--- a/wave/product/projects/product-performance.md
+++ b/wave/product/projects/product-performance.md
@@ -5,10 +5,11 @@ steerable while waves, runs, chats, workers, and audit records accumulate.
 
 ## KRs
 
-- Core user paths hold their named latency budgets for a month of real
-  accumulated data — list waves, open a wave, send/steer chat, inspect
-  audit, attach to a run — measured on the living workspace, never a demo
-  state.
+- Core user paths hold their p95 latency budgets for a month of real
+  accumulated data: list waves, open a wave, send/steer chat, and inspect
+  audit show useful state within 1 second; attaching to a run yields an
+  interactive terminal within 2 seconds. Measure on the living workspace,
+  never a demo state.
 - Budgets are enforced by gates: a regression fails visibly before release,
   demonstrated by at least one caught regression or one full quarter of
   green measured releases.


### PR DESCRIPTION
## Usage

```bash
# build + install the dev app, then launch a wave from the GUI
uv run python scripts/loopflow-dev.py app
open ~/Applications/Loopflow.app

# Swift tests covering path resolution
cd swift && swift test --filter BundledDaemonPathTests
```

## Summary

GUI-launched apps inherit a bare `launchd` PATH, so lfd, `lf`, tmux, and wave launches couldn't find Homebrew or `~/.local/bin` tools. The old fix enriched PATH with a fixed candidate list at `init()`. This replaces that with a real login-shell lookup — but doing it synchronously would have stalled the window behind interactive shell startup, so `GUIProcessEnvironment` becomes an actor that installs the fixed fallback immediately, runs shell discovery in the background behind a three-second deadline, and hands every child launcher the resolved environment once it lands. Concurrent callers share one cached discovery task; shell failure or timeout falls back to the previous fixed candidates and never fails app startup.

Along the way, two unrelated bugs surfaced and got fixed: the dev and release scripts copied the SwiftPM product `LoopflowMac` into the bundle under the wrong name (Launch Services resolves `CFBundleExecutable`, which is `Loopflow`), and a pre-release build of migration `054_step_to_skill` renamed `runs.step_index` to `skill_index` on some ledgers even though that column is a flow position, not a skill name.

## Changes

- `GUIProcessEnvironment` is now an async actor: `fallbackPath` synchronously, `resolved()`/`resolvedPath()` awaited by explicit launchers. The global `setenv` remains only for terminal plumbing that inherits the process environment.
- Child-spawning call sites (`BundledDaemonManager`, `LocalWaveAgentLauncher`, `TmuxSession`, `RegistryQueryLocal`, `LocalShellCommandRunner`) take the environment explicitly rather than reading it from a global.
- `resolveWaveCapableLf` no longer defaults its `pathEnv` and `probe` parameters, making the environment dependency visible at every call.
- Migration `057_runs_step_index_repair` renames `skill_index` back to `step_index` and joins the rename-convergence set, so ledgers that never had the bad column skip it cleanly.
- Dev and release scripts copy the built binary to `MacOS/Loopflow`.
- `wave/product` KRs restated as observable proofs.