### PR TITLE
deps: group dependabot minor+patch, keep majors independent

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,18 +4,38 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    groups:
+      python:
+        update-types:
+          - minor
+          - patch
 
   - package-ecosystem: cargo
     directory: /
     schedule:
       interval: weekly
+    groups:
+      rust:
+        update-types:
+          - minor
+          - patch
 
   - package-ecosystem: swift
     directory: /swift
     schedule:
       interval: weekly
+    groups:
+      swift:
+        update-types:
+          - minor
+          - patch
 
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: weekly
+    groups:
+      actions:
+        update-types:
+          - minor
+          - patch


### PR DESCRIPTION
Groups weekly minor/patch bumps into one PR per ecosystem (python/rust/swift/actions); major bumps still open individually for manual review.

Pairs with the merge queue now enabled on `main` so grouped bumps land themselves once CI is green.