### PR TITLE
release: let existing tags use repaired packaging tooling

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,6 +58,15 @@ jobs:
       - uses: actions/checkout@v7
         with:
           ref: ${{ env.RELEASE_TAG }}
+      - name: Check out current release tooling for a re-run
+        if: github.event_name == 'workflow_dispatch'
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          path: .release-tooling
+      - name: Use current release tooling for a re-run
+        if: github.event_name == 'workflow_dispatch'
+        run: cp .release-tooling/scripts/release-loopflow.py scripts/release-loopflow.py
       - uses: astral-sh/setup-uv@v7
       - name: Fetch secrets
         uses: dopplerhq/secrets-fetch-action@v2.0.0


### PR DESCRIPTION
## Summary

A manually dispatched release rebuilds the immutable tagged source but now uses the current default branch release packager. This makes the documented existing-tag re-run path capable of recovering v0.11.0 after the Loopflow-to-LoopflowMac executable rename fix landed.

Normal tag-triggered releases are unchanged and continue using the tooling committed in their tag.

## Validation

- release workflow YAML parses
- migration release gate passes against v0.11.0
- final validation is re-dispatching v0.11.0 after merge