### PR TITLE
auth: keep profile examples generic

### DIFF
--- a/README.md
+++ b/README.md
@@ -471,34 +471,34 @@ Register provider accounts, then route each repository through personal
 profiles:
 
 ```bash
-lf profile create jack@loopflow.studio --chrome-profile jack@loopflow.studio
-lf profile create loopflow-eng@loopflow.studio --chrome-profile loopflow-eng@loopflow.studio
-lf profile create jackstah@gmail.com --chrome-profile jackstah@gmail.com
+lf profile create primary@example.com --chrome-profile primary@example.com
+lf profile create engineering@example.com --chrome-profile engineering@example.com
+lf profile create personal@example.com --chrome-profile personal@example.com
 
-lf auth import claude --account personal --profile jackstah@gmail.com
-lf auth set claude personal --login-email jackstah@gmail.com
-lf auth connect claude --account jack --profile jack@loopflow.studio
-lf auth set claude jack --login-email jack@loopflow.studio --plan max
+lf auth import claude --account personal --profile personal@example.com
+lf auth set claude personal --login-email personal@example.com
+lf auth connect claude --account primary --profile primary@example.com
+lf auth set claude primary --login-email primary@example.com --plan max
 
-lf auth connect codex --account jack
-lf auth set codex jack --login-email jack@loopflow.studio --plan max
+lf auth connect codex --account primary
+lf auth set codex primary --login-email primary@example.com --plan max
 lf auth connect codex --account engineering
-lf auth set codex engineering --login-email loopflow-eng@loopflow.studio --plan max
+lf auth set codex engineering --login-email engineering@example.com --plan max
 lf auth connect codex --account personal
-lf auth set codex personal --login-email jackstah@gmail.com
+lf auth set codex personal --login-email personal@example.com
 lf auth accounts claude
 
-lf profile account set jack@loopflow.studio claude jack@loopflow.studio
-lf profile account set jack@loopflow.studio codex jack@loopflow.studio
-lf profile account set loopflow-eng@loopflow.studio claude jackstah@gmail.com
-lf profile account set loopflow-eng@loopflow.studio codex loopflow-eng@loopflow.studio
-lf profile account set jackstah@gmail.com claude jackstah@gmail.com
-lf profile account set jackstah@gmail.com codex jackstah@gmail.com
+lf profile account set primary@example.com claude primary@example.com
+lf profile account set primary@example.com codex primary@example.com
+lf profile account set engineering@example.com claude personal@example.com
+lf profile account set engineering@example.com codex engineering@example.com
+lf profile account set personal@example.com claude personal@example.com
+lf profile account set personal@example.com codex personal@example.com
 
 lf profile route set \
-  --default jack@loopflow.studio \
-  --backup loopflow-eng@loopflow.studio \
-  --backup jackstah@gmail.com
+  --default primary@example.com \
+  --backup engineering@example.com \
+  --backup personal@example.com
 lf profile route show
 
 lf auth set claude personal --paid-through 2026-08-14
@@ -506,6 +506,9 @@ lf auth set claude personal --routing explicit-only
 lf auth reset claude personal
 lf auth disconnect claude --account personal
 ```
+
+These addresses are placeholders. Profiles, account bindings, and repository
+routes live in the local Loopflow database; Loopflow ships no account topology.
 
 Claude authorization runs through Claude in Chrome when its browser extension
 is connected. If the controller is unavailable, Loopflow falls back to a hidden

--- a/rust/loopflow/src/lf/commands/auth.rs
+++ b/rust/loopflow/src/lf/commands/auth.rs
@@ -1008,25 +1008,25 @@ mod tests {
     fn chrome_profile_and_provider_login_must_name_the_same_account() {
         let chrome_profile = LocalChromeProfile {
             directory: "Profile 7".to_string(),
-            label: "jack@loopflow.studio".to_string(),
+            label: "primary@example.com".to_string(),
         };
 
         assert_eq!(
             verified_login_for_chrome_profile(
                 Some(&chrome_profile),
-                Some("JACK@LOOPFLOW.STUDIO".to_string()),
+                Some("PRIMARY@EXAMPLE.COM".to_string()),
             )
             .unwrap(),
-            Some("JACK@LOOPFLOW.STUDIO".to_string())
+            Some("PRIMARY@EXAMPLE.COM".to_string())
         );
         assert!(verified_login_for_chrome_profile(
             Some(&chrome_profile),
-            Some("jackstah@gmail.com".to_string()),
+            Some("personal@example.com".to_string()),
         )
         .is_err());
         assert_eq!(
             verified_login_for_chrome_profile(Some(&chrome_profile), None).unwrap(),
-            Some("jack@loopflow.studio".to_string())
+            Some("primary@example.com".to_string())
         );
     }
 }

--- a/rust/loopflow/src/lf/commands/profile.rs
+++ b/rust/loopflow/src/lf/commands/profile.rs
@@ -354,13 +354,13 @@ mod tests {
     fn route_format_preserves_declared_order() {
         assert_eq!(
             format_route(
-                &ProfileId::parse("jack@loopflow.studio").unwrap(),
+                &ProfileId::parse("primary@example.com").unwrap(),
                 &[
-                    ProfileId::parse("loopflow-eng@loopflow.studio").unwrap(),
-                    ProfileId::parse("jackstah@gmail.com").unwrap(),
+                    ProfileId::parse("engineering@example.com").unwrap(),
+                    ProfileId::parse("personal@example.com").unwrap(),
                 ],
             ),
-            "jack@loopflow.studio -> loopflow-eng@loopflow.studio -> jackstah@gmail.com"
+            "primary@example.com -> engineering@example.com -> personal@example.com"
         );
     }
 }

--- a/rust/loopflow/src/lf/commands/ssh.rs
+++ b/rust/loopflow/src/lf/commands/ssh.rs
@@ -533,9 +533,9 @@ mod tests {
     use super::*;
 
     fn full_bundle() -> Credentials {
-        let jack = crate::profile::ProfileId::parse("jack@loopflow.studio").unwrap();
-        let engineering = crate::profile::ProfileId::parse("loopflow-eng@loopflow.studio").unwrap();
-        let personal = crate::profile::ProfileId::parse("jackstah@gmail.com").unwrap();
+        let primary = crate::profile::ProfileId::parse("primary@example.com").unwrap();
+        let engineering = crate::profile::ProfileId::parse("engineering@example.com").unwrap();
+        let personal = crate::profile::ProfileId::parse("personal@example.com").unwrap();
         let claude = crate::provider_account::parse_account_id("primary").unwrap();
         let codex = crate::provider_account::parse_account_id("reserve").unwrap();
         Credentials {
@@ -544,11 +544,11 @@ mod tests {
             codex_token: None,
             profile_bundle: Some(ForwardedProfileBundle::new(
                 crate::repository::RepoId::parse("loopflowstudio/loopflow").unwrap(),
-                jack.clone(),
+                primary.clone(),
                 vec![engineering.clone(), personal.clone()],
                 vec![
                     crate::provider_account::ForwardedProfileProviderAccount {
-                        profile_id: jack,
+                        profile_id: primary,
                         provider: crate::provider_auth::Provider::Claude,
                         account_id: claude.clone(),
                     },
@@ -573,7 +573,7 @@ mod tests {
                         provider: crate::provider_auth::Provider::Claude,
                         account_id: claude.clone(),
                         login_email: Some(
-                            crate::profile::EmailAddress::parse("jackstah@gmail.com").unwrap(),
+                            crate::profile::EmailAddress::parse("personal@example.com").unwrap(),
                         ),
                         credential_state: crate::store::CredentialState::Connected,
                         routing_state: crate::store::RoutingState::Automatic,
@@ -587,8 +587,7 @@ mod tests {
                         provider: crate::provider_auth::Provider::Codex,
                         account_id: codex.clone(),
                         login_email: Some(
-                            crate::profile::EmailAddress::parse("loopflow-eng@loopflow.studio")
-                                .unwrap(),
+                            crate::profile::EmailAddress::parse("engineering@example.com").unwrap(),
                         ),
                         credential_state: crate::store::CredentialState::Connected,
                         routing_state: crate::store::RoutingState::Automatic,

--- a/rust/loopflow/src/lf/mod.rs
+++ b/rust/loopflow/src/lf/mod.rs
@@ -1534,11 +1534,11 @@ mod tests {
             "route",
             "set",
             "--default",
-            "jack@loopflow.studio",
+            "primary@example.com",
             "--backup",
-            "loopflow-eng@loopflow.studio",
+            "engineering@example.com",
             "--backup",
-            "jackstah@gmail.com",
+            "personal@example.com",
         ])
         .expect("parse profile route");
 
@@ -1552,8 +1552,8 @@ mod tests {
                         repo: None,
                     }
                 }
-            }) if default == "jack@loopflow.studio"
-                && backups == vec!["loopflow-eng@loopflow.studio", "jackstah@gmail.com"]
+            }) if default == "primary@example.com"
+                && backups == vec!["engineering@example.com", "personal@example.com"]
         ));
     }
 
@@ -1563,9 +1563,9 @@ mod tests {
             "lf",
             "profile",
             "create",
-            "loopflow-eng@loopflow.studio",
+            "engineering@example.com",
             "--chrome-profile",
-            "loopflow-eng@loopflow.studio",
+            "engineering@example.com",
         ])
         .expect("parse profile Chrome binding");
 
@@ -1576,8 +1576,8 @@ mod tests {
                     profile,
                     chrome_profile: Some(chrome_profile),
                 }
-            }) if profile == "loopflow-eng@loopflow.studio"
-                && chrome_profile == "loopflow-eng@loopflow.studio"
+            }) if profile == "engineering@example.com"
+                && chrome_profile == "engineering@example.com"
         ));
     }
 
@@ -1588,9 +1588,9 @@ mod tests {
             "profile",
             "account",
             "set",
-            "jack@loopflow.studio",
+            "primary@example.com",
             "claude",
-            "jack@loopflow.studio",
+            "primary@example.com",
         ])
         .expect("parse profile account mapping");
 
@@ -1604,9 +1604,9 @@ mod tests {
                         account,
                     }
                 }
-            }) if profile == "jack@loopflow.studio"
+            }) if profile == "primary@example.com"
                 && provider == "claude"
-                && account == "jack@loopflow.studio"
+                && account == "primary@example.com"
         ));
     }
 
@@ -1667,7 +1667,7 @@ mod tests {
             "--account",
             "primary",
             "--profile",
-            "jackstah@gmail.com",
+            "personal@example.com",
         ])
         .expect("parse Loopflow profile binding");
 
@@ -1682,7 +1682,7 @@ mod tests {
                 }
             }) if provider == "claude"
                 && account.as_deref() == Some("primary")
-                && profile == "jackstah@gmail.com"
+                && profile == "personal@example.com"
         ));
     }
 
@@ -1724,7 +1724,7 @@ mod tests {
             "codex",
             "loopflow",
             "--login-email",
-            "loopflow-eng@loopflow.studio",
+            "engineering@example.com",
             "--routing",
             "automatic",
             "--plan",
@@ -1749,7 +1749,7 @@ mod tests {
                 }
             }) if provider == "codex"
                 && account == "loopflow"
-                && login_email == "loopflow-eng@loopflow.studio"
+                && login_email == "engineering@example.com"
                 && routing == "automatic"
                 && plan == "max"
                 && paid_through == "2026-08-14"

--- a/rust/loopflow/src/profile.rs
+++ b/rust/loopflow/src/profile.rs
@@ -236,10 +236,10 @@ mod tests {
     #[test]
     fn profile_ids_are_normalized_emails() {
         assert_eq!(
-            ProfileId::parse(" Loopflow-Eng@Loopflow.Studio ")
+            ProfileId::parse(" Engineering@Example.com ")
                 .unwrap()
                 .as_str(),
-            "loopflow-eng@loopflow.studio"
+            "engineering@example.com"
         );
         assert!(ProfileId::parse("Loopflow").is_err());
         assert!(ProfileId::parse("../loopflow").is_err());
@@ -248,10 +248,10 @@ mod tests {
     #[test]
     fn email_addresses_are_normalized() {
         assert_eq!(
-            EmailAddress::parse(" Jack@Loopflow.Studio ")
+            EmailAddress::parse(" Primary@Example.com ")
                 .unwrap()
                 .as_str(),
-            "jack@loopflow.studio"
+            "primary@example.com"
         );
         assert!(EmailAddress::parse("not-an-email").is_err());
     }

--- a/rust/loopflow/src/provider_account.rs
+++ b/rust/loopflow/src/provider_account.rs
@@ -1202,10 +1202,10 @@ mod tests {
             .await
             .unwrap(),
         );
-        let jack = ProfileId::parse("jack@loopflow.studio").unwrap();
-        let engineering = ProfileId::parse("loopflow-eng@loopflow.studio").unwrap();
-        let personal = ProfileId::parse("jackstah@gmail.com").unwrap();
-        for profile_id in [&jack, &engineering, &personal] {
+        let primary = ProfileId::parse("primary@example.com").unwrap();
+        let engineering = ProfileId::parse("engineering@example.com").unwrap();
+        let personal = ProfileId::parse("personal@example.com").unwrap();
+        for profile_id in [&primary, &engineering, &personal] {
             store
                 .upsert_profile(&Profile {
                     id: profile_id.clone(),
@@ -1219,20 +1219,20 @@ mod tests {
             Provider::Claude,
             parse_account_id("personal").unwrap(),
             temp.path().join("claude-personal"),
-            Some(crate::profile::EmailAddress::parse("jackstah@gmail.com").unwrap()),
+            Some(crate::profile::EmailAddress::parse("personal@example.com").unwrap()),
         );
         let codex_account = new_account(
             Provider::Codex,
             parse_account_id("engineering").unwrap(),
             temp.path().join("codex-engineering"),
-            Some(crate::profile::EmailAddress::parse("loopflow-eng@loopflow.studio").unwrap()),
+            Some(crate::profile::EmailAddress::parse("engineering@example.com").unwrap()),
         );
         store
             .upsert_provider_account(&claude_account)
             .await
             .unwrap();
         store.upsert_provider_account(&codex_account).await.unwrap();
-        for profile_id in [&jack, &engineering, &personal] {
+        for profile_id in [&primary, &engineering, &personal] {
             store
                 .set_profile_provider_account(&ProfileProviderAccount {
                     profile_id: profile_id.clone(),
@@ -1256,7 +1256,7 @@ mod tests {
             .unwrap();
         let route = RepoProfileRoute {
             repo_id: RepoId::parse("loopflowstudio/loopflow").unwrap(),
-            default_profile: jack,
+            default_profile: primary,
             backup_profiles: vec![engineering, personal],
             created_at: 1,
             updated_at: 1,
@@ -1277,17 +1277,17 @@ mod tests {
 
     #[test]
     fn forwarded_bundle_round_trips_without_debugging_tokens() {
-        let jack = ProfileId::parse("jack@loopflow.studio").unwrap();
-        let engineering = ProfileId::parse("loopflow-eng@loopflow.studio").unwrap();
+        let primary = ProfileId::parse("primary@example.com").unwrap();
+        let engineering = ProfileId::parse("engineering@example.com").unwrap();
         let claude = parse_account_id("primary").unwrap();
         let codex = parse_account_id("reserve").unwrap();
         let bundle = ForwardedProfileBundle::new(
             RepoId::parse("loopflowstudio/loopflow").unwrap(),
-            jack.clone(),
+            primary.clone(),
             vec![engineering.clone()],
             vec![
                 ForwardedProfileProviderAccount {
-                    profile_id: jack,
+                    profile_id: primary,
                     provider: Provider::Claude,
                     account_id: claude.clone(),
                 },
@@ -1301,7 +1301,7 @@ mod tests {
                 provider: Provider::Claude,
                 account_id: claude.clone(),
                 login_email: Some(
-                    crate::profile::EmailAddress::parse("jackstah@gmail.com").unwrap(),
+                    crate::profile::EmailAddress::parse("personal@example.com").unwrap(),
                 ),
                 credential_state: CredentialState::Connected,
                 routing_state: RoutingState::Automatic,
@@ -1344,7 +1344,7 @@ mod tests {
             .await
             .unwrap(),
         );
-        let profile_id = ProfileId::parse("loopflow-eng@loopflow.studio").unwrap();
+        let profile_id = ProfileId::parse("engineering@example.com").unwrap();
         let account_id = parse_account_id("engineering").unwrap();
         let bundle = ForwardedProfileBundle::new(
             RepoId::parse("loopflowstudio/loopflow").unwrap(),
@@ -1359,7 +1359,7 @@ mod tests {
                 provider: Provider::Codex,
                 account_id: account_id.clone(),
                 login_email: Some(
-                    crate::profile::EmailAddress::parse("loopflow-eng@loopflow.studio").unwrap(),
+                    crate::profile::EmailAddress::parse("engineering@example.com").unwrap(),
                 ),
                 credential_state: CredentialState::Connected,
                 routing_state: RoutingState::Automatic,

--- a/rust/loopflow/src/provider_auth/mod.rs
+++ b/rust/loopflow/src/provider_auth/mod.rs
@@ -4265,7 +4265,7 @@ mod tests {
                 refresh_token: Some("linear-refresh".to_string()),
                 oauth_client_id: Some("linear-client".to_string()),
                 expires_at: Some(expires_at),
-                login: Some("jack@loopflow.studio".to_string()),
+                login: Some("primary@example.com".to_string()),
                 updated_at: now_unix(),
                 credential_type: CredentialType::OAuth,
             })
@@ -4277,7 +4277,7 @@ mod tests {
         assert_eq!(
             snapshot.status,
             AuthStatus::Active {
-                login: Some("jack@loopflow.studio".to_string())
+                login: Some("primary@example.com".to_string())
             }
         );
         assert_eq!(snapshot.expires_at, Some(expires_at));

--- a/rust/loopflow/src/store/mod.rs
+++ b/rust/loopflow/src/store/mod.rs
@@ -2923,9 +2923,9 @@ mod tests {
         store.upsert_provider_account(&shared).await.unwrap();
 
         for id in [
-            "jack@loopflow.studio",
-            "loopflow-eng@loopflow.studio",
-            "jackstah@gmail.com",
+            "primary@example.com",
+            "engineering@example.com",
+            "personal@example.com",
         ] {
             let profile = Profile {
                 id: ProfileId::parse(id).unwrap(),
@@ -2934,7 +2934,7 @@ mod tests {
             };
             store.upsert_profile(&profile).await.unwrap();
         }
-        for id in ["loopflow-eng@loopflow.studio", "jackstah@gmail.com"] {
+        for id in ["engineering@example.com", "personal@example.com"] {
             store
                 .set_profile_provider_account(&ProfileProviderAccount {
                     profile_id: ProfileId::parse(id).unwrap(),
@@ -2948,7 +2948,7 @@ mod tests {
         }
         store
             .upsert_chrome_profile_binding(&ChromeProfileBinding {
-                profile_id: ProfileId::parse("jack@loopflow.studio").unwrap(),
+                profile_id: ProfileId::parse("primary@example.com").unwrap(),
                 host_id: HostId::parse("studio-mac").unwrap(),
                 chrome_directory: "Profile 7".to_string(),
                 created_at: 1,
@@ -2958,7 +2958,7 @@ mod tests {
             .unwrap();
         store
             .upsert_chrome_profile_binding(&ChromeProfileBinding {
-                profile_id: ProfileId::parse("jack@loopflow.studio").unwrap(),
+                profile_id: ProfileId::parse("primary@example.com").unwrap(),
                 host_id: HostId::parse("mini-heart").unwrap(),
                 chrome_directory: "Default".to_string(),
                 created_at: 1,
@@ -2968,10 +2968,10 @@ mod tests {
             .unwrap();
         let route = RepoProfileRoute {
             repo_id: RepoId::parse("loopflowstudio/loopflow").unwrap(),
-            default_profile: ProfileId::parse("jack@loopflow.studio").unwrap(),
+            default_profile: ProfileId::parse("primary@example.com").unwrap(),
             backup_profiles: vec![
-                ProfileId::parse("loopflow-eng@loopflow.studio").unwrap(),
-                ProfileId::parse("jackstah@gmail.com").unwrap(),
+                ProfileId::parse("engineering@example.com").unwrap(),
+                ProfileId::parse("personal@example.com").unwrap(),
             ],
             created_at: 1,
             updated_at: 1,
@@ -2989,7 +2989,7 @@ mod tests {
         assert_eq!(
             store
                 .profile_provider_account(
-                    &ProfileId::parse("loopflow-eng@loopflow.studio").unwrap(),
+                    &ProfileId::parse("engineering@example.com").unwrap(),
                     Provider::Claude,
                 )
                 .await
@@ -3001,7 +3001,7 @@ mod tests {
         assert_eq!(
             store
                 .chrome_profile_binding(
-                    &ProfileId::parse("jack@loopflow.studio").unwrap(),
+                    &ProfileId::parse("primary@example.com").unwrap(),
                     &HostId::parse("studio-mac").unwrap(),
                 )
                 .await
@@ -3013,7 +3013,7 @@ mod tests {
         assert_eq!(
             store
                 .chrome_profile_binding(
-                    &ProfileId::parse("jack@loopflow.studio").unwrap(),
+                    &ProfileId::parse("primary@example.com").unwrap(),
                     &HostId::parse("mini-heart").unwrap(),
                 )
                 .await
@@ -3030,7 +3030,7 @@ mod tests {
         let store = open_store(&StorageConfig::sqlite(dir.path().join("registry.db")))
             .await
             .unwrap();
-        let profile_id = ProfileId::parse("loopflow-eng@loopflow.studio").unwrap();
+        let profile_id = ProfileId::parse("engineering@example.com").unwrap();
         store
             .upsert_profile(&Profile {
                 id: profile_id.clone(),

--- a/scripts/demo_profile_routing.py
+++ b/scripts/demo_profile_routing.py
@@ -10,9 +10,9 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 PROFILES = (
-    "jack@loopflow.studio",
-    "loopflow-eng@loopflow.studio",
-    "jackstah@gmail.com",
+    "primary@example.com",
+    "engineering@example.com",
+    "personal@example.com",
 )
 
 
@@ -43,14 +43,14 @@ def _run(binary: Path, env: dict[str, str], *args: str) -> str:
 def _seed_accounts(database: Path, demo_home: Path) -> None:
     now = int(time.time())
     accounts = (
-        ("claude", "jack-claude", "jack@loopflow.studio", "max"),
-        ("codex", "jack-codex", "jack@loopflow.studio", "max"),
-        ("claude", "personal-claude", "jackstah@gmail.com", "personal"),
-        ("codex", "personal-codex", "jackstah@gmail.com", "personal"),
+        ("claude", "primary-claude", "primary@example.com", "max"),
+        ("codex", "primary-codex", "primary@example.com", "max"),
+        ("claude", "personal-claude", "personal@example.com", "personal"),
+        ("codex", "personal-codex", "personal@example.com", "personal"),
         (
             "codex",
-            "loopflow-eng-codex",
-            "loopflow-eng@loopflow.studio",
+            "engineering-codex",
+            "engineering@example.com",
             "max",
         ),
     )
@@ -100,16 +100,16 @@ def main() -> int:
         _seed_accounts(database, demo_home)
 
         mappings = (
-            ("jack@loopflow.studio", "claude", "jack-claude"),
-            ("jack@loopflow.studio", "codex", "jack-codex"),
-            ("loopflow-eng@loopflow.studio", "claude", "personal-claude"),
+            ("primary@example.com", "claude", "primary-claude"),
+            ("primary@example.com", "codex", "primary-codex"),
+            ("engineering@example.com", "claude", "personal-claude"),
             (
-                "loopflow-eng@loopflow.studio",
+                "engineering@example.com",
                 "codex",
-                "loopflow-eng-codex",
+                "engineering-codex",
             ),
-            ("jackstah@gmail.com", "claude", "personal-claude"),
-            ("jackstah@gmail.com", "codex", "personal-codex"),
+            ("personal@example.com", "claude", "personal-claude"),
+            ("personal@example.com", "codex", "personal-codex"),
         )
         for profile, provider, account in mappings:
             _run(
@@ -130,11 +130,11 @@ def main() -> int:
             "route",
             "set",
             "--default",
-            "jack@loopflow.studio",
+            "primary@example.com",
             "--backup",
-            "loopflow-eng@loopflow.studio",
+            "engineering@example.com",
             "--backup",
-            "jackstah@gmail.com",
+            "personal@example.com",
         )
 
         _print_step("Profiles", _run(binary, env, "profile", "list"))
@@ -147,7 +147,7 @@ def main() -> int:
         print("\nLook for:")
         print("  1. Profiles are the Google/Chrome login emails.")
         print("  2. Claude and Codex map independently per profile.")
-        print("  3. jackstah@gmail.com Claude is marked shared with loopflow-eng@loopflow.studio.")
+        print("  3. personal@example.com Claude is shared with engineering@example.com.")
         print("  4. The demo home is deleted on exit; live Loopflow is untouched.")
     return 0
 


### PR DESCRIPTION
## Usage

```bash
uv run python scripts/demo_profile_routing.py
```

## Summary

Replace the original operator-specific profile identities and route with `example.com` fixtures across the README, demo, and tests. Real profile identities, provider bindings, and repository route order remain local Loopflow configuration; the shipped system carries no personal account topology.

## Validation

- `cargo test -p loopflow --lib`
- `cargo clippy -p loopflow --all-targets -- -D warnings`
- `uv run ruff check scripts/demo_profile_routing.py`
- `uv run python scripts/demo_profile_routing.py`