### PR TITLE
handoff: resume the same step when work returns

### DIFF
--- a/rust/loopflow/src/lf/commands/handoff.rs
+++ b/rust/loopflow/src/lf/commands/handoff.rs
@@ -196,7 +196,7 @@ async fn wake_parent(store: &Store, handoff: &InteractiveHandoff) {
     let InteractiveHandoffParent::Task(task_id) = &handoff.parent else {
         return;
     };
-    if let Err(error) = resume_task_parent(store, task_id).await {
+    if let Err(error) = resume_task_parent(store, task_id, handoff.outcome.as_ref()).await {
         eprintln!(
             "warning: interactive handoff {} resolved but waking parent Task {} failed: {error}",
             handoff.id, task_id
@@ -204,20 +204,37 @@ async fn wake_parent(store: &Store, handoff: &InteractiveHandoff) {
     }
 }
 
-async fn resume_task_parent(store: &Store, task_id: &TaskSessionId) -> anyhow::Result<()> {
+async fn resume_task_parent(
+    store: &Store,
+    task_id: &TaskSessionId,
+    outcome: Option<&InteractiveHandoffOutcome>,
+) -> anyhow::Result<()> {
     let session = store
         .get_task_session(task_id)
         .await?
         .ok_or_else(|| anyhow!("parent Task Session {task_id} not found"))?;
     crate::ops::task::resume_task_async(
         &session.launch.issue.identifier,
-        None,
+        handoff_resume_message(outcome),
         None,
         Some("interactive handoff resolved".to_string()),
     )
     .await
     .map_err(|error| anyhow!(error.to_string()))?;
     Ok(())
+}
+
+fn handoff_resume_message(outcome: Option<&InteractiveHandoffOutcome>) -> Option<String> {
+    match outcome {
+        Some(InteractiveHandoffOutcome::HandedBack { summary }) => Some(format!(
+            "Resume the interrupted Task step after the human handed back the interactive work:\n{summary}"
+        )),
+        Some(
+            InteractiveHandoffOutcome::Completed { .. }
+            | InteractiveHandoffOutcome::Failed { .. },
+        )
+        | None => None,
+    }
 }
 
 fn parse_session_id(value: &str) -> anyhow::Result<InteractiveHandoffId> {
@@ -279,7 +296,8 @@ fn print_attach(attach: &InteractiveHandoffAttach, json: bool) -> anyhow::Result
 
 #[cfg(test)]
 mod tests {
-    use super::parse_environment;
+    use super::{handoff_resume_message, parse_environment};
+    use crate::interactive_handoff::InteractiveHandoffOutcome;
 
     #[test]
     fn environment_parser_preserves_values_without_building_shell_text() {
@@ -288,5 +306,21 @@ mod tests {
         assert_eq!(parsed.get("LF_HOME").map(String::as_str), Some("/tmp/lf"));
         assert_eq!(parsed.get("EMPTY").map(String::as_str), Some(""));
         assert!(parse_environment(&["LF_HOME=/a".to_string(), "LF_HOME=/b".to_string()]).is_err());
+    }
+
+    #[test]
+    fn hand_back_resumes_the_same_task_step_with_the_human_summary() {
+        let message = handoff_resume_message(Some(&InteractiveHandoffOutcome::HandedBack {
+            summary: "Finish the review fixes headlessly".to_string(),
+        }))
+        .unwrap();
+        assert!(message.contains("Resume the interrupted Task step"));
+        assert!(message.contains("Finish the review fixes headlessly"));
+        assert!(
+            handoff_resume_message(Some(&InteractiveHandoffOutcome::Completed {
+                summary: "Human finished the whole step".to_string(),
+            }))
+            .is_none()
+        );
     }
 }

--- a/rust/loopflow/src/task/runner.rs
+++ b/rust/loopflow/src/task/runner.rs
@@ -112,9 +112,9 @@ async fn run_task_session_inner(session_id: TaskSessionId, lease: &ChildWriteLea
 
     let mut flow = resume_task_phase(&session)?;
     // Reconcile any interactive handoff the parent's prior body opened before this
-    // body runs a provider turn. A terminal outcome advances the flow past the
-    // interactive step; a still-open handoff parks the parent on a human, and this
-    // body ends without ever starting the provider.
+    // body runs a provider turn. A completed outcome advances past work the human
+    // finished, a hand-back resumes the same step, and a still-open handoff parks
+    // the parent without ever starting the provider.
     if reconcile_interactive_rendezvous_at_birth(&store, &mut session, lease, &mut flow).await? {
         return finish_parked(&store, &mut session, lease, None).await;
     }
@@ -1049,9 +1049,8 @@ async fn completed_interaction_review(
 
 /// Reconcile the parent against any interactive handoff before this body runs a
 /// provider turn. Returns `true` when the parent is parked on a human and the
-/// body must end without starting a turn. A terminal outcome — this generation's
-/// or an earlier one's — advances the flow past the interactive step so the
-/// runner continues with the next step; a failed handoff blocks the parent.
+/// body must end without starting a turn. A completed outcome advances the flow,
+/// hand-back resumes the same step, and a failed handoff blocks the parent.
 async fn reconcile_interactive_rendezvous_at_birth(
     store: &SharedStore,
     session: &mut TaskSession,
@@ -1078,10 +1077,10 @@ async fn reconcile_interactive_rendezvous_at_birth(
     }
 }
 
-/// Resolve a terminal interactive handoff at body birth. Completion or hand-back
-/// advances the flow past the interactive step (returns `false` — proceed);
-/// failure blocks the parent for an operator (returns `true` — parked). Evidence
-/// is recorded once, on the generation that wins the wake claim (`fresh`).
+/// Resolve a terminal interactive handoff at body birth. Completion advances the
+/// flow past work the human finished; hand-back resumes the same step; failure
+/// blocks the parent for an operator. Evidence is recorded once, on the
+/// generation that wins the wake claim (`fresh`).
 async fn resume_interactive_step(
     store: &SharedStore,
     session: &mut TaskSession,
@@ -1121,13 +1120,13 @@ async fn resume_interactive_step(
             .await?;
             Ok(true)
         }
-        InteractiveHandoffOutcome::Completed { .. }
-        | InteractiveHandoffOutcome::HandedBack { .. } => {
+        InteractiveHandoffOutcome::Completed { .. } => {
             advance_past_interactive_step(flow, session)?;
             record_task_flow_position(session, flow)?;
             store.update_task_session_for_lease(session, lease).await?;
             Ok(false)
         }
+        InteractiveHandoffOutcome::HandedBack { .. } => Ok(false),
     }
 }
 
@@ -2521,6 +2520,45 @@ mod tests {
         assert!(!super::parked_on_interactive_handoff(&store, &session)
             .await
             .unwrap());
+    }
+
+    #[tokio::test]
+    async fn handed_back_interactive_work_resumes_the_same_flow_step() {
+        let (store, mut session, lease) = conformance_session("codex").await;
+        let mut flow = resume_task_phase(&session).unwrap();
+        let (handoff, _) = store
+            .open_interactive_handoff(task_handoff_request(&session, &lease))
+            .await
+            .unwrap();
+        store
+            .finish_interactive_handoff(
+                &handoff.id,
+                &crate::interactive_handoff::InteractiveHandoffOutcome::HandedBack {
+                    summary: "Finish the remaining review fixes".to_string(),
+                },
+            )
+            .await
+            .unwrap();
+
+        let parked = super::reconcile_interactive_rendezvous_at_birth(
+            &store,
+            &mut session,
+            &lease,
+            &mut flow,
+        )
+        .await
+        .unwrap();
+
+        assert!(!parked);
+        assert_eq!(session.phase_cursor, 0);
+        assert_eq!(session.phase_iteration, 0);
+        assert!(store
+            .get_interactive_handoff(&handoff.id)
+            .await
+            .unwrap()
+            .unwrap()
+            .wake_claimed_at
+            .is_some());
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Usage

```bash
lf handoff hand-back <session-id> --summary "Finish the remaining review fixes"
```

The parent resumes the interrupted flow step and receives the human summary as its next message. `complete` remains distinct: it means the human finished the whole interactive step, so the parent advances.

## Review

- Keeps flow position owned by the durable Task session.
- Keeps `InteractiveHandoff` presentation/execution semantics separate from lifecycle review truth.
- Adds behavior tests for cursor preservation and summary delivery.

## Verification

- `cargo test -p loopflow handed_back --lib`
- `cargo test -p loopflow hand_back_resumes --lib`
- `cargo clippy -p loopflow --all-targets -- -D warnings`