### PR TITLE
migrations: make main the production schema authority

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,8 @@ jobs:
       - name: Fetch canonical migration history
         run: git fetch --no-tags origin main:refs/remotes/origin/main
       - name: Verify migration namespaces
+        env:
+          LOOPFLOW_REQUIRE_ORIGIN_MAIN: "1"
         run: uv run python scripts/check_migrations.py
 
   python-test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,8 @@ jobs:
         with:
           fetch-depth: 0
       - uses: astral-sh/setup-uv@v7
+      - name: Fetch canonical migration history
+        run: git fetch --no-tags origin main:refs/remotes/origin/main
       - name: Verify migration namespaces
         run: uv run python scripts/check_migrations.py
 

--- a/.github/workflows/nightly-packages.yml
+++ b/.github/workflows/nightly-packages.yml
@@ -9,6 +9,7 @@ on:
 
 env:
   LOOPFLOW_BUILD_PROVENANCE: release
+  LOOPFLOW_MIGRATION_AUTHORITY: published
 
 jobs:
   native-packages:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,7 @@ on:
 
 env:
   LOOPFLOW_BUILD_PROVENANCE: release
+  LOOPFLOW_MIGRATION_AUTHORITY: published
   RELEASE_TAG: ${{ inputs.tag || github.ref_name }}
 
 jobs:

--- a/.github/workflows/weekly-release.yml
+++ b/.github/workflows/weekly-release.yml
@@ -80,6 +80,8 @@ jobs:
       # a shipped migration that was edited would silently rewrite the history of
       # every database in the wild.
       - name: Verify migration namespaces
+        env:
+          LOOPFLOW_REQUIRE_ORIGIN_MAIN: "1"
         run: uv run python scripts/check_migrations.py
       - name: Install lf
         run: |

--- a/.github/workflows/weekly-release.yml
+++ b/.github/workflows/weekly-release.yml
@@ -10,6 +10,7 @@ on:
 
 env:
   LOOPFLOW_BUILD_PROVENANCE: release
+  LOOPFLOW_MIGRATION_AUTHORITY: published
 
 jobs:
   tag-check:

--- a/python/tests/test_check_migrations.py
+++ b/python/tests/test_check_migrations.py
@@ -191,3 +191,19 @@ def test_manifests_disagreeing_on_the_version_fails(repo: Path):
     result = check(repo)
     assert result.returncode == 1
     assert "disagree" in result.stderr
+
+
+def test_a_branch_cannot_reuse_an_ordinal_owned_by_current_main(repo: Path):
+    (repo / MIGRATIONS / "0.10.002_main_change.sql").write_text("SELECT 'main';\n")
+    _register(repo, (0, 10, 1, "initial"), (0, 10, 2, "main_change"))
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-qm", "main migration")
+    _git(repo, "update-ref", "refs/remotes/origin/main", "HEAD")
+    _git(repo, "checkout", "-qb", "feature", "HEAD~1")
+
+    (repo / MIGRATIONS / "0.10.002_branch_change.sql").write_text("SELECT 'branch';\n")
+    _register(repo, (0, 10, 1, "initial"), (0, 10, 2, "branch_change"))
+
+    result = check(repo)
+    assert result.returncode == 1
+    assert "collides with 0.10.002_main_change.sql on origin/main" in result.stderr

--- a/python/tests/test_install_script.py
+++ b/python/tests/test_install_script.py
@@ -198,6 +198,32 @@ def test_sync_skills_warns_without_failing_when_lf_cannot_run(
     assert "binaries installed, skills unchanged" in captured.err
 
 
+def test_only_canonical_or_tagged_installs_receive_migration_authority(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    values = {
+        ("rev-parse", "HEAD"): "branch-head",
+        ("symbolic-ref", "--quiet", "refs/remotes/origin/HEAD"): "refs/remotes/origin/main",
+        ("rev-parse", "refs/remotes/origin/main"): "main-head",
+        ("tag", "--points-at", "HEAD"): "",
+        ("status", "--porcelain"): "",
+    }
+    monkeypatch.setattr(
+        install,
+        "_git_stdout",
+        lambda args, repo=install.ROOT, check=True: values[tuple(args)],
+    )
+
+    assert install._migration_authority() == "validation_only"
+    values[("rev-parse", "HEAD")] = "main-head"
+    assert install._migration_authority() == "published"
+    values[("rev-parse", "HEAD")] = "tagged-head"
+    values[("tag", "--points-at", "HEAD")] = "v0.11.2"
+    assert install._migration_authority() == "published"
+    values[("status", "--porcelain")] = " M rust/loopflow/src/store/migrations.rs"
+    assert install._migration_authority() == "validation_only"
+
+
 def test_promote_uses_worktree_build_and_replaces_installed_app(tmp_path: Path) -> None:
     local_bin = tmp_path / "local-bin"
     local_bin.mkdir()

--- a/python/tests/test_new_migration.py
+++ b/python/tests/test_new_migration.py
@@ -1,0 +1,41 @@
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "scripts/new_migration.py"
+MIGRATIONS = Path("rust/loopflow/src/store/migrations")
+
+
+def _git(repo: Path, *args: str) -> None:
+    subprocess.run(["git", *args], cwd=repo, check=True, capture_output=True)
+
+
+def test_allocator_counts_migrations_already_on_origin_main(tmp_path: Path) -> None:
+    (tmp_path / "scripts").mkdir()
+    (tmp_path / "scripts/new_migration.py").write_bytes(SCRIPT.read_bytes())
+    (tmp_path / MIGRATIONS).mkdir(parents=True)
+    (tmp_path / "Cargo.toml").write_text('[workspace.package]\nversion = "0.11.1"\n')
+    (tmp_path / MIGRATIONS / "0.11.001_initial.sql").write_text("SELECT 1;\n")
+    _git(tmp_path, "init", "-q")
+    _git(tmp_path, "config", "user.email", "test@example.com")
+    _git(tmp_path, "config", "user.name", "test")
+    _git(tmp_path, "add", ".")
+    _git(tmp_path, "commit", "-qm", "base")
+
+    (tmp_path / MIGRATIONS / "0.11.002_main.sql").write_text("SELECT 2;\n")
+    _git(tmp_path, "add", ".")
+    _git(tmp_path, "commit", "-qm", "main migration")
+    _git(tmp_path, "update-ref", "refs/remotes/origin/main", "HEAD")
+    _git(tmp_path, "checkout", "-qb", "feature", "HEAD~1")
+
+    result = subprocess.run(
+        [sys.executable, "scripts/new_migration.py", "feature"],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert (tmp_path / MIGRATIONS / "0.11.003_feature.sql").exists()

--- a/rust/loopflow/build.rs
+++ b/rust/loopflow/build.rs
@@ -110,8 +110,8 @@ fn emit_build_provenance(manifest_dir: &Path) {
             .display()
             .to_string()
     };
-    let migration_authority = env::var("LOOPFLOW_MIGRATION_AUTHORITY")
-        .unwrap_or_else(|_| "validation_only".to_string());
+    let migration_authority =
+        env::var("LOOPFLOW_MIGRATION_AUTHORITY").unwrap_or_else(|_| "validation_only".to_string());
     if !matches!(
         migration_authority.as_str(),
         "published" | "validation_only"

--- a/rust/loopflow/build.rs
+++ b/rust/loopflow/build.rs
@@ -5,6 +5,7 @@ use std::env;
 use std::fmt::Write as _;
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::process::Command;
 
 /// Category directories whose skill/flow names are registered flat (no prefix).
 /// Everything else is a namespaced category: names are stored as `<cat>/<name>`.
@@ -109,9 +110,59 @@ fn emit_build_provenance(manifest_dir: &Path) {
             .display()
             .to_string()
     };
+    let migration_authority = env::var("LOOPFLOW_MIGRATION_AUTHORITY")
+        .unwrap_or_else(|_| "validation_only".to_string());
+    if !matches!(
+        migration_authority.as_str(),
+        "published" | "validation_only"
+    ) {
+        panic!(
+            "LOOPFLOW_MIGRATION_AUTHORITY must be `published` or `validation_only`, got `{migration_authority}`"
+        );
+    }
+    let mut source_revision = git_root
+        .and_then(|root| {
+            Command::new("git")
+                .args(["rev-parse", "HEAD"])
+                .current_dir(root)
+                .output()
+                .ok()
+                .filter(|output| output.status.success())
+        })
+        .and_then(|output| String::from_utf8(output.stdout).ok())
+        .map(|revision| revision.trim().to_string())
+        .filter(|revision| !revision.is_empty())
+        .unwrap_or_else(|| "unknown".to_string());
+    let dirty = git_root.is_some_and(|root| {
+        Command::new("git")
+            .args(["status", "--porcelain"])
+            .current_dir(root)
+            .output()
+            .is_ok_and(|output| output.status.success() && !output.stdout.is_empty())
+    });
+    if dirty {
+        source_revision.push_str("-dirty");
+    }
     println!("cargo:rustc-env=LOOPFLOW_BUILD_PROVENANCE={provenance}");
     println!("cargo:rustc-env=LOOPFLOW_BUILD_SOURCE_ROOT={}", source_root);
+    println!("cargo:rustc-env=LOOPFLOW_MIGRATION_AUTHORITY={migration_authority}");
+    println!("cargo:rustc-env=LOOPFLOW_BUILD_SOURCE_REVISION={source_revision}");
     println!("cargo:rerun-if-env-changed=LOOPFLOW_BUILD_PROVENANCE");
+    println!("cargo:rerun-if-env-changed=LOOPFLOW_MIGRATION_AUTHORITY");
+    if let Some(root) = git_root {
+        for git_path in ["HEAD", "refs/heads"] {
+            if let Ok(output) = Command::new("git")
+                .args(["rev-parse", "--git-path", git_path])
+                .current_dir(root)
+                .output()
+            {
+                if output.status.success() {
+                    let path = String::from_utf8_lossy(&output.stdout);
+                    println!("cargo:rerun-if-changed={}", path.trim());
+                }
+            }
+        }
+    }
 }
 
 fn generate_map(dir: &Path, extension: &str, map_name: &str, out_path: &Path) {

--- a/rust/loopflow/src/build_info.rs
+++ b/rust/loopflow/src/build_info.rs
@@ -9,6 +9,12 @@ pub enum BuildProvenance {
     Release,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MigrationAuthority {
+    Published,
+    ValidationOnly,
+}
+
 impl BuildProvenance {
     pub fn as_str(self) -> &'static str {
         match self {
@@ -44,6 +50,18 @@ pub fn source_identity() -> String {
         .unwrap_or_else(|| "release".to_string())
 }
 
+pub fn source_revision() -> &'static str {
+    env!("LOOPFLOW_BUILD_SOURCE_REVISION")
+}
+
+pub fn migration_authority() -> MigrationAuthority {
+    match env!("LOOPFLOW_MIGRATION_AUTHORITY") {
+        "published" => MigrationAuthority::Published,
+        "validation_only" => MigrationAuthority::ValidationOnly,
+        _ => unreachable!("build script validates migration authority"),
+    }
+}
+
 fn parse_provenance(value: &str) -> Option<BuildProvenance> {
     match value {
         "development" => Some(BuildProvenance::Development),
@@ -74,7 +92,10 @@ fn source_identity_for(root: &Path) -> String {
 mod tests {
     use std::path::Path;
 
-    use super::{parse_provenance, provenance, source_identity_for, source_root, BuildProvenance};
+    use super::{
+        migration_authority, parse_provenance, provenance, source_identity_for, source_revision,
+        source_root, BuildProvenance, MigrationAuthority,
+    };
 
     #[test]
     fn source_identity_is_stable_and_distinguishes_worktrees() {
@@ -109,5 +130,10 @@ mod tests {
         );
         assert_eq!(parse_provenance("release"), Some(BuildProvenance::Release));
         assert_eq!(parse_provenance("other"), None);
+        assert!(matches!(
+            migration_authority(),
+            MigrationAuthority::Published | MigrationAuthority::ValidationOnly
+        ));
+        assert!(!source_revision().is_empty());
     }
 }

--- a/rust/loopflow/src/lf/commands/doctor.rs
+++ b/rust/loopflow/src/lf/commands/doctor.rs
@@ -75,6 +75,7 @@ struct DoctorReport<'a> {
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
 struct StoreReport {
     build_provenance: crate::build_info::BuildProvenance,
+    migration_authority: String,
     build_source_identity: String,
     build_source_root: Option<String>,
     database_path: String,
@@ -132,7 +133,7 @@ fn inspect_store(path: &Path) -> StoreReport {
                     Ok(version) => latest_applied_migration = version,
                     Err(error) => migration_error = Some(error.to_string()),
                 }
-                if let Err(error) = crate::store::migrations::latest_version_sqlite(&connection) {
+                if let Err(error) = crate::store::migrations::validate_sqlite(&connection) {
                     migration_error.get_or_insert_with(|| error.to_string());
                 }
             }
@@ -141,6 +142,11 @@ fn inspect_store(path: &Path) -> StoreReport {
     }
     StoreReport {
         build_provenance: crate::build_info::provenance(),
+        migration_authority: match crate::build_info::migration_authority() {
+            crate::build_info::MigrationAuthority::Published => "published",
+            crate::build_info::MigrationAuthority::ValidationOnly => "validation-only",
+        }
+        .to_string(),
         build_source_identity: crate::build_info::source_identity(),
         build_source_root: crate::build_info::source_root().map(|root| root.display().to_string()),
         database_path: path.display().to_string(),
@@ -628,8 +634,8 @@ fn day_of(ts: i64) -> Option<time::Date> {
 fn print_checks(store: &StoreReport, checks: &[Check], rows: usize) {
     let colors = Colors::default();
     println!(
-        "build: {} ({})",
-        store.build_provenance, store.build_source_identity
+        "build: {} ({}) · migrations {}",
+        store.build_provenance, store.build_source_identity, store.migration_authority
     );
     if let Some(root) = &store.build_source_root {
         println!("source: {root}");

--- a/rust/loopflow/src/store/MIGRATIONS.md
+++ b/rust/loopflow/src/store/MIGRATIONS.md
@@ -9,6 +9,10 @@ Write the SQL, paste the printed entry at the end of `MIGRATIONS` in
 `migrations.rs`, and you are done. The store applies every migration a database
 has not seen, in id order, exactly once.
 
+The allocator fetches and counts `origin/main` as well as the current worktree.
+CI compares the proposed chain with `origin/main`, so a concurrent branch that
+reuses an ordinal must rebase and allocate a new one before it can merge.
+
 The runner temporarily disables foreign-key actions around the transaction so a
 SQLite table rebuild cannot cascade-delete child history. It runs
 `PRAGMA foreign_key_check` before commit and restores enforcement afterward; a
@@ -22,11 +26,12 @@ history cannot be mistaken for the state being repaired.
 
 ## The one rule
 
-**A shipped migration is never edited, renamed, or deleted.** Databases in the
-wild already ran it; changing the file changes their history, not their schema.
-Repair a shipped schema with a new forward migration. `check_migrations.py`
-compares every migration against the last release tag and fails the build if one
-moved.
+**A published migration is never edited, renamed, or deleted.** `origin/main`
+is the publication boundary because creator dogfooding runs ahead of patch tags.
+Databases may already have run it; changing the file changes their history, not
+their schema. Repair a published schema with a new forward migration.
+`check_migrations.py` compares every migration against both `origin/main` and
+the last release tag and fails the build if one moved.
 
 ## What the check enforces
 
@@ -34,6 +39,7 @@ moved.
   same ids and names. A file nobody registered never runs; a registry entry whose
   id, name, and file disagree is a lie about what a database applied.
 - The registry is in id order, and no id is namespaced ahead of the package version.
+- Every migration already on `origin/main` has the same ordinal, name, and bytes.
 - Nothing that shipped in the last release tag has changed.
 
 It runs in CI, and — because `lf release` cuts a tag from local state and never
@@ -56,6 +62,10 @@ before anything is cut. Same script, both paths.
   `0.9.001` precedes `0.10.001`, which lexical order would invert.
 - The file stem *is* the `schema_migrations.version` string. `MigrationId` in
   `migrations.rs` is the only thing that formats or parses it.
+- The ledger records the SQL checksum, parent-history fingerprint, build
+  provenance, source checkout and revision, and package version. Old canonical
+  rows receive checksums when the provenance migration first runs; their writer
+  is intentionally left unknown rather than attributed to the upgrading build.
 - The active namespace comes from the workspace `Cargo.toml` version, so a
   migration authored ahead of the version is a release error, not a choice.
 
@@ -64,6 +74,7 @@ before anything is cut. Same script, both paths.
 | State | Message |
 | --- | --- |
 | Behind the chain | applies the missing tail and continues |
+| Unpublished build against `~/.lf/loopflow.db` | validates the applied prefix without running its pending migrations |
 | Pre-namespace `001_initial` stamp | adopted as `0.10.001_initial` — same bytes, no data moved |
 | Known leading migration names under branch-local ordinals | verifies the complete product schema, rewrites the ledger to canonical order, then continues |
 | Carries an unknown id | reports the unknown and latest-known ids — a newer release or a divergent local build wrote it |

--- a/rust/loopflow/src/store/migrations.rs
+++ b/rust/loopflow/src/store/migrations.rs
@@ -233,6 +233,15 @@ const MIGRATIONS: &[Migration] = &[
         name: "task_linear_observations",
         sql: include_str!("migrations/0.11.016_task_linear_observations.sql"),
     },
+    Migration {
+        id: MigrationId {
+            major: 0,
+            minor: 11,
+            ordinal: 17,
+        },
+        name: "migration_provenance",
+        sql: include_str!("migrations/0.11.017_migration_provenance.sql"),
+    },
 ];
 
 /// The exact branch-local history that reached one production ledger before
@@ -316,6 +325,27 @@ pub fn active_namespace() -> (u32, u32) {
 
 pub fn apply_sqlite(conn: &rusqlite::Connection) -> StoreResult<()> {
     apply_sqlite_transaction(conn, |_| Ok(()))
+}
+
+/// Validate the schema this binary already understands without advancing it.
+/// Branch builds use this against the release-owned database: they can reuse
+/// compatible state, but an unpublished migration never becomes durable there.
+pub(crate) fn validate_sqlite(conn: &rusqlite::Connection) -> StoreResult<()> {
+    validate_set(MIGRATIONS).map_err(StoreError::InvalidData)?;
+    if !user_tables(conn)?
+        .iter()
+        .any(|table| table == "schema_migrations")
+    {
+        return Err(StoreError::InvalidData(
+            "a validation-only lf cannot initialize the release database; install a published lf"
+                .to_string(),
+        ));
+    }
+    let applied = applied_versions(conn)?;
+    pending_migrations(&applied, MIGRATIONS)?;
+    validate_applied_checksums(conn, MIGRATIONS)?;
+    validate_schema(conn, &MIGRATIONS[..applied.len()])?;
+    validate_foreign_keys(conn)
 }
 
 fn apply_sqlite_transaction(
@@ -552,14 +582,119 @@ fn apply_set(conn: &rusqlite::Connection, set: &[Migration]) -> StoreResult<()> 
 
     let applied = applied_versions(conn)?;
     for migration in pending_migrations(&applied, set)? {
+        let parent_history = migration_prefix_fingerprint(&applied_versions(conn)?, set)?;
         conn.execute_batch(migration.sql)?;
+        backfill_known_checksums(conn, set)?;
+        insert_applied_migration(conn, migration, &parent_history)?;
+    }
+
+    validate_applied_checksums(conn, set)?;
+    validate_schema(conn, set)
+}
+
+fn migration_checksum(migration: &Migration) -> String {
+    hex::encode(Sha256::digest(migration.sql.as_bytes()))
+}
+
+fn migration_prefix_fingerprint(applied: &[String], set: &[Migration]) -> StoreResult<String> {
+    let mut digest = Sha256::new();
+    digest.update((applied.len() as u64).to_be_bytes());
+    for version in applied {
+        let migration = set
+            .iter()
+            .find(|migration| migration.version() == *version)
+            .ok_or_else(incompatible)?;
+        hash_text(&mut digest, version);
+        hash_text(&mut digest, &migration_checksum(migration));
+    }
+    Ok(hex::encode(digest.finalize()))
+}
+
+fn migration_ledger_has_provenance(conn: &rusqlite::Connection) -> StoreResult<bool> {
+    let mut statement = conn.prepare("PRAGMA table_info(schema_migrations)")?;
+    let columns = statement
+        .query_map([], |row| row.get::<_, String>(1))?
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok([
+        "checksum",
+        "parent_history",
+        "build_provenance",
+        "source_identity",
+        "source_revision",
+        "package_version",
+    ]
+    .iter()
+    .all(|required| columns.iter().any(|column| column == required)))
+}
+
+fn backfill_known_checksums(conn: &rusqlite::Connection, set: &[Migration]) -> StoreResult<()> {
+    if !migration_ledger_has_provenance(conn)? {
+        return Ok(());
+    }
+    for migration in set {
+        conn.execute(
+            "UPDATE schema_migrations SET checksum = ?1
+             WHERE version = ?2 AND checksum IS NULL",
+            (migration_checksum(migration), migration.version()),
+        )?;
+    }
+    Ok(())
+}
+
+fn insert_applied_migration(
+    conn: &rusqlite::Connection,
+    migration: &Migration,
+    parent_history: &str,
+) -> StoreResult<()> {
+    if migration_ledger_has_provenance(conn)? {
+        conn.execute(
+            "INSERT INTO schema_migrations (
+                version, applied_at, checksum, parent_history, build_provenance,
+                source_identity, source_revision, package_version
+             ) VALUES (?1, unixepoch(), ?2, ?3, ?4, ?5, ?6, ?7)",
+            (
+                migration.version(),
+                migration_checksum(migration),
+                parent_history,
+                crate::build_info::provenance().as_str(),
+                crate::build_info::source_identity(),
+                crate::build_info::source_revision(),
+                env!("CARGO_PKG_VERSION"),
+            ),
+        )?;
+    } else {
         conn.execute(
             "INSERT INTO schema_migrations (version, applied_at) VALUES (?1, unixepoch())",
             [migration.version()],
         )?;
     }
+    Ok(())
+}
 
-    validate_schema(conn, set)
+fn validate_applied_checksums(conn: &rusqlite::Connection, set: &[Migration]) -> StoreResult<()> {
+    if !migration_ledger_has_provenance(conn)? {
+        return Ok(());
+    }
+    let mut statement = conn.prepare(
+        "SELECT version, checksum FROM schema_migrations
+         WHERE checksum IS NOT NULL ORDER BY applied_at, rowid",
+    )?;
+    let rows = statement.query_map([], |row| {
+        Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+    })?;
+    for row in rows {
+        let (version, checksum) = row?;
+        let migration = set
+            .iter()
+            .find(|migration| migration.version() == version)
+            .ok_or_else(incompatible)?;
+        if checksum != migration_checksum(migration) {
+            return Err(StoreError::InvalidData(format!(
+                "database migration {version} checksum does not match this lf build"
+            )));
+        }
+    }
+    Ok(())
 }
 
 /// Canonicalize a ledger whose migration names are exactly a known leading
@@ -815,6 +950,12 @@ pub fn validate_set(set: &[Migration]) -> Result<(), String> {
 /// and foreign-key drift.
 fn validate_schema(conn: &rusqlite::Connection, set: &[Migration]) -> StoreResult<()> {
     let expected = rusqlite::Connection::open_in_memory()?;
+    expected.execute_batch(
+        "CREATE TABLE schema_migrations (
+            version TEXT PRIMARY KEY,
+            applied_at INTEGER NOT NULL
+        );",
+    )?;
     for migration in set {
         expected.execute_batch(migration.sql)?;
     }
@@ -969,8 +1110,8 @@ mod tests {
     use super::{
         active_namespace, applied_versions, apply_set, apply_sqlite, apply_sqlite_transaction,
         apply_sqlite_with_backup, backup_before_migration, latest_applied_version_sqlite,
-        latest_known_version, latest_version_sqlite, product_schema, validate_set, Migration,
-        MigrationId, DIVERGENT_MIGRATIONS, MIGRATIONS,
+        latest_known_version, latest_version_sqlite, product_schema, validate_set, validate_sqlite,
+        Migration, MigrationId, DIVERGENT_MIGRATIONS, MIGRATIONS,
     };
     use crate::task::TaskEventKind;
 
@@ -1131,7 +1272,7 @@ mod tests {
             .unwrap());
         assert_eq!(
             latest_version_sqlite(&conn).unwrap(),
-            "0.11.016_task_linear_observations"
+            latest_known_version()
         );
         assert!(product_schema(&conn)
             .unwrap()
@@ -1159,9 +1300,70 @@ mod tests {
                 "0.11.013_task_review_state".to_string(),
                 "0.11.014_task_lifecycle".to_string(),
                 "0.11.015_interaction_reviews".to_string(),
-                "0.11.016_task_linear_observations".to_string()
+                "0.11.016_task_linear_observations".to_string(),
+                "0.11.017_migration_provenance".to_string()
             ]
         );
+    }
+
+    #[test]
+    fn validation_only_open_does_not_apply_an_unpublished_tail() {
+        let conn = open();
+        apply_set(&conn, &MIGRATIONS[..MIGRATIONS.len() - 1]).unwrap();
+
+        validate_sqlite(&conn).unwrap();
+
+        assert_eq!(
+            latest_applied_version_sqlite(&conn).unwrap().as_deref(),
+            Some("0.11.016_task_linear_observations")
+        );
+        assert!(!columns(&conn, "schema_migrations")
+            .iter()
+            .any(|column| column == "checksum"));
+    }
+
+    #[test]
+    fn provenance_migration_records_checksums_and_the_applying_build() {
+        let conn = open();
+        apply_sqlite(&conn).unwrap();
+
+        let old_checksum: Option<String> = conn
+            .query_row(
+                "SELECT checksum FROM schema_migrations WHERE version = '0.10.001_initial'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        let applied_by: (String, String, String, String) = conn
+            .query_row(
+                "SELECT build_provenance, source_identity, source_revision, package_version
+                 FROM schema_migrations WHERE version = '0.11.017_migration_provenance'",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+            )
+            .unwrap();
+
+        assert!(old_checksum.is_some());
+        assert_eq!(applied_by.0, crate::build_info::provenance().as_str());
+        assert_eq!(applied_by.1, crate::build_info::source_identity());
+        assert_eq!(applied_by.2, crate::build_info::source_revision());
+        assert_eq!(applied_by.3, env!("CARGO_PKG_VERSION"));
+    }
+
+    #[test]
+    fn validation_rejects_a_recorded_checksum_mismatch() {
+        let conn = open();
+        apply_sqlite(&conn).unwrap();
+        conn.execute(
+            "UPDATE schema_migrations SET checksum = 'wrong'
+             WHERE version = '0.10.001_initial'",
+            [],
+        )
+        .unwrap();
+
+        let error = validate_sqlite(&conn).unwrap_err();
+
+        assert!(error.to_string().contains("checksum does not match"));
     }
 
     #[test]
@@ -1181,7 +1383,7 @@ mod tests {
             assert_eq!(
                 latest_version_sqlite(&conn)
                     .unwrap_or_else(|error| panic!("divergent prefix {count}: {error}")),
-                "0.11.016_task_linear_observations"
+                latest_known_version()
             );
             assert_eq!(
                 conn.query_row("SELECT COUNT(*) FROM waves", [], |row| row.get::<_, i64>(0))
@@ -1753,7 +1955,7 @@ mod tests {
         apply_sqlite(&conn).unwrap();
         assert_eq!(
             latest_version_sqlite(&conn).unwrap(),
-            "0.11.016_task_linear_observations"
+            latest_known_version()
         );
     }
 
@@ -1777,7 +1979,7 @@ mod tests {
         );
         assert_eq!(
             latest_version_sqlite(&conn).unwrap(),
-            "0.11.016_task_linear_observations"
+            latest_known_version()
         );
     }
 

--- a/rust/loopflow/src/store/migrations/0.11.017_migration_provenance.sql
+++ b/rust/loopflow/src/store/migrations/0.11.017_migration_provenance.sql
@@ -1,0 +1,7 @@
+-- Record the immutable migration bytes and the build that applied them.
+ALTER TABLE schema_migrations ADD COLUMN checksum TEXT;
+ALTER TABLE schema_migrations ADD COLUMN parent_history TEXT;
+ALTER TABLE schema_migrations ADD COLUMN build_provenance TEXT;
+ALTER TABLE schema_migrations ADD COLUMN source_identity TEXT;
+ALTER TABLE schema_migrations ADD COLUMN source_revision TEXT;
+ALTER TABLE schema_migrations ADD COLUMN package_version TEXT;

--- a/rust/loopflow/src/store/mod.rs
+++ b/rust/loopflow/src/store/mod.rs
@@ -221,6 +221,17 @@ fn guard_development_database(
     ))
 }
 
+fn may_apply_migrations(
+    path: &Path,
+    authority: crate::build_info::MigrationAuthority,
+    home: &Path,
+) -> Result<bool, std::io::Error> {
+    if authority == crate::build_info::MigrationAuthority::Published {
+        return Ok(true);
+    }
+    Ok(!same_database_file(path, &home.join(".lf/loopflow.db"))?)
+}
+
 fn same_database_file(left: &Path, right: &Path) -> Result<bool, std::io::Error> {
     if canonicalize_with_missing_tail(left)? == canonicalize_with_missing_tail(right)? {
         return Ok(true);
@@ -856,11 +867,11 @@ pub type SharedStore = Arc<Store>;
 mod tests {
     use super::sqlite::SqliteStore;
     use super::{
-        default_lf_home_dir_for, guard_development_database, open_store, select_store_env_value,
-        CredentialState, PmSnapshotRow, ProviderAccount, ProviderAccountId, RoutingState,
-        RunEventRow, StorageConfig,
+        default_lf_home_dir_for, guard_development_database, may_apply_migrations, open_store,
+        select_store_env_value, CredentialState, PmSnapshotRow, ProviderAccount, ProviderAccountId,
+        RoutingState, RunEventRow, StorageConfig,
     };
-    use crate::build_info::BuildProvenance;
+    use crate::build_info::{BuildProvenance, MigrationAuthority};
     use crate::child_session::{
         BoundaryResult, ChildBodyOutcome, ChildCommand, ChildCommandEffect, ChildCommandKind,
         ChildCommandSource, ChildCommandState, ChildDecisionId, ChildDirective, ChildLeaseState,
@@ -949,6 +960,24 @@ mod tests {
             .unwrap();
         guard_development_database(&production, BuildProvenance::Release, None::<&str>, home)
             .unwrap();
+    }
+
+    #[test]
+    fn only_published_builds_migrate_the_release_database() {
+        let directory = tempfile::tempdir().unwrap();
+        let home = directory.path();
+        let production = home.join(".lf/loopflow.db");
+
+        assert!(
+            !may_apply_migrations(&production, MigrationAuthority::ValidationOnly, home,).unwrap()
+        );
+        assert!(may_apply_migrations(&production, MigrationAuthority::Published, home,).unwrap());
+        assert!(may_apply_migrations(
+            &home.join(".lf-dev/branch/loopflow.db"),
+            MigrationAuthority::ValidationOnly,
+            home,
+        )
+        .unwrap());
     }
 
     #[cfg(unix)]

--- a/rust/loopflow/src/store/sqlite.rs
+++ b/rust/loopflow/src/store/sqlite.rs
@@ -293,13 +293,26 @@ impl SqliteStore {
             "PRAGMA journal_mode = WAL; PRAGMA busy_timeout = 5000; PRAGMA foreign_keys = ON;",
         )?;
 
-        if existing_database {
+        let may_apply_migrations = super::may_apply_migrations(
+            path,
+            crate::build_info::migration_authority(),
+            &super::machine_home_dir(),
+        )
+        .map_err(|error| {
+            StoreError::InvalidData(format!("resolve migration authority: {error}"))
+        })?;
+
+        if !may_apply_migrations {
+            super::migrations::validate_sqlite(&conn)?;
+        } else if existing_database {
             super::migrations::apply_sqlite_with_backup(&conn, path)?;
         } else {
             super::migrations::apply_sqlite(&conn)?;
         }
         validate_run_events_schema(&conn)?;
-        migrate_plaintext_provider_tokens(&mut conn)?;
+        if may_apply_migrations {
+            migrate_plaintext_provider_tokens(&mut conn)?;
+        }
 
         Ok(Self {
             conn: Arc::new(Mutex::new(conn)),

--- a/scripts/check_migrations.py
+++ b/scripts/check_migrations.py
@@ -3,8 +3,8 @@
 
 Fails when a migration is malformed, namespaced ahead of the package version,
 collides with another id, is not registered in Rust (or is registered under a
-different id or name), or — the rule that matters — when a migration that already
-shipped has been edited, renamed, or deleted.
+different id or name), diverges from current main, or — the rule that matters —
+when a migration that already shipped has been edited, renamed, or deleted.
 
 A shipped migration is immutable: databases in the wild have already run it, so
 changing it changes their history, not their schema. Repair a shipped schema with
@@ -17,6 +17,7 @@ Stdlib only, so `lf release` can run it directly without a Python environment.
 
 from __future__ import annotations
 
+import os
 import re
 import subprocess
 import sys
@@ -161,6 +162,68 @@ def _shipped_migrations(tag: str) -> dict[str, bytes]:
     return shipped
 
 
+def _migrations_at_ref(ref: str) -> dict[tuple[int, int, int], tuple[str, bytes]]:
+    exists = subprocess.run(
+        ["git", "rev-parse", "--verify", "--quiet", ref],
+        cwd=REPO_ROOT,
+        capture_output=True,
+    )
+    if exists.returncode != 0:
+        return {}
+    listed = subprocess.run(
+        [
+            "git",
+            "ls-tree",
+            "-r",
+            "--name-only",
+            ref,
+            "--",
+            str(MIGRATIONS_DIR.relative_to(REPO_ROOT)),
+        ],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    migrations = {}
+    for relative in listed.stdout.splitlines():
+        name = Path(relative).name
+        match = MIGRATION_NAME.match(name)
+        if not match:
+            continue
+        major, minor, ordinal, _ = match.groups()
+        content = subprocess.run(
+            ["git", "show", f"{ref}:{relative}"],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            check=True,
+        ).stdout
+        migrations[(int(major), int(minor), int(ordinal))] = (name, content)
+    return migrations
+
+
+def _check_current_main(local: dict[tuple[int, int, int], str]) -> None:
+    """Main is already durable history even before its next release tag."""
+    canonical = _migrations_at_ref("origin/main")
+    if not canonical:
+        if os.environ.get("GITHUB_ACTIONS") == "true":
+            _fail("origin/main is unavailable in CI; the integration-history check cannot run")
+        print("origin/main unavailable — skipping the integration-history check")
+        return
+    for key, (canonical_name, canonical_content) in canonical.items():
+        local_name = local.get(key)
+        if local_name is None:
+            _fail(f"{canonical_name} exists on origin/main but is missing from this branch")
+        if local_name != canonical_name:
+            identity = f"{key[0]}.{key[1]}.{key[2]:03d}"
+            _fail(
+                f"{local_name} collides with {canonical_name} on origin/main at {identity}; "
+                "rebase and allocate a new migration"
+            )
+        if (MIGRATIONS_DIR / local_name).read_bytes() != canonical_content:
+            _fail(f"{local_name} differs from origin/main and is already durable history")
+
+
 def _fail(message: str) -> None:
     print(f"migration check failed: {message}", file=sys.stderr)
     raise SystemExit(1)
@@ -196,6 +259,7 @@ def main() -> None:
         _fail("no migrations found")
 
     _check_registry(ids)
+    _check_current_main(ids)
 
     # Deterministic order across namespaces is the numeric tuple, never the string:
     # `0.10.001` sorts before `0.9.001` lexically.

--- a/scripts/check_migrations.py
+++ b/scripts/check_migrations.py
@@ -206,7 +206,7 @@ def _check_current_main(local: dict[tuple[int, int, int], str]) -> None:
     """Main is already durable history even before its next release tag."""
     canonical = _migrations_at_ref("origin/main")
     if not canonical:
-        if os.environ.get("GITHUB_ACTIONS") == "true":
+        if os.environ.get("LOOPFLOW_REQUIRE_ORIGIN_MAIN") == "1":
             _fail("origin/main is unavailable in CI; the integration-history check cannot run")
         print("origin/main unavailable — skipping the integration-history check")
         return

--- a/scripts/install.py
+++ b/scripts/install.py
@@ -173,13 +173,41 @@ def _refresh_default_branch(repo: Path = ROOT) -> None:
 # --- Builds ---
 
 
+def _migration_authority(repo: Path = ROOT) -> str:
+    """Only a canonical main or tagged checkout may advance the release store."""
+    head = _git_stdout(["rev-parse", "HEAD"], repo=repo, check=False)
+    if not head:
+        return "published"
+    default_ref = _git_stdout(
+        ["symbolic-ref", "--quiet", "refs/remotes/origin/HEAD"],
+        repo=repo,
+        check=False,
+    )
+    canonical = (
+        _git_stdout(["rev-parse", default_ref], repo=repo, check=False) if default_ref else ""
+    )
+    tagged = bool(_git_stdout(["tag", "--points-at", "HEAD"], repo=repo, check=False))
+    dirty = bool(_git_stdout(["status", "--porcelain"], repo=repo, check=False))
+    return "published" if not dirty and (head == canonical or tagged) else "validation_only"
+
+
+def _release_build_env() -> dict[str, str]:
+    return {
+        **os.environ,
+        "LOOPFLOW_BUILD_PROVENANCE": "release",
+        "LOOPFLOW_MIGRATION_AUTHORITY": os.environ.get(
+            "LOOPFLOW_MIGRATION_AUTHORITY", _migration_authority()
+        ),
+    }
+
+
 def _build_binaries() -> None:
     typer.echo("Building lf (cargo release)...")
     _run_or_raise(
         ["cargo", "build", "-p", "loopflow", "--release"],
         "cargo",
         cwd=ROOT,
-        env={**os.environ, "LOOPFLOW_BUILD_PROVENANCE": "release"},
+        env=_release_build_env(),
     )
 
 
@@ -189,7 +217,7 @@ def _build_cli_binaries() -> None:
         ["cargo", "build", "--release", "-p", "loopflow", "--bin", "lf"],
         "cargo",
         cwd=ROOT,
-        env={**os.environ, "LOOPFLOW_BUILD_PROVENANCE": "release"},
+        env=_release_build_env(),
     )
 
 

--- a/scripts/new_migration.py
+++ b/scripts/new_migration.py
@@ -6,12 +6,13 @@
 Writes `rust/loopflow/src/store/migrations/<major>.<minor>.<NNN>_<name>.sql` using
 the major.minor from Cargo.toml and the next free ordinal in that namespace, then
 prints the entry to append to MIGRATIONS in `store/migrations.rs`. Never renumber
-or edit an existing file: once released, an id is history.
+or edit an existing file: once published to main, an id is history.
 """
 
 from __future__ import annotations
 
 import re
+import subprocess
 import sys
 from pathlib import Path
 
@@ -19,6 +20,37 @@ REPO_ROOT = Path(__file__).parent.parent
 MIGRATIONS_DIR = REPO_ROOT / "rust/loopflow/src/store/migrations"
 MIGRATION_NAME = re.compile(r"^(\d+)\.(\d+)\.(\d{3})_([a-z0-9_]+)\.sql$")
 VERSION_LINE = re.compile(r'^version = "([^"]+)"', re.MULTILINE)
+
+
+def _authoritative_migration_names() -> list[str]:
+    default = subprocess.run(
+        ["git", "symbolic-ref", "--quiet", "refs/remotes/origin/HEAD"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    ref = default or "refs/remotes/origin/main"
+    branch = ref.removeprefix("refs/remotes/origin/")
+    subprocess.run(
+        ["git", "fetch", "--quiet", "origin", branch],
+        cwd=REPO_ROOT,
+        capture_output=True,
+    )
+    listed = subprocess.run(
+        [
+            "git",
+            "ls-tree",
+            "-r",
+            "--name-only",
+            ref,
+            "--",
+            str(MIGRATIONS_DIR.relative_to(REPO_ROOT)),
+        ],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+    )
+    return [Path(path).name for path in listed.stdout.splitlines()] if listed.returncode == 0 else []
 
 
 def main() -> None:
@@ -33,10 +65,12 @@ def main() -> None:
         raise SystemExit(1)
     major, minor, _ = match.group(1).split(".")
 
+    names = [path.name for path in MIGRATIONS_DIR.iterdir()]
+    names.extend(_authoritative_migration_names())
     used = [
         int(parsed.group(3))
-        for path in MIGRATIONS_DIR.iterdir()
-        if (parsed := MIGRATION_NAME.match(path.name))
+        for migration_name in names
+        if (parsed := MIGRATION_NAME.match(migration_name))
         and (parsed.group(1), parsed.group(2)) == (major, minor)
     ]
     ordinal = max(used, default=0) + 1


### PR DESCRIPTION
Closes the migration fire’s authoring boundary after #960 restored the live ledger.

- unpublished branch builds validate but never advance the release-owned database
- clean main/tag installs and official packages carry explicit migration authority
- applied migrations record SQL checksums, parent history, source/revision, provenance, and package version
- the allocator counts origin/main and CI rejects ordinal/name/content divergence from main
- doctor surfaces whether a binary has published or validation-only authority

Regression proof: 1,489 Rust tests, 62 Python tests, cargo clippy -D warnings, migration gate, and a copied live database remained at .016 when a branch binary knowing .017 opened it.