### PR TITLE
auth: isolate managed provider logins

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1346,7 +1346,6 @@ dependencies = [
  "rpassword",
  "rusqlite",
  "secrecy",
- "security-framework",
  "serde",
  "serde_json",
  "serde_urlencoded",

--- a/README.md
+++ b/README.md
@@ -571,18 +571,22 @@ Loopflow follows shared mappings to the owning browser identity.
 
 Codex account connection uses Codex's native local OAuth callback. Loopflow
 waits for the human to approve it and verifies the login email from Codex's ID
-token. It does not drive the OpenAI page or use device-code auth. Authenticate
-on the local host before `lf ssh`; SSH forwards the selected credential for the
+token. The resulting grant belongs to that account's home under
+`~/.lf/accounts/codex/`; Loopflow verifies it in a private staging home before
+replacing any working credential, and does not copy the ambient Codex login. It
+does not drive the OpenAI page or use device-code auth. Authenticate on the
+local host before `lf ssh`; SSH forwards the selected credential for the
 process lifetime.
 
-Claude authorization runs through Claude in Chrome when its browser extension
-is connected. If the controller is unavailable, Loopflow falls back to a hidden
-terminal prompt for the one-time handoff code. `profile create
+Claude authorization preselects the profile email and opens one browser window
+in the matching Chrome profile. After you click Authorize, Loopflow reads the
+resulting handoff from the visible page on macOS while restoring the clipboard.
+A hidden terminal prompt is the final fallback. `profile create
 --chrome-profile` binds the profile directory, name, or signed-in email on this
 host; `auth connect --profile` reuses that binding. `auth import` adopts an
-existing isolated Claude or Codex credential without another OAuth flow. When
-the account home is empty, it copies the current macOS Claude Keychain login or
-the ambient Codex OAuth login into the isolated account home.
+existing isolated Claude credential—or the current macOS Keychain login when
+the account home is empty—without another OAuth flow. Import migrates an
+existing grant; use `auth connect --profile` to create an independent grant.
 
 Each provider account keeps independent auth and session state under
 `~/.lf/accounts/`. Profiles reuse those accounts and give each repository a
@@ -596,17 +600,20 @@ treats the account as `explicit-only`; clear the date and set `automatic` if a
 downgraded account should remain a normal fallback.
 
 ```bash
-lf ssh mini -- lf wave product
+lf ssh mini -- lf pr open
 ```
 
 `lf ssh` forwards the current repository's ordered profile route and each
 referenced Claude or Codex credential once, even when profiles share an
-account. It writes no credential files on the remote host. Provider-child
-restarts inherit the routing lease and its accrued cooldowns. Before connecting,
-the local provider CLIs validate or refresh each automatically eligible routed
-login; `lf ssh` fails instead of sending an incomplete route. After the Wave,
-tmux session, or host restarts, start or reconnect from the local machine to
-resolve and forward fresh credentials.
+account. It writes no credential files on the remote host. Before connecting,
+Loopflow validates each automatically eligible routed login and refreshes Codex
+when due; `lf ssh` fails instead of sending an incomplete route.
+
+Forwarded profile auth lasts only for the foreground SSH command. Loopflow
+rejects its own detached Wave, Project, and Task sessions, plus direct remote
+tmux commands, because their credentials would disappear when SSH exits. Other
+shell or daemon detachment is unsupported. Authenticate on the remote host for
+detached or long-running work.
 
 ```bash
 lf status product          # inspect live execution and attention in one Wave

--- a/rust/loopflow/Cargo.toml
+++ b/rust/loopflow/Cargo.toml
@@ -75,9 +75,6 @@ tokio-util = { version = "0.7", features = ["rt"] }
 tower-http = { version = "0.7", features = ["trace"] }
 tempfile = "3.27"
 
-[target.'cfg(target_os = "macos")'.dependencies]
-security-framework = "3"
-
 [dev-dependencies]
 loopflow-test-support = { path = "../loopflow-test-support" }
 tokio = { version = "1", features = ["test-util"] }

--- a/rust/loopflow/src/engine/process.rs
+++ b/rust/loopflow/src/engine/process.rs
@@ -397,6 +397,10 @@ pub(crate) async fn start_lf_session_with_env(
     argv: &[String],
     env: &[(&str, &str)],
 ) -> Result<()> {
+    reject_detached_forwarded_profile(
+        std::env::var_os(crate::provider_account::FORWARDED_PROFILE_BUNDLE_ENV)
+            .is_some_and(|value| !value.is_empty()),
+    )?;
     let context = pinned_execution_context()?;
     let inherited_context = ["LF_RUN_ID", "LF_PROCESS_ID"]
         .into_iter()
@@ -419,6 +423,16 @@ pub(crate) async fn start_lf_session_with_env(
         .collect::<Vec<_>>();
     let shell_command = lf_session_shell_command(argv, &environment);
     start_tmux_session(session, &cwd.display().to_string(), &shell_command).await
+}
+
+fn reject_detached_forwarded_profile(forwarded: bool) -> Result<()> {
+    if forwarded {
+        return Err(anyhow!(
+            "cannot launch a detached session from an ephemeral forwarded provider profile; \
+             keep the remote command in the foreground or authenticate on the remote host"
+        ));
+    }
+    Ok(())
 }
 
 fn extend_session_control_context(
@@ -534,7 +548,8 @@ mod tests {
 
     use super::{
         extend_session_control_context, lf_session_shell_command, reap_child_process,
-        select_binary_override, select_current_home_binary, tmux_installed,
+        reject_detached_forwarded_profile, select_binary_override, select_current_home_binary,
+        tmux_installed,
     };
     use crate::build_info::BuildProvenance;
     use crate::child_session::ChildExecutionContext;
@@ -667,6 +682,15 @@ mod tests {
             command,
             "unset LF_RUN_ID LF_PROCESS_ID LF_WAVE_ID LF_CHANNEL LF_PROJECT_SESSION_ID LF_PROJECT_GENERATION LF_PROJECT_LEASE_TOKEN LF_TASK_SESSION_ID LF_TASK_GENERATION LF_TASK_LEASE_TOKEN LF_BIN LF_HOME LF_DB_PATH LF_CONTROL_BIN LF_CONTROL_HOME LF_CONTROL_DB_PATH; exec env 'LF_RUN_ID'='run-1' 'LF_PROCESS_ID'='process-1' 'LF_DB_PATH'='/tmp/current.db' 'LF_HOME'='/tmp/lf' 'lf' '__task'"
         );
+    }
+
+    #[test]
+    fn detached_session_rejects_an_ephemeral_forwarded_profile() {
+        assert!(reject_detached_forwarded_profile(false).is_ok());
+        assert!(reject_detached_forwarded_profile(true)
+            .unwrap_err()
+            .to_string()
+            .contains("cannot launch a detached session"));
     }
 
     #[tokio::test]

--- a/rust/loopflow/src/lf/commands/auth.rs
+++ b/rust/loopflow/src/lf/commands/auth.rs
@@ -1,7 +1,10 @@
-#[cfg(target_os = "macos")]
+use std::fs;
+use std::fs::OpenOptions;
 use std::path::Path;
 use std::path::PathBuf;
 use std::process::Command;
+#[cfg(target_os = "macos")]
+use std::process::Stdio;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -19,11 +22,10 @@ use crate::provider_account::{
     parse_account_id, remove_account_profile,
 };
 use crate::provider_auth::{
-    capture_claude_profile_credentials, capture_codex_profile_credentials,
-    disconnect_provider_account_auth, drive_claude_browser_authorization, no_event_sink,
+    capture_claude_authorization_code_from_chrome, capture_claude_profile_credentials,
+    disconnect_provider_account_auth, import_ambient_claude_profile_credentials, no_event_sink,
     prepare_provider_account_access_token, provider_account_auth_status,
-    start_provider_account_auth, AuthStatus, ClaudeKeychainGuard, Provider, ProviderAuthService,
-    ProviderAuthSnapshot,
+    start_provider_account_auth, AuthStatus, Provider, ProviderAuthService, ProviderAuthSnapshot,
 };
 use crate::store::{
     open_store, CredentialState, CredentialType, ProviderAccount, ProviderAccountId, ProviderToken,
@@ -192,15 +194,18 @@ async fn connect_managed_account(
     chrome_profile: LocalChromeProfile,
 ) -> Result<()> {
     let account_home = ensure_account_profile(provider, &account_id)?;
-    let controller_profile = (provider == Provider::Claude
-        && account_home.join(".credentials.json").is_file())
-    .then(|| account_home.clone());
-    let keychain_guard = if provider == Provider::Claude {
-        Some(ClaudeKeychainGuard::preserve()?)
-    } else {
-        None
-    };
-    let handle = start_provider_account_auth(provider, account_home.clone()).await?;
+    let _login_lock = acquire_managed_login_lock(&account_home, provider, &account_id)?;
+    let parent = account_home
+        .parent()
+        .ok_or_else(|| anyhow!("account home has no parent directory"))?;
+    let login_home = tempfile::Builder::new()
+        .prefix(".login-")
+        .tempdir_in(parent)
+        .context("create private provider login home")?;
+    let auth_home = login_home.path().to_path_buf();
+    let handle =
+        start_provider_account_auth(provider, auth_home.clone(), chrome_profile.login.as_deref())
+            .await?;
     let flow = handle.response.clone();
     let verification_url = flow
         .verification_uri_complete
@@ -213,26 +218,21 @@ async fn connect_managed_account(
     );
     if handle.requires_authorization_code() {
         open_chrome_profile(&chrome_profile, &verification_url)?;
-        println!("Authorizing with Claude in Chrome...");
-        if let Some(code) = drive_claude_browser_authorization(
+        println!("Approve authorization in the browser.");
+        let code = match capture_claude_authorization_code_from_chrome(
             &verification_url,
-            controller_profile.as_deref(),
-            Some(chrome_profile.label.as_str()),
+            chrome_profile.name.as_str(),
         )
         .await?
         {
-            handle
-                .submit_authorization_code(code.expose_secret())
-                .await?;
-        } else {
-            println!("Chrome controller unavailable; complete authorization in the browser.");
-            let code = SecretString::new(rpassword::prompt_password(
-                "Paste the one-time code from the browser: ",
-            )?);
-            handle
-                .submit_authorization_code(code.expose_secret())
-                .await?;
-        }
+            Some(code) => code,
+            None => SecretString::new(rpassword::prompt_password(
+                "Browser handoff unavailable; paste the one-time code: ",
+            )?),
+        };
+        handle
+            .submit_authorization_code(code.expose_secret())
+            .await?;
     } else {
         println!("Complete authorization in the browser.");
         open_chrome_profile(&chrome_profile, &verification_url)?;
@@ -247,25 +247,13 @@ async fn connect_managed_account(
             )
         })??;
 
-    let observed_claude_login = if provider == Provider::Claude {
-        capture_claude_profile_credentials(&account_home)?;
-        let login = match provider_account_auth_status(provider, account_home.clone()).await? {
-            AuthStatus::Active { login } => login,
-            _ => None,
-        };
-        require_managed_access_token(provider, &account_id, &account_home).await?;
-        if let Some(guard) = keychain_guard {
-            guard.restore()?;
+    let login = match provider {
+        Provider::Claude => {
+            capture_claude_profile_credentials(&auth_home)?;
+            require_managed_access_token(provider, &account_id, &auth_home).await?;
+            None
         }
-        login
-    } else {
-        None
-    };
-
-    let login = if provider == Provider::Claude {
-        observed_claude_login
-    } else {
-        match provider_account_auth_status(provider, account_home.clone()).await? {
+        Provider::Codex => match provider_account_auth_status(provider, auth_home.clone()).await? {
             AuthStatus::Active { login } => login,
             other => {
                 return Err(anyhow!(
@@ -275,9 +263,15 @@ async fn connect_managed_account(
                     other.as_str()
                 ))
             }
-        }
+        },
+        _ => return Err(anyhow!("unsupported managed provider '{provider}'")),
     };
     let login = resolve_profile_login(provider, Some(&chrome_profile), login)?;
+    match provider {
+        Provider::Claude => install_claude_login(login_home.path(), &account_home)?,
+        Provider::Codex => install_codex_login(login_home.path(), &account_home)?,
+        _ => return Err(anyhow!("unsupported managed provider '{provider}'")),
+    }
     register_managed_account(
         store,
         provider,
@@ -293,6 +287,53 @@ async fn connect_managed_account(
         profile_id
     );
     Ok(())
+}
+
+fn acquire_managed_login_lock(
+    account_home: &Path,
+    provider: Provider,
+    account_id: &ProviderAccountId,
+) -> Result<fs::File> {
+    let lock = OpenOptions::new()
+        .create(true)
+        .read(true)
+        .write(true)
+        .truncate(false)
+        .open(account_home.join(".login.lock"))
+        .context("open managed login lock")?;
+    fs2::FileExt::try_lock_exclusive(&lock).map_err(|error| {
+        if error.kind() == std::io::ErrorKind::WouldBlock {
+            anyhow!(
+                "another {} login is already in progress for account '{}'",
+                provider.display_name(),
+                account_id
+            )
+        } else {
+            anyhow!(
+                "could not lock {} account '{}' for login: {error}",
+                provider.display_name(),
+                account_id
+            )
+        }
+    })?;
+    Ok(lock)
+}
+
+fn install_codex_login(login_home: &Path, account_home: &Path) -> Result<()> {
+    let source = login_home.join("auth.json");
+    if !source.is_file() {
+        return Err(anyhow!("Codex login did not produce an OAuth credential"));
+    }
+    fs::rename(source, account_home.join("auth.json")).context("install verified Codex credential")
+}
+
+fn install_claude_login(login_home: &Path, account_home: &Path) -> Result<()> {
+    let source = login_home.join(".credentials.json");
+    if !source.is_file() {
+        return Err(anyhow!("Claude login did not produce an OAuth credential"));
+    }
+    fs::rename(source, account_home.join(".credentials.json"))
+        .context("install verified Claude credential")
 }
 
 async fn register_managed_account(
@@ -424,21 +465,24 @@ async fn import_account(
     raw_chrome_profile: Option<&str>,
 ) -> Result<()> {
     let provider = parse_managed_provider(raw_provider)?;
+    if provider != Provider::Claude {
+        return Err(anyhow!(
+            "existing login import is supported for Claude only"
+        ));
+    }
     let account_id = parse_account_id(raw_account)?;
     let provider_profile = ensure_account_profile(provider, &account_id)?;
+    let profile_id = raw_profile
+        .map(ProfileId::parse)
+        .transpose()
+        .map_err(anyhow::Error::msg)?;
     let chrome_profile = resolve_auth_chrome_profile(raw_profile, raw_chrome_profile).await?;
     let paired_login = chrome_profile
         .as_ref()
-        .map(|profile| profile.label.as_str())
-        .filter(|label| label.contains('@'))
+        .and_then(|profile| profile.login.as_deref())
         .map(String::from);
 
-    let credential_exists = match provider {
-        Provider::Claude => provider_profile.join(".credentials.json").is_file(),
-        Provider::Codex => provider_profile.join("auth.json").is_file(),
-        _ => false,
-    };
-    let login = if credential_exists {
+    let login = if provider_profile.join(".credentials.json").is_file() {
         match provider_account_auth_status(provider, provider_profile.clone()).await? {
             AuthStatus::Active { login } => login,
             other => {
@@ -451,46 +495,36 @@ async fn import_account(
             }
         }
     } else {
-        match provider {
-            Provider::Claude => {
-                let ambient = read_ambient_claude_status()?;
-                if !ambient.logged_in {
-                    return Err(anyhow!("the ambient Claude CLI is not logged in"));
-                }
-                if let (Some(expected), Some(actual)) =
-                    (paired_login.as_deref(), ambient.email.as_deref())
-                {
-                    if !expected.eq_ignore_ascii_case(actual) {
-                        return Err(anyhow!(
-                            "ambient Claude login '{}' does not match paired Chrome profile '{}'",
-                            actual,
-                            expected
-                        ));
-                    }
-                }
-                capture_claude_profile_credentials(&provider_profile)?;
-                ambient.email.or(paired_login)
-            }
-            Provider::Codex => {
-                capture_codex_profile_credentials(&provider_profile)?;
-                match provider_account_auth_status(provider, provider_profile.clone()).await? {
-                    AuthStatus::Active { login } => login,
-                    other => {
-                        return Err(anyhow!(
-                            "ambient Codex credential produced status {}",
-                            other.as_str()
-                        ))
-                    }
-                }
-            }
-            _ => return Err(anyhow!("{} account import is unsupported", provider)),
+        let ambient = read_ambient_claude_status()?;
+        if !ambient.logged_in {
+            return Err(anyhow!("the ambient Claude CLI is not logged in"));
         }
+        if let (Some(expected), Some(actual)) = (paired_login.as_deref(), ambient.email.as_deref())
+        {
+            if !expected.eq_ignore_ascii_case(actual) {
+                return Err(anyhow!(
+                    "ambient Claude login '{}' does not match paired Chrome profile '{}'",
+                    actual,
+                    expected
+                ));
+            }
+        }
+        import_ambient_claude_profile_credentials(&provider_profile)?;
+        ambient.email.or(paired_login)
     };
 
     require_managed_access_token(provider, &account_id, &provider_profile).await?;
     let login = resolve_profile_login(provider, chrome_profile.as_ref(), login)?;
     let store = open_account_store().await?;
-    register_managed_account(&store, provider, &account_id, provider_profile, login, None).await?;
+    register_managed_account(
+        &store,
+        provider,
+        &account_id,
+        provider_profile,
+        login,
+        profile_id.as_ref(),
+    )
+    .await?;
     println!(
         "Imported {} account '{}'",
         provider.display_name(),
@@ -565,10 +599,23 @@ async fn resolve_profile_chrome_profile(
                 profile_id
             )
         })?;
-    Ok(LocalChromeProfile {
-        directory: binding.chrome_directory,
-        label: binding.profile_id.to_string(),
-    })
+    let chrome_profile = crate::profile::resolve_local_chrome_profile(&binding.chrome_directory)
+        .map_err(anyhow::Error::msg)?;
+    let login = chrome_profile.login.as_deref().ok_or_else(|| {
+        anyhow!(
+            "Chrome profile '{}' has no signed-in account",
+            chrome_profile.name
+        )
+    })?;
+    if !login.eq_ignore_ascii_case(profile_id.as_str()) {
+        return Err(anyhow!(
+            "Chrome profile '{}' is signed in as '{}', not '{}'",
+            chrome_profile.name,
+            login,
+            profile_id
+        ));
+    }
+    Ok(chrome_profile)
 }
 
 fn resolve_profile_login(
@@ -576,9 +623,7 @@ fn resolve_profile_login(
     chrome_profile: Option<&LocalChromeProfile>,
     provider_login: Option<String>,
 ) -> Result<Option<String>> {
-    let expected_login = chrome_profile
-        .map(|profile| profile.label.as_str())
-        .filter(|label| label.contains('@'));
+    let expected_login = chrome_profile.and_then(|profile| profile.login.as_deref());
     let Some(expected) = expected_login else {
         return Ok(provider_login);
     };
@@ -607,16 +652,19 @@ fn open_chrome_profile(profile: &LocalChromeProfile, url: &str) -> Result<()> {
     if !chrome.is_file() {
         return Err(anyhow!("Google Chrome is not installed in /Applications"));
     }
-    let status = Command::new(chrome)
+    let status = Command::new("open")
+        .args(["-n", "-a", "Google Chrome", "--args"])
         .arg(format!("--profile-directory={}", profile.directory))
         .arg("--new-window")
         .arg(url)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
         .status()
         .context("open matching Chrome profile")?;
     if !status.success() {
         return Err(anyhow!(
             "Google Chrome could not open profile '{}'",
-            profile.label
+            profile.name
         ));
     }
     Ok(())
@@ -1028,6 +1076,7 @@ fn format_relative_delta(seconds: i64) -> String {
 
 #[cfg(test)]
 mod tests {
+    use std::fs;
     use std::path::PathBuf;
     use std::sync::Arc;
 
@@ -1043,8 +1092,9 @@ mod tests {
     };
 
     use super::{
-        account_for_profile, account_id_for_profile, format_account, format_relative_delta,
-        format_snapshot, parse_paid_through, parse_routing_state, register_managed_account,
+        account_for_profile, account_id_for_profile, acquire_managed_login_lock, format_account,
+        format_relative_delta, format_snapshot, import_account, install_claude_login,
+        install_codex_login, parse_paid_through, parse_routing_state, register_managed_account,
         resolve_profile_login,
     };
 
@@ -1168,11 +1218,74 @@ mod tests {
         assert_eq!(format_relative_delta(172_800), "2d");
     }
 
+    #[tokio::test]
+    async fn codex_login_cannot_be_created_by_importing_ambient_credentials() {
+        let error = import_account("codex", "engineering", None, None)
+            .await
+            .expect_err("Codex imports must require a direct login");
+
+        assert!(error
+            .to_string()
+            .contains("existing login import is supported for Claude only"));
+    }
+
+    #[test]
+    fn verified_codex_login_replaces_the_previous_credential() {
+        let parent = tempfile::tempdir().unwrap();
+        let login_home = parent.path().join("login");
+        let account_home = parent.path().join("account");
+        fs::create_dir_all(&login_home).unwrap();
+        fs::create_dir_all(&account_home).unwrap();
+        fs::write(login_home.join("auth.json"), "verified").unwrap();
+        fs::write(account_home.join("auth.json"), "previous").unwrap();
+
+        install_codex_login(&login_home, &account_home).unwrap();
+
+        assert_eq!(
+            fs::read_to_string(account_home.join("auth.json")).unwrap(),
+            "verified"
+        );
+        assert!(!login_home.join("auth.json").exists());
+    }
+
+    #[test]
+    fn verified_claude_login_replaces_the_previous_credential() {
+        let parent = tempfile::tempdir().unwrap();
+        let login_home = parent.path().join("login");
+        let account_home = parent.path().join("account");
+        fs::create_dir_all(&login_home).unwrap();
+        fs::create_dir_all(&account_home).unwrap();
+        fs::write(login_home.join(".credentials.json"), "verified").unwrap();
+        fs::write(account_home.join(".credentials.json"), "previous").unwrap();
+
+        install_claude_login(&login_home, &account_home).unwrap();
+
+        assert_eq!(
+            fs::read_to_string(account_home.join(".credentials.json")).unwrap(),
+            "verified"
+        );
+        assert!(!login_home.join(".credentials.json").exists());
+    }
+
+    #[test]
+    fn concurrent_login_for_the_same_account_is_rejected() {
+        let account_home = tempfile::tempdir().unwrap();
+        let account_id = ProviderAccountId::parse("engineering").unwrap();
+        let _first =
+            acquire_managed_login_lock(account_home.path(), Provider::Codex, &account_id).unwrap();
+
+        let error = acquire_managed_login_lock(account_home.path(), Provider::Codex, &account_id)
+            .expect_err("second login must not open another browser flow");
+
+        assert!(error.to_string().contains("already in progress"));
+    }
+
     #[test]
     fn codex_profile_and_provider_login_must_name_the_same_account() {
         let chrome_profile = LocalChromeProfile {
             directory: "Profile 7".to_string(),
-            label: "primary@example.com".to_string(),
+            name: "Primary".to_string(),
+            login: Some("primary@example.com".to_string()),
         };
 
         assert_eq!(
@@ -1197,7 +1310,8 @@ mod tests {
     fn claude_uses_the_selected_profile_when_status_omits_email() {
         let chrome_profile = LocalChromeProfile {
             directory: "Profile 7".to_string(),
-            label: "primary@example.com".to_string(),
+            name: "Primary".to_string(),
+            login: Some("primary@example.com".to_string()),
         };
 
         assert_eq!(

--- a/rust/loopflow/src/lf/commands/profile.rs
+++ b/rust/loopflow/src/lf/commands/profile.rs
@@ -58,14 +58,17 @@ async fn create_profile(
         .transpose()
         .map_err(anyhow::Error::msg)?;
     if let Some(chrome_profile) = &chrome_profile {
-        if !chrome_profile
-            .label
-            .eq_ignore_ascii_case(profile_id.as_str())
-        {
+        let login = chrome_profile.login.as_deref().ok_or_else(|| {
+            anyhow!(
+                "Chrome profile '{}' has no signed-in account",
+                raw_chrome_profile.expect("resolved Chrome profile has an input")
+            )
+        })?;
+        if !login.eq_ignore_ascii_case(profile_id.as_str()) {
             return Err(anyhow!(
                 "Chrome profile '{}' is signed in as '{}', not '{}'",
                 raw_chrome_profile.expect("resolved Chrome profile has an input"),
-                chrome_profile.label,
+                login,
                 profile_id
             ));
         }

--- a/rust/loopflow/src/lf/commands/ssh.rs
+++ b/rust/loopflow/src/lf/commands/ssh.rs
@@ -5,6 +5,8 @@
 //! machine, forwarded into the remote process environment as a stdin preamble
 //! (never in argv, `ps`, or logs), and are NOT persisted on the remote — they
 //! die with the process. The remote host stays a stateless compute surface.
+//! Detached work is rejected when a profile bundle is forwarded because it
+//! would outlive that credential lease.
 //!
 //! Forwarded bundle: GitHub (`gh`), Claude/Codex agent OAuth, and — the
 //! capability beyond the shell prototype — the PM/Linear token, which lives in
@@ -113,6 +115,8 @@ pub fn capture_routed(
     let credentials = runtime
         .block_on(resolve_credentials(&[]))
         .map_err(|error| SshCaptureError::Local(error.to_string()))?;
+    reject_detached_profile_forwarding(credentials.profile_bundle.is_some(), cmd)
+        .map_err(|error| SshCaptureError::Local(error.to_string()))?;
     let preamble = build_preamble(
         &credentials,
         dest,
@@ -146,8 +150,22 @@ fn run_with_env(
     let repo = repo.unwrap_or(DEFAULT_REPO);
     let runtime = tokio::runtime::Runtime::new().context("failed to create async runtime")?;
     let credentials = runtime.block_on(resolve_credentials(secret_names))?;
+    reject_detached_profile_forwarding(credentials.profile_bundle.is_some(), cmd)?;
     let preamble = build_preamble(&credentials, dest, repo, cmd, extra_env);
     run_ssh(dest, port, forward_agent, &preamble)
+}
+
+fn reject_detached_profile_forwarding(
+    has_profile_bundle: bool,
+    cmd: &[String],
+) -> anyhow::Result<()> {
+    if has_profile_bundle && cmd.first().is_some_and(|program| program == "tmux") {
+        return Err(anyhow!(
+            "cannot forward ephemeral provider profiles into a remote tmux command; \
+             run the remote command in the foreground or authenticate on the remote host"
+        ));
+    }
+    Ok(())
 }
 
 /// Resolve the credential bundle from local sources. Auth tokens that aren't
@@ -615,6 +633,17 @@ mod tests {
             pm_provider: Some("linear".to_string()),
             secrets: vec![("STRIPE_KEY".to_string(), "sk-live-123".to_string())],
         }
+    }
+
+    #[test]
+    fn remote_tmux_rejects_ephemeral_profile_forwarding() {
+        let cmd = vec!["tmux".to_string(), "list-sessions".to_string()];
+
+        assert!(reject_detached_profile_forwarding(false, &cmd).is_ok());
+        assert!(reject_detached_profile_forwarding(true, &cmd)
+            .unwrap_err()
+            .to_string()
+            .contains("remote tmux"));
     }
 
     #[test]

--- a/rust/loopflow/src/lf/mod.rs
+++ b/rust/loopflow/src/lf/mod.rs
@@ -1502,7 +1502,7 @@ pub enum AuthCommand {
         #[arg(long)]
         profile: Option<String>,
     },
-    /// Adopt an existing Claude or Codex OAuth login into a managed account
+    /// Adopt an existing Claude login into a managed account
     Import {
         provider: String,
         /// Create or register this isolated OAuth account profile

--- a/rust/loopflow/src/profile.rs
+++ b/rust/loopflow/src/profile.rs
@@ -95,7 +95,8 @@ impl fmt::Display for HostId {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LocalChromeProfile {
     pub directory: String,
-    pub label: String,
+    pub name: String,
+    pub login: Option<String>,
 }
 
 #[derive(Debug, serde::Deserialize)]
@@ -152,13 +153,17 @@ fn select_chrome_profile(
     let (directory, profile) = matches
         .pop()
         .expect("one matched Chrome profile should exist");
-    let label = profile
-        .user_name
-        .filter(|login| !login.trim().is_empty())
-        .unwrap_or(profile.name);
+    let login = profile.user_name.filter(|login| !login.trim().is_empty());
     validate_chrome_profile_identifier(&directory)?;
-    validate_chrome_profile_identifier(&label)?;
-    Ok(LocalChromeProfile { directory, label })
+    validate_chrome_profile_identifier(&profile.name)?;
+    if let Some(login) = &login {
+        validate_chrome_profile_identifier(login)?;
+    }
+    Ok(LocalChromeProfile {
+        directory,
+        name: profile.name,
+        login,
+    })
 }
 
 fn validate_chrome_profile_identifier(value: &str) -> Result<(), String> {
@@ -279,7 +284,8 @@ mod tests {
             select_chrome_profile(profiles, "jack@example.com").unwrap(),
             LocalChromeProfile {
                 directory: "Profile 7".to_string(),
-                label: "jack@example.com".to_string(),
+                name: "Loopflow".to_string(),
+                login: Some("jack@example.com".to_string()),
             }
         );
     }

--- a/rust/loopflow/src/provider_account.rs
+++ b/rust/loopflow/src/provider_account.rs
@@ -637,7 +637,7 @@ pub async fn resolve_provider_account(
                         })?;
                     if !retain_authenticated_account(&store, &selection.account, &status).await? {
                         unauthenticated.push(format!(
-                            "'{account_id}' with `lf auth connect {provider} --account {account_id}`"
+                            "'{account_id}' with `lf auth connect {provider} --profile {profile_id}`"
                         ));
                         continue;
                     }

--- a/rust/loopflow/src/provider_auth/mod.rs
+++ b/rust/loopflow/src/provider_auth/mod.rs
@@ -31,8 +31,6 @@ use regex::Regex;
 use reqwest::Url;
 use secrecy::ExposeSecret;
 use secrecy::SecretString;
-#[cfg(target_os = "macos")]
-use security_framework::item::{ItemClass, ItemSearchOptions};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use thiserror::Error;
@@ -65,12 +63,11 @@ const LINEAR_CLIENT_ID_ENV: &str = "LINEAR_CLIENT_ID";
 const LINEAR_CLIENT_SECRET_ENV: &str = "LINEAR_CLIENT_SECRET";
 const LINEAR_OAUTH_DEFAULT_SCOPE: &str = "read,write";
 #[cfg(target_os = "macos")]
-const CLAUDE_KEYCHAIN_SERVICE: &str = "Claude Code-credentials";
-#[cfg(target_os = "macos")]
-const ERR_SEC_ITEM_NOT_FOUND: i32 = -25_300;
 const CLAUDE_BROWSER_AUTH_TIMEOUT: Duration = Duration::from_secs(120);
-const CLAUDE_BROWSER_OUTPUT_SCHEMA: &str = r#"{"type":"object","properties":{"status":{"type":"string","enum":["authorized","unavailable"]},"authorization_code":{"type":["string","null"]}},"required":["status","authorization_code"],"additionalProperties":false}"#;
-const CLAUDE_BROWSER_ALLOWED_TOOLS: &str = "Skill,ToolSearch,mcp__claude-in-chrome__list_connected_browsers,mcp__claude-in-chrome__select_browser,mcp__claude-in-chrome__switch_browser,mcp__claude-in-chrome__tabs_context_mcp,mcp__claude-in-chrome__tabs_create_mcp,mcp__claude-in-chrome__navigate,mcp__claude-in-chrome__get_page_text,mcp__claude-in-chrome__read_page,mcp__claude-in-chrome__find,mcp__claude-in-chrome__computer";
+#[cfg(target_os = "macos")]
+const CLAUDE_KEYCHAIN_WRITE_TIMEOUT: Duration = Duration::from_secs(5);
+#[cfg(target_os = "macos")]
+const LEGACY_CLAUDE_KEYCHAIN_SERVICE: &str = "Claude Code-credentials";
 pub(crate) const TOKEN_REFRESH_LEAD_SECONDS: i64 = 20 * 60;
 
 static USER_CODE_RE: Lazy<Regex> =
@@ -82,8 +79,10 @@ static GH_LOGIN_RE: Lazy<Regex> = Lazy::new(|| {
 });
 static ANSI_ESCAPE_RE: Lazy<Regex> =
     Lazy::new(|| Regex::new(r"\x1B\[[0-9;]*[A-Za-z]").expect("ansi escape regex"));
-static CLAUDE_AUTHORIZATION_CODE_RE: Lazy<Regex> = Lazy::new(|| {
-    Regex::new(r"^[A-Za-z0-9_-]{20,}#[A-Za-z0-9_-]{20,}$").expect("Claude authorization code regex")
+#[cfg(any(target_os = "macos", test))]
+static CLAUDE_AUTHORIZATION_CODE_SEARCH_RE: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r"[A-Za-z0-9_-]{20,}#[A-Za-z0-9_-]{20,}")
+        .expect("Claude authorization code search regex")
 });
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -404,79 +403,10 @@ impl Drop for AuthMonitor {
     }
 }
 
-pub struct ClaudeKeychainGuard {
-    credential: Option<ClaudeKeychainCredential>,
-    armed: bool,
-}
-
+#[cfg(target_os = "macos")]
 struct ClaudeKeychainCredential {
-    #[cfg(target_os = "macos")]
     account: String,
-    #[cfg(target_os = "macos")]
     blob: SecretString,
-}
-
-impl std::fmt::Debug for ClaudeKeychainGuard {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("ClaudeKeychainGuard")
-            .field(
-                "credential",
-                &self.credential.as_ref().map(|_| "[REDACTED]"),
-            )
-            .field("armed", &self.armed)
-            .finish()
-    }
-}
-
-impl ClaudeKeychainGuard {
-    /// Preserve the Claude credential active before managed-account login.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error when macOS refuses the Keychain query or the existing
-    /// credential cannot be decoded.
-    pub fn preserve() -> Result<Self, AuthError> {
-        Ok(Self {
-            credential: read_claude_keychain_credential()?,
-            armed: true,
-        })
-    }
-
-    /// Restore the credential that was active before managed-account login.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error when macOS rejects the Keychain update.
-    pub fn restore(mut self) -> Result<(), AuthError> {
-        let result = restore_claude_keychain_blob(self.credential.as_ref());
-        if result.is_ok() {
-            self.armed = false;
-            self.credential.take();
-        }
-        result
-    }
-}
-
-impl Drop for ClaudeKeychainGuard {
-    fn drop(&mut self) {
-        if self.armed {
-            if let Err(error) = restore_claude_keychain_blob(self.credential.as_ref()) {
-                warn!(%error, "failed to restore Claude Keychain credential");
-            }
-        }
-    }
-}
-
-#[derive(Debug, Deserialize)]
-struct BrowserControllerEnvelope {
-    is_error: bool,
-    structured_output: Option<BrowserControllerResult>,
-}
-
-#[derive(Debug, Deserialize)]
-struct BrowserControllerResult {
-    status: String,
-    authorization_code: Option<String>,
 }
 
 #[derive(Debug, Error)]
@@ -1369,6 +1299,7 @@ impl AuthBroker for GhAuthBroker {
 pub struct ClaudeAuthBroker {
     config_dir: PathBuf,
     keychain_fallback: bool,
+    login_hint: Option<String>,
 }
 
 impl Default for ClaudeAuthBroker {
@@ -1376,21 +1307,32 @@ impl Default for ClaudeAuthBroker {
         Self {
             config_dir: home_dir_or_cwd().join(".claude"),
             keychain_fallback: true,
+            login_hint: None,
         }
     }
 }
 
 impl ClaudeAuthBroker {
-    fn for_profile(config_dir: PathBuf) -> Self {
+    fn for_profile(config_dir: PathBuf, login_hint: Option<String>) -> Self {
         Self {
             config_dir,
             keychain_fallback: false,
+            login_hint,
         }
     }
 
     fn command(&self) -> Command {
         let mut command = Command::new("claude");
         command.env("CLAUDE_CONFIG_DIR", &self.config_dir);
+        command
+    }
+
+    fn login_command(&self) -> Command {
+        let mut command = self.command();
+        command.args(["auth", "login"]);
+        if let Some(login_hint) = self.login_hint.as_deref() {
+            command.args(["--email", login_hint]);
+        }
         command
     }
 }
@@ -1402,8 +1344,7 @@ impl AuthBroker for ClaudeAuthBroker {
     }
 
     async fn start_auth(&self) -> Result<AuthFlowHandle, AuthError> {
-        let mut command = self.command();
-        command.args(["auth", "login"]);
+        let mut command = self.login_command();
         command.env("BROWSER", "echo");
         command.env("CLAUDE_BROWSER", "echo");
 
@@ -1450,7 +1391,7 @@ impl AuthBroker for ClaudeAuthBroker {
     async fn extract_token(&self) -> Option<ProviderToken> {
         extract_claude_token_from_config_dir(&self.config_dir).or_else(|| {
             if self.keychain_fallback {
-                read_claude_keychain_token()
+                read_claude_keychain_token(&self.config_dir)
             } else {
                 None
             }
@@ -1539,10 +1480,22 @@ impl AuthBroker for CodexAuthBroker {
     }
 
     async fn check_status(&self) -> Result<AuthStatus, AuthError> {
-        Ok(match extract_codex_token_from_home(&self.codex_home) {
-            Some(token) => AuthStatus::Active { login: token.login },
-            None => AuthStatus::None,
-        })
+        let Some(mut token) = extract_codex_token_from_home(&self.codex_home) else {
+            return Ok(AuthStatus::None);
+        };
+        if provider_token_refresh_due(&token, now_unix()) {
+            if self.refresh_access_token().await.is_err() {
+                return Ok(AuthStatus::None);
+            }
+            let Some(refreshed) = extract_codex_token_from_home(&self.codex_home) else {
+                return Ok(AuthStatus::None);
+            };
+            token = refreshed;
+            if provider_token_refresh_due(&token, now_unix()) {
+                return Ok(AuthStatus::None);
+            }
+        }
+        Ok(AuthStatus::Active { login: token.login })
     }
 
     async fn disconnect(&self) -> Result<(), AuthError> {
@@ -1570,9 +1523,13 @@ impl AuthBroker for CodexAuthBroker {
 fn provider_account_broker(
     provider: Provider,
     provider_home: PathBuf,
+    login_hint: Option<&str>,
 ) -> Result<Arc<dyn AuthBroker>, AuthError> {
     match provider {
-        Provider::Claude => Ok(Arc::new(ClaudeAuthBroker::for_profile(provider_home))),
+        Provider::Claude => Ok(Arc::new(ClaudeAuthBroker::for_profile(
+            provider_home,
+            login_hint.map(String::from),
+        ))),
         Provider::Codex => Ok(Arc::new(CodexAuthBroker::for_profile(provider_home))),
         _ => Err(AuthError::UnsupportedProvider(provider.to_string())),
     }
@@ -1581,8 +1538,9 @@ fn provider_account_broker(
 pub async fn start_provider_account_auth(
     provider: Provider,
     provider_home: PathBuf,
+    login_hint: Option<&str>,
 ) -> Result<AuthFlowHandle, AuthError> {
-    provider_account_broker(provider, provider_home)?
+    provider_account_broker(provider, provider_home, login_hint)?
         .start_auth()
         .await
 }
@@ -1591,7 +1549,7 @@ pub async fn provider_account_auth_status(
     provider: Provider,
     provider_home: PathBuf,
 ) -> Result<AuthStatus, AuthError> {
-    provider_account_broker(provider, provider_home)?
+    provider_account_broker(provider, provider_home, None)?
         .check_status()
         .await
 }
@@ -1600,7 +1558,7 @@ pub async fn disconnect_provider_account_auth(
     provider: Provider,
     provider_home: PathBuf,
 ) -> Result<(), AuthError> {
-    provider_account_broker(provider, provider_home)?
+    provider_account_broker(provider, provider_home, None)?
         .disconnect()
         .await
 }
@@ -1611,7 +1569,7 @@ pub(crate) async fn prepare_provider_account_access_token(
 ) -> Result<Option<String>, AuthError> {
     let token = match provider {
         Provider::Claude => {
-            let broker = ClaudeAuthBroker::for_profile(provider_home.to_path_buf());
+            let broker = ClaudeAuthBroker::for_profile(provider_home.to_path_buf(), None);
             broker.extract_token().await
         }
         Provider::Codex => {
@@ -1849,109 +1807,88 @@ fn kill_auth_process_group(pid: u32) {
     crate::engine::platform::kill_process(pid);
 }
 
-/// Ask the connected Claude-in-Chrome bridge to complete a Claude OAuth page.
+/// Read Claude's one-time handoff from the visible Chrome page on macOS.
 ///
-/// `Ok(None)` means the browser controller is unavailable and the caller should
-/// use its interactive fallback.
+/// The human still approves the provider page. Loopflow temporarily copies the
+/// rendered page, restores the clipboard inside the same AppleScript command,
+/// and keeps the handoff only in process memory.
 ///
 /// # Errors
 ///
-/// Returns an error for an untrusted URL, malformed controller output, or
-/// controller process I/O failure.
-pub async fn drive_claude_browser_authorization(
+/// Returns an error for an untrusted authorization URL or browser-control I/O
+/// failure. `Ok(None)` means native Chrome control is unavailable or timed out.
+pub async fn capture_claude_authorization_code_from_chrome(
     verification_url: &str,
-    controller_profile: Option<&Path>,
-    browser_profile_label: Option<&str>,
+    _browser_profile_label: &str,
 ) -> Result<Option<SecretString>, AuthError> {
     validate_claude_authorization_url(verification_url)?;
 
-    let browser_instruction = match browser_profile_label {
-        Some(label) => format!(
-            " Use only the connected browser whose profile or account label exactly matches {}. Select it explicitly; if it is absent, return status unavailable.",
-            serde_json::to_string(label).expect("Chrome profile label should serialize")
-        ),
-        None => String::new(),
-    };
-    let prompt = format!(
-        "Act only as Loopflow's Claude OAuth browser controller. Load the claude-in-chrome skill. First list connected browsers. If none are connected, return status unavailable.{browser_instruction} Otherwise open this exact URL in a new tab: {verification_url}\nOnly interact with claude.com and platform.claude.com. If an already signed-in account can continue, click Authorize. Do not sign in, create an account, handle MFA or CAPTCHA, or change account settings. After the callback page appears, read its complete one-time code#state handoff. Return status authorized with that value. Never include the handoff in prose."
-    );
-
-    let mut command = Command::new("claude");
-    command.args([
-        "--chrome",
-        "--print",
-        "--model",
-        "haiku",
-        "--output-format",
-        "json",
-        "--no-session-persistence",
-        "--permission-mode",
-        "dontAsk",
-        "--allowedTools",
-        CLAUDE_BROWSER_ALLOWED_TOOLS,
-        "--max-budget-usd",
-        "1",
-        "--json-schema",
-        CLAUDE_BROWSER_OUTPUT_SCHEMA,
-    ]);
-    if let Some(profile) = controller_profile {
-        command.env("CLAUDE_CONFIG_DIR", profile);
-    }
-    command
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::null())
-        .kill_on_drop(true);
-    #[cfg(unix)]
-    command.process_group(0);
-
-    let mut child = match command.spawn() {
-        Ok(child) => child,
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
-        Err(source) => {
-            return Err(AuthError::CommandSpawn {
-                provider: Provider::Claude,
-                source,
-            });
+    #[cfg(target_os = "macos")]
+    {
+        let deadline = Instant::now() + CLAUDE_BROWSER_AUTH_TIMEOUT;
+        while Instant::now() < deadline {
+            let output = ProcessCommand::new("osascript")
+                .args(["-e", CLAUDE_VISIBLE_PAGE_SCRIPT])
+                .env("LF_CHROME_PROFILE_LABEL", _browser_profile_label)
+                .output()
+                .map_err(|source| AuthError::CommandIo {
+                    provider: Provider::Claude,
+                    source,
+                })?;
+            if !output.status.success() {
+                return Ok(None);
+            }
+            let page = String::from_utf8_lossy(&output.stdout);
+            if let Some(code) = claude_authorization_code_from_page(&page) {
+                return Ok(Some(code));
+            }
+            tokio::time::sleep(Duration::from_secs(1)).await;
         }
-    };
-    let process_group = AuthProcessGroup::new(child.id());
-    let mut stdin = child.stdin.take().ok_or_else(|| AuthError::CommandFailed {
-        provider: Provider::Claude,
-        message: "browser controller did not expose stdin".to_string(),
-    })?;
-    stdin
-        .write_all(prompt.as_bytes())
-        .await
-        .map_err(|source| AuthError::CommandIo {
-            provider: Provider::Claude,
-            source,
-        })?;
-    stdin
-        .shutdown()
-        .await
-        .map_err(|source| AuthError::CommandIo {
-            provider: Provider::Claude,
-            source,
-        })?;
-    drop(stdin);
-
-    let output = tokio::time::timeout(CLAUDE_BROWSER_AUTH_TIMEOUT, child.wait_with_output())
-        .await
-        .map_err(|_| AuthError::CommandFailed {
-            provider: Provider::Claude,
-            message: "browser controller timed out".to_string(),
-        })?
-        .map_err(|source| AuthError::CommandIo {
-            provider: Provider::Claude,
-            source,
-        })?;
-    process_group.complete();
-    if !output.status.success() {
-        return Ok(None);
+        Ok(None)
     }
+    #[cfg(not(target_os = "macos"))]
+    {
+        Ok(None)
+    }
+}
 
-    parse_browser_controller_output(&output.stdout)
+#[cfg(target_os = "macos")]
+const CLAUDE_VISIBLE_PAGE_SCRIPT: &str = r#"
+set savedClipboard to the clipboard
+try
+    set profileLabel to system attribute "LF_CHROME_PROFILE_LABEL"
+    tell application "Google Chrome" to activate
+    tell application "System Events"
+        tell process "Google Chrome"
+            set authWindows to every window whose name contains "Authentication code | Claude Platform"
+            set pageText to ""
+            repeat with authWindow in authWindows
+                if name of authWindow contains "(" & profileLabel & ")" then
+                    perform action "AXRaise" of authWindow
+                    delay 0.2
+                    keystroke "a" using command down
+                    delay 0.1
+                    keystroke "c" using command down
+                    delay 0.2
+                    set pageText to the clipboard as text
+                    exit repeat
+                end if
+            end repeat
+        end tell
+    end tell
+    set the clipboard to savedClipboard
+    return pageText
+on error
+    set the clipboard to savedClipboard
+    error
+end try
+"#;
+
+#[cfg(any(target_os = "macos", test))]
+fn claude_authorization_code_from_page(page: &str) -> Option<SecretString> {
+    CLAUDE_AUTHORIZATION_CODE_SEARCH_RE
+        .find(page)
+        .map(|value| SecretString::new(value.as_str().to_string()))
 }
 
 fn validate_claude_authorization_url(verification_url: &str) -> Result<(), AuthError> {
@@ -1966,30 +1903,6 @@ fn validate_claude_authorization_url(verification_url: &str) -> Result<(), AuthE
         });
     }
     Ok(())
-}
-
-fn parse_browser_controller_output(output: &[u8]) -> Result<Option<SecretString>, AuthError> {
-    let envelope: BrowserControllerEnvelope =
-        serde_json::from_slice(output).map_err(|_| AuthError::CommandFailed {
-            provider: Provider::Claude,
-            message: "browser controller returned invalid JSON".to_string(),
-        })?;
-    if envelope.is_error {
-        return Ok(None);
-    }
-    let Some(result) = envelope.structured_output else {
-        return Ok(None);
-    };
-    match (result.status.as_str(), result.authorization_code) {
-        ("unavailable", _) => Ok(None),
-        ("authorized", Some(code)) if CLAUDE_AUTHORIZATION_CODE_RE.is_match(&code) => {
-            Ok(Some(SecretString::new(code)))
-        }
-        _ => Err(AuthError::CommandFailed {
-            provider: Provider::Claude,
-            message: "browser controller returned a malformed authorization handoff".to_string(),
-        }),
-    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -2384,7 +2297,7 @@ pub(crate) fn extract_claude_token(home_dir: &Path) -> Option<ProviderToken> {
     // The file is absent on machines where Claude Code stashed its OAuth blob in
     // the macOS keychain (service "Claude Code-credentials", JSON under
     // `.claudeAiOauth`). Fall back to reading it there.
-    read_claude_keychain_token()
+    read_claude_keychain_token(&config_dir)
 }
 
 fn extract_claude_token_from_config_dir(config_dir: &Path) -> Option<ProviderToken> {
@@ -2425,24 +2338,41 @@ fn claude_token_from_credentials_json(content: &str) -> Option<ProviderToken> {
     })
 }
 
-/// Copy Claude's current macOS Keychain credential into an isolated profile.
+/// Keep Claude's completed login in its isolated profile.
 ///
-/// Non-macOS Claude installations already write the native credentials file,
-/// so this is a no-op there.
+/// Claude may write the native credentials file directly. On macOS versions
+/// that use Keychain instead, copy that credential into the isolated profile.
 ///
 /// # Errors
 ///
 /// Returns an error when the Keychain credential is missing or the private
 /// profile file cannot be written atomically.
 pub fn capture_claude_profile_credentials(config_dir: &Path) -> Result<(), AuthError> {
+    let native = config_dir.join(".credentials.json");
+    if fs::read_to_string(native)
+        .ok()
+        .and_then(|content| claude_token_from_credentials_json(&content))
+        .is_some()
+    {
+        return Ok(());
+    }
     #[cfg(target_os = "macos")]
     {
-        let credential = read_claude_keychain_credential()?.ok_or_else(|| {
-            AuthError::Filesystem(
-                "Claude completed login without a readable macOS Keychain credential".to_string(),
-            )
-        })?;
-        write_claude_profile_credentials(config_dir, &credential.blob)
+        let service = claude_keychain_service(config_dir);
+        let deadline = Instant::now() + CLAUDE_KEYCHAIN_WRITE_TIMEOUT;
+        loop {
+            if let Some(credential) = read_claude_keychain_credential(&service)? {
+                write_claude_profile_credentials(config_dir, &credential.blob)?;
+                return delete_claude_keychain_credential(&service, &credential.account);
+            }
+            if Instant::now() >= deadline {
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(100));
+        }
+        Err(AuthError::Filesystem(
+            "Claude completed login without a readable macOS Keychain credential".to_string(),
+        ))
     }
     #[cfg(not(target_os = "macos"))]
     {
@@ -2451,62 +2381,44 @@ pub fn capture_claude_profile_credentials(config_dir: &Path) -> Result<(), AuthE
     }
 }
 
-/// Copy the ambient Codex OAuth credential into an isolated profile.
+/// Copy the ambient Claude login into an isolated profile.
 ///
 /// # Errors
 ///
-/// Returns an error when the ambient credential is missing, is not a ChatGPT
-/// OAuth credential, or cannot be written into the private profile.
-pub fn capture_codex_profile_credentials(codex_home: &Path) -> Result<(), AuthError> {
-    let source = home_dir_or_cwd().join(".codex/auth.json");
-    let credential = SecretString::new(fs::read_to_string(&source).map_err(|error| {
-        AuthError::Filesystem(format!("read ambient Codex credential: {error}"))
-    })?);
-    write_codex_profile_credentials(codex_home, &credential)
-}
-
-fn write_codex_profile_credentials(
-    codex_home: &Path,
-    credential: &SecretString,
-) -> Result<(), AuthError> {
-    let json = serde_json::from_str(credential.expose_secret()).map_err(|error| {
-        AuthError::Filesystem(format!("parse ambient Codex credential: {error}"))
-    })?;
-    if codex_token_from_auth_json(&json).is_none() {
-        return Err(AuthError::Filesystem(
-            "ambient Codex credential does not contain a ChatGPT OAuth access token".to_string(),
-        ));
+/// Returns an error when the ambient credential is missing or cannot be copied.
+pub fn import_ambient_claude_profile_credentials(config_dir: &Path) -> Result<(), AuthError> {
+    let ambient = home_dir_or_cwd().join(".claude");
+    if let Ok(content) = fs::read_to_string(ambient.join(".credentials.json")) {
+        if claude_token_from_credentials_json(&content).is_some() {
+            return write_claude_profile_credentials(config_dir, &SecretString::new(content));
+        }
     }
-    fs::create_dir_all(codex_home).map_err(|error| {
-        AuthError::Filesystem(format!("create {}: {error}", codex_home.display()))
-    })?;
-    let destination = codex_home.join("auth.json");
-    let mut temporary = tempfile::NamedTempFile::new_in(codex_home).map_err(|error| {
-        AuthError::Filesystem(format!("create private Codex credential file: {error}"))
-    })?;
-    temporary
-        .write_all(credential.expose_secret().as_bytes())
-        .map_err(|error| {
-            AuthError::Filesystem(format!("write private Codex credential file: {error}"))
-        })?;
-    temporary.as_file().sync_all().map_err(|error| {
-        AuthError::Filesystem(format!("sync private Codex credential file: {error}"))
-    })?;
-    temporary.persist(&destination).map_err(|error| {
-        AuthError::Filesystem(format!("install private Codex credential file: {error}"))
-    })?;
-    #[cfg(unix)]
+    #[cfg(target_os = "macos")]
     {
-        use std::os::unix::fs::PermissionsExt;
-
-        fs::set_permissions(&destination, fs::Permissions::from_mode(0o600)).map_err(|error| {
-            AuthError::Filesystem(format!("protect {}: {error}", destination.display()))
-        })?;
+        let credential =
+            read_claude_keychain_credential_for_config(&ambient)?.ok_or_else(|| {
+                AuthError::Filesystem(
+                    "the ambient Claude login has no readable macOS Keychain credential"
+                        .to_string(),
+                )
+            })?;
+        write_claude_profile_credentials(config_dir, &credential.blob)
     }
-    Ok(())
+    #[cfg(not(target_os = "macos"))]
+    {
+        Err(AuthError::Filesystem(
+            "the ambient Claude login has no native credential file".to_string(),
+        ))
+    }
 }
 
 #[cfg(any(target_os = "macos", test))]
+fn claude_keychain_service(config_dir: &Path) -> String {
+    let digest = Sha256::digest(config_dir.to_string_lossy().as_bytes());
+    let suffix = format!("{digest:x}");
+    format!("Claude Code-credentials-{}", &suffix[..8])
+}
+
 fn write_claude_profile_credentials(
     config_dir: &Path,
     credential: &SecretString,
@@ -2546,47 +2458,21 @@ fn write_claude_profile_credentials(
 }
 
 #[cfg(target_os = "macos")]
-fn read_claude_keychain_credential() -> Result<Option<ClaudeKeychainCredential>, AuthError> {
-    let mut search = ItemSearchOptions::new();
-    search
-        .class(ItemClass::generic_password())
-        .service(CLAUDE_KEYCHAIN_SERVICE)
-        .load_attributes(true)
-        .limit(1);
-    let items = match search.search() {
-        Ok(items) => items,
-        Err(error) if error.code() == ERR_SEC_ITEM_NOT_FOUND => return Ok(None),
-        Err(error) => {
-            return Err(AuthError::Filesystem(format!(
-                "read Claude Keychain credential metadata: {error}"
-            )))
-        }
+fn read_claude_keychain_credential(
+    service: &str,
+) -> Result<Option<ClaudeKeychainCredential>, AuthError> {
+    let Some(account) = read_claude_keychain_account_with_security(service)? else {
+        return Ok(None);
     };
-    let account = items.into_iter().find_map(|item| {
-        item.simplify_dict()
-            .and_then(|attributes| attributes.get("acct").cloned())
-    });
-    let Some(account) = account else {
-        return Err(AuthError::Filesystem(
-            "Claude Keychain credential is missing its account metadata".to_string(),
-        ));
-    };
-    let blob = match security_framework::passwords::get_generic_password(
-        CLAUDE_KEYCHAIN_SERVICE,
-        &account,
-    ) {
-        Ok(blob) => blob,
-        Err(native_error) => read_claude_keychain_blob_with_security().map_err(
-            |fallback_error| {
-                AuthError::Filesystem(format!(
-                    "read Claude Keychain credential: {native_error}; security fallback: {fallback_error}"
-                ))
-            },
-        )?,
-    };
+    let blob = read_claude_keychain_blob_with_security(service).map_err(|error| {
+        AuthError::Filesystem(format!("read Claude Keychain credential: {error}"))
+    })?;
     let blob = String::from_utf8(blob).map_err(|_| {
         AuthError::Filesystem("Claude Keychain credential is not valid UTF-8".to_string())
     })?;
+    if claude_token_from_credentials_json(&blob).is_none() {
+        return Ok(None);
+    }
     Ok(Some(ClaudeKeychainCredential {
         account,
         blob: SecretString::new(blob),
@@ -2594,68 +2480,115 @@ fn read_claude_keychain_credential() -> Result<Option<ClaudeKeychainCredential>,
 }
 
 #[cfg(target_os = "macos")]
-fn read_claude_keychain_blob_with_security() -> Result<Vec<u8>, String> {
+fn read_claude_keychain_credential_for_config(
+    config_dir: &Path,
+) -> Result<Option<ClaudeKeychainCredential>, AuthError> {
+    let scoped_service = claude_keychain_service(config_dir);
+    if let Some(credential) = read_claude_keychain_credential(&scoped_service)? {
+        return Ok(Some(credential));
+    }
+    let ambient = home_dir_or_cwd().join(".claude");
+    if config_dir == ambient {
+        return read_claude_keychain_credential(LEGACY_CLAUDE_KEYCHAIN_SERVICE);
+    }
+    Ok(None)
+}
+
+#[cfg(target_os = "macos")]
+fn read_claude_keychain_account_with_security(service: &str) -> Result<Option<String>, AuthError> {
     let output = ProcessCommand::new("security")
-        .args(["find-generic-password", "-s", CLAUDE_KEYCHAIN_SERVICE, "-w"])
+        .args(["find-generic-password", "-s", service])
+        .output()
+        .map_err(|error| {
+            AuthError::Filesystem(format!("read Claude Keychain metadata: {error}"))
+        })?;
+    if !output.status.success() {
+        if security_item_not_found(&output) {
+            return Ok(None);
+        }
+        return Err(AuthError::Filesystem(format!(
+            "read Claude Keychain metadata: security exited with {}",
+            output.status
+        )));
+    }
+    let metadata = String::from_utf8(output.stdout).map_err(|_| {
+        AuthError::Filesystem("Claude Keychain metadata is not valid UTF-8".to_string())
+    })?;
+    parse_security_keychain_account(&metadata)
+        .map(Some)
+        .ok_or_else(|| {
+            AuthError::Filesystem(
+                "Claude Keychain credential is missing its account metadata".to_string(),
+            )
+        })
+}
+
+#[cfg(any(target_os = "macos", test))]
+fn parse_security_keychain_account(metadata: &str) -> Option<String> {
+    metadata.lines().find_map(|line| {
+        line.trim()
+            .strip_prefix("\"acct\"<blob>=\"")?
+            .strip_suffix('"')
+            .map(String::from)
+    })
+}
+
+#[cfg(target_os = "macos")]
+fn read_claude_keychain_blob_with_security(service: &str) -> Result<Vec<u8>, String> {
+    let output = ProcessCommand::new("security")
+        .args(["find-generic-password", "-s", service, "-w"])
         .output()
         .map_err(|error| error.to_string())?;
     if !output.status.success() {
         return Err(format!("security exited with {}", output.status));
     }
-    Ok(output.stdout)
+    Ok(trim_security_password_output(output.stdout))
 }
 
-#[cfg(not(target_os = "macos"))]
-fn read_claude_keychain_credential() -> Result<Option<ClaudeKeychainCredential>, AuthError> {
-    Ok(None)
+#[cfg(any(target_os = "macos", test))]
+fn trim_security_password_output(mut output: Vec<u8>) -> Vec<u8> {
+    if output.last() == Some(&b'\n') {
+        output.pop();
+        if output.last() == Some(&b'\r') {
+            output.pop();
+        }
+    }
+    output
 }
 
 #[cfg(target_os = "macos")]
-fn restore_claude_keychain_blob(
-    credential: Option<&ClaudeKeychainCredential>,
-) -> Result<(), AuthError> {
-    match credential {
-        Some(credential) => security_framework::passwords::set_generic_password(
-            CLAUDE_KEYCHAIN_SERVICE,
-            &credential.account,
-            credential.blob.expose_secret().as_bytes(),
-        )
+fn security_item_not_found(output: &std::process::Output) -> bool {
+    String::from_utf8_lossy(&output.stderr).contains("could not be found")
+}
+
+#[cfg(target_os = "macos")]
+fn delete_claude_keychain_credential(service: &str, account: &str) -> Result<(), AuthError> {
+    let output = ProcessCommand::new("security")
+        .args(["delete-generic-password", "-a", account, "-s", service])
+        .output()
         .map_err(|error| {
-            AuthError::Filesystem(format!("restore Claude Keychain credential: {error}"))
-        }),
-        None => {
-            let Some(current) = read_claude_keychain_credential()? else {
-                return Ok(());
-            };
-            match security_framework::passwords::delete_generic_password(
-                CLAUDE_KEYCHAIN_SERVICE,
-                &current.account,
-            ) {
-                Ok(()) => Ok(()),
-                Err(error) if error.code() == ERR_SEC_ITEM_NOT_FOUND => Ok(()),
-                Err(error) => Err(AuthError::Filesystem(format!(
-                    "clear Claude Keychain credential: {error}"
-                ))),
-            }
-        }
+            AuthError::Filesystem(format!("clear Claude Keychain credential: {error}"))
+        })?;
+    if output.status.success() || security_item_not_found(&output) {
+        Ok(())
+    } else {
+        Err(AuthError::Filesystem(format!(
+            "clear Claude Keychain credential: security exited with {}",
+            output.status
+        )))
     }
 }
 
-#[cfg(not(target_os = "macos"))]
-fn restore_claude_keychain_blob(
-    _credential: Option<&ClaudeKeychainCredential>,
-) -> Result<(), AuthError> {
-    Ok(())
-}
-
 #[cfg(target_os = "macos")]
-fn read_claude_keychain_token() -> Option<ProviderToken> {
-    let credential = read_claude_keychain_credential().ok().flatten()?;
+fn read_claude_keychain_token(config_dir: &Path) -> Option<ProviderToken> {
+    let credential = read_claude_keychain_credential_for_config(config_dir)
+        .ok()
+        .flatten()?;
     claude_token_from_credentials_json(credential.blob.expose_secret())
 }
 
 #[cfg(not(target_os = "macos"))]
-fn read_claude_keychain_token() -> Option<ProviderToken> {
+fn read_claude_keychain_token(_config_dir: &Path) -> Option<ProviderToken> {
     None
 }
 
@@ -2667,10 +2600,6 @@ fn extract_codex_token_from_home(codex_home: &Path) -> Option<ProviderToken> {
     let auth_path = codex_home.join("auth.json");
     let content = fs::read_to_string(auth_path).ok()?;
     let json: serde_json::Value = serde_json::from_str(&content).ok()?;
-    codex_token_from_auth_json(&json)
-}
-
-fn codex_token_from_auth_json(json: &serde_json::Value) -> Option<ProviderToken> {
     // Store OAuth access tokens only.
     // Never capture manual API keys from Codex auth state.
     let token = json
@@ -2682,15 +2611,16 @@ fn codex_token_from_auth_json(json: &serde_json::Value) -> Option<ProviderToken>
                 .and_then(|v| v.as_str())
         })?;
     let expires_at = read_json_expires_at(
-        json,
+        &json,
         &[
             "expires_at",
             "expiresAt",
             "accessTokenExpiresAt",
             "access_token_expires_at",
         ],
-    );
-    let login = codex_login_from_auth(json);
+    )
+    .or_else(|| jwt_claims(token)?.get("exp")?.as_i64());
+    let login = codex_login_from_auth(&json);
     Some(ProviderToken {
         provider: "codex".to_string(),
         access_token: token.to_string(),
@@ -2712,13 +2642,17 @@ fn codex_login_from_auth(json: &serde_json::Value) -> Option<String> {
                 .and_then(|tokens| tokens.get("id_token"))
                 .and_then(serde_json::Value::as_str)
         })?;
-    let payload = id_token.split('.').nth(1)?.trim_end_matches('=');
-    let claims = URL_SAFE_NO_PAD.decode(payload).ok()?;
-    let claims = serde_json::from_slice::<serde_json::Value>(&claims).ok()?;
+    let claims = jwt_claims(id_token)?;
     claims
         .get("email")
         .and_then(serde_json::Value::as_str)
         .map(str::to_string)
+}
+
+fn jwt_claims(token: &str) -> Option<serde_json::Value> {
+    let payload = token.split('.').nth(1)?.trim_end_matches('=');
+    let claims = URL_SAFE_NO_PAD.decode(payload).ok()?;
+    serde_json::from_slice(&claims).ok()
 }
 
 async fn refresh_codex_access_token(codex_home: &Path) -> Result<(), AuthError> {
@@ -3933,31 +3867,22 @@ mod tests {
     }
 
     #[test]
-    fn browser_controller_returns_only_valid_structured_handoffs() {
-        let expected = "abcdefghijklmnopqrstuvwxyz0123456789#ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
-        let output = serde_json::to_vec(&serde_json::json!({
-            "is_error": false,
-            "structured_output": {
-                "status": "authorized",
-                "authorization_code": expected,
-            }
-        }))
-        .expect("controller output");
+    fn visible_claude_page_parser_extracts_only_a_complete_handoff() {
+        let expected = "abcdefghijklmnopqrstuvwxyz#ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+        let page = format!("Authorization complete\n{expected}\nCopy this code");
 
-        let code = parse_browser_controller_output(&output)
-            .expect("valid controller output")
-            .expect("authorization code");
+        let code = claude_authorization_code_from_page(&page).expect("authorization handoff");
+
         assert_eq!(code.expose_secret(), expected);
+        assert!(claude_authorization_code_from_page("short#code").is_none());
+    }
 
-        let malformed = serde_json::to_vec(&serde_json::json!({
-            "is_error": false,
-            "structured_output": {
-                "status": "authorized",
-                "authorization_code": "explanation instead of a handoff",
-            }
-        }))
-        .expect("malformed controller output");
-        assert!(parse_browser_controller_output(&malformed).is_err());
+    #[test]
+    fn claude_keychain_service_is_scoped_to_the_config_directory() {
+        assert_eq!(
+            claude_keychain_service(Path::new("/tmp/claude-profile")),
+            "Claude Code-credentials-7182514b"
+        );
     }
 
     #[test]
@@ -3987,6 +3912,21 @@ mod tests {
         assert_eq!(
             fs::read_to_string(&path).expect("replacement credential file"),
             replacement
+        );
+    }
+
+    #[test]
+    fn completed_claude_login_accepts_a_native_profile_credential() {
+        let temp = tempdir().expect("tempdir");
+        let payload =
+            r#"{"claudeAiOauth":{"accessToken":"profile-token","expiresAt":4102444800000}}"#;
+        fs::write(temp.path().join(".credentials.json"), payload).expect("profile credential");
+
+        capture_claude_profile_credentials(temp.path()).expect("accept native credential");
+
+        assert_eq!(
+            fs::read_to_string(temp.path().join(".credentials.json")).unwrap(),
+            payload
         );
     }
 
@@ -4096,6 +4036,50 @@ mod tests {
         assert!(!gh_logout_is_already_disconnected("fatal: unknown host"));
     }
 
+    #[test]
+    fn managed_claude_login_preselects_the_profile_email() {
+        let broker = ClaudeAuthBroker::for_profile(
+            PathBuf::from("/tmp/managed-claude"),
+            Some("engineering@example.com".to_string()),
+        );
+        let command = broker.login_command();
+        let args: Vec<_> = command
+            .as_std()
+            .get_args()
+            .map(|value| value.to_string_lossy().into_owned())
+            .collect();
+
+        assert_eq!(
+            args,
+            ["auth", "login", "--email", "engineering@example.com"]
+        );
+    }
+
+    #[test]
+    fn keychain_metadata_parser_reads_the_account_without_the_password() {
+        let metadata = r#"keychain: "/Users/operator/Library/Keychains/login.keychain-db"
+attributes:
+    "acct"<blob>="operator"
+    "svce"<blob>="Claude Code-credentials""#;
+
+        assert_eq!(
+            parse_security_keychain_account(metadata).as_deref(),
+            Some("operator")
+        );
+    }
+
+    #[test]
+    fn security_password_output_keeps_internal_newlines() {
+        assert_eq!(
+            trim_security_password_output(b"{\n  \"token\": \"value\"\n}\n".to_vec()),
+            b"{\n  \"token\": \"value\"\n}".to_vec()
+        );
+        assert_eq!(
+            trim_security_password_output(b"single-line\r\n".to_vec()),
+            b"single-line".to_vec()
+        );
+    }
+
     #[tokio::test]
     async fn claude_disconnect_keeps_settings_and_removes_auth_entries() {
         let temp = tempdir().expect("tempdir");
@@ -4106,7 +4090,7 @@ mod tests {
         fs::create_dir_all(claude_dir.join("session-cache")).expect("session dir");
         fs::write(claude_dir.join("session-cache").join("entry"), "cached").expect("session entry");
 
-        let broker = ClaudeAuthBroker::for_profile(temp.path().join(".claude"));
+        let broker = ClaudeAuthBroker::for_profile(temp.path().join(".claude"), None);
         broker.disconnect().await.expect("disconnect");
 
         assert!(claude_dir.join("settings.json").exists());
@@ -4529,42 +4513,26 @@ mod tests {
     }
 
     #[test]
-    fn write_codex_profile_credentials_installs_private_oauth_state() {
+    fn extract_codex_token_reads_expiry_from_the_access_token() {
         let tmp = tempdir().expect("tempdir");
-        let claims = URL_SAFE_NO_PAD.encode(r#"{"email":"engineering@example.com"}"#);
-        let id_token = format!("header.{claims}.signature");
-        let credential = SecretString::new(
+        let codex_dir = tmp.path().join(".codex");
+        fs::create_dir_all(&codex_dir).expect("create codex dir");
+        let claims = URL_SAFE_NO_PAD.encode(r#"{"exp":4102444800}"#);
+        let access_token = format!("header.{claims}.signature");
+        fs::write(
+            codex_dir.join("auth.json"),
             serde_json::json!({
-                "auth_mode": "chatgpt",
                 "tokens": {
-                    "access_token": "nested-oauth-token",
-                    "id_token": id_token,
+                    "access_token": access_token,
                 }
             })
             .to_string(),
-        );
+        )
+        .expect("write auth json");
 
-        write_codex_profile_credentials(tmp.path(), &credential).expect("install Codex credential");
+        let token = extract_codex_token(tmp.path()).expect("oauth token should load");
 
-        let token = extract_codex_token_from_home(tmp.path()).expect("OAuth token");
-        assert_eq!(token.login.as_deref(), Some("engineering@example.com"));
-        let permissions = fs::metadata(tmp.path().join("auth.json"))
-            .expect("credential metadata")
-            .permissions()
-            .mode();
-        assert_eq!(permissions & 0o777, 0o600);
-    }
-
-    #[test]
-    fn write_codex_profile_credentials_rejects_manual_api_keys() {
-        let tmp = tempdir().expect("tempdir");
-        let credential = SecretString::new(r#"{"api_key":"manual-key"}"#.to_string());
-
-        let error = write_codex_profile_credentials(tmp.path(), &credential)
-            .expect_err("manual API key must not be imported");
-
-        assert!(error.to_string().contains("ChatGPT OAuth access token"));
-        assert!(!tmp.path().join("auth.json").exists());
+        assert_eq!(token.expires_at, Some(4_102_444_800));
     }
 
     #[test]


### PR DESCRIPTION
## Usage

Run lf auth connect PROVIDER --profile PROFILE to create or replace one isolated login.

## What changed

Managed Claude and Codex logins stage credentials privately before installation, serialize concurrent browser flows, validate stale Codex grants, and keep forwarded SSH auth foreground-only. Chrome opens one explicit account window; Claude authorization remains a human click with local handoff capture.

## Verification

- cargo test -p loopflow --lib: 1314 passed
- cargo clippy --all-targets -- -D warnings
- native managed Claude auth status: logged in