### PR TITLE
pull-local-bin: fix empty-args expansion under macOS bash 3.2

### DIFF
--- a/scripts/pull-local-bin.sh
+++ b/scripts/pull-local-bin.sh
@@ -62,4 +62,5 @@ while [[ $# -gt 0 ]]; do
 done
 
 repo="$(git -C "$repo" rev-parse --show-toplevel)"
-exec uv run --with typer python "$repo/scripts/install.py" refresh "${args[@]}"
+# bash 3.2 (macOS) treats an empty array as unbound under set -u
+exec uv run --with typer python "$repo/scripts/install.py" refresh ${args[@]+"${args[@]}"}


### PR DESCRIPTION
bash 3.2 treats "${args[@]}" as unbound under set -u when the array is empty, so the script died on line 65 whenever run with no flags. Guard the expansion with ${args[@]+...}.