### PR TITLE
product: make wave chat KRs measurable

### DIFF
--- a/wave/product/projects/wave-chat.md
+++ b/wave/product/projects/wave-chat.md
@@ -8,53 +8,9 @@ cold starts without growing a second brain.
 
 ## KRs
 
-- One steward thread stays coherent through a month of real use: reports
-  folded, decisions traceable, no reset required and no second thread
-  spawned to escape the first.
-- The thread survives every boundary it meets in a week of dogfood — app
-  restart, process reattach, replay, land, branch, machine move — 5/5
-  trials each, with zero learnings lost.
-- Every retained fact cites its source: for a month of memory changes, each
-  one points to the chat event, worker report, or run trace that justified
-  it — unsourced facts are failure events.
-- MEMORY.md stays prompt-sized while facts accumulate for a month, and
-  still answers "decided / constrained / in flight" at a glance.
-- Send, steer, interrupt, and resume hit the right session 100% of a
-  week's uses without exposing runtime plumbing.
-
-## Open questions
-
-**What does "steer" mean on a harness that cannot be steered?** Only Codex
-exposes a true mid-turn steer today; Claude and OpenCode take input only at a
-turn boundary, so a message to a live pass queues for the next body. The
-send/steer/interrupt KR above is written as if steering is universal, and it is
-not. Two readings, and the choice is a product decision rather than a schedule
-item:
-
-- *Steer degrades honestly.* On an unsteerable harness the message queues, and
-  the surface says so — the thread shows "will reach it at the next step."
-  Costs latency; keeps one verb.
-- *Steer means steer.* Interrupt the body, fold the message into its successor's
-  birth context. Uniform semantics; pays a restart per steer.
-
-Unblocking the first reading needs nothing from a vendor. The second is worth
-pricing before assuming the vendors will close the gap for us.
-
-**Steering is a Mac capability, not a chat capability.** `lf chat` always posts
-`op:"say"`; only the Mac composer emits `op=steer`. Whatever the answer above,
-the CLI and the Mac must reach the same session with the same verb, or the KR
-is measuring one surface and claiming both.
-
-**Two CLI surfaces claim the thread.** `lf wavechat` is a one-pane TUI that both
-follows a wave's events and posts into its thread — `lf chat` + `lf sub` fused,
-the same fusion the verb split exists to undo. Both are in the tree because
-deleting a verb that just landed on main is not a rebase's call. One should go,
-and the split (`serve` boots, `chat` attaches, `sub` reads the bus) is the shape
-this project defends.
-
-**Does a hand deserve a private steer channel?** A detached loop's driver holds
-no subscription, so a broadcast on a hand's channel reaches live `lf sub`
-listeners and nobody else. The wave's thread is the ear a hand reliably has, at
-pass granularity. On a store bus the fast path is a poll cursor the driver could
-hold — cheap either way, which makes this a question about whether a hand should
-be addressable at all, not a bug on the way past.
+- For one month of real use, every product surface shares one steward thread: every report is folded, every consequential decision is traceable to its originating event, and zero resets or second threads are used to recover coherence.
+- Over one week of dogfood, that thread survives app restarts, process reattachments, replay, land, branch, and machine moves in 5/5 trials per boundary with zero lost messages, decisions, or retained facts.
+- For one month of memory changes, every retained fact links to the chat event, worker report, or run trace that justifies it; any unsourced fact breaks the streak.
+- During one month of accumulating facts, prompt assembly truncates zero wave memories and 10/10 cold-start reviews identify current decisions, constraints, and in-flight work from `MEMORY.md` without reading the raw journal.
+- Across one month of releases, `lf chat` remains the sole CLI owner of the human thread and `lf sub` remains bus-only; CLI help, docs, and surface integrations expose zero overlapping chat commands or thread/bus fusions.
+- Across one week of mixed CLI and Mac use on Codex, Claude, and OpenCode, send, steer, interrupt, and resume target the selected wave's single thread in N/N trials; each steer is visibly reported as mid-turn or queued for the next turn boundary, with zero wrong-wave deliveries and no runtime or session identifiers exposed.


### PR DESCRIPTION
## What changed

The Wave Chat project's KRs are rewritten as measurable proofs and the four-item "Open questions" section is dropped.

```
wave/product/projects/wave-chat.md | 6 insertions, 50 deletions
```

## Summary

The old KRs read as aspirations ("stays coherent," "survives every boundary") paired with a long open-questions section debating steer semantics, CLI surface overlap, and hand steer channels. This tightens the project so a maintainer can tell when the bet holds: each KR now carries an explicit window (one month of use, one week of dogfood), a pass condition (5/5 boundary trials, 10/10 cold-start reviews, N/N send/steer/interrupt targeting), and a named failure event (unsourced fact breaks the streak, any truncated wave memory fails). The open-questions block is removed — the resolved product decisions (steer degrades honestly and reports mid-turn vs. queued; `lf chat` owns the human thread, `lf sub` stays bus-only) are folded directly into the KRs as the observable end states they now assert.

## Changes

- KRs restated as proofs with time windows, trial counts, and explicit failure events
- Steer semantics resolved into a KR: each steer is reported as mid-turn or queued for the next turn boundary across Codex, Claude, and OpenCode
- CLI ownership resolved into a KR: `lf chat` sole human-thread owner, `lf sub` bus-only, zero overlapping commands
- "Open questions" section deleted