### PR TITLE
task review: add durable parent dialogue protocol

### DIFF
--- a/rust/loopflow/src/bin/lf.rs
+++ b/rust/loopflow/src/bin/lf.rs
@@ -7,7 +7,9 @@ use tracing::debug;
 use tracing_subscriber::EnvFilter;
 
 use loopflow::journal::{self, LfEventFields, LfEventType, LfNode};
-use loopflow::lf::{Cli, Commands, ProjectCommand, TaskCommand};
+use loopflow::lf::{
+    Cli, Commands, ProjectCommand, ProjectReviewCommand, TaskCommand, TaskReviewCommand,
+};
 
 #[derive(Clone, Default)]
 struct FlagTables {
@@ -845,6 +847,40 @@ fn run_project_command(repo: &Path, command: &ProjectCommand) -> anyhow::Result<
             }
             Ok(())
         }
+        ProjectCommand::Review { command } => match command {
+            ProjectReviewCommand::Message {
+                review_id,
+                message,
+                json,
+            } => {
+                let command =
+                    loopflow::ops::project::project_review_message(review_id, message.clone())?;
+                if *json {
+                    println!("{}", serde_json::to_string_pretty(&command)?);
+                } else {
+                    println!("{} → {}", review_id, command.id);
+                }
+                Ok(())
+            }
+            ProjectReviewCommand::Complete {
+                review_id,
+                disposition,
+                outcome,
+                json,
+            } => {
+                let review = loopflow::ops::project::project_review_complete(
+                    review_id,
+                    disposition,
+                    outcome.clone(),
+                )?;
+                if *json {
+                    println!("{}", serde_json::to_string_pretty(&review)?);
+                } else {
+                    println!("{} → {}", review.id, review.status.as_str());
+                }
+                Ok(())
+            }
+        },
         ProjectCommand::Wait {
             project_id,
             until,
@@ -1095,6 +1131,21 @@ fn run_task_command(repo: &Path, command: &TaskCommand) -> anyhow::Result<()> {
             }
             Ok(())
         }
+        TaskCommand::Review { command } => match command {
+            TaskReviewCommand::Reply {
+                review_id,
+                message,
+                json,
+            } => {
+                let review = loopflow::ops::task::task_review_reply(review_id, message.clone())?;
+                if *json {
+                    println!("{}", serde_json::to_string_pretty(&review)?);
+                } else {
+                    println!("{} → reply recorded", review.id);
+                }
+                Ok(())
+            }
+        },
         TaskCommand::Wait {
             issue,
             until,

--- a/rust/loopflow/src/chat/turns.rs
+++ b/rust/loopflow/src/chat/turns.rs
@@ -374,6 +374,25 @@ fn task_activity_fields(event: &TaskEventKind) -> ActivityFields {
         TaskEventKind::Progress { summary } => {
             activity(ChildActivityKind::StateChanged, "Task progress", summary)
         }
+        TaskEventKind::InteractionReviewRequested { review } => activity(
+            ChildActivityKind::DecisionRequired,
+            &format!("{} review requested", review.step),
+            &review.reason,
+        ),
+        TaskEventKind::InteractionReviewMessage { author, text, .. } => activity(
+            ChildActivityKind::StateChanged,
+            &format!("Review message from {}", author.as_str()),
+            text,
+        ),
+        TaskEventKind::InteractionReviewCompleted {
+            disposition,
+            outcome,
+            ..
+        } => activity(
+            ChildActivityKind::DecisionResolved,
+            &format!("Review {}", disposition.as_str()),
+            outcome,
+        ),
         TaskEventKind::PrStarted {
             sequence, branch, ..
         } => activity(

--- a/rust/loopflow/src/interaction_review.rs
+++ b/rust/loopflow/src/interaction_review.rs
@@ -1,0 +1,334 @@
+//! One interactive flow exercise, conducted by a human or a parent agent.
+
+use std::path::PathBuf;
+use std::str::FromStr;
+
+use serde::{Deserialize, Serialize};
+use time::OffsetDateTime;
+
+use crate::child_session::prefixed_uuid_id;
+use crate::engine::InteractionPolicy;
+use crate::id::WaveId;
+use crate::project_session::ProjectSessionId;
+use crate::task::{TaskLifecyclePhase, TaskSessionId};
+
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[non_exhaustive]
+pub enum InteractionReviewDataError {
+    #[error("invalid interaction-review id: {0}")]
+    InvalidId(String),
+    #[error("invalid interaction-review status: {0}")]
+    InvalidStatus(String),
+    #[error("invalid interaction-review disposition: {0}")]
+    InvalidDisposition(String),
+    #[error("invalid interaction review: {0}")]
+    InvalidInvariant(String),
+}
+
+prefixed_uuid_id!(
+    InteractionReviewId,
+    "ir_",
+    InteractionReviewDataError,
+    InteractionReviewDataError::InvalidId
+);
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", content = "id", rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum InteractionReviewer {
+    Human,
+    Project(ProjectSessionId),
+    Wave(WaveId),
+}
+
+impl InteractionReviewer {
+    pub fn kind(&self) -> &'static str {
+        match self {
+            Self::Human => "human",
+            Self::Project(_) => "project",
+            Self::Wave(_) => "wave",
+        }
+    }
+
+    pub fn id(&self) -> Option<&str> {
+        match self {
+            Self::Human => None,
+            Self::Project(id) => Some(id.as_str()),
+            Self::Wave(id) => Some(id.as_str()),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum InteractionReviewStatus {
+    Requested,
+    Active,
+    Completed,
+}
+
+impl InteractionReviewStatus {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Requested => "requested",
+            Self::Active => "active",
+            Self::Completed => "completed",
+        }
+    }
+
+    pub fn is_terminal(self) -> bool {
+        self == Self::Completed
+    }
+}
+
+impl FromStr for InteractionReviewStatus {
+    type Err = InteractionReviewDataError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "requested" => Ok(Self::Requested),
+            "active" => Ok(Self::Active),
+            "completed" => Ok(Self::Completed),
+            _ => Err(InteractionReviewDataError::InvalidStatus(value.to_string())),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum InteractionReviewDisposition {
+    Approved,
+    ChangesRequested,
+}
+
+impl InteractionReviewDisposition {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Approved => "approved",
+            Self::ChangesRequested => "changes_requested",
+        }
+    }
+}
+
+impl FromStr for InteractionReviewDisposition {
+    type Err = InteractionReviewDataError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "approved" => Ok(Self::Approved),
+            "changes_requested" => Ok(Self::ChangesRequested),
+            _ => Err(InteractionReviewDataError::InvalidDisposition(
+                value.to_string(),
+            )),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum InteractionReviewMessageAuthor {
+    Task,
+    Reviewer,
+}
+
+impl InteractionReviewMessageAuthor {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Task => "task",
+            Self::Reviewer => "reviewer",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct InteractionReviewPr {
+    pub number: u32,
+    pub url: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct InteractionReviewEvidence {
+    pub worktree: PathBuf,
+    pub branch: String,
+    pub base_commit: String,
+    pub head_commit: String,
+    pub worktree_fingerprint: String,
+    pub pr: Option<InteractionReviewPr>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct InteractionReview {
+    pub id: InteractionReviewId,
+    pub wave_id: WaveId,
+    pub project_session_id: ProjectSessionId,
+    pub task_session_id: TaskSessionId,
+    pub phase: TaskLifecyclePhase,
+    pub phase_epoch: u32,
+    pub flow: String,
+    pub step: String,
+    pub step_index: u32,
+    pub phase_iteration: u32,
+    pub policy: InteractionPolicy,
+    pub reviewer: InteractionReviewer,
+    pub status: InteractionReviewStatus,
+    pub reason: String,
+    pub prompt: String,
+    pub evidence: InteractionReviewEvidence,
+    pub requested_by_generation: u32,
+    pub reviewer_generation: Option<u32>,
+    pub disposition: Option<InteractionReviewDisposition>,
+    pub outcome: Option<String>,
+    pub requested_at: OffsetDateTime,
+    pub completed_at: Option<OffsetDateTime>,
+}
+
+impl InteractionReview {
+    pub fn validate(&self) -> Result<(), InteractionReviewDataError> {
+        for (name, value) in [
+            ("flow", self.flow.as_str()),
+            ("step", self.step.as_str()),
+            ("reason", self.reason.as_str()),
+            ("prompt", self.prompt.as_str()),
+            ("branch", self.evidence.branch.as_str()),
+            ("base commit", self.evidence.base_commit.as_str()),
+            ("head commit", self.evidence.head_commit.as_str()),
+            (
+                "worktree fingerprint",
+                self.evidence.worktree_fingerprint.as_str(),
+            ),
+        ] {
+            if value.trim().is_empty() {
+                return Err(InteractionReviewDataError::InvalidInvariant(format!(
+                    "{name} cannot be empty"
+                )));
+            }
+        }
+        if !self.evidence.worktree.is_absolute() {
+            return Err(InteractionReviewDataError::InvalidInvariant(
+                "worktree must be absolute".to_string(),
+            ));
+        }
+        if self.phase_epoch == 0 || self.requested_by_generation == 0 {
+            return Err(InteractionReviewDataError::InvalidInvariant(
+                "phase epoch and requesting generation must be positive".to_string(),
+            ));
+        }
+        if let Some(pr) = &self.evidence.pr {
+            if pr.number == 0 || pr.url.trim().is_empty() {
+                return Err(InteractionReviewDataError::InvalidInvariant(
+                    "PR evidence requires a positive number and URL".to_string(),
+                ));
+            }
+        }
+        match (self.policy, &self.reviewer) {
+            (InteractionPolicy::Require, InteractionReviewer::Human)
+            | (InteractionPolicy::Defer, InteractionReviewer::Project(_))
+            | (InteractionPolicy::Defer, InteractionReviewer::Wave(_)) => {}
+            _ => {
+                return Err(InteractionReviewDataError::InvalidInvariant(
+                    "reviewer does not match the interaction policy".to_string(),
+                ))
+            }
+        }
+        match &self.reviewer {
+            InteractionReviewer::Human => {}
+            InteractionReviewer::Project(id) if id == &self.project_session_id => {}
+            InteractionReviewer::Wave(id) if id == &self.wave_id => {}
+            InteractionReviewer::Project(_) | InteractionReviewer::Wave(_) => {
+                return Err(InteractionReviewDataError::InvalidInvariant(
+                    "reviewer is not the owning parent".to_string(),
+                ))
+            }
+        }
+        match self.status {
+            InteractionReviewStatus::Requested | InteractionReviewStatus::Active => {
+                if self.disposition.is_some()
+                    || self.outcome.is_some()
+                    || self.completed_at.is_some()
+                {
+                    return Err(InteractionReviewDataError::InvalidInvariant(
+                        "open reviews cannot carry terminal evidence".to_string(),
+                    ));
+                }
+            }
+            InteractionReviewStatus::Completed => {
+                if self.disposition.is_none()
+                    || self
+                        .outcome
+                        .as_ref()
+                        .is_none_or(|outcome| outcome.trim().is_empty())
+                    || self.completed_at.is_none()
+                {
+                    return Err(InteractionReviewDataError::InvalidInvariant(
+                        "completed reviews require disposition, outcome, and completion time"
+                            .to_string(),
+                    ));
+                }
+            }
+        }
+        if matches!(
+            self.reviewer,
+            InteractionReviewer::Project(_) | InteractionReviewer::Wave(_)
+        ) && self.status == InteractionReviewStatus::Completed
+            && self.reviewer_generation.is_none()
+        {
+            return Err(InteractionReviewDataError::InvalidInvariant(
+                "completed agent reviews require the reviewer generation".to_string(),
+            ));
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn review() -> InteractionReview {
+        let project_session_id = ProjectSessionId::new();
+        InteractionReview {
+            id: InteractionReviewId::new(),
+            wave_id: WaveId::new(),
+            project_session_id: project_session_id.clone(),
+            task_session_id: TaskSessionId::new(),
+            phase: TaskLifecyclePhase::Gate,
+            phase_epoch: 3,
+            flow: "task-gate".to_string(),
+            step: "demo".to_string(),
+            step_index: 0,
+            phase_iteration: 0,
+            policy: InteractionPolicy::Defer,
+            reviewer: InteractionReviewer::Project(project_session_id),
+            status: InteractionReviewStatus::Requested,
+            reason: "show the delivered behavior".to_string(),
+            prompt: "Conduct the demo exercise.".to_string(),
+            evidence: InteractionReviewEvidence {
+                worktree: PathBuf::from("/repo.task"),
+                branch: "jack/task".to_string(),
+                base_commit: "base".to_string(),
+                head_commit: "head".to_string(),
+                worktree_fingerprint: "fingerprint".to_string(),
+                pr: None,
+            },
+            requested_by_generation: 3,
+            reviewer_generation: None,
+            disposition: None,
+            outcome: None,
+            requested_at: OffsetDateTime::now_utc(),
+            completed_at: None,
+        }
+    }
+
+    #[test]
+    fn headless_review_requires_a_parent_and_completed_evidence() {
+        let mut value = review();
+        assert!(value.validate().is_ok());
+        value.reviewer = InteractionReviewer::Human;
+        assert!(value.validate().is_err());
+        value.reviewer = InteractionReviewer::Project(value.project_session_id.clone());
+        value.status = InteractionReviewStatus::Completed;
+        assert!(value.validate().is_err());
+    }
+}

--- a/rust/loopflow/src/lf/mod.rs
+++ b/rust/loopflow/src/lf/mod.rs
@@ -707,6 +707,27 @@ pub enum MemoryCommand {
 }
 
 #[derive(Subcommand, Debug)]
+pub enum ProjectReviewCommand {
+    /// Ask the reviewed Task a FIFO follow-up question
+    Message {
+        review_id: String,
+        message: String,
+        #[arg(long)]
+        json: bool,
+    },
+    /// Complete the review with an explicit disposition and findings
+    Complete {
+        review_id: String,
+        #[arg(long, value_parser = ["approved", "changes-requested"])]
+        disposition: String,
+        #[arg(long)]
+        outcome: String,
+        #[arg(long)]
+        json: bool,
+    },
+}
+
+#[derive(Subcommand, Debug)]
 pub enum ProjectCommand {
     /// Create a Linear Project first, then start its durable Project Session
     Start {
@@ -799,6 +820,11 @@ pub enum ProjectCommand {
         #[arg(long)]
         json: bool,
     },
+    /// Conduct an interactive exercise assigned by a child Task
+    Review {
+        #[command(subcommand)]
+        command: ProjectReviewCommand,
+    },
     /// Wait without polling an LM
     Wait {
         project_id: String,
@@ -837,6 +863,17 @@ pub enum ProjectCommand {
         /// Parent wave (default: ambient wave)
         #[arg(short = 'w', long = "wave")]
         wave: Option<String>,
+    },
+}
+
+#[derive(Subcommand, Debug)]
+pub enum TaskReviewCommand {
+    /// Reply to the reviewer without replacing the current Task direction
+    Reply {
+        review_id: String,
+        message: String,
+        #[arg(long)]
+        json: bool,
     },
 }
 
@@ -974,6 +1011,11 @@ pub enum TaskCommand {
         timeout: String,
         #[arg(long)]
         json: bool,
+    },
+    /// Continue the dialogue for the current interactive exercise
+    Review {
+        #[command(subcommand)]
+        command: TaskReviewCommand,
     },
     /// Wait without polling an LM
     Wait {
@@ -1956,6 +1998,59 @@ mod tests {
             }) if launch == "launch-1" && turn == "turn-1"
         ));
         assert!(Cli::try_parse_from(["lf", "trace", "run-1", "--content"]).is_err());
+    }
+
+    #[test]
+    fn interaction_review_dialogue_commands_parse() {
+        let project = Cli::try_parse_from([
+            "lf",
+            "project",
+            "review",
+            "complete",
+            "ir_review",
+            "--disposition",
+            "changes-requested",
+            "--outcome",
+            "Cover the empty state",
+        ])
+        .expect("parse Project review completion");
+        assert!(matches!(
+            project.command,
+            Some(Commands::Project {
+                cmd: ProjectCommand::Review {
+                    command: ProjectReviewCommand::Complete {
+                        review_id,
+                        disposition,
+                        outcome,
+                        ..
+                    }
+                }
+            }) if review_id == "ir_review"
+                && disposition == "changes-requested"
+                && outcome == "Cover the empty state"
+        ));
+
+        let task = Cli::try_parse_from([
+            "lf",
+            "task",
+            "review",
+            "reply",
+            "ir_review",
+            "The empty state is now visible",
+        ])
+        .expect("parse Task review reply");
+        assert!(matches!(
+            task.command,
+            Some(Commands::Task {
+                cmd: TaskCommand::Review {
+                    command: TaskReviewCommand::Reply {
+                        review_id,
+                        message,
+                        ..
+                    }
+                }
+            }) if review_id == "ir_review" && message == "The empty state is now visible"
+        ));
     }
 
     #[test]

--- a/rust/loopflow/src/lib.rs
+++ b/rust/loopflow/src/lib.rs
@@ -6,6 +6,7 @@ pub mod engine;
 pub mod flowloop;
 pub mod harness;
 pub mod id;
+pub mod interaction_review;
 pub mod interactive_handoff;
 pub mod journal;
 pub mod lf;

--- a/rust/loopflow/src/ops/project.rs
+++ b/rust/loopflow/src/ops/project.rs
@@ -14,6 +14,9 @@ use crate::engine::process::{
     tmux_session_slug,
 };
 use crate::id::WaveId;
+use crate::interaction_review::{
+    InteractionReview, InteractionReviewDisposition, InteractionReviewId,
+};
 use crate::ops::{ChildReceiptUntil, OpsError, OpsResult};
 use crate::project_session::{
     ProjectEventKind, ProjectSession, ProjectSessionId, ProjectSessionStatus,
@@ -941,6 +944,87 @@ pub fn project_request_decision(
             }
             tokio::time::sleep(Duration::from_millis(100)).await;
         }
+    })
+}
+
+pub fn project_review_message(
+    review_id: &str,
+    text: String,
+) -> OpsResult<crate::child_session::ChildCommand> {
+    let review_id = InteractionReviewId::parse(review_id)
+        .map_err(|error| project_error(format!("invalid interaction review: {error}")))?;
+    block_on_project(async move {
+        let store = project_store().await?;
+        let review = store
+            .get_interaction_review(&review_id)
+            .await
+            .map_err(|error| project_error(error.to_string()))?
+            .ok_or_else(|| project_error(format!("interaction review {review_id} not found")))?;
+        let ambient = std::env::var("LF_PROJECT_SESSION_ID").map_err(|_| {
+            project_error("review messages must run inside the assigned Project Session")
+        })?;
+        if ambient != review.project_session_id.as_str() {
+            return Err(project_error(format!(
+                "Project Session {ambient} cannot conduct review {review_id} assigned to {}",
+                review.project_session_id
+            )));
+        }
+        let lease = project_write_lease_from_env().map_err(|error| {
+            project_error(format!("Project body has no write authority: {error}"))
+        })?;
+        store
+            .send_project_interaction_review_message(
+                &review_id,
+                &review.project_session_id,
+                &lease,
+                &text,
+            )
+            .await
+            .map_err(|error| project_error(error.to_string()))
+    })
+}
+
+pub fn project_review_complete(
+    review_id: &str,
+    disposition: &str,
+    outcome: String,
+) -> OpsResult<InteractionReview> {
+    let review_id = InteractionReviewId::parse(review_id)
+        .map_err(|error| project_error(format!("invalid interaction review: {error}")))?;
+    let disposition = disposition
+        .replace('-', "_")
+        .parse::<InteractionReviewDisposition>()
+        .map_err(|error| project_error(error.to_string()))?;
+    block_on_project(async move {
+        let store = project_store().await?;
+        let review = store
+            .get_interaction_review(&review_id)
+            .await
+            .map_err(|error| project_error(error.to_string()))?
+            .ok_or_else(|| project_error(format!("interaction review {review_id} not found")))?;
+        let ambient = std::env::var("LF_PROJECT_SESSION_ID").map_err(|_| {
+            project_error("review completion must run inside the assigned Project Session")
+        })?;
+        if ambient != review.project_session_id.as_str() {
+            return Err(project_error(format!(
+                "Project Session {ambient} cannot complete review {review_id} assigned to {}",
+                review.project_session_id
+            )));
+        }
+        let lease = project_write_lease_from_env().map_err(|error| {
+            project_error(format!("Project body has no write authority: {error}"))
+        })?;
+        let (completed, _) = store
+            .complete_project_interaction_review(
+                &review_id,
+                &review.project_session_id,
+                &lease,
+                disposition,
+                &outcome,
+            )
+            .await
+            .map_err(|error| project_error(error.to_string()))?;
+        Ok(completed)
     })
 }
 

--- a/rust/loopflow/src/ops/task.rs
+++ b/rust/loopflow/src/ops/task.rs
@@ -21,6 +21,7 @@ use crate::engine::worktrees::{
 };
 use crate::engine::{expand_flow, load_flow, ConcreteStep};
 use crate::id::WaveId;
+use crate::interaction_review::{InteractionReview, InteractionReviewId};
 use crate::ops::error::{OpsError, OpsResult};
 use crate::session_context::{
     LinearIssueId, LinearIssueSnapshot, LinearProjectId, LinearProjectSnapshot, TaskLaunchReceipt,
@@ -2740,6 +2741,39 @@ pub fn task_request_decision(
             }
             tokio::time::sleep(Duration::from_millis(50)).await;
         }
+    })
+}
+
+pub fn task_review_reply(review_id: &str, text: String) -> OpsResult<InteractionReview> {
+    let review_id = InteractionReviewId::parse(review_id)
+        .map_err(|error| task_error(format!("invalid interaction review: {error}")))?;
+    block_on_task(async move {
+        let store = task_store().await?;
+        let review = store
+            .get_interaction_review(&review_id)
+            .await
+            .map_err(|error| task_error(error.to_string()))?
+            .ok_or_else(|| task_error(format!("interaction review {review_id} not found")))?;
+        let ambient = std::env::var("LF_TASK_SESSION_ID").map_err(|_| {
+            task_error("interaction review replies must run inside the reviewed Task Session")
+        })?;
+        if ambient != review.task_session_id.as_str() {
+            return Err(task_error(format!(
+                "Task Session {ambient} cannot reply to review {review_id} for {}",
+                review.task_session_id
+            )));
+        }
+        let lease = task_write_lease_from_env()
+            .map_err(|error| task_error(format!("Task body has no write authority: {error}")))?;
+        store
+            .reply_to_interaction_review(&review_id, &review.task_session_id, &lease, &text)
+            .await
+            .map_err(|error| task_error(error.to_string()))?;
+        store
+            .get_interaction_review(&review_id)
+            .await
+            .map_err(|error| task_error(error.to_string()))?
+            .ok_or_else(|| task_error(format!("interaction review {review_id} disappeared")))
     })
 }
 

--- a/rust/loopflow/src/store/interaction_reviews.rs
+++ b/rust/loopflow/src/store/interaction_reviews.rs
@@ -1,0 +1,127 @@
+use crate::child_session::{ChildCommand, ChildWriteLease};
+use crate::id::WaveId;
+use crate::interaction_review::{
+    InteractionReview, InteractionReviewDisposition, InteractionReviewId,
+};
+use crate::project_session::ProjectSessionId;
+use crate::task::{TaskSession, TaskSessionId};
+
+use super::{run_sqlite, Store, StoreResult};
+
+impl Store {
+    // The Task runner begins calling this in the routing slice stacked on this protocol.
+    #[allow(dead_code)]
+    pub(crate) async fn open_interaction_review(
+        &self,
+        session: &TaskSession,
+        review: &InteractionReview,
+        lease: &ChildWriteLease,
+    ) -> StoreResult<(InteractionReview, bool)> {
+        let session = session.clone();
+        let review = review.clone();
+        let lease = lease.clone();
+        run_sqlite(&self.sqlite, move |store| {
+            store.open_interaction_review(&session, &review, &lease)
+        })
+        .await
+    }
+
+    pub async fn get_interaction_review(
+        &self,
+        review_id: &InteractionReviewId,
+    ) -> StoreResult<Option<InteractionReview>> {
+        let review_id = review_id.clone();
+        run_sqlite(&self.sqlite, move |store| {
+            store.get_interaction_review(&review_id)
+        })
+        .await
+    }
+
+    pub async fn interaction_review_at(
+        &self,
+        task_session_id: &TaskSessionId,
+        phase_epoch: u32,
+        phase_iteration: u32,
+        step_index: u32,
+    ) -> StoreResult<Option<InteractionReview>> {
+        let task_session_id = task_session_id.clone();
+        run_sqlite(&self.sqlite, move |store| {
+            store.interaction_review_at(&task_session_id, phase_epoch, phase_iteration, step_index)
+        })
+        .await
+    }
+
+    pub async fn list_interaction_reviews(
+        &self,
+        wave_id: Option<&WaveId>,
+    ) -> StoreResult<Vec<InteractionReview>> {
+        let wave_id = wave_id.cloned();
+        run_sqlite(&self.sqlite, move |store| {
+            store.list_interaction_reviews(wave_id.as_ref())
+        })
+        .await
+    }
+
+    pub(crate) async fn send_project_interaction_review_message(
+        &self,
+        review_id: &InteractionReviewId,
+        project_session_id: &ProjectSessionId,
+        lease: &ChildWriteLease,
+        text: &str,
+    ) -> StoreResult<ChildCommand> {
+        let review_id = review_id.clone();
+        let project_session_id = project_session_id.clone();
+        let lease = lease.clone();
+        let text = text.to_string();
+        run_sqlite(&self.sqlite, move |store| {
+            store.send_project_interaction_review_message(
+                &review_id,
+                &project_session_id,
+                &lease,
+                &text,
+            )
+        })
+        .await
+    }
+
+    pub(crate) async fn reply_to_interaction_review(
+        &self,
+        review_id: &InteractionReviewId,
+        task_session_id: &TaskSessionId,
+        lease: &ChildWriteLease,
+        text: &str,
+    ) -> StoreResult<()> {
+        let review_id = review_id.clone();
+        let task_session_id = task_session_id.clone();
+        let lease = lease.clone();
+        let text = text.to_string();
+        run_sqlite(&self.sqlite, move |store| {
+            store.reply_to_interaction_review(&review_id, &task_session_id, &lease, &text)
+        })
+        .await
+    }
+
+    pub(crate) async fn complete_project_interaction_review(
+        &self,
+        review_id: &InteractionReviewId,
+        project_session_id: &ProjectSessionId,
+        lease: &ChildWriteLease,
+        disposition: InteractionReviewDisposition,
+        outcome: &str,
+    ) -> StoreResult<(InteractionReview, bool)> {
+        let review_id = review_id.clone();
+        let project_session_id = project_session_id.clone();
+        let lease = lease.clone();
+        let outcome = outcome.to_string();
+        run_sqlite(&self.sqlite, move |store| {
+            store.complete_project_interaction_review(
+                &review_id,
+                &project_session_id,
+                &lease,
+                disposition,
+                &outcome,
+            )
+        })
+        .await
+    }
+}

--- a/rust/loopflow/src/store/migrations.rs
+++ b/rust/loopflow/src/store/migrations.rs
@@ -214,6 +214,15 @@ const MIGRATIONS: &[Migration] = &[
         name: "task_lifecycle",
         sql: include_str!("migrations/0.11.014_task_lifecycle.sql"),
     },
+    Migration {
+        id: MigrationId {
+            major: 0,
+            minor: 11,
+            ordinal: 15,
+        },
+        name: "interaction_reviews",
+        sql: include_str!("migrations/0.11.015_interaction_reviews.sql"),
+    },
 ];
 
 /// The exact branch-local history that reached one production ledger before
@@ -888,7 +897,7 @@ mod tests {
             .unwrap());
         assert_eq!(
             latest_version_sqlite(&conn).unwrap(),
-            "0.11.014_task_lifecycle"
+            "0.11.015_interaction_reviews"
         );
         assert!(product_schema(&conn)
             .unwrap()
@@ -914,7 +923,8 @@ mod tests {
                 "0.11.011_profiles".to_string(),
                 "0.11.012_provider_account_lifecycle".to_string(),
                 "0.11.013_task_review_state".to_string(),
-                "0.11.014_task_lifecycle".to_string()
+                "0.11.014_task_lifecycle".to_string(),
+                "0.11.015_interaction_reviews".to_string()
             ]
         );
     }
@@ -936,7 +946,7 @@ mod tests {
             assert_eq!(
                 latest_version_sqlite(&conn)
                     .unwrap_or_else(|error| panic!("divergent prefix {count}: {error}")),
-                "0.11.014_task_lifecycle"
+                "0.11.015_interaction_reviews"
             );
             assert_eq!(
                 conn.query_row("SELECT COUNT(*) FROM waves", [], |row| row.get::<_, i64>(0))
@@ -1439,7 +1449,7 @@ mod tests {
         apply_sqlite(&conn).unwrap();
         assert_eq!(
             latest_version_sqlite(&conn).unwrap(),
-            "0.11.014_task_lifecycle"
+            "0.11.015_interaction_reviews"
         );
     }
 
@@ -1462,7 +1472,7 @@ mod tests {
         );
         assert_eq!(
             latest_version_sqlite(&conn).unwrap(),
-            "0.11.014_task_lifecycle"
+            "0.11.015_interaction_reviews"
         );
     }
 

--- a/rust/loopflow/src/store/migrations/0.11.015_interaction_reviews.sql
+++ b/rust/loopflow/src/store/migrations/0.11.015_interaction_reviews.sql
@@ -1,0 +1,44 @@
+CREATE TABLE interaction_reviews (
+    id TEXT PRIMARY KEY NOT NULL,
+    wave_id TEXT NOT NULL REFERENCES waves(id) ON DELETE CASCADE,
+    project_session_id TEXT NOT NULL REFERENCES project_sessions(id) ON DELETE CASCADE,
+    task_session_id TEXT NOT NULL REFERENCES task_sessions(id) ON DELETE CASCADE,
+    phase TEXT NOT NULL CHECK (phase IN ('kickoff', 'iterate', 'gate')),
+    phase_epoch INTEGER NOT NULL CHECK (phase_epoch > 0),
+    flow TEXT NOT NULL,
+    step TEXT NOT NULL,
+    step_index INTEGER NOT NULL CHECK (step_index >= 0),
+    phase_iteration INTEGER NOT NULL CHECK (phase_iteration >= 0),
+    policy TEXT NOT NULL CHECK (policy IN ('require', 'defer')),
+    reviewer_kind TEXT NOT NULL CHECK (reviewer_kind IN ('human', 'project', 'wave')),
+    reviewer_id TEXT,
+    status TEXT NOT NULL CHECK (status IN ('requested', 'active', 'completed')),
+    reason TEXT NOT NULL,
+    prompt TEXT NOT NULL,
+    worktree TEXT NOT NULL,
+    branch TEXT NOT NULL,
+    base_commit TEXT NOT NULL,
+    head_commit TEXT NOT NULL,
+    worktree_fingerprint TEXT NOT NULL,
+    pr_number INTEGER CHECK (pr_number IS NULL OR pr_number > 0),
+    pr_url TEXT,
+    requested_by_generation INTEGER NOT NULL CHECK (requested_by_generation > 0),
+    reviewer_generation INTEGER CHECK (reviewer_generation IS NULL OR reviewer_generation > 0),
+    disposition TEXT CHECK (disposition IN ('approved', 'changes_requested')),
+    outcome TEXT,
+    requested_at INTEGER NOT NULL,
+    completed_at INTEGER,
+    UNIQUE (task_session_id, phase_epoch, phase_iteration, step_index),
+    CHECK ((reviewer_kind = 'human') = (reviewer_id IS NULL)),
+    CHECK ((pr_number IS NULL) = (pr_url IS NULL)),
+    CHECK (
+        (status = 'completed') =
+        (disposition IS NOT NULL AND outcome IS NOT NULL AND completed_at IS NOT NULL)
+    )
+);
+
+CREATE INDEX interaction_reviews_wave_status
+    ON interaction_reviews(wave_id, status, requested_at, id);
+
+CREATE INDEX interaction_reviews_task_status
+    ON interaction_reviews(task_session_id, status, requested_at, id);

--- a/rust/loopflow/src/store/mod.rs
+++ b/rust/loopflow/src/store/mod.rs
@@ -13,6 +13,7 @@ use crate::provider_auth::Provider;
 use crate::repository::RepoId;
 use crate::wave::Wave;
 mod child_sessions;
+mod interaction_reviews;
 mod interactive_handoffs;
 pub mod migrations;
 pub mod rows;
@@ -866,6 +867,10 @@ mod tests {
         ChildProcessGeneration, ChildRef, ObservationRecipient,
     };
     use crate::id::WaveId;
+    use crate::interaction_review::{
+        InteractionReview, InteractionReviewDisposition, InteractionReviewEvidence,
+        InteractionReviewId, InteractionReviewStatus, InteractionReviewer,
+    };
     use crate::profile::{
         ChromeProfileBinding, EmailAddress, HostId, Profile, ProfileId, ProfileProviderAccount,
         ProviderProfileCandidate, RepoProfileRoute,
@@ -880,8 +885,9 @@ mod tests {
         ProjectLaunchReceipt, TaskLaunchReceipt,
     };
     use crate::task::{
-        AfterMerge, GithubPr, PmWritebackState, PrPhase, PrPublication, TaskEventKind, TaskPr,
-        TaskPrId, TaskSession, TaskSessionId, TaskSessionStatus,
+        AfterMerge, GithubPr, PmWritebackState, PrPhase, PrPublication, TaskEventKind,
+        TaskGateProposal, TaskLifecyclePhase, TaskPr, TaskPrId, TaskSession, TaskSessionId,
+        TaskSessionStatus,
     };
     use crate::wave::Wave;
     use std::env;
@@ -1239,6 +1245,295 @@ mod tests {
             gating.gate_proposal.unwrap().reason,
             "implementation complete"
         );
+    }
+
+    #[tokio::test]
+    async fn interaction_review_is_idempotent_and_supports_fifo_parent_dialogue() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = open_store(&StorageConfig::sqlite(dir.path().join("registry.db")))
+            .await
+            .unwrap();
+        let wave = make_wave("/repo");
+        store.create_wave(&wave).await.unwrap();
+
+        let mut project = make_project_session(&wave);
+        project.status = ProjectSessionStatus::Created;
+        project.status_reason = "reserved".to_string();
+        project.latest_process = None;
+        store.create_project_session(&project).await.unwrap();
+        project.begin_generation("project-reviewer".to_string());
+        let project_lease = store
+            .reserve_project_process(&project, ProjectSessionStatus::Created)
+            .await
+            .unwrap()
+            .unwrap();
+        if let Some(process) = &mut project.latest_process {
+            process.state = ChildLeaseState::Active;
+        }
+        project.set_status(ProjectSessionStatus::Running, "reviewer active");
+        store
+            .activate_project_process(&project, &project_lease)
+            .await
+            .unwrap();
+
+        let mut task = make_task_session(&wave, &project);
+        task.lifecycle = crate::task::TaskLifecyclePlan::headless("task");
+        task.lifecycle_phase = TaskLifecyclePhase::Gate;
+        task.phase_epoch = 3;
+        task.gate_cycle = 1;
+        task.gate_proposal = Some(TaskGateProposal {
+            status: TaskSessionStatus::Waiting,
+            reason: "PR ready".to_string(),
+        });
+        task.set_status(TaskSessionStatus::Waiting, "ready for gate review");
+        store
+            .create_task_session(&task, &make_task_pr(&task))
+            .await
+            .unwrap();
+        task.begin_generation("task-review".to_string());
+        let task_lease = store
+            .reserve_task_process(&task, TaskSessionStatus::Waiting)
+            .await
+            .unwrap()
+            .unwrap();
+        if let Some(process) = &mut task.latest_process {
+            process.state = ChildLeaseState::Active;
+        }
+        task.set_status(TaskSessionStatus::Running, "review requested");
+        store
+            .activate_task_process(&task, &task_lease)
+            .await
+            .unwrap();
+
+        let review = InteractionReview {
+            id: InteractionReviewId::new(),
+            wave_id: wave.id().clone(),
+            project_session_id: project.id.clone(),
+            task_session_id: task.id.clone(),
+            phase: task.lifecycle_phase,
+            phase_epoch: task.phase_epoch,
+            flow: task.phase_plan().flow.clone(),
+            step: "demo".to_string(),
+            step_index: 0,
+            phase_iteration: task.phase_iteration,
+            policy: task.phase_plan().interaction_policy,
+            reviewer: InteractionReviewer::Project(project.id.clone()),
+            status: InteractionReviewStatus::Requested,
+            reason: "prove the task outcome".to_string(),
+            prompt: "Demonstrate each Done When criterion.".to_string(),
+            evidence: InteractionReviewEvidence {
+                worktree: task.worktree.clone(),
+                branch: "jack/reviewed-task".to_string(),
+                base_commit: "base".to_string(),
+                head_commit: "head".to_string(),
+                worktree_fingerprint: "fingerprint".to_string(),
+                pr: None,
+            },
+            requested_by_generation: task_lease.generation,
+            reviewer_generation: None,
+            disposition: None,
+            outcome: None,
+            requested_at: OffsetDateTime::now_utc(),
+            completed_at: None,
+        };
+        let (opened, created) = store
+            .open_interaction_review(&task, &review, &task_lease)
+            .await
+            .unwrap();
+        assert!(created);
+        let mut replay = review.clone();
+        replay.id = InteractionReviewId::new();
+        let (same, created) = store
+            .open_interaction_review(&task, &replay, &task_lease)
+            .await
+            .unwrap();
+        assert!(!created);
+        assert_eq!(same.id, opened.id);
+        let mut future_step = review.clone();
+        future_step.id = InteractionReviewId::new();
+        future_step.step = "code-review".to_string();
+        future_step.step_index = 1;
+        assert!(store
+            .open_interaction_review(&task, &future_step, &task_lease)
+            .await
+            .is_err());
+
+        let command = store
+            .send_project_interaction_review_message(
+                &opened.id,
+                &project.id,
+                &project_lease,
+                "Show the stored state after the product action.",
+            )
+            .await
+            .unwrap();
+        assert!(matches!(command.kind, ChildCommandKind::FollowUp { .. }));
+        assert_eq!(
+            command.source,
+            ChildCommandSource::Project(project.id.clone())
+        );
+        let second_command = store
+            .send_project_interaction_review_message(
+                &opened.id,
+                &project.id,
+                &project_lease,
+                "Then connect that row to the implementation.",
+            )
+            .await
+            .unwrap();
+        let claimed = store
+            .claim_child_commands(&ChildRef::Task(task.id.clone()), task_lease.generation)
+            .await
+            .unwrap();
+        assert_eq!(
+            claimed
+                .iter()
+                .map(|command| command.id.clone())
+                .collect::<Vec<_>>(),
+            vec![command.id, second_command.id]
+        );
+        store
+            .reply_to_interaction_review(
+                &opened.id,
+                &task.id,
+                &task_lease,
+                "The action writes row 42; the admin view reads that row.",
+            )
+            .await
+            .unwrap();
+
+        let (completed, changed) = store
+            .complete_project_interaction_review(
+                &opened.id,
+                &project.id,
+                &project_lease,
+                InteractionReviewDisposition::Approved,
+                "Product action and stored row agree.",
+            )
+            .await
+            .unwrap();
+        assert!(changed);
+        assert_eq!(completed.status, InteractionReviewStatus::Completed);
+        assert_eq!(
+            completed.reviewer_generation,
+            Some(project_lease.generation)
+        );
+        let (_, changed) = store
+            .complete_project_interaction_review(
+                &opened.id,
+                &project.id,
+                &project_lease,
+                InteractionReviewDisposition::Approved,
+                "Product action and stored row agree.",
+            )
+            .await
+            .unwrap();
+        assert!(!changed);
+        let commands = store
+            .list_child_commands(&ChildRef::Task(task.id.clone()))
+            .await
+            .unwrap();
+        assert_eq!(commands.len(), 3);
+        assert!(matches!(
+            &commands[2].kind,
+            ChildCommandKind::FollowUp { text }
+                if text.contains("interaction_review_completed")
+                    && text.contains("disposition=\"approved\"")
+        ));
+
+        let events = store.task_events_after(&task.id, 0).await.unwrap();
+        let messages = events
+            .iter()
+            .filter(|event| matches!(event.kind, TaskEventKind::InteractionReviewMessage { .. }))
+            .count();
+        assert_eq!(messages, 3);
+        let project_observations = store
+            .pending_observations(&ObservationRecipient::Project {
+                session_id: project.id.clone(),
+            })
+            .await
+            .unwrap();
+        let review_observations = project_observations
+            .iter()
+            .filter(|observation| {
+                matches!(
+                    &observation.payload,
+                    ChildEventPayload::Task {
+                        event: TaskEventKind::InteractionReviewRequested { .. }
+                            | TaskEventKind::InteractionReviewMessage { .. }
+                            | TaskEventKind::InteractionReviewCompleted { .. }
+                    }
+                )
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(review_observations.len(), 2);
+        assert!(matches!(
+            &review_observations[0].payload,
+            ChildEventPayload::Task {
+                event: TaskEventKind::InteractionReviewRequested { .. }
+            }
+        ));
+        assert!(matches!(
+            &review_observations[1].payload,
+            ChildEventPayload::Task {
+                event: TaskEventKind::InteractionReviewMessage {
+                    author: crate::interaction_review::InteractionReviewMessageAuthor::Task,
+                    ..
+                }
+            }
+        ));
+        let wave_observations = store
+            .pending_observations(&ObservationRecipient::Wave {
+                wave_id: wave.id().clone(),
+            })
+            .await
+            .unwrap()
+            .into_iter()
+            .filter(|observation| {
+                matches!(
+                    observation.payload,
+                    ChildEventPayload::Task {
+                        event: TaskEventKind::InteractionReviewRequested { .. }
+                            | TaskEventKind::InteractionReviewMessage { .. }
+                            | TaskEventKind::InteractionReviewCompleted { .. }
+                    }
+                )
+            })
+            .count();
+        assert_eq!(wave_observations, 0);
+
+        task.enter_iterate().unwrap();
+        task.enter_gate(TaskGateProposal {
+            status: TaskSessionStatus::Waiting,
+            reason: "PR ready after review changes".to_string(),
+        })
+        .unwrap();
+        store
+            .update_task_session_for_lease(&task, &task_lease)
+            .await
+            .unwrap();
+        let mut next_gate_review = review.clone();
+        next_gate_review.id = InteractionReviewId::new();
+        next_gate_review.phase_epoch = task.phase_epoch;
+        next_gate_review.evidence.head_commit = "head-after-review".to_string();
+        next_gate_review.evidence.worktree_fingerprint = "fingerprint-after-review".to_string();
+        next_gate_review.requested_at = OffsetDateTime::now_utc();
+        let (next_gate_review, created) = store
+            .open_interaction_review(&task, &next_gate_review, &task_lease)
+            .await
+            .unwrap();
+        assert!(created);
+        assert_ne!(next_gate_review.id, completed.id);
+
+        let reviews = store
+            .list_interaction_reviews(Some(wave.id()))
+            .await
+            .unwrap();
+        assert_eq!(reviews.len(), 2);
+        assert!(reviews.contains(&completed));
+        assert!(reviews.iter().any(|review| {
+            review.id == next_gate_review.id && review.phase_epoch == next_gate_review.phase_epoch
+        }));
     }
 
     #[tokio::test]

--- a/rust/loopflow/src/store/sqlite.rs
+++ b/rust/loopflow/src/store/sqlite.rs
@@ -23,6 +23,7 @@ use crate::trace::{
 use crate::wave::Wave;
 
 mod child_sessions;
+mod interaction_reviews;
 mod interactive_handoffs;
 
 #[derive(Debug, Clone)]

--- a/rust/loopflow/src/store/sqlite/child_sessions.rs
+++ b/rust/loopflow/src/store/sqlite/child_sessions.rs
@@ -2478,7 +2478,7 @@ const TASK_SESSION_COLUMNS: &str = "SELECT
     kickoff_flow, kickoff_interaction_policy, gate_flow, gate_interaction_policy,
     lifecycle_phase, phase_epoch, gate_cycle, gate_proposal_json
     FROM task_sessions";
-const TASK_SESSION_SELECT: &str = "SELECT
+pub(super) const TASK_SESSION_SELECT: &str = "SELECT
     id, issue_id, issue_identifier, issue_title, issue_description,
     project_id, project_slug, project_name, project_prompt_context, wave_id,
     status, status_reason, status_at, worktree, workspace_slug,
@@ -2719,7 +2719,7 @@ fn map_child_directive_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<ChildDir
     })
 }
 
-fn insert_child_command(conn: &Connection, command: &ChildCommand) -> StoreResult<()> {
+pub(super) fn insert_child_command(conn: &Connection, command: &ChildCommand) -> StoreResult<()> {
     conn.execute(
         "INSERT INTO child_commands (
             id, target_kind, session_id, source_json, kind_json, created_at,
@@ -2934,7 +2934,7 @@ fn lease_revoked(kind: &str, id: &str, lease: &ChildWriteLease) -> StoreError {
     }
 }
 
-fn require_child_write_lease(
+pub(super) fn require_child_write_lease(
     conn: &Connection,
     target: &ChildRef,
     lease: &ChildWriteLease,
@@ -3146,7 +3146,7 @@ fn task_command_datetime(index: usize, value: i64) -> rusqlite::Result<time::Off
         .map_err(|error| invalid_column(index, error))
 }
 
-fn map_task_session_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<TaskSession> {
+pub(super) fn map_task_session_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<TaskSession> {
     let status_text: String = row.get(10)?;
     let status = status_text
         .parse()
@@ -3775,7 +3775,7 @@ fn child_columns(source: &ChildRef) -> (&'static str, String) {
     }
 }
 
-fn insert_task_event_in(
+pub(super) fn insert_task_event_in(
     conn: &Connection,
     session: &TaskSession,
     kind: &TaskEventKind,

--- a/rust/loopflow/src/store/sqlite/interaction_reviews.rs
+++ b/rust/loopflow/src/store/sqlite/interaction_reviews.rs
@@ -1,0 +1,567 @@
+use std::path::PathBuf;
+use std::str::FromStr;
+
+use rusqlite::{params, OptionalExtension, TransactionBehavior};
+
+use crate::child_session::{
+    ChildCommand, ChildCommandKind, ChildCommandSource, ChildRef, ChildWriteLease,
+};
+use crate::engine::InteractionPolicy;
+use crate::id::WaveId;
+use crate::interaction_review::{
+    InteractionReview, InteractionReviewDataError, InteractionReviewDisposition,
+    InteractionReviewEvidence, InteractionReviewId, InteractionReviewMessageAuthor,
+    InteractionReviewPr, InteractionReviewStatus, InteractionReviewer,
+};
+use crate::project_session::ProjectSessionId;
+use crate::store::rows::unix_to_datetime;
+use crate::store::{StoreError, StoreResult};
+use crate::task::{TaskEventKind, TaskLifecyclePhase, TaskSession, TaskSessionId};
+
+use super::child_sessions::{
+    insert_child_command, insert_task_event_in, map_task_session_row, require_child_write_lease,
+    TASK_SESSION_SELECT,
+};
+use super::SqliteStore;
+
+const INTERACTION_REVIEW_COLUMNS: &str = "SELECT
+    id, wave_id, project_session_id, task_session_id,
+    phase, phase_epoch, flow, step, step_index, phase_iteration, policy,
+    reviewer_kind, reviewer_id, status, reason, prompt,
+    worktree, branch, base_commit, head_commit, worktree_fingerprint,
+    pr_number, pr_url, requested_by_generation, reviewer_generation,
+    disposition, outcome, requested_at, completed_at
+    FROM interaction_reviews";
+
+impl SqliteStore {
+    pub(crate) fn open_interaction_review(
+        &self,
+        session: &TaskSession,
+        review: &InteractionReview,
+        lease: &ChildWriteLease,
+    ) -> StoreResult<(InteractionReview, bool)> {
+        review.validate().map_err(invalid_review)?;
+        session
+            .validate()
+            .map_err(|error| StoreError::InvalidData(error.to_string()))?;
+        if session.id != review.task_session_id
+            || session.wave_id != review.wave_id
+            || session.project_session_id != review.project_session_id
+            || session.lifecycle_phase != review.phase
+            || session.phase_epoch != review.phase_epoch
+            || session.phase_plan().flow != review.flow
+            || session.phase_plan().interaction_policy != review.policy
+            || session.phase_cursor != review.step_index
+            || session.phase_iteration != review.phase_iteration
+        {
+            return Err(StoreError::InvalidData(
+                "interaction review does not match its Task lifecycle waitpoint".to_string(),
+            ));
+        }
+        if review.status != InteractionReviewStatus::Requested {
+            return Err(StoreError::InvalidData(
+                "new interaction reviews must be requested".to_string(),
+            ));
+        }
+        if review.requested_by_generation != lease.generation {
+            return Err(StoreError::InvalidData(format!(
+                "interaction review generation {} does not match Task lease generation {}",
+                review.requested_by_generation, lease.generation
+            )));
+        }
+        if !matches!(
+            &review.reviewer,
+            InteractionReviewer::Project(id) if id == &session.project_session_id
+        ) && review.reviewer != InteractionReviewer::Human
+        {
+            return Err(StoreError::InvalidData(
+                "Task reviews must target their owning Project or the human".to_string(),
+            ));
+        }
+
+        let mut conn = self.conn.lock().expect("store mutex poisoned");
+        let transaction = conn.transaction_with_behavior(TransactionBehavior::Immediate)?;
+        require_child_write_lease(&transaction, &ChildRef::Task(session.id.clone()), lease)?;
+        if let Some(existing) = review_at_waitpoint(
+            &transaction,
+            &review.task_session_id,
+            review.phase_epoch,
+            review.phase_iteration,
+            review.step_index,
+        )? {
+            if !same_waitpoint(&existing, review) {
+                return Err(StoreError::InvalidData(
+                    "interaction review waitpoint already belongs to a different exercise"
+                        .to_string(),
+                ));
+            }
+            transaction.commit()?;
+            return Ok((existing, false));
+        }
+
+        insert_review(&transaction, review)?;
+        insert_task_event_in(
+            &transaction,
+            session,
+            &TaskEventKind::InteractionReviewRequested {
+                review: Box::new(review.clone()),
+            },
+        )?;
+        transaction.commit()?;
+        Ok((review.clone(), true))
+    }
+
+    pub(crate) fn get_interaction_review(
+        &self,
+        review_id: &InteractionReviewId,
+    ) -> StoreResult<Option<InteractionReview>> {
+        let conn = self.conn.lock().expect("store mutex poisoned");
+        conn.query_row(
+            &format!("{INTERACTION_REVIEW_COLUMNS} WHERE id=?1"),
+            [review_id.as_str()],
+            map_review_row,
+        )
+        .optional()
+        .map_err(StoreError::from)
+    }
+
+    pub(crate) fn interaction_review_at(
+        &self,
+        task_session_id: &TaskSessionId,
+        phase_epoch: u32,
+        phase_iteration: u32,
+        step_index: u32,
+    ) -> StoreResult<Option<InteractionReview>> {
+        let conn = self.conn.lock().expect("store mutex poisoned");
+        review_at_waitpoint(
+            &conn,
+            task_session_id,
+            phase_epoch,
+            phase_iteration,
+            step_index,
+        )
+    }
+
+    pub(crate) fn list_interaction_reviews(
+        &self,
+        wave_id: Option<&WaveId>,
+    ) -> StoreResult<Vec<InteractionReview>> {
+        let conn = self.conn.lock().expect("store mutex poisoned");
+        let query = match wave_id {
+            Some(_) => {
+                format!("{INTERACTION_REVIEW_COLUMNS} WHERE wave_id=?1 ORDER BY requested_at, id")
+            }
+            None => format!("{INTERACTION_REVIEW_COLUMNS} ORDER BY requested_at, id"),
+        };
+        let mut statement = conn.prepare(&query)?;
+        let mut reviews = Vec::new();
+        if let Some(wave_id) = wave_id {
+            let rows = statement.query_map([wave_id.as_str()], map_review_row)?;
+            for row in rows {
+                reviews.push(row?);
+            }
+        } else {
+            let rows = statement.query_map([], map_review_row)?;
+            for row in rows {
+                reviews.push(row?);
+            }
+        }
+        Ok(reviews)
+    }
+
+    pub(crate) fn send_project_interaction_review_message(
+        &self,
+        review_id: &InteractionReviewId,
+        project_session_id: &ProjectSessionId,
+        lease: &ChildWriteLease,
+        text: &str,
+    ) -> StoreResult<ChildCommand> {
+        let text = require_text("review message", text)?;
+        let mut conn = self.conn.lock().expect("store mutex poisoned");
+        let transaction = conn.transaction_with_behavior(TransactionBehavior::Immediate)?;
+        require_child_write_lease(
+            &transaction,
+            &ChildRef::Project(project_session_id.clone()),
+            lease,
+        )?;
+        let review = require_open_project_review(&transaction, review_id, project_session_id)?;
+        let session = transaction.query_row(
+            TASK_SESSION_SELECT,
+            [review.task_session_id.as_str()],
+            map_task_session_row,
+        )?;
+        transaction.execute(
+            "UPDATE interaction_reviews
+             SET status='active', reviewer_generation=COALESCE(reviewer_generation, ?2)
+             WHERE id=?1 AND status IN ('requested', 'active')",
+            params![review_id.as_str(), i64::from(lease.generation)],
+        )?;
+        let command = ChildCommand::new(
+            ChildRef::Task(review.task_session_id.clone()),
+            ChildCommandSource::Project(project_session_id.clone()),
+            ChildCommandKind::FollowUp {
+                text: format!(
+                    "<interaction_review_message review_id=\"{review_id}\" from=\"reviewer\">\n{text}\n</interaction_review_message>"
+                ),
+            },
+        );
+        insert_child_command(&transaction, &command)?;
+        insert_task_event_in(
+            &transaction,
+            &session,
+            &TaskEventKind::InteractionReviewMessage {
+                review_id: review_id.clone(),
+                author: InteractionReviewMessageAuthor::Reviewer,
+                text,
+            },
+        )?;
+        transaction.commit()?;
+        Ok(command)
+    }
+
+    pub(crate) fn reply_to_interaction_review(
+        &self,
+        review_id: &InteractionReviewId,
+        task_session_id: &TaskSessionId,
+        lease: &ChildWriteLease,
+        text: &str,
+    ) -> StoreResult<()> {
+        let text = require_text("review reply", text)?;
+        let mut conn = self.conn.lock().expect("store mutex poisoned");
+        let transaction = conn.transaction_with_behavior(TransactionBehavior::Immediate)?;
+        require_child_write_lease(
+            &transaction,
+            &ChildRef::Task(task_session_id.clone()),
+            lease,
+        )?;
+        let review = transaction
+            .query_row(
+                &format!("{INTERACTION_REVIEW_COLUMNS} WHERE id=?1"),
+                [review_id.as_str()],
+                map_review_row,
+            )
+            .optional()?
+            .ok_or(StoreError::NotFound)?;
+        if &review.task_session_id != task_session_id || review.status.is_terminal() {
+            return Err(StoreError::InvalidData(
+                "interaction review is not open for this Task Session".to_string(),
+            ));
+        }
+        let session = transaction.query_row(
+            TASK_SESSION_SELECT,
+            [task_session_id.as_str()],
+            map_task_session_row,
+        )?;
+        transaction.execute(
+            "UPDATE interaction_reviews SET status='active'
+             WHERE id=?1 AND status IN ('requested', 'active')",
+            [review_id.as_str()],
+        )?;
+        insert_task_event_in(
+            &transaction,
+            &session,
+            &TaskEventKind::InteractionReviewMessage {
+                review_id: review_id.clone(),
+                author: InteractionReviewMessageAuthor::Task,
+                text,
+            },
+        )?;
+        transaction.commit()?;
+        Ok(())
+    }
+
+    pub(crate) fn complete_project_interaction_review(
+        &self,
+        review_id: &InteractionReviewId,
+        project_session_id: &ProjectSessionId,
+        lease: &ChildWriteLease,
+        disposition: InteractionReviewDisposition,
+        outcome: &str,
+    ) -> StoreResult<(InteractionReview, bool)> {
+        let outcome = require_text("review outcome", outcome)?;
+        let mut conn = self.conn.lock().expect("store mutex poisoned");
+        let transaction = conn.transaction_with_behavior(TransactionBehavior::Immediate)?;
+        require_child_write_lease(
+            &transaction,
+            &ChildRef::Project(project_session_id.clone()),
+            lease,
+        )?;
+        let review = transaction
+            .query_row(
+                &format!("{INTERACTION_REVIEW_COLUMNS} WHERE id=?1"),
+                [review_id.as_str()],
+                map_review_row,
+            )
+            .optional()?
+            .ok_or(StoreError::NotFound)?;
+        if review.reviewer != InteractionReviewer::Project(project_session_id.clone()) {
+            return Err(StoreError::InvalidData(
+                "only the assigned Project reviewer may complete this review".to_string(),
+            ));
+        }
+        if review.status == InteractionReviewStatus::Completed {
+            if review.disposition == Some(disposition)
+                && review.outcome.as_deref() == Some(outcome.as_str())
+            {
+                transaction.commit()?;
+                return Ok((review, false));
+            }
+            return Err(StoreError::InvalidData(
+                "interaction review already has a different completion".to_string(),
+            ));
+        }
+        if review.status.is_terminal() {
+            return Err(StoreError::InvalidData(
+                "interaction review is already terminal".to_string(),
+            ));
+        }
+        let completed_at = time::OffsetDateTime::now_utc();
+        transaction.execute(
+            "UPDATE interaction_reviews
+             SET status='completed', reviewer_generation=?2, disposition=?3,
+                 outcome=?4, completed_at=?5
+             WHERE id=?1",
+            params![
+                review_id.as_str(),
+                i64::from(lease.generation),
+                disposition.as_str(),
+                outcome,
+                completed_at.unix_timestamp(),
+            ],
+        )?;
+        let command = ChildCommand::new(
+            ChildRef::Task(review.task_session_id.clone()),
+            ChildCommandSource::Project(project_session_id.clone()),
+            ChildCommandKind::FollowUp {
+                text: format!(
+                    "<interaction_review_completed review_id=\"{review_id}\" disposition=\"{}\">\n{outcome}\n</interaction_review_completed>",
+                    disposition.as_str()
+                ),
+            },
+        );
+        insert_child_command(&transaction, &command)?;
+        let session = transaction.query_row(
+            TASK_SESSION_SELECT,
+            [review.task_session_id.as_str()],
+            map_task_session_row,
+        )?;
+        insert_task_event_in(
+            &transaction,
+            &session,
+            &TaskEventKind::InteractionReviewCompleted {
+                review_id: review_id.clone(),
+                disposition,
+                outcome,
+            },
+        )?;
+        let completed = transaction.query_row(
+            &format!("{INTERACTION_REVIEW_COLUMNS} WHERE id=?1"),
+            [review_id.as_str()],
+            map_review_row,
+        )?;
+        transaction.commit()?;
+        Ok((completed, true))
+    }
+}
+
+fn insert_review(conn: &rusqlite::Connection, review: &InteractionReview) -> StoreResult<()> {
+    conn.execute(
+        "INSERT INTO interaction_reviews (
+            id, wave_id, project_session_id, task_session_id,
+            phase, phase_epoch, flow, step, step_index, phase_iteration, policy,
+            reviewer_kind, reviewer_id, status, reason, prompt,
+            worktree, branch, base_commit, head_commit, worktree_fingerprint,
+            pr_number, pr_url, requested_by_generation, reviewer_generation,
+            disposition, outcome, requested_at, completed_at
+         ) VALUES (
+            ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11,
+            ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21,
+            ?22, ?23, ?24, ?25, ?26, ?27, ?28, ?29
+         )",
+        params![
+            review.id.as_str(),
+            review.wave_id.as_str(),
+            review.project_session_id.as_str(),
+            review.task_session_id.as_str(),
+            review.phase.as_str(),
+            i64::from(review.phase_epoch),
+            review.flow,
+            review.step,
+            i64::from(review.step_index),
+            i64::from(review.phase_iteration),
+            review.policy.as_str(),
+            review.reviewer.kind(),
+            review.reviewer.id(),
+            review.status.as_str(),
+            review.reason,
+            review.prompt,
+            review.evidence.worktree.display().to_string(),
+            review.evidence.branch,
+            review.evidence.base_commit,
+            review.evidence.head_commit,
+            review.evidence.worktree_fingerprint,
+            review.evidence.pr.as_ref().map(|pr| i64::from(pr.number)),
+            review.evidence.pr.as_ref().map(|pr| pr.url.as_str()),
+            i64::from(review.requested_by_generation),
+            review.reviewer_generation.map(i64::from),
+            review.disposition.map(InteractionReviewDisposition::as_str),
+            review.outcome,
+            review.requested_at.unix_timestamp(),
+            review.completed_at.map(|at| at.unix_timestamp()),
+        ],
+    )?;
+    Ok(())
+}
+
+fn review_at_waitpoint(
+    conn: &rusqlite::Connection,
+    task_session_id: &TaskSessionId,
+    phase_epoch: u32,
+    phase_iteration: u32,
+    step_index: u32,
+) -> StoreResult<Option<InteractionReview>> {
+    conn.query_row(
+        &format!(
+            "{INTERACTION_REVIEW_COLUMNS}
+             WHERE task_session_id=?1 AND phase_epoch=?2
+               AND phase_iteration=?3 AND step_index=?4"
+        ),
+        params![
+            task_session_id.as_str(),
+            i64::from(phase_epoch),
+            i64::from(phase_iteration),
+            i64::from(step_index)
+        ],
+        map_review_row,
+    )
+    .optional()
+    .map_err(StoreError::from)
+}
+
+fn same_waitpoint(left: &InteractionReview, right: &InteractionReview) -> bool {
+    left.wave_id == right.wave_id
+        && left.project_session_id == right.project_session_id
+        && left.task_session_id == right.task_session_id
+        && left.phase == right.phase
+        && left.phase_epoch == right.phase_epoch
+        && left.flow == right.flow
+        && left.step == right.step
+        && left.step_index == right.step_index
+        && left.phase_iteration == right.phase_iteration
+        && left.policy == right.policy
+        && left.reviewer == right.reviewer
+}
+
+fn require_open_project_review(
+    conn: &rusqlite::Connection,
+    review_id: &InteractionReviewId,
+    project_session_id: &ProjectSessionId,
+) -> StoreResult<InteractionReview> {
+    let review = conn
+        .query_row(
+            &format!("{INTERACTION_REVIEW_COLUMNS} WHERE id=?1"),
+            [review_id.as_str()],
+            map_review_row,
+        )
+        .optional()?
+        .ok_or(StoreError::NotFound)?;
+    if review.reviewer != InteractionReviewer::Project(project_session_id.clone())
+        || review.status.is_terminal()
+    {
+        return Err(StoreError::InvalidData(
+            "interaction review is not open for this Project reviewer".to_string(),
+        ));
+    }
+    Ok(review)
+}
+
+fn map_review_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<InteractionReview> {
+    let reviewer_kind = row.get::<_, String>(11)?;
+    let reviewer_id = row.get::<_, Option<String>>(12)?;
+    let reviewer = match (reviewer_kind.as_str(), reviewer_id) {
+        ("human", None) => InteractionReviewer::Human,
+        ("project", Some(id)) => InteractionReviewer::Project(ProjectSessionId::from_raw(id)),
+        ("wave", Some(id)) => InteractionReviewer::Wave(
+            WaveId::parse(&id).map_err(|error| invalid_column(12, error))?,
+        ),
+        _ => {
+            return Err(invalid_column(
+                11,
+                InteractionReviewDataError::InvalidInvariant(
+                    "stored reviewer is incomplete".to_string(),
+                ),
+            ))
+        }
+    };
+    let pr_number = row.get::<_, Option<i64>>(21)?.map(|number| number as u32);
+    let pr_url = row.get::<_, Option<String>>(22)?;
+    let pr = match (pr_number, pr_url) {
+        (Some(number), Some(url)) => Some(InteractionReviewPr { number, url }),
+        (None, None) => None,
+        _ => {
+            return Err(invalid_column(
+                21,
+                InteractionReviewDataError::InvalidInvariant(
+                    "stored PR evidence is incomplete".to_string(),
+                ),
+            ))
+        }
+    };
+    Ok(InteractionReview {
+        id: InteractionReviewId::from_raw(row.get::<_, String>(0)?),
+        wave_id: row.get(1)?,
+        project_session_id: ProjectSessionId::from_raw(row.get::<_, String>(2)?),
+        task_session_id: TaskSessionId::from_raw(row.get::<_, String>(3)?),
+        phase: TaskLifecyclePhase::from_str(&row.get::<_, String>(4)?)
+            .map_err(|error| invalid_column(4, error))?,
+        phase_epoch: row.get::<_, i64>(5)? as u32,
+        flow: row.get(6)?,
+        step: row.get(7)?,
+        step_index: row.get::<_, i64>(8)? as u32,
+        phase_iteration: row.get::<_, i64>(9)? as u32,
+        policy: InteractionPolicy::from_str(&row.get::<_, String>(10)?)
+            .map_err(|error| invalid_column(10, error))?,
+        reviewer,
+        status: InteractionReviewStatus::from_str(&row.get::<_, String>(13)?)
+            .map_err(|error| invalid_column(13, error))?,
+        reason: row.get(14)?,
+        prompt: row.get(15)?,
+        evidence: InteractionReviewEvidence {
+            worktree: PathBuf::from(row.get::<_, String>(16)?),
+            branch: row.get(17)?,
+            base_commit: row.get(18)?,
+            head_commit: row.get(19)?,
+            worktree_fingerprint: row.get(20)?,
+            pr,
+        },
+        requested_by_generation: row.get::<_, i64>(23)? as u32,
+        reviewer_generation: row.get::<_, Option<i64>>(24)?.map(|value| value as u32),
+        disposition: row
+            .get::<_, Option<String>>(25)?
+            .map(|value| InteractionReviewDisposition::from_str(&value))
+            .transpose()
+            .map_err(|error| invalid_column(25, error))?,
+        outcome: row.get(26)?,
+        requested_at: unix_to_datetime(row.get(27)?),
+        completed_at: row.get::<_, Option<i64>>(28)?.map(unix_to_datetime),
+    })
+}
+
+fn require_text(name: &str, value: &str) -> StoreResult<String> {
+    let value = value.trim();
+    if value.is_empty() {
+        return Err(StoreError::InvalidData(format!("{name} cannot be empty")));
+    }
+    Ok(value.to_string())
+}
+
+fn invalid_review(error: InteractionReviewDataError) -> StoreError {
+    StoreError::InvalidData(error.to_string())
+}
+
+fn invalid_column(
+    index: usize,
+    error: impl std::error::Error + Send + Sync + 'static,
+) -> rusqlite::Error {
+    rusqlite::Error::FromSqlConversionFailure(index, rusqlite::types::Type::Text, Box::new(error))
+}

--- a/rust/loopflow/src/task/mod.rs
+++ b/rust/loopflow/src/task/mod.rs
@@ -17,6 +17,10 @@ use crate::child_session::{
 };
 use crate::engine::InteractionPolicy;
 use crate::id::WaveId;
+use crate::interaction_review::{
+    InteractionReview, InteractionReviewDisposition, InteractionReviewId,
+    InteractionReviewMessageAuthor,
+};
 use crate::project_session::ProjectSessionId;
 use crate::session_context::TaskLaunchReceipt;
 
@@ -784,6 +788,19 @@ pub enum TaskEventKind {
     Progress {
         summary: String,
     },
+    InteractionReviewRequested {
+        review: Box<InteractionReview>,
+    },
+    InteractionReviewMessage {
+        review_id: InteractionReviewId,
+        author: InteractionReviewMessageAuthor,
+        text: String,
+    },
+    InteractionReviewCompleted {
+        review_id: InteractionReviewId,
+        disposition: InteractionReviewDisposition,
+        outcome: String,
+    },
     PrStarted {
         pr_id: TaskPrId,
         sequence: u32,
@@ -817,6 +834,11 @@ impl TaskEventKind {
     pub fn is_project_observable(&self) -> bool {
         match self {
             Self::Started | Self::Progress { .. } => false,
+            Self::InteractionReviewMessage {
+                author: InteractionReviewMessageAuthor::Reviewer,
+                ..
+            }
+            | Self::InteractionReviewCompleted { .. } => false,
             Self::BodyLeaseChanged { process } => matches!(
                 process.state,
                 ChildLeaseState::Revoked | ChildLeaseState::Finished
@@ -833,7 +855,11 @@ impl TaskEventKind {
         self.is_project_observable()
             && !matches!(
                 self,
-                Self::DecisionRequested { .. } | Self::DecisionResolved { .. }
+                Self::DecisionRequested { .. }
+                    | Self::DecisionResolved { .. }
+                    | Self::InteractionReviewRequested { .. }
+                    | Self::InteractionReviewMessage { .. }
+                    | Self::InteractionReviewCompleted { .. }
             )
     }
 }


### PR DESCRIPTION
## Try it!

```bash
cargo test -p loopflow interaction_review --lib
cargo test -p loopflow store::migrations::tests::a_fresh_database_applies_the_whole_chain_once --lib
cargo clippy -p loopflow --all-targets -- -D warnings
```

The protocol test opens one headless Gate review, proves replay idempotency at the same lifecycle waitpoint, conducts two FIFO parent questions plus a Task reply, records an authorized disposition, and then proves a later Gate epoch creates a fresh review.

## Intent

Give interactive Task steps one durable conversation and decision record whether the reviewer is a human or the owning Project. This is the transport boundary that lets headless execution preserve the same review exercise instead of skipping it.

## Assumptions

- A Task review belongs to one exact phase epoch, iteration, and step cursor.
- The owning Project is the only agent reviewer for a Task; attended completion follows separately.
- Parent questions and final disposition must enter the existing Task provider session as ordered follow-ups, never steer replacements.

## Key decisions

- Fence both writers with their active Task or Project generation lease.
- Persist the review request and its full evidence snapshot in the Task event observed by the Project.
- Wake the Project only for the request and Task-authored replies; reviewer echoes and completion do not self-wake or leak into the root Wave.
- Queue the final disposition back to the Task so approval and changes-requested survive provider timing and restarts.

## Not included

Task-runner routing, attended human handoff, `--headless` launch UX, skill rewrites, and Wave catch-up are stacked follow-ups.