### PR TITLE
release: package the renamed Mac executable

### DIFF
--- a/python/tests/test_release_loopflow.py
+++ b/python/tests/test_release_loopflow.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import importlib.util
+import plistlib
+import sys
+from pathlib import Path
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[2] / "scripts"
+SCRIPT_PATH = SCRIPTS_DIR / "release-loopflow.py"
+MODULE_NAME = "_release_loopflow_script_module"
+spec = importlib.util.spec_from_file_location(MODULE_NAME, SCRIPT_PATH)
+if spec is None or spec.loader is None:
+    raise RuntimeError(f"failed to load module spec from {SCRIPT_PATH}")
+release_loopflow = importlib.util.module_from_spec(spec)
+sys.path.insert(0, str(SCRIPTS_DIR))
+try:
+    sys.modules[MODULE_NAME] = release_loopflow
+    spec.loader.exec_module(release_loopflow)
+finally:
+    sys.path.pop(0)
+
+
+def test_release_bundle_renames_swift_product_to_bundle_executable(tmp_path: Path) -> None:
+    build_dir = tmp_path / "build"
+    build_dir.mkdir()
+    (build_dir / "LoopflowMac").write_bytes(b"swift-product")
+
+    info_plist = tmp_path / "Info.plist"
+    with info_plist.open("wb") as file:
+        plistlib.dump({"CFBundleExecutable": "Loopflow"}, file)
+
+    app_macos_dir = tmp_path / "Loopflow.app" / "Contents" / "MacOS"
+    app_macos_dir.mkdir(parents=True)
+    release_loopflow._copy_app_executable(build_dir, info_plist, app_macos_dir)
+
+    assert (app_macos_dir / "Loopflow").read_bytes() == b"swift-product"
+    assert not (app_macos_dir / "LoopflowMac").exists()

--- a/scripts/release-loopflow.py
+++ b/scripts/release-loopflow.py
@@ -12,6 +12,7 @@ it uses whatever Developer ID Application identity is in the keychain.
 from __future__ import annotations
 
 import os
+import plistlib
 import shutil
 import subprocess
 import sys
@@ -22,6 +23,7 @@ from bundle_version import read_release_version, stamp_bundle_version
 
 REPO_ROOT = Path(__file__).parent.parent
 SWIFT_DIR = REPO_ROOT / "swift"
+SWIFT_APP_PRODUCT = "LoopflowMac"
 
 
 def run(
@@ -148,6 +150,18 @@ def _copy_bundled_tools(app_macos_dir: Path) -> None:
         shutil.copy(source, app_macos_dir / binary)
 
 
+def _copy_app_executable(build_dir: Path, info_plist: Path, app_macos_dir: Path) -> None:
+    with info_plist.open("rb") as file:
+        executable = plistlib.load(file).get("CFBundleExecutable")
+    if not isinstance(executable, str) or not executable:
+        raise RuntimeError(f"Missing CFBundleExecutable in {info_plist}")
+
+    source = build_dir / SWIFT_APP_PRODUCT
+    if not source.is_file():
+        raise RuntimeError(f"Missing built app executable: {source}")
+    shutil.copy(source, app_macos_dir / executable)
+
+
 def release() -> int:
     print("Building Loopflow release...", flush=True)
 
@@ -171,8 +185,9 @@ def release() -> int:
     (app_dir / "Resources").mkdir(parents=True)
 
     build_dir = SWIFT_DIR / ".build" / "release"
-    shutil.copy(build_dir / "Loopflow", app_dir / "MacOS")
-    shutil.copy(SWIFT_DIR / "LoopflowMac" / "Info.plist", app_dir)
+    info_plist = SWIFT_DIR / "LoopflowMac" / "Info.plist"
+    _copy_app_executable(build_dir, info_plist, app_dir / "MacOS")
+    shutil.copy(info_plist, app_dir)
     stamp_bundle_version(app_dir / "Info.plist", version)
     shutil.copy(SWIFT_DIR / "LoopflowMac" / "Loopflow.sdef", app_dir / "Resources")
     shutil.copy(SWIFT_DIR / "LoopflowMac" / "AppIcon.icns", app_dir / "Resources")


### PR DESCRIPTION
The v0.11.0 release built the SwiftPM product as LoopflowMac, but the DMG packager still looked for the retired .build/release/Loopflow path. Read CFBundleExecutable from Info.plist, copy LoopflowMac under that bundle name, and cover the mapping with a focused regression test.\n\nValidation: uv run pytest python/tests/ (46 passed); ruff check and format.