### PR TITLE
store: remove the development production-db escape hatch

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -97,12 +97,12 @@ and traces. Callers open it directly. Installed release builds share
 Builds made from a source checkout use
 `~/.lf-dev/worktrees/<source-identity>/loopflow.db`, so branches cannot migrate
 one another's development store. They refuse `~/.lf/loopflow.db` even when it
-arrives through `LF_DB_PATH`; `LF_ALLOW_PRODUCTION_DB_FROM_DEV=1` is the
-break-glass override. Release packaging stamps its provenance explicitly.
+arrives through `LF_DB_PATH`. Release packaging stamps its provenance
+explicitly; there is no development override for the release database.
 
 Session runners carry their pinned binary and store through the internal
 `LF_CONTROL_BIN`, `LF_CONTROL_HOME`, and `LF_CONTROL_DB_PATH` variables. Provider
-agents do not inherit `LF_BIN`, `LF_HOME`, `LF_DB_PATH`, or the break-glass flag.
+agents do not inherit `LF_BIN`, `LF_HOME`, or `LF_DB_PATH`.
 Before an existing on-disk database advances, SQLite writes an atomic backup
 named for the previously applied migration.
 

--- a/rust/loopflow/src/harness/mod.rs
+++ b/rust/loopflow/src/harness/mod.rs
@@ -31,8 +31,7 @@ pub(crate) fn configure_vendor_tokio_env(command: &mut tokio::process::Command) 
         .env(crate::store::CONTROL_DB_PATH_ENV, control_db)
         .env_remove("LF_BIN")
         .env_remove("LF_HOME")
-        .env_remove("LF_DB_PATH")
-        .env_remove(crate::store::DEV_PRODUCTION_DB_OPT_IN_ENV);
+        .env_remove("LF_DB_PATH");
     Ok(())
 }
 
@@ -54,8 +53,7 @@ fn set_vendor_std_env(
         .env(crate::store::CONTROL_DB_PATH_ENV, control_db)
         .env_remove("LF_BIN")
         .env_remove("LF_HOME")
-        .env_remove("LF_DB_PATH")
-        .env_remove(crate::store::DEV_PRODUCTION_DB_OPT_IN_ENV);
+        .env_remove("LF_DB_PATH");
 }
 
 #[derive(Debug, Clone)]
@@ -78,7 +76,6 @@ mod environment_tests {
             .env("LF_BIN", "/ambient/lf")
             .env("LF_HOME", "/production")
             .env("LF_DB_PATH", "/production/loopflow.db")
-            .env("LF_ALLOW_PRODUCTION_DB_FROM_DEV", "1")
             .env("LF_CONTROL_HOME", "/old-control");
 
         set_vendor_std_env(
@@ -95,7 +92,6 @@ mod environment_tests {
         assert_eq!(environment["LF_HOME"], None);
         assert_eq!(environment["LF_DB_PATH"], None);
         assert_eq!(environment["LF_BIN"], None);
-        assert_eq!(environment["LF_ALLOW_PRODUCTION_DB_FROM_DEV"], None);
         assert_eq!(
             environment["LF_CONTROL_BIN"],
             Some(OsString::from("/control/lf"))

--- a/rust/loopflow/src/store/mod.rs
+++ b/rust/loopflow/src/store/mod.rs
@@ -1,6 +1,6 @@
 //! Daemonless local persistence shared by `lf`, Waves, Projects, and Tasks.
 
-use std::ffi::{OsStr, OsString};
+use std::ffi::OsString;
 use std::path::{Component, Path, PathBuf};
 use std::sync::Arc;
 
@@ -110,7 +110,6 @@ impl StorageConfig {
 pub const CONTROL_BIN_ENV: &str = "LF_CONTROL_BIN";
 pub const CONTROL_HOME_ENV: &str = "LF_CONTROL_HOME";
 pub const CONTROL_DB_PATH_ENV: &str = "LF_CONTROL_DB_PATH";
-pub const DEV_PRODUCTION_DB_OPT_IN_ENV: &str = "LF_ALLOW_PRODUCTION_DB_FROM_DEV";
 
 fn machine_home_dir() -> PathBuf {
     dirs::home_dir().unwrap_or_else(|| PathBuf::from("."))
@@ -174,12 +173,7 @@ pub fn database_path_from_env() -> Result<PathBuf, std::io::Error> {
         }
         lf_home_dir().join(candidate)
     };
-    guard_development_database(
-        &path,
-        crate::build_info::provenance(),
-        std::env::var_os(DEV_PRODUCTION_DB_OPT_IN_ENV),
-        &machine_home_dir(),
-    )?;
+    guard_development_database(&path, crate::build_info::provenance(), &machine_home_dir())?;
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent)?;
     }
@@ -201,10 +195,9 @@ fn select_store_env_value(
 fn guard_development_database(
     path: &Path,
     provenance: crate::build_info::BuildProvenance,
-    opt_in: Option<impl AsRef<OsStr>>,
     home: &Path,
 ) -> Result<(), std::io::Error> {
-    if provenance.is_release() || opt_in.as_ref().is_some_and(|value| value.as_ref() == "1") {
+    if provenance.is_release() {
         return Ok(());
     }
     let production = home.join(".lf/loopflow.db");
@@ -214,7 +207,7 @@ fn guard_development_database(
     Err(std::io::Error::new(
         std::io::ErrorKind::PermissionDenied,
         format!(
-            "development lf ({}) refuses production database {}; use a release lf or set {DEV_PRODUCTION_DB_OPT_IN_ENV}=1 to break glass",
+            "development lf ({}) refuses production database {}; use an installed release lf",
             crate::build_info::source_identity(),
             production.display()
         ),
@@ -938,28 +931,14 @@ mod tests {
     }
 
     #[test]
-    fn development_production_gate_requires_exact_break_glass_value() {
+    fn development_production_gate_has_no_override() {
         let directory = tempfile::tempdir().unwrap();
         let home = directory.path();
         let production = home.join(".lf/loopflow.db");
-        assert!(guard_development_database(
-            &production,
-            BuildProvenance::Development,
-            None::<&str>,
-            home,
-        )
-        .is_err());
-        assert!(guard_development_database(
-            &production,
-            BuildProvenance::Development,
-            Some("true"),
-            home,
-        )
-        .is_err());
-        guard_development_database(&production, BuildProvenance::Development, Some("1"), home)
-            .unwrap();
-        guard_development_database(&production, BuildProvenance::Release, None::<&str>, home)
-            .unwrap();
+        assert!(
+            guard_development_database(&production, BuildProvenance::Development, home,).is_err()
+        );
+        guard_development_database(&production, BuildProvenance::Release, home).unwrap();
     }
 
     #[test]
@@ -995,7 +974,6 @@ mod tests {
         assert!(guard_development_database(
             &alias.join("loopflow.db"),
             BuildProvenance::Development,
-            None::<&str>,
             &home,
         )
         .is_err());
@@ -1010,7 +988,6 @@ mod tests {
         assert!(guard_development_database(
             &home.join(".lf/new/../loopflow.db"),
             BuildProvenance::Development,
-            None::<&str>,
             &home,
         )
         .is_err());
@@ -1027,13 +1004,7 @@ mod tests {
         let alias = directory.path().join("alias.db");
         std::fs::hard_link(&production, &alias).unwrap();
 
-        assert!(guard_development_database(
-            &alias,
-            BuildProvenance::Development,
-            None::<&str>,
-            &home,
-        )
-        .is_err());
+        assert!(guard_development_database(&alias, BuildProvenance::Development, &home,).is_err());
     }
 
     fn make_wave(repo: &str) -> Wave {

--- a/scripts/loopflow-dev.py
+++ b/scripts/loopflow-dev.py
@@ -49,7 +49,7 @@ LOOPFLOW_STREAM_LOG = DEV_LOG_DIR / f"{REPO_ROOT.name}.loopflow-run-debug.log"
 
 def _app_environment(repo: Path) -> dict[str, str]:
     env = {"LOOPFLOW_DEV_WAVE_REPO": str(repo)}
-    for key in ("LF_HOME", "LF_DB_PATH", "LF_ALLOW_PRODUCTION_DB_FROM_DEV"):
+    for key in ("LF_HOME", "LF_DB_PATH"):
         if value := os.environ.get(key):
             env[key] = value
     return env


### PR DESCRIPTION
Deletes LF_ALLOW_PRODUCTION_DB_FROM_DEV and removes the override from the store gate entirely. Development builds always use isolated stores and cannot open the release database, including through aliases or LF_DB_PATH. Installed release builds remain the only production-store entry point; unpublished release-provenance builds are still validation-only under #962.\n\nValidation: targeted Rust store and harness tests, 62 Python tests, cargo clippy --all-targets -- -D warnings, migration history check, and a binary proof that setting the deleted variable still returns PermissionDenied.