### PR TITLE
opencode: resolve bare `opencode` to the Loopflow-owned opencode/glm-5.2 default

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -203,12 +203,14 @@ Harnesses: `claude`, `codex`, `gemini`, `opencode`. Use `harness:model` for spec
 Gemini is supported for direct `lf` commands. Wave, Project, and Task Sessions
 require `claude`, `codex`, or `opencode`.
 
-OpenCode passes model strings through to its own provider system:
+OpenCode model strings use `provider/model` form. Bare `opencode` resolves to
+the Loopflow-owned `opencode/glm-5.2` default, which Loopflow sends explicitly
+so OpenCode config cannot silently fall back to a lower-capability model:
 
 ```yaml
-agent: opencode                          # use opencode's default model
-agent: opencode:anthropic/claude-sonnet  # explicit model
-agent: opencode:openai/gpt-4o            # any provider opencode supports
+agent: opencode                          # Loopflow default: opencode/glm-5.2
+agent: opencode:opencode/glm-5.2         # same default, explicit
+agent: opencode:moonshotai/kimi-k2       # explicit provider/model
 ```
 
 ### Supported Harnesses

--- a/rust/loopflow/src/engine/agent.rs
+++ b/rust/loopflow/src/engine/agent.rs
@@ -2138,6 +2138,19 @@ trust_level = "trusted"
     }
 
     #[test]
+    fn build_model_command_uses_loopflow_default_for_bare_opencode() {
+        let launch = AgentConfig {
+            agent: Some("opencode".to_string()),
+            ..default_launch()
+        };
+        let process = auto_process();
+        let cmd = build_model_command(&launch, &process, &AgentCapabilities::default());
+        assert_eq!(cmd.first(), Some(&"opencode".to_string()));
+        assert!(cmd.contains(&"--model".to_string()));
+        assert!(cmd.contains(&"opencode/glm-5.2".to_string()));
+    }
+
+    #[test]
     fn build_model_command_falls_back_to_claude_for_unknown_model() {
         let unknown_model = "gpt-5.1-codex-high";
         let launch = AgentConfig {

--- a/rust/loopflow/src/engine/config.rs
+++ b/rust/loopflow/src/engine/config.rs
@@ -259,7 +259,8 @@ impl Default for Config {
 /// - claude -> opus (Claude Opus 4.5)
 /// - gemini -> 2.5-pro (Gemini 2.5 Pro)
 /// - codex -> None (let Codex CLI pick its default)
-/// - opencode -> None (let OpenCode use its own config)
+/// - opencode -> opencode/glm-5.2 (Loopflow-owned default, sent explicitly so
+///   OpenCode config cannot silently fall back to a lower-capability model)
 pub fn parse_agent(agent: &str) -> (String, Option<String>) {
     if let Some((harness, model)) = agent.split_once(':') {
         return (harness.to_string(), Some(model.to_string()));
@@ -269,6 +270,7 @@ pub fn parse_agent(agent: &str) -> (String, Option<String>) {
     let default_model = match harness.as_str() {
         "claude" => Some("opus".to_string()),
         "gemini" => Some("2.5-pro".to_string()),
+        "opencode" => Some("opencode/glm-5.2".to_string()),
         _ => None,
     };
     (harness, default_model)
@@ -409,10 +411,10 @@ mod tests {
     }
 
     #[test]
-    fn parse_agent_opencode_no_default() {
+    fn parse_agent_opencode_default() {
         let (harness, model) = parse_agent("opencode");
         assert_eq!(harness, "opencode");
-        assert_eq!(model, None);
+        assert_eq!(model, Some("opencode/glm-5.2".to_string()));
     }
 
     #[test]

--- a/rust/loopflow/src/engine/launch.rs
+++ b/rust/loopflow/src/engine/launch.rs
@@ -193,12 +193,10 @@ fn validate_agent_policy(agent: &str) -> Result<(), CoreError> {
         return Ok(());
     }
 
-    let Some(variant) = variant else {
-        return Err(CoreError::ExecutionFailed(
-            "unsupported OpenCode model selection: use 'opencode:<provider>/<model>' and choose either 'opencode/*' (non-claude/non-codex) or 'moonshotai/kimi*'".to_string(),
-        ));
-    };
-
+    // `parse_agent` resolves bare `opencode` to the Loopflow-owned
+    // `opencode/glm-5.2` default, so a variant is always present for OpenCode.
+    // Validate explicit selections against the supported set.
+    let variant = variant.expect("parse_agent resolves a default model for the opencode harness");
     if is_supported_opencode_model_variant(&variant) {
         return Ok(());
     }
@@ -611,10 +609,10 @@ Test skill body.
     }
 
     #[test]
-    fn prepare_launch_prompt_rejects_bare_opencode_model() {
+    fn prepare_launch_prompt_accepts_bare_opencode_default() {
         let tmp = create_repo_fixture();
         let config = default_test_config();
-        let err = prepare_launch_prompt(
+        let prepared = prepare_launch_prompt(
             &config,
             LaunchPromptInput {
                 repo_root: tmp.path().to_path_buf(),
@@ -623,10 +621,11 @@ Test skill body.
                 ..LaunchPromptInput::default()
             },
         )
-        .expect_err("bare OpenCode model should fail");
+        .expect("bare OpenCode should resolve to the Loopflow-owned default");
 
-        assert!(err
-            .to_string()
-            .contains("unsupported OpenCode model selection"));
+        // The bare agent string is preserved; `parse_agent` resolves the
+        // `opencode/glm-5.2` default at consumption time so explicit selections
+        // still win.
+        assert_eq!(prepared.config.agent.as_deref(), Some("opencode"));
     }
 }

--- a/rust/loopflow/src/harness/opencode.rs
+++ b/rust/loopflow/src/harness/opencode.rs
@@ -720,4 +720,23 @@ mod tests {
         );
         assert!(payload.get("model").is_none());
     }
+
+    #[test]
+    fn build_turn_payload_uses_loopflow_default_for_bare_opencode() {
+        let payload = build_turn_payload(
+            "hello",
+            &AgentConfig {
+                agent: Some("opencode".to_string()),
+                ..Default::default()
+            },
+            false,
+        );
+        assert_eq!(
+            payload.get("model"),
+            Some(&json!({
+                "providerID": "opencode",
+                "modelID": "glm-5.2"
+            }))
+        );
+    }
 }


### PR DESCRIPTION
## Usage

```yaml
agent: opencode                          # Loopflow default: opencode/glm-5.2
agent: opencode:opencode/glm-5.2         # same default, explicit
agent: opencode:moonshotai/kimi-k2       # explicit provider/model
```

## Summary

Bare `opencode` used to pass no model, letting OpenCode's own config pick — which could silently fall back to a lower-capability model. Now `parse_agent` resolves bare `opencode` to the Loopflow-owned `opencode/glm-5.2` default, and Loopflow sends that model explicitly on every turn. Explicit `opencode:<provider>/<model>` selections still win.

## Changes

- `parse_agent` maps the `opencode` harness to a `opencode/glm-5.2` default model (was `None`).
- `validate_agent_policy` no longer rejects bare `opencode`; since a variant is always resolved, it just validates explicit selections against the supported set.
- Turn payloads for bare `opencode` now carry `{providerID: opencode, modelID: glm-5.2}`.
- Docs updated to describe the `provider/model` form and the Loopflow default; tests updated to assert the new default flows through `build_model_command`, `build_turn_payload`, and launch preparation.
