### PR TITLE
pm: composable task updates and isolated task-session context

### DIFF
--- a/rust/loopflow/src/engine/process.rs
+++ b/rust/loopflow/src/engine/process.rs
@@ -60,7 +60,18 @@ pub(crate) async fn start_lf_session_with_env(
     argv: &[String],
     env: &[(&str, &str)],
 ) -> Result<()> {
-    let shell_command = lf_session_shell_command(argv, env);
+    let inherited_context = ["LF_RUN_ID", "LF_PROCESS_ID", "LF_HOME", "LF_DB_PATH"]
+        .into_iter()
+        .filter(|key| !env.iter().any(|(explicit, _)| explicit == key))
+        .filter_map(|key| std::env::var(key).ok().map(|value| (key, value)))
+        .collect::<Vec<_>>();
+    let mut child_env = env.to_vec();
+    child_env.extend(
+        inherited_context
+            .iter()
+            .map(|(key, value)| (*key, value.as_str())),
+    );
+    let shell_command = lf_session_shell_command(argv, &child_env);
     start_tmux_session(session, &cwd.display().to_string(), &shell_command).await
 }
 
@@ -75,11 +86,11 @@ pub(crate) fn lf_session_shell_command(argv: &[String], env: &[(&str, &str)]) ->
         .map(|(key, value)| format!("{}={}", shell_escape(key), shell_escape(value)))
         .collect::<Vec<_>>()
         .join(" ");
-    let clear_identity = "unset LF_WAVE_ID LF_CHANNEL LF_PROJECT_SESSION_ID LF_PROJECT_GENERATION LF_TASK_SESSION_ID LF_TASK_GENERATION";
+    let clear_context = "unset LF_RUN_ID LF_PROCESS_ID LF_WAVE_ID LF_CHANNEL LF_PROJECT_SESSION_ID LF_PROJECT_GENERATION LF_TASK_SESSION_ID LF_TASK_GENERATION LF_HOME LF_DB_PATH";
     if env.is_empty() {
-        format!("{clear_identity}; exec {command}")
+        format!("{clear_context}; exec {command}")
     } else {
-        format!("{clear_identity}; exec env {env} {command}")
+        format!("{clear_context}; exec env {env} {command}")
     }
 }
 
@@ -140,7 +151,7 @@ mod tests {
 
         assert_eq!(
             command,
-            "unset LF_WAVE_ID LF_CHANNEL LF_PROJECT_SESSION_ID LF_PROJECT_GENERATION LF_TASK_SESSION_ID LF_TASK_GENERATION; exec env 'LF_TASK_SESSION_ID'='task-1' 'LF_WAVE_ID'='infra' 'lf' '__task'"
+            "unset LF_RUN_ID LF_PROCESS_ID LF_WAVE_ID LF_CHANNEL LF_PROJECT_SESSION_ID LF_PROJECT_GENERATION LF_TASK_SESSION_ID LF_TASK_GENERATION LF_HOME LF_DB_PATH; exec env 'LF_TASK_SESSION_ID'='task-1' 'LF_WAVE_ID'='infra' 'lf' '__task'"
         );
     }
 
@@ -152,7 +163,26 @@ mod tests {
 
         assert_eq!(
             command,
-            "unset LF_WAVE_ID LF_CHANNEL LF_PROJECT_SESSION_ID LF_PROJECT_GENERATION LF_TASK_SESSION_ID LF_TASK_GENERATION; exec 'lf' 'wave' 'child'"
+            "unset LF_RUN_ID LF_PROCESS_ID LF_WAVE_ID LF_CHANNEL LF_PROJECT_SESSION_ID LF_PROJECT_GENERATION LF_TASK_SESSION_ID LF_TASK_GENERATION LF_HOME LF_DB_PATH; exec 'lf' 'wave' 'child'"
+        );
+    }
+
+    #[test]
+    fn lf_session_replaces_tmux_invocation_context() {
+        let argv = vec!["lf".to_string(), "__task".to_string()];
+        let command = lf_session_shell_command(
+            &argv,
+            &[
+                ("LF_RUN_ID", "run-1"),
+                ("LF_PROCESS_ID", "process-1"),
+                ("LF_DB_PATH", "/tmp/current.db"),
+                ("LF_HOME", "/tmp/lf"),
+            ],
+        );
+
+        assert_eq!(
+            command,
+            "unset LF_RUN_ID LF_PROCESS_ID LF_WAVE_ID LF_CHANNEL LF_PROJECT_SESSION_ID LF_PROJECT_GENERATION LF_TASK_SESSION_ID LF_TASK_GENERATION LF_HOME LF_DB_PATH; exec env 'LF_RUN_ID'='run-1' 'LF_PROCESS_ID'='process-1' 'LF_DB_PATH'='/tmp/current.db' 'LF_HOME'='/tmp/lf' 'lf' '__task'"
         );
     }
 }

--- a/rust/loopflow/src/lf/commands/ops/mod.rs
+++ b/rust/loopflow/src/lf/commands/ops/mod.rs
@@ -436,7 +436,11 @@ pub fn run_pm(cmd: &PmCommand) -> Result<()> {
                 project: project.clone(),
                 refresh,
             };
-            let result = crate::ops::pm::pm_show(&repo_root, &options, progress)?;
+            let result = if *json {
+                crate::ops::pm::pm_show(&repo_root, &options, &crate::ops::NullProgress)?
+            } else {
+                crate::ops::pm::pm_show(&repo_root, &options, progress)?
+            };
             if *json {
                 println!("{}", serde_json::to_string(&result)?);
             } else {

--- a/rust/loopflow/src/pm/linear.rs
+++ b/rust/loopflow/src/pm/linear.rs
@@ -172,7 +172,7 @@ const COMPLETE_ITEM_MUTATION: &str = r#"mutation CompleteIssue($id: String!, $st
   }
 }"#;
 
-const LIST_COMPLETED_WORKFLOW_STATES_QUERY: &str = r#"query CompletedWorkflowStates($teamId: String!) {
+const LIST_COMPLETED_WORKFLOW_STATES_QUERY: &str = r#"query CompletedWorkflowStates($teamId: ID!) {
   workflowStates(filter: { team: { id: { eq: $teamId } }, type: { eq: "completed" } }) {
     nodes {
       id
@@ -180,7 +180,7 @@ const LIST_COMPLETED_WORKFLOW_STATES_QUERY: &str = r#"query CompletedWorkflowSta
   }
 }"#;
 
-const LIST_UNSTARTED_WORKFLOW_STATES_QUERY: &str = r#"query UnstartedWorkflowStates($teamId: String!) {
+const LIST_UNSTARTED_WORKFLOW_STATES_QUERY: &str = r#"query UnstartedWorkflowStates($teamId: ID!) {
   workflowStates(filter: { team: { id: { eq: $teamId } }, type: { eq: "unstarted" } }) {
     nodes {
       id
@@ -980,14 +980,19 @@ mod tests {
             MOVE_ITEM_MUTATION,
             COMPLETE_ITEM_MUTATION,
             CREATE_COMMENT_MUTATION,
-            LIST_COMPLETED_WORKFLOW_STATES_QUERY,
-            LIST_UNSTARTED_WORKFLOW_STATES_QUERY,
         ] {
             assert!(!query.contains(": ID!"));
         }
         assert!(MOVE_ITEM_MUTATION.contains("$projectId: String!"));
         assert!(COMPLETE_ITEM_MUTATION.contains("$stateId: String!"));
         assert!(CREATE_COMMENT_MUTATION.contains("$issueId: String!"));
+    }
+
+    #[test]
+    fn workflow_state_filters_use_linear_team_id() {
+        assert!(CREATE_ITEM_MUTATION.contains("$teamId: String!"));
+        assert!(LIST_COMPLETED_WORKFLOW_STATES_QUERY.contains("$teamId: ID!"));
+        assert!(LIST_UNSTARTED_WORKFLOW_STATES_QUERY.contains("$teamId: ID!"));
     }
 
     #[tokio::test]

--- a/rust/loopflow/src/pm/linear.rs
+++ b/rust/loopflow/src/pm/linear.rs
@@ -148,8 +148,8 @@ const CREATE_ITEM_MUTATION: &str = r#"mutation CreateIssue($teamId: String!, $pr
   }
 }"#;
 
-const UPDATE_ITEM_MUTATION: &str = r#"mutation UpdateIssue($id: String!, $title: String, $description: String) {
-  issueUpdate(id: $id, input: { title: $title, description: $description }) {
+const UPDATE_ITEM_MUTATION: &str = r#"mutation UpdateIssue($id: String!, $input: IssueUpdateInput!) {
+  issueUpdate(id: $id, input: $input) {
     issue {
       id
     }
@@ -540,14 +540,20 @@ impl LinearClient {
         let Some(update) = update.text_update() else {
             return Ok(());
         };
+        let mut input = serde_json::Map::new();
+        if let Some(name) = update.name {
+            input.insert("title".to_string(), json!(name));
+        }
+        if let Some(description) = update.description {
+            input.insert("description".to_string(), json!(description));
+        }
 
         let _: Value = self
             .graphql(
                 UPDATE_ITEM_MUTATION,
                 json!({
                     "id": item_id,
-                    "title": update.name,
-                    "description": update.description,
+                    "input": input,
                 }),
             )
             .await?;
@@ -1247,6 +1253,45 @@ mod tests {
         let create_body: Value =
             serde_json::from_str(&requests[1].body).expect("create body is json");
         assert_eq!(create_body["variables"]["stateId"], json!("state-todo"));
+        let update_body: Value =
+            serde_json::from_str(&requests[2].body).expect("update body is json");
+        assert_eq!(
+            update_body["variables"]["input"],
+            json!({
+                "title": "Implement Linear client",
+                "description": "Build the GraphQL adapter and tests",
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn update_item_omits_absent_text_fields() {
+        let (base_url, requests) = test_server::spawn(vec![json_response(
+            StatusCode::OK,
+            json!({ "data": { "issueUpdate": { "issue": { "id": "issue-123" } } } }),
+        )])
+        .await;
+        let client = LinearClient::with_base_url("linear-secret".to_string(), None, base_url);
+
+        client
+            .update_item(
+                "issue-123",
+                &PmItemUpdate {
+                    name: None,
+                    description: Some("Only the description changes".to_string()),
+                },
+            )
+            .await
+            .expect("description-only update succeeds");
+
+        let requests = requests.lock().await;
+        let update_body: Value =
+            serde_json::from_str(&requests[0].body).expect("update body is json");
+        assert_eq!(
+            update_body["variables"]["input"],
+            json!({ "description": "Only the description changes" })
+        );
+        assert!(update_body["variables"]["input"].get("title").is_none());
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Usage

```bash
lf op pm show --json          # clean JSON, no progress chatter on stdout
lf op pm sync                 # description-only edits no longer clobber titles
```

## Summary

Two fixes that surfaced while driving Linear from headless runs. Linear's `issueUpdate` was being sent `title: null` / `description: null` whenever only one of the two changed, so a description-only update wiped the issue title; the mutation now takes a real `IssueUpdateInput` built from just the fields present on the update. The workflow-state queries were also declaring `$teamId: String!` where Linear's schema wants `ID!`, which made status transitions fail outright. And `lf op pm show --json` was interleaving progress output with the JSON payload, so it's now run with `NullProgress` when `--json` is set — the stdout is parseable again.

Separately, tmux-launched `lf` sessions were inheriting a stale invocation context. The shell command now unsets `LF_RUN_ID`, `LF_PROCESS_ID`, `LF_HOME`, and `LF_DB_PATH` alongside the existing identity vars, and `start_lf_session_with_env` forwards the caller's values for those four unless the caller passed them explicitly. A worker launched from inside a run lands on the same db and home instead of silently picking up whatever the tmux server was started with.

## Changes

- `pm/linear.rs`: `UPDATE_ITEM_MUTATION` takes `$input: IssueUpdateInput!`; absent fields are omitted rather than sent as null
- `pm/linear.rs`: workflow-state queries use `$teamId: ID!`; the query-shape test now asserts per-query rather than banning `ID!` everywhere
- `ops/mod.rs`: `pm show --json` uses `NullProgress` so progress never lands on stdout
- `engine/process.rs`: session shell command clears run/process/home/db-path context; explicit env wins over inherited
