### PR TITLE
lf: open the desktop app by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -393,6 +393,11 @@ curl -fsSL https://github.com/loopflowstudio/loopflow/releases/latest/download/i
 
 Or grab the desktop app: download [`Loopflow-latest.dmg`](https://downloads.loopflow.studio/Loopflow-latest.dmg) and drag **Loopflow** to Applications. The app bundles `lf`.
 
+```bash
+lf              # open or focus Loopflow.app
+lf desktop      # explicit alias
+```
+
 Default install location is `~/.local/bin`. Override with `LF_INSTALL_DIR=/path`.
 
 `install.sh` downloads the `lf` binary. Run `lf init` to connect coding agents and preferences.

--- a/docs/lf.md
+++ b/docs/lf.md
@@ -5,13 +5,14 @@ title: lf Command Reference
 
 # lf Command Reference
 
-`lf` launches prompts and operates durable Waves, Projects, and Tasks. Prompt
-commands assemble context for Claude, Codex, Gemini, or OpenCode; lifecycle and
-repository commands use the same CLI.
+`lf` opens or focuses Loopflow.app. Named commands launch prompts and operate
+durable Waves, Projects, and Tasks.
 
 ## Basic Usage
 
 ```bash
+lf                                 # open or focus Loopflow.app
+lf desktop                         # explicit alias
 lf <skill>                        # run a skill file
 lf <skill>: args                  # run with arguments
 lf <namespace>/<skill>            # run a namespaced skill (e.g. gstack/office-hours)

--- a/rust/loopflow/src/bin/lf.rs
+++ b/rust/loopflow/src/bin/lf.rs
@@ -1201,6 +1201,7 @@ fn main() -> anyhow::Result<()> {
                     loopflow::lf::commands::run::run(None, Some(&text), &cli)
                 })
             }
+            Some(Commands::Desktop) => loopflow::lf::commands::desktop::run(),
             Some(Commands::Pr { cmd }) => in_repo_runtime(&args, |_| {
                 loopflow::lf::commands::ops::run_pr(cmd.as_ref(), cli.model.as_deref())
             }),
@@ -1394,9 +1395,10 @@ fn main() -> anyhow::Result<()> {
                     Err(err) => Err(err),
                 }
             }
-            None => in_repo_runtime(&args, |_| {
-                loopflow::lf::commands::run::run(None, None, &cli)
-            }),
+            None if raw_args.len() == 1 => loopflow::lf::commands::desktop::run(),
+            None => anyhow::bail!(
+                "no command specified; bare `lf` opens Loopflow.app; run a named skill, flow, or `lf : <prompt>` to start an agent"
+            ),
         }
     };
 
@@ -1416,8 +1418,9 @@ mod tests {
     fn derived_tables_cover_commands_flags_and_aliases() {
         let tables = arg_tables();
         for command in [
-            ":", "pr", "wt", "rebase", "commit", "auth", "release", "pm", "task", "project",
-            "flow", "skill", "chat", "memory", "usage", "ls", "status", "runs", "trace", "help",
+            ":", "desktop", "pr", "wt", "rebase", "commit", "auth", "release", "pm", "task",
+            "project", "flow", "skill", "chat", "memory", "usage", "ls", "status", "runs", "trace",
+            "help",
         ] {
             assert!(tables.commands.contains_key(command), "command {command}");
         }
@@ -1484,6 +1487,12 @@ mod tests {
     fn reorder_args_uppercase_bool_alias_after_skill() {
         let args = vec!["lf".to_string(), "debug".to_string(), "-C".to_string()];
         assert_eq!(reorder_args(args), vec!["lf", "-C", "debug"]);
+    }
+
+    #[test]
+    fn desktop_is_an_explicit_alias_for_the_bare_app_launch() {
+        let cli = Cli::try_parse_from(["lf", "desktop"]).unwrap();
+        assert!(matches!(cli.command, Some(Commands::Desktop)));
     }
 
     #[test]

--- a/rust/loopflow/src/lf/commands/desktop.rs
+++ b/rust/loopflow/src/lf/commands/desktop.rs
@@ -1,0 +1,18 @@
+use std::process::Command;
+
+use anyhow::{bail, Context};
+
+pub fn run() -> anyhow::Result<()> {
+    if !cfg!(target_os = "macos") {
+        bail!("Loopflow.app is available on macOS only");
+    }
+
+    let status = Command::new("open")
+        .args(["-a", "Loopflow"])
+        .status()
+        .context("launch Loopflow.app with the macOS `open` command")?;
+    if !status.success() {
+        bail!("cannot launch Loopflow.app: `open -a Loopflow` exited with {status}");
+    }
+    Ok(())
+}

--- a/rust/loopflow/src/lf/commands/mod.rs
+++ b/rust/loopflow/src/lf/commands/mod.rs
@@ -1,6 +1,7 @@
 pub mod auth;
 pub mod chat;
 pub mod context;
+pub mod desktop;
 pub mod doctor;
 #[cfg(test)]
 pub(crate) mod fixtures;

--- a/rust/loopflow/src/lf/mod.rs
+++ b/rust/loopflow/src/lf/mod.rs
@@ -6,7 +6,7 @@ pub mod output;
 
 #[derive(Parser, Debug, Default)]
 #[command(name = "lf")]
-#[command(about = "Run skills and flows with coding agents")]
+#[command(about = "Open Loopflow or run its CLI")]
 #[command(version)]
 pub struct Cli {
     #[command(subcommand)]
@@ -133,6 +133,8 @@ pub enum Commands {
         #[arg(trailing_var_arg = true)]
         prompt: Vec<String>,
     },
+    /// Open or focus Loopflow.app
+    Desktop,
     /// Pull request lifecycle
     Pr {
         #[command(subcommand)]

--- a/rust/loopflow/src/store/migrations.rs
+++ b/rust/loopflow/src/store/migrations.rs
@@ -137,6 +137,15 @@ const MIGRATIONS: &[Migration] = &[
         id: MigrationId {
             major: 0,
             minor: 11,
+            ordinal: 6,
+        },
+        name: "context_launch_work",
+        sql: include_str!("migrations/0.11.006_context_launch_work.sql"),
+    },
+    Migration {
+        id: MigrationId {
+            major: 0,
+            minor: 11,
             ordinal: 7,
         },
         name: "task_pr_parent",
@@ -670,6 +679,7 @@ mod tests {
                 "0.11.003_child_body_lease".to_string(),
                 "0.11.004_task_pr_ci_state".to_string(),
                 "0.11.005_provider_accounts".to_string(),
+                "0.11.006_context_launch_work".to_string(),
                 "0.11.007_task_pr_parent".to_string()
             ]
         );

--- a/rust/loopflow/src/store/migrations/0.11.006_context_launch_work.sql
+++ b/rust/loopflow/src/store/migrations/0.11.006_context_launch_work.sql
@@ -1,0 +1,8 @@
+-- Preserve the durable Project and Task identity surrounding each agent launch.
+-- Historical rows remain explicitly unattributed.
+
+ALTER TABLE agent_launches ADD COLUMN project TEXT;
+ALTER TABLE agent_launches ADD COLUMN task TEXT;
+
+CREATE INDEX idx_agent_launches_project ON agent_launches(project, started_at);
+CREATE INDEX idx_agent_launches_task ON agent_launches(task, started_at);


### PR DESCRIPTION
## Usage

```bash
lf              # open or focus Loopflow.app
lf desktop      # explicit alias
```

## Summary

Bare `lf` now opens the primary Loopflow application instead of launching an implicit vendor session. Agent work requires a named skill, flow, or inline prompt. The canonical migration chain also restores `0.11.006_context_launch_work` before `.007`, so databases written by the Context Lab build remain readable by current releases.