### PR TITLE
skills: support parent reviewers when headless

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,9 @@ The default policy requires a human for kickoff and gate while deferring
 interactive inner-loop steps to the owning Project. `--headless` defers every
 interactive step to that Project instead. It runs the same kickoff, inner-loop,
 and gate skills; it does not skip them. Re-run an idle Task with `--headless` to
-mark its remaining lifecycle headless.
+mark its remaining lifecycle headless. Interactive skills define both attended
+and parent-reviewer behavior; parent questions and Task answers stay in the
+same durable review conversation.
 
 Start dependent work without sharing the parent's worktree:
 

--- a/rust/loopflow/src/engine/builtins.rs
+++ b/rust/loopflow/src/engine/builtins.rs
@@ -235,6 +235,53 @@ mod tests {
     }
 
     #[test]
+    fn interactive_skills_support_human_and_parent_reviewers() {
+        for name in [
+            "code-review",
+            "demo",
+            "design",
+            "explore",
+            "refine",
+            "review-design",
+            "review-open-work",
+            "review",
+            "init",
+        ] {
+            let skill = get_builtin_skill(name).expect("interactive builtin skill");
+            assert!(
+                skill.contains("## Reviewer mode"),
+                "{name} does not define reviewer modes"
+            );
+            assert!(
+                skill.contains("**Human reviewer:**"),
+                "{name} does not define attended behavior"
+            );
+            assert!(
+                skill.contains("**Parent reviewer:**"),
+                "{name} does not define headless parent behavior"
+            );
+            assert!(
+                skill.contains("review protocol"),
+                "{name} does not route parent dialogue through the review protocol"
+            );
+        }
+
+        let demo = get_builtin_skill("demo").expect("demo skill");
+        for evidence in [
+            "every Done When",
+            "product",
+            "code",
+            "admin state",
+            "logs",
+            "stats",
+            "metrics",
+            "real sign-in/login path",
+        ] {
+            assert!(demo.contains(evidence), "demo omits {evidence:?} evidence");
+        }
+    }
+
+    #[test]
     fn execution_context_grants_delegation_by_tier() {
         assert!(LOOPFLOW_DOC.contains("Execute Here First"));
         assert!(!LOOPFLOW_DOC.contains("lf pm show"));

--- a/rust/loopflow/src/engine/builtins/build/skill/code-review.md
+++ b/rust/loopflow/src/engine/builtins/build/skill/code-review.md
@@ -7,6 +7,19 @@ action_style: exploratory
 ---
 Walk through structural and architectural decisions with the human. The diff is the starting point; the codebase's trajectory is the subject.
 
+## Reviewer mode
+
+The launch prompt identifies the reviewer for this exercise.
+
+- **Human reviewer:** use the conversation below. Present one decision at a
+  time, incorporate their reaction, and let them choose the disposition.
+- **Parent reviewer:** conduct the same architectural review independently.
+  Inspect the supplied evidence and surrounding code, use the review protocol
+  to ask the Task only for missing evidence, and never wait for an unavailable
+  human. Approve only when the structure is sound; otherwise request changes
+  with concrete findings and the trajectory they protect. Do not implement the
+  Task's fixes yourself.
+
 ## Voice
 
 The human chose to look at code, not behavior. They're thinking about architecture — how this change fits into the larger vision. Meet them there. Don't narrate the diff mechanically; orient them in the design space this change opens up.

--- a/rust/loopflow/src/engine/builtins/build/skill/demo.md
+++ b/rust/loopflow/src/engine/builtins/build/skill/demo.md
@@ -7,6 +7,18 @@ action_style: procedural
 ---
 Walk the human through experiencing what changed, then decide together what's next.
 
+## Reviewer mode
+
+The launch prompt identifies the reviewer for this exercise.
+
+- **Human reviewer:** guide the human through the experience, pause for their
+  reaction, and decide together what happens next.
+- **Parent reviewer:** run the same demo independently from the supplied
+  evidence. Use the review protocol to ask the Task only for missing evidence;
+  never invent a human reaction or wait for one. Approve only when the demo and
+  every applicable Done When claim are proven. Otherwise request changes with
+  the failed or missing proof. Do not implement the Task's fixes yourself.
+
 ## Orientation
 
 Before starting, orient yourself in this branch:
@@ -38,6 +50,30 @@ Before any code discussion, ground the human in the experience:
 
 If the design doc in `scratch/` has a "Done when" section with a verification command, start there.
 
+## Prove every Done When
+
+Before presenting a verdict, enumerate every Done When claim in the design doc
+and build a compact evidence matrix:
+
+| Done When | Proof surface | Action | Observed result |
+|---|---|---|---|
+| <claim> | product \| code \| admin state \| log \| stat/metric | <what ran or was inspected> | pass \| gap, with evidence |
+
+Choose the surface that most directly proves each claim:
+
+- **Product:** experience the behavior through the real user path.
+- **Code/tests:** use source, tests, and command output for structural or
+  programmatic claims.
+- **Operations:** inspect admin state, logs, counters, stats, or metrics when
+  the result is observable there rather than in the product.
+
+A diff proves construction, not behavior. Use code alone only when the Done
+When is itself structural. For authentication, account, or permissions work,
+exercise a real sign-in/login path with a real configured profile. Do not
+bypass login with seeded state, a mocked user, or an admin shortcut. If the
+required credential or environment is unavailable, mark that claim unproven
+rather than narrating the expected result.
+
 ## Demo
 
 Run things. Show output. Let the human react.
@@ -50,7 +86,9 @@ For CLI/library changes: run the commands, show the output. Before/after when it
 
 For API changes: show example calls and responses.
 
-Pause after the demo. Ask what they noticed. Their reaction shapes the rest of the session.
+With a human reviewer, pause after the demo and ask what they noticed. Their
+reaction shapes the rest of the session. With a parent reviewer, use the
+evidence matrix and observed behavior to choose the review disposition.
 
 ## After the demo
 

--- a/rust/loopflow/src/engine/builtins/build/skill/design.md
+++ b/rust/loopflow/src/engine/builtins/build/skill/design.md
@@ -21,7 +21,22 @@ Before starting, orient yourself in this branch:
 Write design artifacts, notes, and open questions under `scratch/`. Don't
 re-derive what these already record.
 
-**Start by asking what they want to build.** Don't start writing or exploring until you understand the goal. This is a conversation.
+## Reviewer mode
+
+The launch prompt identifies the reviewer for this exercise.
+
+- **Human reviewer:** start by asking what they want to build. Use the
+  conversation to discover and reshape intent.
+- **Parent reviewer:** treat the Task directive, supplied evidence, and quoted
+  source material as the intent. Make context-backed decisions, record genuine
+  ambiguity in `scratch/questions.md`, and complete all four phases without
+  waiting for a human. Choose implement or wave using the size criteria below
+  and state the assumptions behind the choice. Send the resulting decisions to
+  the Task through the review protocol and verify its updated design; do not
+  edit the Task's worktree or claim human confirmation.
+
+With a human reviewer, don't start writing or exploring until you understand
+the goal. This is a conversation.
 
 If on main, create a feature branch first: `git checkout -b <feature-name>`.
 
@@ -67,7 +82,9 @@ Either signal suggests breaking into a wave. Bias toward "yes it fits" when it's
 
 ### Phase 4: Fork
 
-Present the size assessment to the user and ask explicitly: **implement or wave?**
+Present the size assessment to the human reviewer and ask explicitly:
+**implement or wave?** When a parent reviewer is assigned, make that decision
+from the evidence and record why.
 
 - "This looks like it fits in one commit—ready to implement?" or
 - "This is bigger than one commit—want me to break it into a wave?"

--- a/rust/loopflow/src/engine/builtins/build/skill/explore.md
+++ b/rust/loopflow/src/engine/builtins/build/skill/explore.md
@@ -6,6 +6,17 @@ action_style: exploratory
 ---
 Investigate the codebase. Answer questions. Let the human drive.
 
+## Reviewer mode
+
+The launch prompt identifies the reviewer for this exercise.
+
+- **Human reviewer:** let the human drive and wait for their questions.
+- **Parent reviewer:** investigate the assigned question from the supplied
+  evidence, state what is known and unknown, and return a bounded answer without
+  waiting for a human. Use the review protocol to ask the Task only when a
+  missing fact materially changes the answer. Do not turn exploration into
+  implementation or unsolicited critique.
+
 ## Orientation
 
 Before starting, orient yourself in this branch:
@@ -25,7 +36,8 @@ re-derive what these already record.
 
 1. If there's a diff (`git diff main...HEAD`), summarize it briefly (2-3 sentences)
 2. Otherwise, describe what you see in the codebase structure
-3. Wait for questions
+3. Wait for questions only when a human reviewer is present; otherwise answer
+   the assigned question and stop
 
 ## What to do
 

--- a/rust/loopflow/src/engine/builtins/build/skill/refine.md
+++ b/rust/loopflow/src/engine/builtins/build/skill/refine.md
@@ -5,6 +5,19 @@ action_style: exploratory
 ---
 Iteratively refine text through structured feedback.
 
+## Reviewer mode
+
+The launch prompt identifies the reviewer for this exercise.
+
+- **Human reviewer:** use contrasting options to learn their preferences, then
+  apply what they choose.
+- **Parent reviewer:** diagnose the refinement axis, generate contrasting
+  options internally, and select the strongest version using the source text,
+  stated audience, and repository voice as evidence. Do not wait for a
+  preference or fabricate one. Preserve unresolved tradeoffs in a short note
+  and send the selected revision to the Task through the review protocol. Verify
+  its reply rather than editing the Task's worktree yourself.
+
 ## Voice
 
 Each session starts fresh. Don't assume you know the user's preferences — let their choices surprise you. Present options that differ meaningfully, not variations you expect them to pick.
@@ -69,6 +82,8 @@ Requests get filtered through your rules—first match wins, and anything that p
 If the problem is structure, show restructured versions. If it's voice, show the same content in different tones. Match the options to the diagnosed axis.
 
 ## Questions to ask
+
+Ask these only when a human reviewer is present:
 
 - "Which feels closer to what you want? What specifically makes it better?"
 - "Is this too formal/casual? Too detailed/vague?"

--- a/rust/loopflow/src/engine/builtins/build/skill/review-design.md
+++ b/rust/loopflow/src/engine/builtins/build/skill/review-design.md
@@ -7,6 +7,19 @@ action_style: exploratory
 ---
 Reshape the AI-elaborated design into the human's actual intent.
 
+## Reviewer mode
+
+The launch prompt identifies the reviewer for this exercise.
+
+- **Human reviewer:** use the session below to let the human reshape the design
+  and explicitly confirm its key decisions.
+- **Parent reviewer:** use the Task directive, quoted user language, supplied
+  evidence, and wave constraints as the best available intent. Revise the
+  design, record context-backed assumptions and genuine ambiguities, and never
+  wait for or invent human confirmation. Use the review protocol to ask the
+  Task for missing evidence and to send each design change. Verify the Task's
+  updated doc rather than editing its worktree yourself.
+
 ## Orientation
 
 Before starting, orient yourself in this branch:
@@ -71,7 +84,9 @@ During the session:
 
 ## End state
 
-The scratch doc reflects the human's intent, not the AI's elaboration. The human has explicitly confirmed the key decisions. The doc is ready to drive implementation.
+With a human reviewer, the scratch doc reflects explicitly confirmed intent.
+With a parent reviewer, it distinguishes evidence-backed decisions from
+assumptions. In either mode the doc is ready to drive implementation.
 
 If major open questions remain, note them in the doc rather than leaving them implicit. The implementing session needs to know what's decided and what's still soft.
 

--- a/rust/loopflow/src/engine/builtins/build/skill/review-open-work.md
+++ b/rust/loopflow/src/engine/builtins/build/skill/review-open-work.md
@@ -5,6 +5,20 @@ produces: scratch/open-work.md, possibly dispatched ship runs and branch prunes
 ---
 Clear outstanding branches, PRs, worktrees, and waves until the repo has an obvious next move.
 
+## Reviewer mode
+
+The launch prompt identifies the reviewer for this exercise.
+
+- **Human reviewer:** discuss each row and obtain the confirmations required
+  below.
+- **Parent reviewer:** perform the full scan and make evidence-backed triage
+  decisions without waiting for a human. Send concrete actions to the Task as
+  FIFO review messages and verify its replies; do not mutate the Task's
+  branches or worktrees yourself. Ship/ship-partial decisions are within this
+  exercise. Abandon, prune, or archive only when the launch directive already
+  grants that destructive authority; otherwise leave the exact action in the
+  punch list and mark the missing authority in the review outcome.
+
 ## Orientation
 
 Before starting, orient yourself in this branch:
@@ -76,9 +90,12 @@ Recommendations:
 
 Judge waves by progress toward README Goals/Vision, not activity counts. Commit counts and PR counts are signals; delivered value is the answer. Call out **busy without progress** and **lack of action** explicitly.
 
-### 3. Discuss Pass 1 row by row
+### 3. Resolve Pass 1 row by row
 
-Walk each row with the user.
+Walk each row with the human reviewer. With a parent reviewer, send each action
+to the Task through the review protocol and verify the returned evidence.
+The execution bullets below are direct human-session actions; a parent reviewer
+assigns them to the Task instead.
 
 - **ship**: dispatch `lf ship` in that worktree as a background job. Do not wait. Log to `scratch/ship-logs/<branch>.log` in the main repo.
 - **ship-partial**: dispatch `lf ship` the same way; the ship flow defaults toward landing and deferring leftovers into Linear tasks.
@@ -94,7 +111,7 @@ mkdir -p scratch/ship-logs
 
 Fire and forget. Multiple ships can run in parallel across sibling worktrees. Move to the next row immediately.
 
-### 4. Discuss Pass 2 wave by wave
+### 4. Resolve Pass 2 wave by wave
 
 After Pass 1 actions are dispatched or the user says to move on, audit each wave:
 

--- a/rust/loopflow/src/engine/builtins/govern/skill/review.md
+++ b/rust/loopflow/src/engine/builtins/govern/skill/review.md
@@ -5,6 +5,18 @@ interactive: true
 ---
 Review what the chord already played.
 
+## Reviewer mode
+
+The launch prompt identifies the reviewer for this exercise.
+
+- **Human reviewer:** conduct the retrospective checkpoint below and record
+  the human's reaction.
+- **Parent reviewer:** independently audit the played mutations against their
+  evidence and wave objectives. Record each keep/amend/revert verdict as
+  `parent reviewer judgment`, never as human reaction. Send concrete amendment
+  or revert work to the Task through the review protocol and verify its reply;
+  do not implement the Task's changes yourself.
+
 ## Orientation
 
 Before starting, orient yourself in this branch:
@@ -63,7 +75,7 @@ Write `scratch/wave-review.md`:
 # Chord Review — <date>
 
 ## Summary
-<overall human reaction>
+<overall human reaction or explicitly labeled parent reviewer judgment>
 
 ## Decisions
 ### <mutation title>

--- a/rust/loopflow/src/engine/builtins/ops/skill/init.md
+++ b/rust/loopflow/src/engine/builtins/ops/skill/init.md
@@ -4,6 +4,19 @@ produces: .lf/config.yaml
 ---
 Guide the user through setting up loopflow in this repository.
 
+## Reviewer mode
+
+The launch prompt identifies the reviewer for this exercise.
+
+- **Human reviewer:** ask the setup questions below one at a time.
+- **Parent reviewer:** run the same detection, preserve a valid existing
+  default, and otherwise choose the sole detected agent or the first detected
+  supported harness. Send the exact repo-config change to the Task through the
+  review protocol and verify its reply; do not edit the Task's repository
+  yourself. Never create or modify personal user config without a human—report
+  those choices as deferred. If no agent is installed, return the install
+  instructions and request changes.
+
 ## Phase 1: Environment check
 
 Run these checks:
@@ -34,7 +47,9 @@ User config: ~/.lf/config.yaml (exists)
 
 ## Phase 2: Agent guidance
 
-**Multiple agents found:** Report all, ask which to default to.
+**Multiple agents found:** Report all. Ask the human reviewer which to default
+to; with a parent reviewer, preserve the valid existing default or choose the
+first detected supported harness.
 
 **One agent found:** Default to it, report the choice.
 
@@ -55,7 +70,10 @@ Repo config (`.lf/config.yaml`) is for team conventions. Only write repo
 properties — never personal preferences like yolo, ide, chrome, or autoprune.
 
 **No `.lf/config.yaml`:**
-- Ask: "Initialize loopflow in this repo? This creates .lf/config.yaml"
+- Ask the human reviewer: "Initialize loopflow in this repo? This creates
+  .lf/config.yaml"
+- With a parent reviewer, direct the Task to create it with the deterministic
+  default selected above
 - Create the config with detected agent as default
 
 **Existing `.lf/config.yaml`:**
@@ -88,13 +106,16 @@ in the user file.
 
 **User config exists:** Mention it and move on. Don't modify it.
 
-**No user config:** Offer to create `~/.lf/config.yaml` with a couple of common
-preferences:
+**No user config:** With a human reviewer, offer to create `~/.lf/config.yaml`
+with a couple of common preferences:
 - Skip permission prompts (yolo)? [y/N]
 - Preferred IDE setup? [skip]
 
 Keep it brief — two questions, not an interrogation. Generate only what the user
 chose. If they skip everything, don't create the file.
+
+With a parent reviewer, do not ask these questions and do not create the user
+file. Report the personal choices as deferred.
 
 ## Phase 5: Optional extras
 

--- a/tests/goldens/builtin_code_review.md
+++ b/tests/goldens/builtin_code_review.md
@@ -140,6 +140,19 @@ The skill.
 <lf:skill:code-review>
 Walk through structural and architectural decisions with the human. The diff is the starting point; the codebase's trajectory is the subject.
 
+## Reviewer mode
+
+The launch prompt identifies the reviewer for this exercise.
+
+- **Human reviewer:** use the conversation below. Present one decision at a
+  time, incorporate their reaction, and let them choose the disposition.
+- **Parent reviewer:** conduct the same architectural review independently.
+  Inspect the supplied evidence and surrounding code, use the review protocol
+  to ask the Task only for missing evidence, and never wait for an unavailable
+  human. Approve only when the structure is sound; otherwise request changes
+  with concrete findings and the trajectory they protect. Do not implement the
+  Task's fixes yourself.
+
 ## Voice
 
 The human chose to look at code, not behavior. They're thinking about architecture — how this change fits into the larger vision. Meet them there. Don't narrate the diff mechanically; orient them in the design space this change opens up.

--- a/tests/goldens/builtin_demo.md
+++ b/tests/goldens/builtin_demo.md
@@ -140,6 +140,18 @@ The skill.
 <lf:skill:demo>
 Walk the human through experiencing what changed, then decide together what's next.
 
+## Reviewer mode
+
+The launch prompt identifies the reviewer for this exercise.
+
+- **Human reviewer:** guide the human through the experience, pause for their
+  reaction, and decide together what happens next.
+- **Parent reviewer:** run the same demo independently from the supplied
+  evidence. Use the review protocol to ask the Task only for missing evidence;
+  never invent a human reaction or wait for one. Approve only when the demo and
+  every applicable Done When claim are proven. Otherwise request changes with
+  the failed or missing proof. Do not implement the Task's fixes yourself.
+
 ## Orientation
 
 Before starting, orient yourself in this branch:
@@ -171,6 +183,30 @@ Before any code discussion, ground the human in the experience:
 
 If the design doc in `scratch/` has a "Done when" section with a verification command, start there.
 
+## Prove every Done When
+
+Before presenting a verdict, enumerate every Done When claim in the design doc
+and build a compact evidence matrix:
+
+| Done When | Proof surface | Action | Observed result |
+|---|---|---|---|
+| <claim> | product \| code \| admin state \| log \| stat/metric | <what ran or was inspected> | pass \| gap, with evidence |
+
+Choose the surface that most directly proves each claim:
+
+- **Product:** experience the behavior through the real user path.
+- **Code/tests:** use source, tests, and command output for structural or
+  programmatic claims.
+- **Operations:** inspect admin state, logs, counters, stats, or metrics when
+  the result is observable there rather than in the product.
+
+A diff proves construction, not behavior. Use code alone only when the Done
+When is itself structural. For authentication, account, or permissions work,
+exercise a real sign-in/login path with a real configured profile. Do not
+bypass login with seeded state, a mocked user, or an admin shortcut. If the
+required credential or environment is unavailable, mark that claim unproven
+rather than narrating the expected result.
+
 ## Demo
 
 Run things. Show output. Let the human react.
@@ -183,7 +219,9 @@ For CLI/library changes: run the commands, show the output. Before/after when it
 
 For API changes: show example calls and responses.
 
-Pause after the demo. Ask what they noticed. Their reaction shapes the rest of the session.
+With a human reviewer, pause after the demo and ask what they noticed. Their
+reaction shapes the rest of the session. With a parent reviewer, use the
+evidence matrix and observed behavior to choose the review disposition.
 
 ## After the demo
 


### PR DESCRIPTION
## Usage

```bash
lf task <name> --headless
cargo test -p loopflow interactive_skills_support_human_and_parent_reviewers
```

## Summary

Headless Tasks defer interactive inner-loop steps to their owning Project, but the interactive builtin skills only described attended, human-driven behavior. This teaches each interactive skill both modes: the launch prompt names the reviewer, and every skill now defines a **Human reviewer** path (the existing conversation) alongside a **Parent reviewer** path that conducts the same exercise independently, routes questions and answers through the durable review protocol, and never blocks on an unavailable human. Parent reviewers make evidence-backed decisions and request changes with concrete findings rather than implementing the Task's fixes themselves.

## Changes

- Added a `## Reviewer mode` section to the interactive skills: `code-review`, `demo`, `design`, `explore`, `refine`, `review-design`, `review-open-work`, `review`, and `init`.
- `demo` gains a "Prove every Done When" evidence matrix — pick the surface (product, code/tests, admin state, logs, stats/metrics) that most directly proves each claim, and exercise a real sign-in path for auth work instead of seeded or mocked state.
- Phrasing throughout distinguishes human-confirmed decisions from parent-reviewer judgment (e.g. `review` labels its summary; `review-open-work` renames "Discuss" passes to "Resolve").
- New test asserting each interactive builtin defines both reviewer modes, routes through the review protocol, and that `demo` enumerates its evidence surfaces.
- README note that interactive skills define both attended and parent-reviewer behavior in one durable review conversation.