### PR TITLE
task review: conduct attended lifecycle gates

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,24 @@ mark its remaining lifecycle headless. Interactive skills define both attended
 and parent-reviewer behavior; parent questions and Task answers stay in the
 same durable review conversation.
 
+Review an attended kickoff or gate in the Task's existing provider session:
+
+```bash
+lf task status INF-123                 # status reason names the review id
+lf task attach INF-123                 # watch the exercise and type FIFO replies
+lf task review message ir_... "Show the real sign-in path"
+lf task review complete ir_... \
+  --disposition changes-requested \
+  --outcome "The login proof is missing"
+```
+
+Bare input while attached to a human review is a FIFO review message, not a
+steer. Use `/interrupt` explicitly to interrupt the provider. Approval advances
+the lifecycle; requested Gate changes return the same Task to another inner-loop
+cycle. The durable review records the exercise, evidence snapshot, conversation,
+disposition, and outcome. A generic interactive handoff only tells another UI
+how to present or attach to the existing session; it does not decide the review.
+
 Start dependent work without sharing the parent's worktree:
 
 ```bash

--- a/docs/lf.md
+++ b/docs/lf.md
@@ -152,6 +152,9 @@ lf task start "fix the flaky chord-timeout test" --project <linear-project-id>
 lf task run DES-123 --directive "fix the parser before the docs"
 lf task run DES-125 --headless                       # Project reviews every interactive step
 lf task run DES-124 --stack-on DES-123
+lf task status DES-123                               # review id appears in the status reason
+lf task review message ir_... "Show the real sign-in path"
+lf task review complete ir_... --disposition approved --outcome "Done When proof holds"
 lf task steer DES-123 "rename the flag"
 lf task interrupt DES-123 --message "take the smaller approach"
 lf task receipt COMMAND_ID --until incorporated --timeout 30s --json
@@ -174,6 +177,19 @@ Its provider process and transcript are a replaceable body generation: plain
 Session, directive, worktree, and PR chain while selecting another provider.
 The Session remains resumable through serial PRs, review, and explicit
 completion.
+Every Task runs `kickoff → iterate N → gate`. Standard Tasks conduct interactive
+kickoff and gate steps with the human in the existing provider transcript, while
+the owning Project conducts interactive iteration steps. `--headless` assigns
+all three phases to the Project without skipping their skills. Approval exits a
+Gate; `changes-requested` sends the same Task back to Iterate.
+
+`lf task attach` is the live attended-review prototype. Bare attached input and
+`lf task review message` become FIFO follow-ups, so the provider answers in the
+same session rather than losing a one-shot batch process. `/interrupt` remains
+an explicit interruption. The human closes the durable checkpoint with
+`lf task review complete`; the worker records its replies with
+`lf task review reply`.
+
 `--stack-on` places a new Task worktree on another Task's published PR. Its PR
 targets that parent branch automatically, then collapses onto `main` after the
 parent merges. The two Tasks keep separate identities, worktrees, and workers.
@@ -222,7 +238,8 @@ list to one parent.
 This contract carries presentation instructions, not a terminal stream. tmux
 or the vendor owns terminal bytes. The handoff references the parent's existing
 body generation; it does not create a second process lease or generic Session
-catalog.
+catalog. It can present a human interaction review, but the review remains the
+only record that can approve the Task or return it to Iterate.
 
 ## Speaking to Waves
 

--- a/rust/loopflow/src/bin/lf.rs
+++ b/rust/loopflow/src/bin/lf.rs
@@ -1136,6 +1136,19 @@ fn run_task_command(repo: &Path, command: &TaskCommand) -> anyhow::Result<()> {
             Ok(())
         }
         TaskCommand::Review { command } => match command {
+            TaskReviewCommand::Message {
+                review_id,
+                message,
+                json,
+            } => {
+                let review = loopflow::ops::task::task_review_message(review_id, message.clone())?;
+                if *json {
+                    println!("{}", serde_json::to_string_pretty(&review)?);
+                } else {
+                    println!("{} → human message queued", review.id);
+                }
+                Ok(())
+            }
             TaskReviewCommand::Reply {
                 review_id,
                 message,
@@ -1146,6 +1159,24 @@ fn run_task_command(repo: &Path, command: &TaskCommand) -> anyhow::Result<()> {
                     println!("{}", serde_json::to_string_pretty(&review)?);
                 } else {
                     println!("{} → reply recorded", review.id);
+                }
+                Ok(())
+            }
+            TaskReviewCommand::Complete {
+                review_id,
+                disposition,
+                outcome,
+                json,
+            } => {
+                let review = loopflow::ops::task::task_review_complete(
+                    review_id,
+                    disposition,
+                    outcome.clone(),
+                )?;
+                if *json {
+                    println!("{}", serde_json::to_string_pretty(&review)?);
+                } else {
+                    println!("{} → {}", review.id, review.status.as_str());
                 }
                 Ok(())
             }

--- a/rust/loopflow/src/lf/mod.rs
+++ b/rust/loopflow/src/lf/mod.rs
@@ -879,10 +879,27 @@ pub enum ProjectCommand {
 
 #[derive(Subcommand, Debug)]
 pub enum TaskReviewCommand {
+    /// Send the human reviewer's next FIFO message to the existing Task session
+    Message {
+        review_id: String,
+        message: String,
+        #[arg(long)]
+        json: bool,
+    },
     /// Reply to the reviewer without replacing the current Task direction
     Reply {
         review_id: String,
         message: String,
+        #[arg(long)]
+        json: bool,
+    },
+    /// Finish a human review with an explicit disposition and evidence
+    Complete {
+        review_id: String,
+        #[arg(long, value_parser = ["approved", "changes-requested"])]
+        disposition: String,
+        #[arg(long)]
+        outcome: String,
         #[arg(long)]
         json: bool,
     },
@@ -2092,6 +2109,56 @@ mod tests {
                     }
                 }
             }) if review_id == "ir_review" && message == "The empty state is now visible"
+        ));
+
+        let human_message = Cli::try_parse_from([
+            "lf",
+            "task",
+            "review",
+            "message",
+            "ir_review",
+            "Show me the empty state",
+        ])
+        .expect("parse human review message");
+        assert!(matches!(
+            human_message.command,
+            Some(Commands::Task {
+                cmd: TaskCommand::Review {
+                    command: TaskReviewCommand::Message {
+                        review_id,
+                        message,
+                        ..
+                    }
+                }
+            }) if review_id == "ir_review" && message == "Show me the empty state"
+        ));
+
+        let human_complete = Cli::try_parse_from([
+            "lf",
+            "task",
+            "review",
+            "complete",
+            "ir_review",
+            "--disposition",
+            "approved",
+            "--outcome",
+            "The empty state is proven",
+        ])
+        .expect("parse human review completion");
+        assert!(matches!(
+            human_complete.command,
+            Some(Commands::Task {
+                cmd: TaskCommand::Review {
+                    command: TaskReviewCommand::Complete {
+                        review_id,
+                        disposition,
+                        outcome,
+                        ..
+                    }
+                }
+            }) if review_id == "ir_review"
+                && disposition == "approved"
+                && outcome == "The empty state is proven"
         ));
     }
 

--- a/rust/loopflow/src/ops/task.rs
+++ b/rust/loopflow/src/ops/task.rs
@@ -21,7 +21,9 @@ use crate::engine::worktrees::{
 };
 use crate::engine::{expand_flow, load_flow, ConcreteStep};
 use crate::id::WaveId;
-use crate::interaction_review::{InteractionReview, InteractionReviewId};
+use crate::interaction_review::{
+    InteractionReview, InteractionReviewDisposition, InteractionReviewId,
+};
 use crate::ops::error::{OpsError, OpsResult};
 use crate::session_context::{
     LinearIssueId, LinearIssueSnapshot, LinearProjectId, LinearProjectSnapshot, TaskLaunchReceipt,
@@ -2987,6 +2989,62 @@ pub fn task_review_reply(review_id: &str, text: String) -> OpsResult<Interaction
             .await
             .map_err(|error| task_error(error.to_string()))?
             .ok_or_else(|| task_error(format!("interaction review {review_id} disappeared")))
+    })
+}
+
+fn _require_human_review_authority() -> OpsResult<()> {
+    for variable in [
+        "LF_TASK_SESSION_ID",
+        "LF_PROJECT_SESSION_ID",
+        "LF_RUN_ID",
+        "LF_PROCESS_ID",
+    ] {
+        if std::env::var_os(variable).is_some() {
+            return Err(task_error(
+                "human review commands cannot run inside a Task, Project, or Wave agent session",
+            ));
+        }
+    }
+    Ok(())
+}
+
+pub fn task_review_message(review_id: &str, text: String) -> OpsResult<InteractionReview> {
+    _require_human_review_authority()?;
+    let review_id = InteractionReviewId::parse(review_id)
+        .map_err(|error| task_error(format!("invalid interaction review: {error}")))?;
+    block_on_task(async move {
+        let store = task_store().await?;
+        store
+            .send_human_interaction_review_message(&review_id, ChildCommandSource::Human, &text)
+            .await
+            .map_err(|error| task_error(error.to_string()))?;
+        store
+            .get_interaction_review(&review_id)
+            .await
+            .map_err(|error| task_error(error.to_string()))?
+            .ok_or_else(|| task_error(format!("interaction review {review_id} disappeared")))
+    })
+}
+
+pub fn task_review_complete(
+    review_id: &str,
+    disposition: &str,
+    outcome: String,
+) -> OpsResult<InteractionReview> {
+    _require_human_review_authority()?;
+    let review_id = InteractionReviewId::parse(review_id)
+        .map_err(|error| task_error(format!("invalid interaction review: {error}")))?;
+    let disposition = disposition
+        .replace('-', "_")
+        .parse::<InteractionReviewDisposition>()
+        .map_err(|error| task_error(error.to_string()))?;
+    block_on_task(async move {
+        let store = task_store().await?;
+        store
+            .complete_human_interaction_review(&review_id, disposition, &outcome)
+            .await
+            .map_err(|error| task_error(error.to_string()))
+            .map(|(review, _)| review)
     })
 }
 

--- a/rust/loopflow/src/store/interaction_reviews.rs
+++ b/rust/loopflow/src/store/interaction_reviews.rs
@@ -1,4 +1,4 @@
-use crate::child_session::{ChildCommand, ChildWriteLease};
+use crate::child_session::{ChildCommand, ChildCommandSource, ChildWriteLease};
 use crate::id::WaveId;
 use crate::interaction_review::{
     InteractionReview, InteractionReviewDisposition, InteractionReviewId,
@@ -82,6 +82,35 @@ impl Store {
         .await
     }
 
+    pub(crate) async fn activate_human_interaction_review(
+        &self,
+        session: &TaskSession,
+        review_id: &InteractionReviewId,
+        lease: &ChildWriteLease,
+    ) -> StoreResult<InteractionReview> {
+        let session = session.clone();
+        let review_id = review_id.clone();
+        let lease = lease.clone();
+        run_sqlite(&self.sqlite, move |store| {
+            store.activate_human_interaction_review(&session, &review_id, &lease)
+        })
+        .await
+    }
+
+    pub(crate) async fn send_human_interaction_review_message(
+        &self,
+        review_id: &InteractionReviewId,
+        source: ChildCommandSource,
+        text: &str,
+    ) -> StoreResult<ChildCommand> {
+        let review_id = review_id.clone();
+        let text = text.to_string();
+        run_sqlite(&self.sqlite, move |store| {
+            store.send_human_interaction_review_message(&review_id, source, &text)
+        })
+        .await
+    }
+
     pub(crate) async fn reply_to_interaction_review(
         &self,
         review_id: &InteractionReviewId,
@@ -119,6 +148,20 @@ impl Store {
                 disposition,
                 &outcome,
             )
+        })
+        .await
+    }
+
+    pub(crate) async fn complete_human_interaction_review(
+        &self,
+        review_id: &InteractionReviewId,
+        disposition: InteractionReviewDisposition,
+        outcome: &str,
+    ) -> StoreResult<(InteractionReview, bool)> {
+        let review_id = review_id.clone();
+        let outcome = outcome.to_string();
+        run_sqlite(&self.sqlite, move |store| {
+            store.complete_human_interaction_review(&review_id, disposition, &outcome)
         })
         .await
     }

--- a/rust/loopflow/src/store/mod.rs
+++ b/rust/loopflow/src/store/mod.rs
@@ -1534,6 +1534,129 @@ mod tests {
         assert!(reviews.iter().any(|review| {
             review.id == next_gate_review.id && review.phase_epoch == next_gate_review.phase_epoch
         }));
+
+        task.enter_iterate().unwrap();
+        task.lifecycle = crate::task::TaskLifecyclePlan::standard("task");
+        task.enter_gate(TaskGateProposal {
+            status: TaskSessionStatus::Waiting,
+            reason: "PR ready for attended review".to_string(),
+        })
+        .unwrap();
+        store
+            .update_task_session_for_lease(&task, &task_lease)
+            .await
+            .unwrap();
+        let mut human_review = review.clone();
+        human_review.id = InteractionReviewId::new();
+        human_review.phase_epoch = task.phase_epoch;
+        human_review.policy = crate::engine::InteractionPolicy::Require;
+        human_review.reviewer = InteractionReviewer::Human;
+        human_review.evidence.head_commit = "head-for-human".to_string();
+        human_review.evidence.worktree_fingerprint = "fingerprint-for-human".to_string();
+        human_review.requested_at = OffsetDateTime::now_utc();
+        let (human_review, created) = store
+            .open_interaction_review(&task, &human_review, &task_lease)
+            .await
+            .unwrap();
+        assert!(created);
+        let active = store
+            .activate_human_interaction_review(&task, &human_review.id, &task_lease)
+            .await
+            .unwrap();
+        assert_eq!(active.status, InteractionReviewStatus::Active);
+        let first_human_message = store
+            .send_human_interaction_review_message(
+                &human_review.id,
+                ChildCommandSource::Human,
+                "Show me the user-visible result.",
+            )
+            .await
+            .unwrap();
+        let attached_message = store
+            .send_human_interaction_review_message(
+                &human_review.id,
+                ChildCommandSource::Attachment,
+                "Now connect it to the stored row.",
+            )
+            .await
+            .unwrap();
+        let claimed = store
+            .claim_child_commands(&ChildRef::Task(task.id.clone()), task_lease.generation)
+            .await
+            .unwrap();
+        let human_dialogue = claimed
+            .iter()
+            .filter(|command| {
+                matches!(
+                    command.source,
+                    ChildCommandSource::Human | ChildCommandSource::Attachment
+                )
+            })
+            .map(|command| command.id.clone())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            human_dialogue,
+            vec![first_human_message.id, attached_message.id]
+        );
+        store
+            .reply_to_interaction_review(
+                &human_review.id,
+                &task.id,
+                &task_lease,
+                "The product result and stored row agree.",
+            )
+            .await
+            .unwrap();
+        assert!(store
+            .send_project_interaction_review_message(
+                &human_review.id,
+                &project.id,
+                &project_lease,
+                "Project agents cannot impersonate the human.",
+            )
+            .await
+            .is_err());
+        let (completed_human_review, changed) = store
+            .complete_human_interaction_review(
+                &human_review.id,
+                InteractionReviewDisposition::ChangesRequested,
+                "The login proof is still missing.",
+            )
+            .await
+            .unwrap();
+        assert!(changed);
+        assert_eq!(completed_human_review.reviewer_generation, None);
+        assert_eq!(
+            completed_human_review.disposition,
+            Some(InteractionReviewDisposition::ChangesRequested)
+        );
+        let (_, changed) = store
+            .complete_human_interaction_review(
+                &human_review.id,
+                InteractionReviewDisposition::ChangesRequested,
+                "The login proof is still missing.",
+            )
+            .await
+            .unwrap();
+        assert!(!changed);
+        assert!(store
+            .complete_project_interaction_review(
+                &human_review.id,
+                &project.id,
+                &project_lease,
+                InteractionReviewDisposition::Approved,
+                "The Project cannot approve the human checkpoint.",
+            )
+            .await
+            .is_err());
+        assert_eq!(
+            store
+                .list_interaction_reviews(Some(wave.id()))
+                .await
+                .unwrap()
+                .len(),
+            3
+        );
     }
 
     #[tokio::test]

--- a/rust/loopflow/src/store/sqlite/interaction_reviews.rs
+++ b/rust/loopflow/src/store/sqlite/interaction_reviews.rs
@@ -185,46 +185,69 @@ impl SqliteStore {
             lease,
         )?;
         let review = require_open_project_review(&transaction, review_id, project_session_id)?;
-        let session = transaction.query_row(
-            TASK_SESSION_SELECT,
-            [review.task_session_id.as_str()],
-            map_task_session_row,
-        )?;
-        transaction.execute(
-            "UPDATE interaction_reviews
-             SET status='active', reviewer_generation=COALESCE(reviewer_generation, ?2)
-             WHERE id=?1 AND status IN ('requested', 'active')",
-            params![review_id.as_str(), i64::from(lease.generation)],
-        )?;
-        let command = ChildCommand::new(
-            ChildRef::Task(review.task_session_id.clone()),
+        let command = _send_interaction_review_message(
+            &transaction,
+            &review,
             ChildCommandSource::Project(project_session_id.clone()),
-            ChildCommandKind::FollowUp {
-                text: format!(
-                    "<interaction_review_message review_id=\"{review_id}\" from=\"reviewer\">\n{text}\n\nReply with `lf task review reply {review_id} \"<answer and evidence>\"`.\n</interaction_review_message>"
-                ),
-            },
-        );
-        insert_child_command(&transaction, &command)?;
-        insert_task_event_in(
-            &transaction,
-            &session,
-            &TaskEventKind::CommandChanged {
-                command_id: command.id.clone(),
-                state: crate::child_session::ChildCommandState::Persisted,
-                effect: command.effect,
-                error: None,
-            },
+            Some(lease.generation),
+            &text,
         )?;
-        insert_task_event_in(
-            &transaction,
-            &session,
-            &TaskEventKind::InteractionReviewMessage {
-                review_id: review_id.clone(),
-                author: InteractionReviewMessageAuthor::Reviewer,
-                text,
-            },
+        transaction.commit()?;
+        Ok(command)
+    }
+
+    pub(crate) fn activate_human_interaction_review(
+        &self,
+        session: &TaskSession,
+        review_id: &InteractionReviewId,
+        lease: &ChildWriteLease,
+    ) -> StoreResult<InteractionReview> {
+        let mut conn = self.conn.lock().expect("store mutex poisoned");
+        let transaction = conn.transaction_with_behavior(TransactionBehavior::Immediate)?;
+        require_child_write_lease(&transaction, &ChildRef::Task(session.id.clone()), lease)?;
+        let review = require_open_human_review(&transaction, review_id)?;
+        if review.task_session_id != session.id
+            || review.phase_epoch != session.phase_epoch
+            || review.phase_iteration != session.phase_iteration
+            || review.step_index != session.phase_cursor
+        {
+            return Err(StoreError::InvalidData(
+                "human interaction review is stale for this Task lifecycle waitpoint".to_string(),
+            ));
+        }
+        transaction.execute(
+            "UPDATE interaction_reviews SET status='active'
+             WHERE id=?1 AND status IN ('requested', 'active')",
+            [review_id.as_str()],
         )?;
+        let active = transaction.query_row(
+            &format!("{INTERACTION_REVIEW_COLUMNS} WHERE id=?1"),
+            [review_id.as_str()],
+            map_review_row,
+        )?;
+        transaction.commit()?;
+        Ok(active)
+    }
+
+    pub(crate) fn send_human_interaction_review_message(
+        &self,
+        review_id: &InteractionReviewId,
+        source: ChildCommandSource,
+        text: &str,
+    ) -> StoreResult<ChildCommand> {
+        if !matches!(
+            source,
+            ChildCommandSource::Human | ChildCommandSource::Attachment
+        ) {
+            return Err(StoreError::InvalidData(
+                "human review messages require human or attachment authority".to_string(),
+            ));
+        }
+        let text = require_text("review message", text)?;
+        let mut conn = self.conn.lock().expect("store mutex poisoned");
+        let transaction = conn.transaction_with_behavior(TransactionBehavior::Immediate)?;
+        let review = require_open_human_review(&transaction, review_id)?;
+        let command = _send_interaction_review_message(&transaction, &review, source, None, &text)?;
         transaction.commit()?;
         Ok(command)
     }
@@ -309,79 +332,192 @@ impl SqliteStore {
                 "only the assigned Project reviewer may complete this review".to_string(),
             ));
         }
-        if review.status == InteractionReviewStatus::Completed {
-            if review.disposition == Some(disposition)
-                && review.outcome.as_deref() == Some(outcome.as_str())
-            {
-                transaction.commit()?;
-                return Ok((review, false));
-            }
-            return Err(StoreError::InvalidData(
-                "interaction review already has a different completion".to_string(),
-            ));
-        }
-        if review.status.is_terminal() {
-            return Err(StoreError::InvalidData(
-                "interaction review is already terminal".to_string(),
-            ));
-        }
-        let completed_at = time::OffsetDateTime::now_utc();
-        transaction.execute(
-            "UPDATE interaction_reviews
-             SET status='completed', reviewer_generation=?2, disposition=?3,
-                 outcome=?4, completed_at=?5
-             WHERE id=?1",
-            params![
-                review_id.as_str(),
-                i64::from(lease.generation),
-                disposition.as_str(),
-                outcome,
-                completed_at.unix_timestamp(),
-            ],
-        )?;
-        let command = ChildCommand::new(
-            ChildRef::Task(review.task_session_id.clone()),
+        let result = _complete_interaction_review(
+            &transaction,
+            review,
             ChildCommandSource::Project(project_session_id.clone()),
-            ChildCommandKind::FollowUp {
-                text: format!(
-                    "<interaction_review_completed review_id=\"{review_id}\" disposition=\"{}\">\n{outcome}\n</interaction_review_completed>",
-                    disposition.as_str()
-                ),
-            },
-        );
-        insert_child_command(&transaction, &command)?;
-        let session = transaction.query_row(
-            TASK_SESSION_SELECT,
-            [review.task_session_id.as_str()],
-            map_task_session_row,
-        )?;
-        insert_task_event_in(
-            &transaction,
-            &session,
-            &TaskEventKind::CommandChanged {
-                command_id: command.id.clone(),
-                state: crate::child_session::ChildCommandState::Persisted,
-                effect: command.effect,
-                error: None,
-            },
-        )?;
-        insert_task_event_in(
-            &transaction,
-            &session,
-            &TaskEventKind::InteractionReviewCompleted {
-                review_id: review_id.clone(),
-                disposition,
-                outcome,
-            },
-        )?;
-        let completed = transaction.query_row(
-            &format!("{INTERACTION_REVIEW_COLUMNS} WHERE id=?1"),
-            [review_id.as_str()],
-            map_review_row,
+            Some(lease.generation),
+            disposition,
+            &outcome,
         )?;
         transaction.commit()?;
-        Ok((completed, true))
+        Ok(result)
     }
+
+    pub(crate) fn complete_human_interaction_review(
+        &self,
+        review_id: &InteractionReviewId,
+        disposition: InteractionReviewDisposition,
+        outcome: &str,
+    ) -> StoreResult<(InteractionReview, bool)> {
+        let outcome = require_text("review outcome", outcome)?;
+        let mut conn = self.conn.lock().expect("store mutex poisoned");
+        let transaction = conn.transaction_with_behavior(TransactionBehavior::Immediate)?;
+        let review = transaction
+            .query_row(
+                &format!("{INTERACTION_REVIEW_COLUMNS} WHERE id=?1"),
+                [review_id.as_str()],
+                map_review_row,
+            )
+            .optional()?
+            .ok_or(StoreError::NotFound)?;
+        if review.reviewer != InteractionReviewer::Human {
+            return Err(StoreError::InvalidData(
+                "only a human may complete this interaction review".to_string(),
+            ));
+        }
+        let result = _complete_interaction_review(
+            &transaction,
+            review,
+            ChildCommandSource::Human,
+            None,
+            disposition,
+            &outcome,
+        )?;
+        transaction.commit()?;
+        Ok(result)
+    }
+}
+
+fn _send_interaction_review_message(
+    transaction: &rusqlite::Transaction<'_>,
+    review: &InteractionReview,
+    source: ChildCommandSource,
+    reviewer_generation: Option<u32>,
+    text: &str,
+) -> StoreResult<ChildCommand> {
+    let session = transaction.query_row(
+        TASK_SESSION_SELECT,
+        [review.task_session_id.as_str()],
+        map_task_session_row,
+    )?;
+    match reviewer_generation {
+        Some(generation) => {
+            transaction.execute(
+                "UPDATE interaction_reviews
+                 SET status='active', reviewer_generation=COALESCE(reviewer_generation, ?2)
+                 WHERE id=?1 AND status IN ('requested', 'active')",
+                params![review.id.as_str(), i64::from(generation)],
+            )?;
+        }
+        None => {
+            transaction.execute(
+                "UPDATE interaction_reviews SET status='active'
+                 WHERE id=?1 AND status IN ('requested', 'active')",
+                [review.id.as_str()],
+            )?;
+        }
+    }
+    let command = ChildCommand::new(
+        ChildRef::Task(review.task_session_id.clone()),
+        source,
+        ChildCommandKind::FollowUp {
+            text: format!(
+                "<interaction_review_message review_id=\"{}\" from=\"reviewer\">\n{text}\n\nReply with `lf task review reply {} \"<answer and evidence>\"`.\n</interaction_review_message>",
+                review.id, review.id
+            ),
+        },
+    );
+    insert_child_command(transaction, &command)?;
+    insert_task_event_in(
+        transaction,
+        &session,
+        &TaskEventKind::CommandChanged {
+            command_id: command.id.clone(),
+            state: crate::child_session::ChildCommandState::Persisted,
+            effect: command.effect,
+            error: None,
+        },
+    )?;
+    insert_task_event_in(
+        transaction,
+        &session,
+        &TaskEventKind::InteractionReviewMessage {
+            review_id: review.id.clone(),
+            author: InteractionReviewMessageAuthor::Reviewer,
+            text: text.to_string(),
+        },
+    )?;
+    Ok(command)
+}
+
+fn _complete_interaction_review(
+    transaction: &rusqlite::Transaction<'_>,
+    review: InteractionReview,
+    source: ChildCommandSource,
+    reviewer_generation: Option<u32>,
+    disposition: InteractionReviewDisposition,
+    outcome: &str,
+) -> StoreResult<(InteractionReview, bool)> {
+    if review.status == InteractionReviewStatus::Completed {
+        if review.disposition == Some(disposition) && review.outcome.as_deref() == Some(outcome) {
+            return Ok((review, false));
+        }
+        return Err(StoreError::InvalidData(
+            "interaction review already has a different completion".to_string(),
+        ));
+    }
+    if review.status.is_terminal() {
+        return Err(StoreError::InvalidData(
+            "interaction review is already terminal".to_string(),
+        ));
+    }
+    let completed_at = time::OffsetDateTime::now_utc();
+    transaction.execute(
+        "UPDATE interaction_reviews
+         SET status='completed', reviewer_generation=?2, disposition=?3,
+             outcome=?4, completed_at=?5
+         WHERE id=?1",
+        params![
+            review.id.as_str(),
+            reviewer_generation.map(i64::from),
+            disposition.as_str(),
+            outcome,
+            completed_at.unix_timestamp(),
+        ],
+    )?;
+    let command = ChildCommand::new(
+        ChildRef::Task(review.task_session_id.clone()),
+        source,
+        ChildCommandKind::FollowUp {
+            text: format!(
+                "<interaction_review_completed review_id=\"{}\" disposition=\"{}\">\n{outcome}\n</interaction_review_completed>",
+                review.id,
+                disposition.as_str()
+            ),
+        },
+    );
+    insert_child_command(transaction, &command)?;
+    let session = transaction.query_row(
+        TASK_SESSION_SELECT,
+        [review.task_session_id.as_str()],
+        map_task_session_row,
+    )?;
+    insert_task_event_in(
+        transaction,
+        &session,
+        &TaskEventKind::CommandChanged {
+            command_id: command.id.clone(),
+            state: crate::child_session::ChildCommandState::Persisted,
+            effect: command.effect,
+            error: None,
+        },
+    )?;
+    insert_task_event_in(
+        transaction,
+        &session,
+        &TaskEventKind::InteractionReviewCompleted {
+            review_id: review.id.clone(),
+            disposition,
+            outcome: outcome.to_string(),
+        },
+    )?;
+    let completed = transaction.query_row(
+        &format!("{INTERACTION_REVIEW_COLUMNS} WHERE id=?1"),
+        [review.id.as_str()],
+        map_review_row,
+    )?;
+    Ok((completed, true))
 }
 
 fn insert_review(conn: &rusqlite::Connection, review: &InteractionReview) -> StoreResult<()> {
@@ -490,6 +626,26 @@ fn require_open_project_review(
     {
         return Err(StoreError::InvalidData(
             "interaction review is not open for this Project reviewer".to_string(),
+        ));
+    }
+    Ok(review)
+}
+
+fn require_open_human_review(
+    conn: &rusqlite::Connection,
+    review_id: &InteractionReviewId,
+) -> StoreResult<InteractionReview> {
+    let review = conn
+        .query_row(
+            &format!("{INTERACTION_REVIEW_COLUMNS} WHERE id=?1"),
+            [review_id.as_str()],
+            map_review_row,
+        )
+        .optional()?
+        .ok_or(StoreError::NotFound)?;
+    if review.reviewer != InteractionReviewer::Human || review.status.is_terminal() {
+        return Err(StoreError::InvalidData(
+            "interaction review is not open for the human reviewer".to_string(),
         ));
     }
     Ok(review)

--- a/rust/loopflow/src/task/runner.rs
+++ b/rust/loopflow/src/task/runner.rs
@@ -15,8 +15,8 @@ use crate::child_control::{
 };
 use crate::child_session::{
     task_write_lease_from_env, unincorporated_directive_version, BoundaryResult, ChildBodyOutcome,
-    ChildCommand, ChildCommandEffect, ChildCommandId, ChildCommandKind, ChildCommandState,
-    ChildDirective, ChildLeaseState, ChildRef, ChildWriteLease,
+    ChildCommand, ChildCommandEffect, ChildCommandId, ChildCommandKind, ChildCommandSource,
+    ChildCommandState, ChildDirective, ChildLeaseState, ChildRef, ChildWriteLease,
 };
 use crate::engine::InteractionPolicy;
 use crate::harness::{default_create_harness, ApprovalPolicy, Harness};
@@ -40,6 +40,12 @@ use crate::wave::Wave;
 struct PreparedTaskStep {
     turn: crate::lf::commands::run::PreparedHarnessTurn,
     review: Option<InteractionReview>,
+}
+
+#[derive(Debug)]
+struct StartedTaskStep {
+    review: Option<InteractionReviewId>,
+    provider_turn_active: bool,
 }
 
 pub async fn run_task_session(session_id: TaskSessionId, generation: u32) -> Result<()> {
@@ -164,12 +170,30 @@ async fn run_task_session_inner(session_id: TaskSessionId, lease: &ChildWriteLea
     {
         return finish_command_stop(&store, &mut session, lease, harness.as_mut(), stop).await;
     }
+    let mut review_start = None;
     let mut review_recovery = None;
     let mut interaction_review = if let Some(review) = prepared.review.take() {
         open_interaction_review_body(&store, &session, lease, &mut flow, &review).await?;
-        match review.status {
-            InteractionReviewStatus::Requested => {}
-            InteractionReviewStatus::Active => {
+        match (review.status, &review.reviewer) {
+            (InteractionReviewStatus::Requested, InteractionReviewer::Human) => {
+                store
+                    .activate_human_interaction_review(&session, &review.id, lease)
+                    .await?;
+                review_start = Some(PendingInput::system(prepared.turn.input.clone()));
+            }
+            (InteractionReviewStatus::Requested, _) => {}
+            (InteractionReviewStatus::Active, InteractionReviewer::Human) => {
+                review_start = Some(PendingInput::system(format!(
+                    "Resume human interaction review {} after a Task process restart. Continue \
+the `{}` exercise in this existing provider transcript. Human messages arrive as FIFO follow-ups; \
+answer them here and record each answer with `lf task review reply {} \"<answer and evidence>\"`. \
+The human finishes the checkpoint with `lf task review complete {0} --disposition \
+approved|changes-requested --outcome \"<findings and evidence>\"`. The complete Task and skill \
+context follows so recovery does not depend on the interrupted turn having reached the provider.\n\n{}",
+                    review.id, review.step, review.id, prepared.turn.input
+                )));
+            }
+            (InteractionReviewStatus::Active, _) => {
                 review_recovery = Some(PendingInput::system(format!(
                     "Resume interaction review {} after a Task process restart. Inspect the \
 existing provider transcript for the latest reviewer question, then answer it with \
@@ -177,7 +201,7 @@ existing provider transcript for the latest reviewer question, then answer it wi
                     review.id, review.id
                 )));
             }
-            InteractionReviewStatus::Completed => {
+            (InteractionReviewStatus::Completed, _) => {
                 let disposition = review.disposition.ok_or_else(|| {
                     anyhow!(
                         "completed interaction review {} has no disposition",
@@ -200,6 +224,9 @@ The durable reviewer outcome is:\n{}",
     } else {
         None
     };
+    if let Some(review_start) = review_start {
+        pending.push_front(review_start);
+    }
     if pending.is_empty() {
         pending.extend(review_recovery);
     }
@@ -230,7 +257,7 @@ The durable reviewer outcome is:\n{}",
         }
     });
     println!(
-        "task {}> attached; /status, /interrupt [message], /detach, or type an instruction",
+        "task {}> attached; /status, /interrupt [message], /detach, or type a message/instruction",
         session.launch.issue.identifier
     );
     let mut command_poll = tokio::time::interval(Duration::from_millis(200));
@@ -341,6 +368,43 @@ The durable reviewer outcome is:\n{}",
                         } else {
                             None
                         };
+                        if completed_review.is_some() {
+                            // Completion and its final FollowUp commit atomically. Claim after
+                            // observing completion so that message cannot leak into the next phase.
+                            let commands = claim_commands(
+                                &store,
+                                &session,
+                                lease,
+                                &mut seen_commands,
+                            ).await?;
+                            if let Some(stop) = absorb_commands(
+                                &store,
+                                &session,
+                                lease,
+                                commands,
+                                harness.as_mut(),
+                                false,
+                                &mut pending,
+                            ).await? {
+                                return finish_command_stop(
+                                    &store,
+                                    &mut session,
+                                    lease,
+                                    harness.as_mut(),
+                                    stop,
+                                ).await;
+                            }
+                            if apply_next_pending(
+                                &store,
+                                &session,
+                                lease,
+                                harness.as_mut(),
+                                &mut pending,
+                            ).await? {
+                                provider_turn_active = true;
+                                continue 'runner;
+                            }
+                        }
                         let review_body_completed = completed_review.is_some();
                         let mut flow_iteration_completed = if flow_turn_active {
                             finish_task_flow_turn(&mut flow, status)?
@@ -377,11 +441,18 @@ The durable reviewer outcome is:\n{}",
                             if flow_iteration_completed
                                 && session.lifecycle_phase == TaskLifecyclePhase::Kickoff
                             {
+                                let reason = if matches!(
+                                    completed_review
+                                        .as_ref()
+                                        .map(|(disposition, _)| disposition),
+                                    Some(InteractionReviewDisposition::ChangesRequested)
+                                ) {
+                                    "Task kickoff requested changes; iteration is starting"
+                                } else {
+                                    "Task kickoff approved; autonomous iteration is starting"
+                                };
                                 session.enter_iterate()?;
-                                session.set_status(
-                                    TaskSessionStatus::Running,
-                                    "Task kickoff approved; autonomous iteration is starting",
-                                );
+                                session.set_status(TaskSessionStatus::Running, reason);
                                 store.update_task_session_for_lease(&session, lease).await?;
                                 flow = resume_task_phase(&session)?;
                                 flow_iteration_completed = false;
@@ -402,7 +473,7 @@ The durable reviewer outcome is:\n{}",
                                     "Task gate requested changes; returning to iteration",
                                 );
                                 store.update_task_session_for_lease(&session, lease).await?;
-                                interaction_review = start_resumed_task_phase(
+                                let started = start_resumed_task_phase(
                                     &store,
                                     &mut session,
                                     lease,
@@ -411,8 +482,9 @@ The durable reviewer outcome is:\n{}",
                                     wave.name(),
                                 )
                                 .await?;
+                                interaction_review = started.review;
                                 flow_turn_active = interaction_review.is_none();
-                                provider_turn_active = flow_turn_active;
+                                provider_turn_active = started.provider_turn_active;
                                 last_text.clear();
                                 continue 'runner;
                             }
@@ -454,7 +526,7 @@ The durable reviewer outcome is:\n{}",
                                         "Task gate requested changes; returning to iteration",
                                     );
                                     store.update_task_session_for_lease(&session, lease).await?;
-                                    interaction_review = start_resumed_task_phase(
+                                    let started = start_resumed_task_phase(
                                         &store,
                                         &mut session,
                                         lease,
@@ -463,8 +535,9 @@ The durable reviewer outcome is:\n{}",
                                         wave.name(),
                                     )
                                     .await?;
+                                    interaction_review = started.review;
                                     flow_turn_active = interaction_review.is_none();
-                                    provider_turn_active = flow_turn_active;
+                                    provider_turn_active = started.provider_turn_active;
                                     last_text.clear();
                                     continue 'runner;
                                 }
@@ -481,7 +554,7 @@ The durable reviewer outcome is:\n{}",
                                     &flow,
                                 )
                                 .await?;
-                                interaction_review = start_prepared_task_step(
+                                let started = start_prepared_task_step(
                                     &store,
                                     &mut session,
                                     lease,
@@ -490,8 +563,9 @@ The durable reviewer outcome is:\n{}",
                                     prepared,
                                 )
                                 .await?;
+                                interaction_review = started.review;
                                 flow_turn_active = interaction_review.is_none();
-                                provider_turn_active = flow_turn_active;
+                                provider_turn_active = started.provider_turn_active;
                                 continue 'runner;
                             }
                             let summary = progress_summary(&last_text);
@@ -562,7 +636,7 @@ The durable reviewer outcome is:\n{}",
                                     &flow,
                                 )
                                 .await?;
-                                interaction_review = start_prepared_task_step(
+                                let started = start_prepared_task_step(
                                     &store,
                                     &mut session,
                                     lease,
@@ -571,8 +645,9 @@ The durable reviewer outcome is:\n{}",
                                     prepared,
                                 )
                                 .await?;
+                                interaction_review = started.review;
                                 flow_turn_active = interaction_review.is_none();
-                                provider_turn_active = flow_turn_active;
+                                provider_turn_active = started.provider_turn_active;
                                 last_text.clear();
                                 continue 'runner;
                             } else if let Some(pr) = observed_pr
@@ -603,7 +678,7 @@ The durable reviewer outcome is:\n{}",
                                         &flow,
                                     )
                                     .await?;
-                                    interaction_review = start_prepared_task_step(
+                                    let started = start_prepared_task_step(
                                         &store,
                                         &mut session,
                                         lease,
@@ -612,8 +687,9 @@ The durable reviewer outcome is:\n{}",
                                         prepared,
                                     )
                                     .await?;
+                                    interaction_review = started.review;
                                     flow_turn_active = interaction_review.is_none();
-                                    provider_turn_active = flow_turn_active;
+                                    provider_turn_active = started.provider_turn_active;
                                     last_text.clear();
                                     continue 'runner;
                                 }
@@ -638,7 +714,7 @@ The durable reviewer outcome is:\n{}",
                                 );
                                 gate_fingerprint = Some(task_gate_fingerprint(&session)?);
                                 store.update_task_session_for_lease(&session, lease).await?;
-                                interaction_review = start_resumed_task_phase(
+                                let started = start_resumed_task_phase(
                                     &store,
                                     &mut session,
                                     lease,
@@ -647,8 +723,9 @@ The durable reviewer outcome is:\n{}",
                                     wave.name(),
                                 )
                                 .await?;
+                                interaction_review = started.review;
                                 flow_turn_active = interaction_review.is_none();
-                                provider_turn_active = flow_turn_active;
+                                provider_turn_active = started.provider_turn_active;
                                 last_text.clear();
                                 continue 'runner;
                             }
@@ -740,7 +817,7 @@ The durable reviewer outcome is:\n{}",
                                     &flow,
                                 )
                                 .await?;
-                                interaction_review = start_prepared_task_step(
+                                let started = start_prepared_task_step(
                                     &store,
                                     &mut session,
                                     lease,
@@ -749,8 +826,9 @@ The durable reviewer outcome is:\n{}",
                                     prepared,
                                 )
                                 .await?;
+                                interaction_review = started.review;
                                 flow_turn_active = interaction_review.is_none();
-                                provider_turn_active = flow_turn_active;
+                                provider_turn_active = started.provider_turn_active;
                                 continue 'runner;
                             }
                         }
@@ -834,10 +912,37 @@ async fn prepare_task_flow_step(
         crate::lf::commands::run::prepare_harness_turn(&step.step, &seed, wave_name, None)?;
     prepared.config.agent = Some(session.agent.clone());
     let skill = crate::engine::load_skill(&step.step, Path::new(&session.worktree))?;
-    let review = if skill.interactive.unwrap_or(false)
-        && session.phase_plan().interaction_policy == InteractionPolicy::Defer
-    {
+    let review = if skill.interactive.unwrap_or(false) {
         let id = InteractionReviewId::new();
+        let policy = session.phase_plan().interaction_policy;
+        let (reviewer, prompt, reviewer_name) = match policy {
+            InteractionPolicy::Require => {
+                let protocol = human_interaction_review_protocol(&id, &step.step);
+                (
+                    InteractionReviewer::Human,
+                    format!(
+                        "{protocol}\n\n{}",
+                        skill
+                            .content
+                            .as_deref()
+                            .unwrap_or("Follow the named skill.")
+                    ),
+                    "Human",
+                )
+            }
+            InteractionPolicy::Defer => (
+                InteractionReviewer::Project(session.project_session_id.clone()),
+                interaction_review_prompt(
+                    &id,
+                    &step.step,
+                    skill
+                        .content
+                        .as_deref()
+                        .unwrap_or("Follow the named skill."),
+                ),
+                "Project",
+            ),
+        };
         let request = InteractionReview {
             id: id.clone(),
             wave_id: session.wave_id.clone(),
@@ -849,22 +954,15 @@ async fn prepare_task_flow_step(
             step: step.step.clone(),
             step_index: step.index,
             phase_iteration: step.iteration,
-            policy: InteractionPolicy::Defer,
-            reviewer: InteractionReviewer::Project(session.project_session_id.clone()),
+            policy,
+            reviewer,
             status: InteractionReviewStatus::Requested,
             reason: session
                 .gate_proposal
                 .as_ref()
                 .map(|proposal| proposal.reason.clone())
                 .unwrap_or_else(|| session.status_reason.clone()),
-            prompt: interaction_review_prompt(
-                &id,
-                &step.step,
-                skill
-                    .content
-                    .as_deref()
-                    .unwrap_or("Follow the named skill."),
-            ),
+            prompt,
             evidence: InteractionReviewEvidence {
                 worktree: session.worktree.clone(),
                 branch: pr.branch.clone(),
@@ -887,8 +985,14 @@ async fn prepare_task_flow_step(
             .open_interaction_review(session, &request, lease)
             .await?
             .0;
+        if review.reviewer == InteractionReviewer::Human {
+            prepared.input.push_str("\n\n");
+            prepared
+                .input
+                .push_str(&human_interaction_review_protocol(&review.id, &step.step));
+        }
         session.status_reason = format!(
-            "Task {} cycle {}, interactive step {} is {} in Project review {}",
+            "Task {} cycle {}, interactive step {} is {} in {reviewer_name} review {}",
             session.lifecycle_phase.as_str(),
             session.lifecycle_cycle(),
             step.step,
@@ -904,6 +1008,18 @@ async fn prepare_task_flow_step(
         turn: prepared,
         review,
     })
+}
+
+fn human_interaction_review_protocol(review_id: &InteractionReviewId, skill: &str) -> String {
+    format!(
+        "Conduct the interactive `{skill}` exercise with the human in this existing Task provider \
+session. Ask bounded questions and wait for their FIFO follow-up messages. Respond in this \
+transcript, then record each answer with `lf task review reply {review_id} \
+\"<answer and evidence>\"`. Do not approve yourself. The human finishes the checkpoint with \
+`lf task review complete {review_id} --disposition approved|changes-requested --outcome \
+\"<findings and evidence>\"`. Approval lets the lifecycle advance; requested changes return \
+the same Task to Iterate."
+    )
 }
 
 fn interaction_review_prompt(
@@ -987,13 +1103,37 @@ async fn start_prepared_task_step(
     harness: &mut dyn Harness,
     flow: &mut Playhead,
     mut prepared: PreparedTaskStep,
-) -> Result<Option<InteractionReviewId>> {
+) -> Result<StartedTaskStep> {
     if let Some(review) = prepared.review.take() {
         open_interaction_review_body(store, session, lease, flow, &review).await?;
-        Ok(Some(review.id))
+        let provider_turn_active = if review.reviewer == InteractionReviewer::Human {
+            store
+                .activate_human_interaction_review(session, &review.id, lease)
+                .await?;
+            apply_input(
+                store,
+                session,
+                lease,
+                harness,
+                &prepared.turn.input,
+                None,
+                None,
+            )
+            .await?;
+            true
+        } else {
+            false
+        };
+        Ok(StartedTaskStep {
+            review: Some(review.id),
+            provider_turn_active,
+        })
     } else {
         start_task_flow_turn(store, session, lease, harness, flow, prepared.turn).await?;
-        Ok(None)
+        Ok(StartedTaskStep {
+            review: None,
+            provider_turn_active: true,
+        })
     }
 }
 
@@ -1004,7 +1144,7 @@ async fn start_resumed_task_phase(
     harness: &mut dyn Harness,
     flow: &mut Playhead,
     wave_name: &str,
-) -> Result<Option<InteractionReviewId>> {
+) -> Result<StartedTaskStep> {
     *flow = resume_task_phase(session)?;
     let prepared = prepare_task_flow_step(store, session, lease, wave_name, flow).await?;
     start_prepared_task_step(store, session, lease, harness, flow, prepared).await
@@ -1281,6 +1421,29 @@ async fn handle_attachment(
             .status();
         return Ok(());
     }
+    if !line.starts_with("/interrupt") {
+        let review = store
+            .interaction_review_at(
+                &session.id,
+                session.phase_epoch,
+                session.phase_iteration,
+                session.phase_cursor,
+            )
+            .await?;
+        if let Some(review) = review.filter(|review| {
+            review.reviewer == InteractionReviewer::Human && !review.status.is_terminal()
+        }) {
+            let command = store
+                .send_human_interaction_review_message(
+                    &review.id,
+                    ChildCommandSource::Attachment,
+                    line,
+                )
+                .await?;
+            println!("queued {} for human review {}", command.id, review.id);
+            return Ok(());
+        }
+    }
     let kind = if let Some(message) = line.strip_prefix("/interrupt") {
         let message = message.trim();
         ChildCommandKind::Interrupt {
@@ -1293,7 +1456,7 @@ async fn handle_attachment(
     };
     let command = ChildCommand::new(
         ChildRef::Task(session.id.clone()),
-        crate::child_session::ChildCommandSource::Attachment,
+        ChildCommandSource::Attachment,
         kind,
     );
     let replacement = match &command.kind {
@@ -1688,8 +1851,9 @@ mod tests {
 
     use super::{
         absorb_commands, apply_input, apply_next_pending, handle_attachment,
-        interaction_review_prompt, prepare_task_flow_step, progress_summary, resume_task_phase,
-        task_seed, CommandStop,
+        human_interaction_review_protocol, interaction_review_prompt, prepare_task_flow_step,
+        progress_summary, resume_task_phase, start_prepared_task_step, task_seed, CommandStop,
+        PreparedTaskStep,
     };
     use crate::child_session::{
         ChildBodyHandoffRequest, ChildCommand, ChildCommandEffect, ChildCommandKind,
@@ -1710,6 +1874,7 @@ mod tests {
         PmWritebackState, TaskEventKind, TaskGateProposal, TaskLifecyclePhase, TaskLifecyclePlan,
         TaskPr, TaskPrId, TaskSession, TaskSessionId, TaskSessionStatus,
     };
+    use crate::wave::playhead::Playhead;
     use crate::wave::Wave;
 
     struct ScriptedHarness {
@@ -1880,26 +2045,16 @@ mod tests {
         (store, session, lease)
     }
 
-    #[test]
-    fn progress_summary_bounds_wave_visible_text() {
-        let summary = progress_summary(&"x".repeat(2_500));
-        assert_eq!(summary.chars().count(), 2_000);
-        assert!(summary.ends_with('…'));
-    }
-
-    #[test]
-    fn deferred_review_prompt_assigns_the_skill_and_two_way_protocol() {
-        let review_id = InteractionReviewId::new();
-        let prompt = interaction_review_prompt(&review_id, "demo", "Prove each Done When.");
-
-        assert!(prompt.contains("interactive `demo` exercise"));
-        assert!(prompt.contains(&format!("lf project review message {review_id}")));
-        assert!(prompt.contains(&format!("lf project review complete {review_id}")));
-        assert!(prompt.contains("Prove each Done When."));
-    }
-
-    #[tokio::test]
-    async fn headless_interactive_step_opens_parent_review_with_current_evidence() {
+    async fn prepared_gate_review(
+        lifecycle: TaskLifecyclePlan,
+    ) -> (
+        tempfile::TempDir,
+        SharedStore,
+        TaskSession,
+        ChildWriteLease,
+        Playhead,
+        PreparedTaskStep,
+    ) {
         let repo = tempfile::tempdir().unwrap();
         for args in [
             ["init", "-b", "main"].as_slice(),
@@ -1948,7 +2103,7 @@ mod tests {
             .unwrap();
         session.current_directive_version = 1;
         session.worktree = repo.path().to_path_buf();
-        session.lifecycle = TaskLifecyclePlan::headless("task");
+        session.lifecycle = lifecycle;
         session.lifecycle_phase = TaskLifecyclePhase::Gate;
         session.phase_epoch = 3;
         session.gate_cycle = 1;
@@ -1961,10 +2116,46 @@ mod tests {
             .await
             .unwrap();
         let flow = resume_task_phase(&session).unwrap();
-
         let prepared = prepare_task_flow_step(&store, &mut session, &lease, "test-wave", &flow)
             .await
             .unwrap();
+        (repo, store, session, lease, flow, prepared)
+    }
+
+    #[test]
+    fn progress_summary_bounds_wave_visible_text() {
+        let summary = progress_summary(&"x".repeat(2_500));
+        assert_eq!(summary.chars().count(), 2_000);
+        assert!(summary.ends_with('…'));
+    }
+
+    #[test]
+    fn deferred_review_prompt_assigns_the_skill_and_two_way_protocol() {
+        let review_id = InteractionReviewId::new();
+        let prompt = interaction_review_prompt(&review_id, "demo", "Prove each Done When.");
+
+        assert!(prompt.contains("interactive `demo` exercise"));
+        assert!(prompt.contains(&format!("lf project review message {review_id}")));
+        assert!(prompt.contains(&format!("lf project review complete {review_id}")));
+        assert!(prompt.contains("Prove each Done When."));
+    }
+
+    #[test]
+    fn human_review_prompt_keeps_the_decision_with_the_human() {
+        let review_id = InteractionReviewId::new();
+        let prompt = human_interaction_review_protocol(&review_id, "demo");
+
+        assert!(prompt.contains("existing Task provider session"));
+        assert!(prompt.contains("FIFO follow-up messages"));
+        assert!(prompt.contains(&format!("lf task review reply {review_id}")));
+        assert!(prompt.contains(&format!("lf task review complete {review_id}")));
+        assert!(prompt.contains("requested changes return"));
+    }
+
+    #[tokio::test]
+    async fn headless_interactive_step_opens_parent_review_with_current_evidence() {
+        let (repo, store, session, _lease, _flow, prepared) =
+            prepared_gate_review(TaskLifecyclePlan::headless("task")).await;
         let review = prepared.review.expect("demo is deferred to the Project");
 
         assert_eq!(review.phase, TaskLifecyclePhase::Gate);
@@ -1993,6 +2184,92 @@ mod tests {
                 .unwrap()
                 .id,
             review.id
+        );
+    }
+
+    #[tokio::test]
+    async fn standard_interactive_step_starts_human_review_in_existing_provider_session() {
+        let (_repo, store, mut session, lease, mut flow, prepared) =
+            prepared_gate_review(TaskLifecyclePlan::standard("task")).await;
+        let review = prepared.review.clone().expect("demo requires human review");
+        let replayed = prepare_task_flow_step(&store, &mut session, &lease, "test-wave", &flow)
+            .await
+            .unwrap();
+        assert_eq!(
+            replayed.review.as_ref().map(|review| &review.id),
+            Some(&review.id)
+        );
+        assert!(replayed.turn.input.contains(review.id.as_str()));
+        let mut harness = ScriptedHarness::new(true);
+
+        let started = start_prepared_task_step(
+            &store,
+            &mut session,
+            &lease,
+            &mut harness,
+            &mut flow,
+            replayed,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            review.reviewer,
+            crate::interaction_review::InteractionReviewer::Human
+        );
+        assert_eq!(review.policy, crate::engine::InteractionPolicy::Require);
+        assert_eq!(started.review, Some(review.id.clone()));
+        assert!(started.provider_turn_active);
+        assert_eq!(harness.sent.len(), 1);
+        assert!(harness.sent[0].contains(review.id.as_str()));
+        assert!(harness.sent[0].contains("lf task review complete"));
+        assert!(flow.active.is_some());
+        assert_eq!(
+            store
+                .get_interaction_review(&review.id)
+                .await
+                .unwrap()
+                .unwrap()
+                .status,
+            crate::interaction_review::InteractionReviewStatus::Active
+        );
+        assert!(session.status_reason.contains("Human review"));
+    }
+
+    #[tokio::test]
+    async fn attached_human_review_input_is_fifo_followup_not_steer() {
+        let (_repo, store, session, lease, _flow, prepared) =
+            prepared_gate_review(TaskLifecyclePlan::standard("task")).await;
+        let review = prepared.review.expect("demo requires human review");
+
+        handle_attachment(
+            &store,
+            &session,
+            &lease,
+            "Show the login path from the product.".to_string(),
+        )
+        .await
+        .unwrap();
+
+        let commands = store
+            .list_child_commands(&ChildRef::Task(session.id.clone()))
+            .await
+            .unwrap();
+        let message = commands.last().expect("attached review message is durable");
+        assert_eq!(message.source, ChildCommandSource::Attachment);
+        assert!(matches!(
+            &message.kind,
+            ChildCommandKind::FollowUp { text }
+                if text.contains(review.id.as_str()) && text.contains("Show the login path")
+        ));
+        assert_eq!(
+            store
+                .get_task_session(&session.id)
+                .await
+                .unwrap()
+                .unwrap()
+                .current_directive_version,
+            1
         );
     }
 

--- a/rust/loopflow/src/task/runner.rs
+++ b/rust/loopflow/src/task/runner.rs
@@ -1197,6 +1197,15 @@ async fn reconcile_interactive_rendezvous_at_birth(
     lease: &ChildWriteLease,
     flow: &mut Playhead,
 ) -> Result<bool> {
+    let review_owns_current_step = store
+        .interaction_review_at(
+            &session.id,
+            session.phase_epoch,
+            session.phase_iteration,
+            session.phase_cursor,
+        )
+        .await?
+        .is_some();
     let parent = InteractiveHandoffParent::Task(session.id.clone());
     match interactive_rendezvous::resolve(store, &parent, lease.generation).await? {
         Rendezvous::None => Ok(false),
@@ -1212,15 +1221,25 @@ async fn reconcile_interactive_rendezvous_at_birth(
             Ok(true)
         }
         Rendezvous::Resume { outcome, fresh } => {
-            resume_interactive_step(store, session, lease, flow, outcome, fresh).await
+            resume_interactive_step(
+                store,
+                session,
+                lease,
+                flow,
+                outcome,
+                fresh,
+                review_owns_current_step,
+            )
+            .await
         }
     }
 }
 
 /// Resolve a terminal interactive handoff at body birth. Completion advances the
-/// flow past work the human finished; hand-back resumes the same step; failure
-/// blocks the parent for an operator. Evidence is recorded once, on the
-/// generation that wins the wake claim (`fresh`).
+/// flow past work the human finished unless an InteractionReview owns the same
+/// step; a handoff can wake that review but cannot decide it. Hand-back resumes
+/// the same step, and failure blocks the parent for an operator. Evidence is
+/// recorded once, on the generation that wins the wake claim (`fresh`).
 async fn resume_interactive_step(
     store: &SharedStore,
     session: &mut TaskSession,
@@ -1228,6 +1247,7 @@ async fn resume_interactive_step(
     flow: &mut Playhead,
     outcome: InteractiveHandoffOutcome,
     fresh: bool,
+    review_owns_current_step: bool,
 ) -> Result<bool> {
     if fresh {
         let detail = match &outcome {
@@ -1260,13 +1280,14 @@ async fn resume_interactive_step(
             .await?;
             Ok(true)
         }
-        InteractiveHandoffOutcome::Completed { .. } => {
+        InteractiveHandoffOutcome::Completed { .. } if !review_owns_current_step => {
             advance_past_interactive_step(flow, session)?;
             record_task_flow_position(session, flow)?;
             store.update_task_session_for_lease(session, lease).await?;
             Ok(false)
         }
-        InteractiveHandoffOutcome::HandedBack { .. } => Ok(false),
+        InteractiveHandoffOutcome::Completed { .. }
+        | InteractiveHandoffOutcome::HandedBack { .. } => Ok(false),
     }
 }
 
@@ -2829,6 +2850,59 @@ mod tests {
         assert!(!parked);
         assert_eq!(session.phase_cursor, 0);
         assert_eq!(session.phase_iteration, 0);
+        assert!(store
+            .get_interactive_handoff(&handoff.id)
+            .await
+            .unwrap()
+            .unwrap()
+            .wake_claimed_at
+            .is_some());
+    }
+
+    #[tokio::test]
+    async fn completed_handoff_cannot_advance_past_interaction_review() {
+        let (_repo, store, mut session, lease, mut flow, prepared) =
+            prepared_gate_review(TaskLifecyclePlan::standard("task")).await;
+        let review = prepared.review.expect("demo requires human review");
+        let (handoff, _) = store
+            .open_interactive_handoff(task_handoff_request(&session, &lease))
+            .await
+            .unwrap();
+        store
+            .finish_interactive_handoff(
+                &handoff.id,
+                &crate::interactive_handoff::InteractiveHandoffOutcome::Completed {
+                    summary: "human finished the login".to_string(),
+                },
+            )
+            .await
+            .unwrap();
+
+        let parked = super::reconcile_interactive_rendezvous_at_birth(
+            &store,
+            &mut session,
+            &lease,
+            &mut flow,
+        )
+        .await
+        .unwrap();
+
+        assert!(!parked);
+        assert_eq!(session.phase_cursor, review.step_index);
+        assert_eq!(session.phase_iteration, review.phase_iteration);
+        assert_eq!(
+            store
+                .interaction_review_at(
+                    &session.id,
+                    session.phase_epoch,
+                    session.phase_iteration,
+                    session.phase_cursor,
+                )
+                .await
+                .unwrap()
+                .map(|current| current.id),
+            Some(review.id)
+        );
         assert!(store
             .get_interactive_handoff(&handoff.id)
             .await


### PR DESCRIPTION
## Usage

```bash
lf task run DES-123
lf task status DES-123
lf task attach DES-123

lf task review message ir_... "Show the real sign-in path"
lf task review complete ir_... \
  --disposition changes-requested \
  --outcome "The login proof is missing"
```

Standard Tasks now conduct interactive kickoff and gate exercises with the human in the Task provider session. Bare attached input and `task review message` are FIFO follow-ups; `/interrupt` remains explicit. Approval advances the lifecycle. Gate changes return the same Task to Iterate. Headless Tasks keep routing the same exercises to the owning Project.

## Durable boundary

- Each attended exercise is an `InteractionReview` at an exact Task flow position.
- The existing Task provider session stays alive across human questions and answers.
- Restart recovery reopens the same review with its full Task and skill context.
- A generic `InteractiveHandoff` may present or wake the work, but cannot approve a lifecycle review or advance past one.
- Human reviewer authority is rejected from managed Task, Project, and Wave agent environments.

## Review findings

The structural review separated presentation from judgment: handoffs own human-only actions; InteractionReviews alone own approval and return-to-Iterate. A final follow-up is drained before Gate settlement so it cannot leak into the next phase.

## Verification

- `cargo nextest run --all` — 1463 passed, 2 skipped
- `cargo clippy -p loopflow --all-targets -- -D warnings`

Includes the correction from #956 while that PR clears the merge queue; GitHub will remove the duplicate diff when main advances.