### PR TITLE
claude: preserve skill prompts in worktree sessions

### DIFF
--- a/rust/loopflow/src/lf/commands/util.rs
+++ b/rust/loopflow/src/lf/commands/util.rs
@@ -130,6 +130,8 @@ fn build_session_command(
                 args.push("--add-dir".to_string());
                 args.push(dir.to_string_lossy().to_string());
             }
+            // Claude's variadic --add-dir otherwise consumes the positional prompt.
+            args.push("--".to_string());
             args.push(prompt.to_string());
             Ok(SessionCommand {
                 program: "claude".to_string(),
@@ -333,7 +335,7 @@ mod tests {
             launch.command,
             SessionCommand {
                 program: "claude".to_string(),
-                args: args(&["--model", "sonnet", "fix it"]),
+                args: args(&["--model", "sonnet", "--", "fix it"]),
                 cwd: path(),
             }
         );
@@ -365,6 +367,7 @@ mod tests {
                 .unwrap(),
             main.canonicalize().unwrap()
         );
+        assert!(launch.command.args.ends_with(&args(&["--", "fix it"])));
     }
 
     #[test]


### PR DESCRIPTION
## Usage

```bash
lf <interactive-skill> -m claude
```

## Summary

Preserve the interactive skill seed when launching Claude from a Git worktree. Claude treats `--add-dir` as variadic, so the main-repo permission argument previously consumed the positional prompt and opened a blank session.

## Changes

- terminate Claude options before the positional prompt
- cover worktree launches with a regression assertion