### PR TITLE
reviews: run manual Wave catch-up exercises

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,18 @@ cycle. The durable review records the exercise, evidence snapshot, conversation,
 disposition, and outcome. A generic interactive handoff only tells another UI
 how to present or attach to the existing session; it does not decide the review.
 
+Catch up accumulated parent-review and integration debt across a Wave:
+
+```bash
+lf reviews catch-up --wave product --plan             # inspect the evidence packet
+lf reviews catch-up --wave product --skill demo       # prove the integrated experience
+lf reviews catch-up --wave product --skill code-review
+```
+
+Catch-up reads every durable parent-reviewed interaction in the Wave and runs
+one human exercise over their current integrated state. It does not change the
+original Task dispositions; findings become follow-up Tasks.
+
 Start dependent work without sharing the parent's worktree:
 
 ```bash

--- a/docs/lf.md
+++ b/docs/lf.md
@@ -190,6 +190,22 @@ an explicit interruption. The human closes the durable checkpoint with
 `lf task review complete`; the worker records its replies with
 `lf task review reply`.
 
+Run a manual Wave catch-up after headless work accumulates review or integration
+debt:
+
+```bash
+lf reviews catch-up --wave product --plan
+lf reviews catch-up --wave product --skill demo
+lf reviews catch-up --wave product --skill code-review
+```
+
+The command assembles completed and still-open parent reviews with their Task,
+Project, commit, worktree, PR, disposition, and outcome evidence. `demo` proves
+each relevant design-doc Done When through the product, code, admin state, logs,
+stats, or metrics, including real sign-in when authentication is in scope.
+`code-review` reviews the combined architecture and integration seams. Catch-up
+never rewrites the original lifecycle decisions; it files follow-up work.
+
 `--stack-on` places a new Task worktree on another Task's published PR. Its PR
 targets that parent branch automatically, then collapses onto `main` after the
 parent merges. The two Tasks keep separate identities, worktrees, and workers.

--- a/rust/loopflow/src/bin/lf.rs
+++ b/rust/loopflow/src/bin/lf.rs
@@ -1384,6 +1384,24 @@ fn main() -> anyhow::Result<()> {
             Some(Commands::Project { cmd }) => {
                 in_repo_runtime(&args, |repo| run_project_command(repo, cmd))
             }
+            Some(Commands::Reviews { cmd }) => in_repo_runtime(&args, |repo| {
+                let plan = loopflow::lf::commands::reviews::prepare(cmd, cli.wave.as_deref())?;
+                if plan.preview {
+                    println!("{}", plan.prompt);
+                    return Ok(());
+                }
+                eprintln!(
+                    "catching up {} parent reviews with {}",
+                    plan.review_count, plan.skill
+                );
+                run_target_in_repo(
+                    repo,
+                    &plan.skill,
+                    Some(&plan.prompt),
+                    &cli,
+                    &args,
+                )
+            }),
             Some(Commands::Task { cmd }) => {
                 in_repo_runtime(&args, |repo| run_task_command(repo, cmd))
             }

--- a/rust/loopflow/src/lf/commands/home.rs
+++ b/rust/loopflow/src/lf/commands/home.rs
@@ -115,7 +115,7 @@ pub fn route(
     ))
 }
 
-/// The repo/PR/release/PM operations that must run where the Wave's work lives.
+/// The repo/PR/release/PM/review operations that must run where the Wave's work lives.
 /// Deliberately minimal — everything else stays local until a concrete need
 /// grows the set.
 fn is_routable(command: &Commands) -> bool {
@@ -126,6 +126,7 @@ fn is_routable(command: &Commands) -> bool {
             | Commands::Rebase { .. }
             | Commands::Release { .. }
             | Commands::Pm { .. }
+            | Commands::Reviews { .. }
     )
 }
 
@@ -185,6 +186,12 @@ mod tests {
             no_add: false,
         }));
         assert!(is_routable(&Commands::Pr { cmd: None }));
+        assert!(is_routable(&Commands::Reviews {
+            cmd: crate::lf::ReviewsCommand::CatchUp {
+                skill: "demo".to_string(),
+                plan: false,
+            },
+        }));
         assert!(!is_routable(&Commands::Status {
             wave: None,
             json: false,

--- a/rust/loopflow/src/lf/commands/mod.rs
+++ b/rust/loopflow/src/lf/commands/mod.rs
@@ -13,6 +13,7 @@ pub mod memory;
 pub mod ops;
 pub mod profile;
 pub mod radio;
+pub mod reviews;
 pub mod run;
 pub mod runs;
 pub mod ssh;

--- a/rust/loopflow/src/lf/commands/reviews.rs
+++ b/rust/loopflow/src/lf/commands/reviews.rs
@@ -1,0 +1,215 @@
+use anyhow::{anyhow, Context, Result};
+
+use crate::interaction_review::{InteractionReview, InteractionReviewer};
+use crate::lf::ReviewsCommand;
+use crate::store::{open_store, storage_config_from_env};
+use crate::task::TaskSession;
+
+#[derive(Debug)]
+pub struct CatchUpPlan {
+    pub skill: String,
+    pub prompt: String,
+    pub review_count: usize,
+    pub preview: bool,
+}
+
+#[derive(Debug)]
+struct CatchUpItem {
+    review: InteractionReview,
+    task: Option<TaskSession>,
+}
+
+pub fn prepare(command: &ReviewsCommand, wave: Option<&str>) -> Result<CatchUpPlan> {
+    let ReviewsCommand::CatchUp {
+        skill,
+        plan: preview,
+    } = command;
+    let wave = crate::ops::resolve_wave_name(wave)
+        .ok_or_else(|| anyhow!("cannot determine Wave; pass --wave <name>"))?;
+    let runtime = tokio::runtime::Runtime::new().context("start review catch-up runtime")?;
+    runtime.block_on(_prepare(&wave, skill, *preview))
+}
+
+async fn _prepare(wave_name: &str, skill: &str, preview: bool) -> Result<CatchUpPlan> {
+    let config = storage_config_from_env().context("resolve the shared Loopflow store")?;
+    let store = open_store(&config)
+        .await
+        .context("open the shared Loopflow store")?;
+    let wave = store
+        .get_wave_by_name(wave_name)
+        .await?
+        .ok_or_else(|| anyhow!("Wave {wave_name} is not registered"))?;
+    let reviews = store.list_interaction_reviews(Some(wave.id())).await?;
+    let mut items = Vec::new();
+    for review in reviews {
+        if matches!(&review.reviewer, InteractionReviewer::Human) {
+            continue;
+        }
+        let task = store.get_task_session(&review.task_session_id).await?;
+        items.push(CatchUpItem { review, task });
+    }
+    if items.is_empty() {
+        anyhow::bail!("Wave {wave_name} has no parent-reviewed interaction evidence to catch up");
+    }
+    Ok(CatchUpPlan {
+        skill: skill.to_string(),
+        prompt: format_catch_up_prompt(wave_name, skill, &items),
+        review_count: items.len(),
+        preview,
+    })
+}
+
+fn format_catch_up_prompt(wave: &str, skill: &str, items: &[CatchUpItem]) -> String {
+    let completed = items
+        .iter()
+        .filter(|item| item.review.status.is_terminal())
+        .count();
+    let open = items.len() - completed;
+    let exercise = match skill {
+        "demo" => {
+            "For every relevant `Done When` in the design docs, build a proof matrix and show how it holds through the product, code, admin state, logs, stats, or metrics. Exercise real sign-in/login when authentication is in scope; do not bypass it."
+        }
+        "code-review" => {
+            "Review the combined code trajectory and integration seams, not each diff in isolation. Identify structural debt, conflicting decisions, missing operational evidence, and the smallest concrete follow-up work."
+        }
+        _ => "Conduct the named review exercise over the combined Wave evidence.",
+    };
+    let mut prompt = format!(
+        "Reviewer Mode: Human\n\nConduct one `{skill}` catch-up for Wave `{wave}` over {completed} completed parent reviews and {open} still-open parent reviews. This is a manual integration and feedback pass, not Task lifecycle authority. Do not rewrite source InteractionReview dispositions. Record new work as follow-up Tasks under the appropriate Project.\n\n{exercise}\n\nTreat each recorded outcome as a claim to verify against the current integrated product. Group the walkthrough by user-visible capability and shared seam rather than replaying Tasks chronologically. End with: proven now, regressed or contradictory, still unproven, and concrete follow-up Tasks.\n\n# Durable review evidence\n"
+    );
+    for item in items {
+        prompt.push_str(&format_catch_up_item(item));
+    }
+    prompt
+}
+
+fn format_catch_up_item(item: &CatchUpItem) -> String {
+    let review = &item.review;
+    let task = item.task.as_ref();
+    let task_label = task
+        .map(|task| {
+            format!(
+                "{} — {}",
+                task.launch.issue.identifier, task.launch.issue.title
+            )
+        })
+        .unwrap_or_else(|| review.task_session_id.to_string());
+    let project = task
+        .map(|task| task.launch.project.name.as_str())
+        .unwrap_or("unknown project");
+    let reviewer = review
+        .reviewer
+        .id()
+        .map(|id| format!("{} {id}", review.reviewer.kind()))
+        .unwrap_or_else(|| review.reviewer.kind().to_string());
+    let disposition = review
+        .disposition
+        .map(|value| value.as_str())
+        .unwrap_or("pending");
+    let outcome = review
+        .outcome
+        .as_deref()
+        .unwrap_or("No outcome recorded yet.");
+    let pull_request = review
+        .evidence
+        .pr
+        .as_ref()
+        .map(|pr| format!("#{} {}", pr.number, pr.url))
+        .unwrap_or_else(|| "none".to_string());
+    format!(
+        "\n## {} · {} / {}\n\n- Task: {}\n- Project: {}\n- Reviewer: {}\n- Status: {} / {}\n- Reason: {}\n- Outcome: {}\n- Evidence: worktree `{}`, branch `{}`, base `{}`, head `{}`, PR {}\n- Requested at: {}\n",
+        review.id,
+        review.phase.as_str(),
+        review.step,
+        task_label,
+        project,
+        reviewer,
+        review.status.as_str(),
+        disposition,
+        review.reason,
+        outcome,
+        review.evidence.worktree.display(),
+        review.evidence.branch,
+        review.evidence.base_commit,
+        review.evidence.head_commit,
+        pull_request,
+        review.requested_at,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use time::OffsetDateTime;
+
+    use super::{format_catch_up_prompt, CatchUpItem};
+    use crate::engine::InteractionPolicy;
+    use crate::id::WaveId;
+    use crate::interaction_review::{
+        InteractionReview, InteractionReviewDisposition, InteractionReviewEvidence,
+        InteractionReviewId, InteractionReviewStatus, InteractionReviewer,
+    };
+    use crate::project_session::ProjectSessionId;
+    use crate::task::{TaskLifecyclePhase, TaskSessionId};
+
+    fn review(status: InteractionReviewStatus) -> InteractionReview {
+        let completed = status.is_terminal();
+        let project = ProjectSessionId::new();
+        InteractionReview {
+            id: InteractionReviewId::new(),
+            wave_id: WaveId::new(),
+            project_session_id: project.clone(),
+            task_session_id: TaskSessionId::new(),
+            phase: TaskLifecyclePhase::Gate,
+            phase_epoch: 3,
+            flow: "task-gate".to_string(),
+            step: "demo".to_string(),
+            step_index: 0,
+            phase_iteration: 0,
+            policy: InteractionPolicy::Defer,
+            reviewer: InteractionReviewer::Project(project),
+            status,
+            reason: "Prove login works".to_string(),
+            prompt: "Conduct a demo".to_string(),
+            evidence: InteractionReviewEvidence {
+                worktree: PathBuf::from("/repo.login"),
+                branch: "task/login".to_string(),
+                base_commit: "base".to_string(),
+                head_commit: "head".to_string(),
+                worktree_fingerprint: "fingerprint".to_string(),
+                pr: None,
+            },
+            requested_by_generation: 1,
+            reviewer_generation: Some(1),
+            disposition: completed.then_some(InteractionReviewDisposition::Approved),
+            outcome: completed.then(|| "Login proven through the product".to_string()),
+            requested_at: OffsetDateTime::UNIX_EPOCH,
+            completed_at: completed.then_some(OffsetDateTime::UNIX_EPOCH),
+        }
+    }
+
+    #[test]
+    fn demo_catch_up_turns_parent_reviews_into_human_proof_work() {
+        let items = [
+            CatchUpItem {
+                review: review(InteractionReviewStatus::Completed),
+                task: None,
+            },
+            CatchUpItem {
+                review: review(InteractionReviewStatus::Requested),
+                task: None,
+            },
+        ];
+
+        let prompt = format_catch_up_prompt("product", "demo", &items);
+
+        assert!(prompt.contains("Reviewer Mode: Human"));
+        assert!(prompt.contains("1 completed parent reviews and 1 still-open"));
+        assert!(prompt.contains("For every relevant `Done When`"));
+        assert!(prompt.contains("product, code, admin state, logs, stats, or metrics"));
+        assert!(prompt.contains("real sign-in/login"));
+        assert!(prompt.contains("Do not rewrite source InteractionReview dispositions"));
+        assert!(prompt.contains("Login proven through the product"));
+    }
+}

--- a/rust/loopflow/src/lf/mod.rs
+++ b/rust/loopflow/src/lf/mod.rs
@@ -248,6 +248,11 @@ pub enum Commands {
         #[command(subcommand)]
         cmd: ProjectCommand,
     },
+    /// Review accumulated parent-reviewed work across one Wave
+    Reviews {
+        #[command(subcommand)]
+        cmd: ReviewsCommand,
+    },
     /// Linear-backed Task Session lifecycle
     Task {
         #[command(subcommand)]
@@ -902,6 +907,18 @@ pub enum TaskReviewCommand {
         outcome: String,
         #[arg(long)]
         json: bool,
+    },
+}
+
+#[derive(Subcommand, Debug)]
+pub enum ReviewsCommand {
+    /// Run one human catch-up exercise over the Wave's deferred reviews
+    CatchUp {
+        #[arg(long, default_value = "demo", value_parser = ["demo", "code-review"])]
+        skill: String,
+        /// Print the assembled review evidence without launching an agent
+        #[arg(long)]
+        plan: bool,
     },
 }
 
@@ -2160,6 +2177,33 @@ mod tests {
                 && disposition == "approved"
                 && outcome == "The empty state is proven"
         ));
+    }
+
+    #[test]
+    fn wave_review_catch_up_selects_a_bounded_human_exercise() {
+        let cli = Cli::try_parse_from([
+            "lf",
+            "--wave",
+            "product",
+            "reviews",
+            "catch-up",
+            "--skill",
+            "code-review",
+            "--plan",
+        ])
+        .expect("parse Wave review catch-up");
+
+        assert_eq!(cli.wave.as_deref(), Some("product"));
+        assert!(matches!(
+            cli.command,
+            Some(Commands::Reviews {
+                cmd: ReviewsCommand::CatchUp {
+                    skill,
+                    plan: true,
+                }
+            }) if skill == "code-review"
+        ));
+        assert!(Cli::try_parse_from(["lf", "reviews", "catch-up", "--skill", "design",]).is_err());
     }
 
     #[test]


### PR DESCRIPTION
## Usage

```bash
lf reviews catch-up --wave product --plan
lf reviews catch-up --wave product --skill demo
lf reviews catch-up --wave product --skill code-review
```

`--plan` prints the exact evidence packet without launching an agent. The live commands gather every completed and still-open parent-reviewed InteractionReview in the Wave, attach Task/Project/commit/worktree/PR/disposition/outcome evidence, and launch one attended human exercise over the integrated state.

`demo` requires a proof matrix for each relevant design-doc Done When using product, code, admin state, logs, stats, or metrics, with real sign-in/login when auth is in scope. `code-review` reviews the combined architecture and integration seams.

Catch-up is deliberately not lifecycle authority: it cannot rewrite source Task dispositions. New findings become follow-up Tasks. The command routes to the Wave Home so the evidence and worktrees are local to the reviewer.

## Review findings

This stays manual and receipt-free for the prototype. It rereads all durable parent reviews on every invocation, making no claim that debt was cleared merely because a session launched.

## Verification

- catch-up prompt behavior and bounded skill selection tests
- generated CLI flag-table test
- Wave Home routing test
- `cargo clippy -p loopflow --all-targets -- -D warnings`