### PR TITLE
docs: state when migration namespaces are chosen

### DIFF
--- a/rust/loopflow/src/store/MIGRATIONS.md
+++ b/rust/loopflow/src/store/MIGRATIONS.md
@@ -35,10 +35,11 @@ before anything is cut. Same script, both paths.
 0.10.001_initial.sql
  │  │  │   └── name — part of the identity, so a rename is a break
  │  │  └────── ordinal, three digits, restarting in each namespace
- └──┴───────── namespace: the Loopflow major.minor that first ships it
+ └──┴───────── namespace: package major.minor when authored
 ```
 
-- Patch releases append into the current namespace; a minor bump starts a new one.
+- Patch releases append into the current namespace; after a minor bump,
+  subsequent migrations start a new one.
   `0.11.001` and `0.12.001` are distinct migrations.
 - Order is the numeric tuple `(major, minor, ordinal)`, never a string sort —
   `0.9.001` precedes `0.10.001`, which lexical order would invert.

--- a/rust/loopflow/src/store/migrations.rs
+++ b/rust/loopflow/src/store/migrations.rs
@@ -9,7 +9,7 @@ use crate::store::{StoreError, StoreResult};
 
 /// A migration's release-scoped identity: `{major}.{minor}.{ordinal:03}`.
 ///
-/// The namespace is the Loopflow major.minor that first ships the migration;
+/// The namespace is the package major.minor when the migration is authored;
 /// patch releases append into the same namespace. Ordering is the numeric tuple,
 /// never a string sort — `0.9.001` precedes `0.10.001`, which lexical order
 /// would invert.


### PR DESCRIPTION
Clarify the implemented contract: a migration takes the package major.minor active when it is authored; patch releases append there, and migrations authored after a minor bump begin the next namespace. This keeps the docs aligned with new_migration.py and the release gate.\n\nValidation: cargo fmt --check; migration check.