### PR TITLE
mac: Home control on the wave row over lf home probe/start

### DIFF
--- a/swift/Loopflow/Services/RegistryQuery.swift
+++ b/swift/Loopflow/Services/RegistryQuery.swift
@@ -65,6 +65,24 @@ public struct RegistryQuery: Sendable {
         )
     }
 
+    /// Probe one Wave's Home for liveness and the single contextual action.
+    /// The app never does SSH — `lf home probe` classifies the Home (local reads
+    /// are instant, remote routes one `lf status` over the credential-forwarding
+    /// transport) and returns the shared `HomeRuntimeDto`. Probe on demand per
+    /// focused Wave, never once per row.
+    public func homeProbe(wave: String, cwd: String?) async throws -> HomeRuntime {
+        let stdout = try await run(["home", "probe", wave, "--json"], cwd)
+        return try Self.decode(HomeRuntime.self, from: stdout)
+    }
+
+    /// Idempotently start a Wave on its *configured Home* (not this machine) and
+    /// return the attach identity. Safe to repeat: an already-running Home comes
+    /// back with `started == false` rather than launched twice.
+    public func homeStart(wave: String, cwd: String?) async throws -> HomeStartResult {
+        let stdout = try await run(["home", "start", wave, "--json"], cwd)
+        return try Self.decode(HomeStartResult.self, from: stdout)
+    }
+
     /// Every durable plan row across the machine, joined to the same Task
     /// references and live evidence as `lf status`. One subprocess reads every
     /// Wave; an optional scope filters that shared snapshot at the source.
@@ -261,14 +279,14 @@ public enum HomeLocation: Decodable, Sendable, Hashable {
 }
 
 /// `HomeState` (`engine/wave_home.rs`) — a Home's observed liveness.
-enum HomeState: String, Decodable, Equatable {
+public enum HomeState: String, Decodable, Sendable, Equatable {
     case unreachable, stopped, running, unknown
 }
 
 /// `HomeActionDto` — the single contextual action a surface should offer, so the
 /// UI never branches on `HomeState` itself: Attach when running, Start when
 /// reachable-but-stopped, or the actionable reason otherwise.
-enum HomeAction: Decodable, Equatable {
+public enum HomeAction: Decodable, Sendable, Equatable {
     case attach(endpoint: String)
     case start(home: String)
     case reason(message: String)
@@ -277,7 +295,7 @@ enum HomeAction: Decodable, Equatable {
         case kind, endpoint, home, message
     }
 
-    init(from decoder: Decoder) throws {
+    public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         switch try container.decode(String.self, forKey: .kind) {
         case "attach":
@@ -300,12 +318,22 @@ enum HomeAction: Decodable, Equatable {
 /// with its evidence, the attach endpoint when running, and the one action.
 /// This is the shared contract the conductor renders; the app never probes SSH
 /// itself — it calls `lf home probe|start --json`.
-struct HomeRuntime: Decodable, Equatable {
-    let home: WaveHome
-    let state: HomeState
-    let reason: String
-    let endpoint: String?
-    let action: HomeAction
+public struct HomeRuntime: Decodable, Sendable, Equatable {
+    public let home: WaveHome
+    public let state: HomeState
+    public let reason: String
+    public let endpoint: String?
+    public let action: HomeAction
+}
+
+/// `HomeStartResult` (`ops/home.rs`) — the receipt from an idempotent
+/// `lf home start`: whether this call launched the resident (`false` = it was
+/// already running) plus the same runtime evidence a probe returns. The
+/// `runtime.endpoint` is the attach identity to open.
+public struct HomeStartResult: Decodable, Sendable, Equatable {
+    public let wave: String
+    public let started: Bool
+    public let runtime: HomeRuntime
 }
 
 /// `WaveSnapshot` (`lf/commands/waves.rs`) — every field present, Optionals

--- a/swift/LoopflowMac/Views/RoadmapView.swift
+++ b/swift/LoopflowMac/Views/RoadmapView.swift
@@ -270,6 +270,7 @@ struct RoadmapView: View {
                         roadmap: roadmap,
                         activeControlId: activeControlId,
                         onOpen: { openWave(roadmap.wave) },
+                        onError: { controlError = $0 },
                         onTaskAction: { task, action in
                             perform(action, on: RoadmapTaskSelection(wave: roadmap.wave, task: task))
                         },
@@ -320,26 +321,11 @@ struct RoadmapView: View {
         }
     }
 
+    /// Navigate to the Wave. Starting a stopped Wave is the Home control's job
+    /// now — it runs `lf home start` on the *configured Home*, not this machine,
+    /// then this fires to open the detail.
     private func openWave(_ wave: WaveSnapshot) {
-        guard !wave.live else {
-            onOpenWave(wave)
-            return
-        }
-        activeControlId = "wave:\(wave.id)"
-        controlError = nil
-        Task {
-            do {
-                let repo = wave.repo
-                let name = wave.name
-                try await Task.detached(priority: .userInitiated) {
-                    try LocalWaveAgentLauncher.launchWave(repoPath: repo, waveName: name)
-                }.value
-                onOpenWave(wave)
-            } catch {
-                controlError = error.localizedDescription
-            }
-            activeControlId = nil
-        }
+        onOpenWave(wave)
     }
 
     private enum TaskControl {
@@ -401,10 +387,121 @@ struct RoadmapView: View {
     }
 }
 
+/// A Wave's inherited Home on its row: the address always visible, plus the
+/// probed liveness and the *one* contextual action the shared `HomeRuntimeDto`
+/// dictates. The app never does SSH — `lf home probe|start` classifies the Home
+/// and Start runs on the configured Home, not this machine. Probed once per
+/// Wave card on appear (local reads are instant; a remote Home costs one routed
+/// probe), never once per row and never on the 15s roadmap poll.
+private struct WaveHomeControl: View {
+    let wave: WaveSnapshot
+    let onOpen: () -> Void
+    let onError: (String) -> Void
+
+    @Environment(\.palette) private var palette
+    @State private var runtime: HomeRuntime?
+    @State private var probeError: String?
+    @State private var isProbing = false
+    @State private var isActing = false
+
+    var body: some View {
+        VStack(alignment: .trailing, spacing: Spacing.xxs) {
+            HStack(spacing: Spacing.xs) {
+                Image(systemName: "house")
+                    .font(Typography.caption(9))
+                    .foregroundStyle(palette.textSecondary)
+                Text(wave.home.address)
+                    .font(Typography.caption(10).weight(.medium))
+                    .foregroundStyle(palette.textSecondary)
+                    .textSelection(.enabled)
+                if isProbing {
+                    ProgressView().controlSize(.small)
+                } else if let runtime {
+                    stateChip(runtime.state)
+                }
+            }
+            action
+        }
+        .task(id: wave.id) { await probe() }
+    }
+
+    @ViewBuilder
+    private var action: some View {
+        if isActing {
+            ProgressView().controlSize(.small)
+        } else if let runtime {
+            switch runtime.action {
+            case .attach:
+                Button("Open") { onOpen() }
+                    .buttonStyle(.borderedProminent)
+                    .controlSize(.small)
+                    .help(runtime.endpoint.map { "Attach to \($0)" } ?? "Open the Wave")
+            case .start(let home):
+                Button("Start on \(home)") { Task { await start() } }
+                    .buttonStyle(.bordered)
+                    .controlSize(.small)
+            case .reason(let message):
+                Text(message)
+                    .font(Typography.caption(9))
+                    .foregroundStyle(Color.statusWarning)
+                    .lineLimit(2)
+                    .textSelection(.enabled)
+            }
+        } else if let probeError {
+            Text(probeError)
+                .font(Typography.caption(9))
+                .foregroundStyle(Color.statusError)
+                .lineLimit(2)
+        }
+    }
+
+    private func stateChip(_ state: HomeState) -> some View {
+        let (label, color): (String, Color) = switch state {
+        case .running: ("running", .statusSuccess)
+        case .stopped: ("stopped", .statusNeutral)
+        case .unreachable: ("unreachable", .statusError)
+        case .unknown: ("unknown", .statusWarning)
+        }
+        return Text(label)
+            .font(Typography.caption(9).weight(.semibold))
+            .foregroundStyle(color)
+            .padding(.horizontal, Spacing.xs)
+            .padding(.vertical, 1)
+            .background(color.opacity(0.12))
+            .clipShape(Capsule())
+    }
+
+    @MainActor
+    private func probe() async {
+        isProbing = true
+        defer { isProbing = false }
+        do {
+            runtime = try await RegistryQueryLocal.shared.homeProbe(wave: wave.name, cwd: wave.repo)
+            probeError = nil
+        } catch {
+            probeError = error.localizedDescription
+        }
+    }
+
+    @MainActor
+    private func start() async {
+        isActing = true
+        defer { isActing = false }
+        do {
+            let result = try await RegistryQueryLocal.shared.homeStart(wave: wave.name, cwd: wave.repo)
+            runtime = result.runtime
+            onOpen()
+        } catch {
+            onError(error.localizedDescription)
+        }
+    }
+}
+
 private struct RoadmapWaveCard: View {
     let roadmap: WaveRoadmap
     let activeControlId: String?
     let onOpen: () -> Void
+    let onError: (String) -> Void
     let onTaskAction: (RoadmapTask, RoadmapTaskAction) -> Void
     let onInterrupt: (RoadmapTask) -> Void
     let onOpenWorktree: (TaskWorkspaceSnapshot) -> Void
@@ -434,18 +531,7 @@ private struct RoadmapWaveCard: View {
                     }
                 }
                 Spacer()
-                Button {
-                    onOpen()
-                } label: {
-                    if activeControlId == "wave:\(roadmap.wave.id)" {
-                        ProgressView().controlSize(.small)
-                    } else {
-                        Text(roadmap.wave.live ? "Open chat" : "Start & open")
-                    }
-                }
-                .buttonStyle(.bordered)
-                .controlSize(.small)
-                .disabled(activeControlId != nil)
+                WaveHomeControl(wave: roadmap.wave, onOpen: onOpen, onError: onError)
             }
 
             switch roadmap.projects {

--- a/swift/LoopflowTests/RegistryQueryTests.swift
+++ b/swift/LoopflowTests/RegistryQueryTests.swift
@@ -108,6 +108,45 @@ struct RegistryQueryTests {
         #expect(result.waves.isEmpty)
     }
 
+    @Test("lf home probe decodes the state and the one contextual action")
+    func homeProbeDecodesStateAndAction() async throws {
+        let json = #"""
+        {"home":{"address":"jack@local","owner":"jack","location":{"kind":"local"}},
+         "state":"stopped","reason":"reachable, no resident","endpoint":null,
+         "action":{"kind":"start","home":"jack@local"}}
+        """#
+        let query = RegistryQuery { args, cwd in
+            #expect(args == ["home", "probe", "product", "--json"])
+            #expect(cwd == "/tmp/repo")
+            return json
+        }
+
+        let runtime = try await query.homeProbe(wave: "product", cwd: "/tmp/repo")
+        #expect(runtime.state == .stopped)
+        #expect(runtime.endpoint == nil)
+        #expect(runtime.action == .start(home: "jack@local"))
+    }
+
+    @Test("lf home start returns the idempotency flag and the attach identity")
+    func homeStartReturnsAttachIdentity() async throws {
+        let json = #"""
+        {"wave":"product","started":true,
+         "runtime":{"home":{"address":"jack@local","owner":"jack","location":{"kind":"local"}},
+          "state":"running","reason":"resident answering","endpoint":"127.0.0.1:7777",
+          "action":{"kind":"attach","endpoint":"127.0.0.1:7777"}}}
+        """#
+        let query = RegistryQuery { args, cwd in
+            #expect(args == ["home", "start", "product", "--json"])
+            #expect(cwd == "/tmp/repo")
+            return json
+        }
+
+        let result = try await query.homeStart(wave: "product", cwd: "/tmp/repo")
+        #expect(result.started)
+        #expect(result.runtime.state == .running)
+        #expect(result.runtime.action == .attach(endpoint: "127.0.0.1:7777"))
+    }
+
     /// Unreadable evidence must reach the surface as its reason, never as an
     /// empty list — a broken ledger is not a quiet wave.
     @Test("lf status keeps unavailable evidence unavailable")


### PR DESCRIPTION
## Usage

Open the Loopflow Mac app and look at any Wave card in the roadmap. Each row now shows its Home address, a probed liveness chip, and one contextual action:

- **Open** — the resident is running; attaches to its endpoint
- **Start on `<home>`** — reachable but stopped; runs `lf home start` on the *configured* Home
- an actionable reason — when the Home can't be reached

```bash
lf home probe <wave> --json
lf home start <wave> --json
```

## Summary

The Wave row's old "Start & open" button launched the wave locally via `LocalWaveAgentLauncher`, which was wrong for any Wave whose Home is a different machine. This replaces that button with a `WaveHomeControl` that renders the shared `HomeRuntimeDto` contract: it probes the Home once per card (on appear, keyed to the Wave — never per row and never on the 15s roadmap poll), shows liveness, and offers the single action the DTO dictates. The app never does SSH itself — `lf home probe` classifies the Home (local reads instant, remote routed over credential-forwarding) and `lf home start` idempotently starts the resident on its configured Home, returning the attach identity. `openWave` is now pure navigation; starting is the control's job.

## Changes

- `RegistryQuery`: add `homeProbe` and `homeStart`; make `HomeState`, `HomeAction`, `HomeRuntime` public and add the new `HomeStartResult` DTO (`wave`, `started`, `runtime`)
- `RoadmapView`: new `WaveHomeControl` view (address + state chip + contextual action); drop the local-launch path from `openWave` and the `activeControlId` start button
- Tests: decode a `stopped` probe into its Start action, and decode a `started` result into its running attach identity