### PR TITLE
mac: drive the Wave surface's loading and error states for the screenshot proof

### DIFF
--- a/scripts/generate_screenshots.py
+++ b/scripts/generate_screenshots.py
@@ -51,6 +51,7 @@ class Screenshot:
     # UI test options
     ui_test_mode: str | None = None
     ui_test_select_branch: str | None = None
+    ui_test_detail_state: str | None = None
     ui_test_delay: float | None = None
 
 
@@ -80,6 +81,7 @@ def load_manifest(path: Path) -> Manifest:
                 directions=shot.get("directions", []),
                 ui_test_mode=shot.get("ui_test_mode"),
                 ui_test_select_branch=shot.get("ui_test_select_branch"),
+                ui_test_detail_state=shot.get("ui_test_detail_state"),
                 ui_test_delay=shot.get("ui_test_delay"),
             )
         )
@@ -455,6 +457,8 @@ def capture_ui_test_screenshot(
         env["LOOPFLOW_UI_TEST_MODE"] = shot.ui_test_mode
     if shot.ui_test_select_branch:
         env["LOOPFLOW_UI_TEST_SELECT_BRANCH"] = shot.ui_test_select_branch
+    if shot.ui_test_detail_state:
+        env["LOOPFLOW_UI_TEST_DETAIL_STATE"] = shot.ui_test_detail_state
     if shot.ui_test_delay is not None:
         env["LOOPFLOW_UI_TEST_DELAY"] = str(shot.ui_test_delay)
 

--- a/scripts/screenshots.yaml
+++ b/scripts/screenshots.yaml
@@ -56,20 +56,43 @@ screenshots:
     select_tab: runs
     directions: [conductor, listener]
 
-  # UI test captures (flow-focused, slower)
-  - name: loopflow-main-uitest
+  # Stable Wave surface (W2-178) — the Proof's five states, driven offline
+  # through the mock-waves fixture (no registry). Each captures one state the
+  # Task must prove; together they are the screenshot fixture the Proof names.
+
+  # selected — the populated detail hierarchy: objective, Projects, KRs, Task
+  # lenses, and (in the list) the child Wave indented under its parent.
+  - name: wave-surface-selected
     type: uitest
     ui_test_mode: mock-waves
     ui_test_delay: 2
 
-  - name: loopflow-wave-running-uitest
+  # future-child indentation — select a leaf so the list, with cadenza indented
+  # under infrastructure, is the subject rather than the detail hierarchy.
+  - name: wave-surface-child-indentation
     type: uitest
     ui_test_mode: mock-waves
-    ui_test_select_branch: wave-auth-feature
+    ui_test_select_branch: cadenza
     ui_test_delay: 2
 
-  - name: loopflow-wave-waiting-uitest
+  # loading — the pre-snapshot state: objective from the cached plan, with the
+  # "Loading live detail…" affordance where Projects will resolve.
+  - name: wave-surface-loading
     type: uitest
     ui_test_mode: mock-waves
-    ui_test_select_branch: wave-api-refactor
+    ui_test_detail_state: loading
+    ui_test_delay: 2
+
+  # error — a failed refresh preserves the last-good detail under one quiet
+  # "showing cached plan · live status unavailable" footer, not a raw error.
+  - name: wave-surface-error
+    type: uitest
+    ui_test_mode: mock-waves
+    ui_test_detail_state: error
+    ui_test_delay: 2
+
+  # empty — no Waves: the calm empty surface, not a giant error.
+  - name: wave-surface-empty
+    type: uitest
+    ui_test_mode: empty-workspaces
     ui_test_delay: 2

--- a/swift/LoopflowMac/MockWaveFixture.swift
+++ b/swift/LoopflowMac/MockWaveFixture.swift
@@ -28,6 +28,28 @@ enum MockWaveFixture {
         return (env?.isEmpty == false ? env : nil) ?? detailWaveName
     }
 
+    /// Which detail-pane state the selected Wave renders. `selected` is the
+    /// populated hierarchy; `loading` holds the pre-snapshot state so the plan
+    /// pane shows its loading affordance; `error` preserves the cached detail
+    /// under the "showing cached plan · live status unavailable" footer (the
+    /// PR #932 preservation behavior). A screenshot run picks one with
+    /// `LOOPFLOW_UI_TEST_DETAIL_STATE`, so the fixture covers every state the
+    /// Proof names without a live registry.
+    enum DetailState: String {
+        case selected
+        case loading
+        case error
+    }
+
+    static var detailState: DetailState {
+        let raw = ProcessInfo.processInfo.environment["LOOPFLOW_UI_TEST_DETAIL_STATE"]
+        return raw.flatMap(DetailState.init(rawValue:)) ?? .selected
+    }
+
+    /// The failure a mock `error` state reports — a plausible offline reason,
+    /// never a raw stack. `WaveDetailReading` frames it as the disclosed footer.
+    static let refreshError = RegistryQueryError("the local registry is unreachable")
+
     /// The stable list, one Wave per lens state: green (a live body), red
     /// (stopped with active work), black (off and clean), plus a child Wave
     /// (parent set) to exercise future-ancestry row indentation.
@@ -70,6 +92,30 @@ enum MockWaveFixture {
     /// `lf status --json` emits (the round-tripped `wave_detail.json` fixture).
     static func selectedWaveDetail() -> WaveDetailSnapshot? {
         try? JSONDecoder().decode(WaveDetailSnapshot.self, from: Data(detailJSON.utf8))
+    }
+
+    /// The detail reading a `mock-waves` capture renders for `waveName` in the
+    /// given state, plus whether the pane still awaits its first live read (the
+    /// loading affordance stays on screen only while awaiting). Pure so the
+    /// screenshot states are covered without launching the app.
+    static func detailReading(
+        waveName: String,
+        state: DetailState
+    ) -> (reading: WaveDetailReading, awaitingFirstRead: Bool) {
+        let snapshot = waveName == detailWaveName ? selectedWaveDetail() : nil
+        var reading = WaveDetailReading()
+        switch state {
+        case .loading:
+            reading.clear()
+            return (reading, true)
+        case .error:
+            if let snapshot { reading.update(snapshot) }
+            reading.recordFailure(refreshError)
+            return (reading, false)
+        case .selected:
+            if let snapshot { reading.update(snapshot) } else { reading.clear() }
+            return (reading, false)
+        }
     }
 
     static let detailJSON = #"""

--- a/swift/LoopflowMac/Views/WaveDetailPane.swift
+++ b/swift/LoopflowMac/Views/WaveDetailPane.swift
@@ -151,6 +151,10 @@ private struct WavePlanView: View {
 
     @Environment(\.palette) private var palette
     @State private var reading = WaveDetailReading()
+    // True until the first live read resolves. It gates the loading affordance,
+    // so an empty projects area during the pre-snapshot window reads as
+    // "loading" rather than "no projects".
+    @State private var isAwaitingDetail = true
 
     private var identity: String { "\(repoPath)|\(wave.id)" }
     private var refreshIdentity: String { "\(identity)|\(refreshSignal)" }
@@ -266,9 +270,19 @@ private struct WavePlanView: View {
                     }
                 }
             } else if plan.projects.isEmpty {
-                Text("No projects yet.")
-                    .font(Typography.caption())
-                    .foregroundStyle(palette.textSecondary)
+                if isAwaitingDetail {
+                    HStack(spacing: Spacing.sm) {
+                        ProgressView().controlSize(.small)
+                        Text("Loading live detail…")
+                            .font(Typography.caption())
+                            .foregroundStyle(palette.textSecondary)
+                    }
+                    .accessibilityIdentifier("wave-detail-loading")
+                } else {
+                    Text("No projects yet.")
+                        .font(Typography.caption())
+                        .foregroundStyle(palette.textSecondary)
+                }
             } else {
                 LazyVStack(alignment: .leading, spacing: Spacing.md) {
                     ForEach(plan.projects) { project in
@@ -304,16 +318,12 @@ private struct WavePlanView: View {
 
     private func refreshDetail() async {
         if AppTestMode.current() == .mockWaves {
-            if wave.name == MockWaveFixture.detailWaveName,
-               let snapshot = MockWaveFixture.selectedWaveDetail() {
-                reading.update(snapshot)
-            } else {
-                reading.clear()
-            }
+            applyMockDetail()
             return
         }
         guard wave.isRegistered else {
             reading.clear()
+            isAwaitingDetail = false
             return
         }
         do {
@@ -327,6 +337,18 @@ private struct WavePlanView: View {
             guard !Task.isCancelled else { return }
             reading.recordFailure(error)
         }
+        isAwaitingDetail = false
+    }
+
+    /// The `mock-waves` detail rendering: the fixture owns the state→reading
+    /// decision (see `MockWaveFixture.detailReading`); the view just applies it.
+    private func applyMockDetail() {
+        let outcome = MockWaveFixture.detailReading(
+            waveName: wave.name,
+            state: MockWaveFixture.detailState
+        )
+        reading = outcome.reading
+        isAwaitingDetail = outcome.awaitingFirstRead
     }
 }
 

--- a/swift/LoopflowTests/MockWaveFixtureTests.swift
+++ b/swift/LoopflowTests/MockWaveFixtureTests.swift
@@ -44,4 +44,52 @@ struct MockWaveFixtureTests {
         #expect(WaveLens.forTask(try #require(byId["INF-123"]).attention).color == .red)
         #expect(WaveLens.forTask(try #require(byId["INF-124"]).attention).color == .black)
     }
+
+    // The Proof requires the screenshot fixture to cover empty, loading, error,
+    // selected, and future-child indentation. Empty is the `empty-workspaces`
+    // mode; selected and indentation are proven above. These cover the detail
+    // states the mock surface drives with `LOOPFLOW_UI_TEST_DETAIL_STATE`.
+
+    @Test("the selected detail state renders the populated hierarchy, no longer awaiting")
+    func selectedDetailState() {
+        let outcome = MockWaveFixture.detailReading(
+            waveName: MockWaveFixture.detailWaveName,
+            state: .selected
+        )
+        #expect(outcome.reading.snapshot != nil)
+        #expect(outcome.reading.errorMessage == nil)
+        #expect(outcome.awaitingFirstRead == false)
+    }
+
+    @Test("the loading detail state withholds the snapshot and keeps the loading affordance")
+    func loadingDetailState() {
+        let outcome = MockWaveFixture.detailReading(
+            waveName: MockWaveFixture.detailWaveName,
+            state: .loading
+        )
+        #expect(outcome.reading.snapshot == nil)
+        #expect(outcome.reading.errorMessage == nil)
+        #expect(outcome.awaitingFirstRead)  // loading affordance stays on screen
+    }
+
+    @Test("the error detail state preserves the last-good detail under a framed footer")
+    func errorDetailState() {
+        let outcome = MockWaveFixture.detailReading(
+            waveName: MockWaveFixture.detailWaveName,
+            state: .error
+        )
+        // The cached detail survives the failed refresh (PR #932 behavior)...
+        #expect(outcome.reading.snapshot?.wave.name == "infrastructure")
+        // ...framed as a quiet footer reason, never a raw error dominating the pane.
+        #expect(outcome.reading.errorMessage == "Wave status unavailable: the local registry is unreachable")
+        #expect(outcome.awaitingFirstRead == false)
+    }
+
+    @Test("detailState reads LOOPFLOW_UI_TEST_DETAIL_STATE, defaulting to selected")
+    func detailStateParsing() {
+        #expect(MockWaveFixture.DetailState(rawValue: "loading") == .loading)
+        #expect(MockWaveFixture.DetailState(rawValue: "error") == .error)
+        #expect(MockWaveFixture.DetailState(rawValue: "selected") == .selected)
+        #expect(MockWaveFixture.DetailState(rawValue: "nonsense") == nil)
+    }
 }


### PR DESCRIPTION
## Try it

```bash
# capture each proof state offline through the mock-waves fixture
LOOPFLOW_UI_TEST_MODE=mock-waves LOOPFLOW_UI_TEST_DETAIL_STATE=loading <run screenshots>
uv run python scripts/generate_screenshots.py

# cover the states in isolation
swift test --filter MockWaveFixtureTests
```

## Summary

The Stable Wave Surface proof names five states its screenshot fixture must cover — empty, loading, error, selected, and future-child indentation. Selected, indentation, and empty were already driven offline; this adds loading and error so the whole proof is captured without a live registry. A new `LOOPFLOW_UI_TEST_DETAIL_STATE` env var picks which detail-pane state a `mock-waves` capture renders, and `MockWaveFixture` owns the state→reading decision so the view just applies it. The detail pane now distinguishes a pre-snapshot empty projects area (a "Loading live detail…" affordance) from a genuinely empty plan ("No projects yet"), and the error state preserves the last-good cached detail under the quiet "showing cached plan · live status unavailable" footer rather than a raw stack.

## Changes

- `MockWaveFixture` gains a `DetailState` enum (`selected`/`loading`/`error`), a `detailState` env reader, and a pure `detailReading(waveName:state:)` that returns the `WaveDetailReading` plus whether the pane still awaits its first live read.
- `WavePlanView` tracks `isAwaitingDetail` to gate the loading affordance, and routes `mock-waves` refreshes through the fixture via `applyMockDetail()`.
- `screenshots.yaml` replaces the old `loopflow-*-uitest` shots with five `wave-surface-*` captures (selected, child-indentation, loading, error, empty); the generator threads the new `ui_test_detail_state` field through to the env.
- Tests assert each detail state's reading — snapshot presence, error framing (PR #932 preservation), and env parsing with a `selected` default.
