### PR TITLE
release: accept crates.io already-exists on publish re-run

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -302,10 +302,12 @@ jobs:
       - name: Publish to crates.io
         run: |
           output=$(cargo publish -p loopflow 2>&1) && exit 0
-          # Tolerate "already uploaded" so re-runs succeed
-          if echo "$output" | grep -q "already uploaded"; then
-            echo "Version already on crates.io, skipping"
+          echo "$output"
+          # Publishing an already-published version is success, not failure: a
+          # re-run of a partially-failed release must reach the steps after it.
+          # Cargo's wording for this has changed over time, so match both.
+          if echo "$output" | grep -Eq "already exists on crates.io index|already uploaded"; then
+            echo "Version already on crates.io, skipping publish"
           else
-            echo "$output"
             exit 1
           fi


### PR DESCRIPTION
## Summary

The recovered v0.11.0 run published every GitHub asset, the signed DMG, and the crate, but the aggregate workflow stayed red. Cargo now reports an idempotent publish as `already exists on crates.io index`; the workflow only recognized the older `already uploaded` wording and treated that already-published crate as a failure.

The guard now accepts both known Cargo messages while leaving every other publish error fatal. Cargo output is always printed so the release log remains diagnostic.

## Changes

- accept both `already exists on crates.io index` and `already uploaded`
- keep unknown cargo-publish failures red
- print cargo output on both idempotent and failure paths

## Evidence

Release run 29369842288 published v0.11.0 successfully; `cargo info loopflow@0.11.0` downloads the crate, and the GitHub Release contains four native tarballs, Loopflow.dmg, and install.sh. This PR removes only the false-negative aggregate status for future re-entry.