### PR TITLE
task: recover abandoned work on the current successor model

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ lf task receipt COMMAND_ID --until incorporated --timeout 30s --json
 lf task acknowledge INF-123 --directive 2 --summary "the shared primitive is first"
 lf task decide INF-123 DECISION_ID revise --message "cover the boundary race"
 lf task wait INF-123
+lf task recover INF-123 --reason "the earlier attempt was abandoned by mistake"
 lf task resume INF-123 --model codex --reason "Claude quota exhausted"
 ```
 
@@ -117,6 +118,12 @@ completion. A provider process and transcript are a replaceable body generation;
 plain `resume` keeps compatible provider history, while `--model` hands the same
 Session to another agent. Root Task PRs target `main`; dependent Tasks get their
 own worktree and target the parent Task's active PR until it merges.
+
+`abandon` is terminal. `lf task recover` deliberately creates one linked Task
+Session successor, adopting the abandoned attempt's worktree, directive, and
+complete serial PR history. It refuses missing, detached, mid-operation, or
+branch-mismatched worktrees before moving ownership; `resume` starts the fresh
+body after recovery.
 
 Task Sessions inherit the Wave objective, curated memory, Project definition,
 and KRs. Typed, idempotent Task observations keep the Wave informed without

--- a/rust/loopflow/src/bin/lf.rs
+++ b/rust/loopflow/src/bin/lf.rs
@@ -1302,6 +1302,14 @@ fn run_task_command(repo: &Path, command: &TaskCommand) -> anyhow::Result<()> {
             )?;
             print_task_control(&result, *json)
         }
+        TaskCommand::Recover {
+            issue,
+            reason,
+            json,
+        } => {
+            let session = loopflow::ops::task::task_recover(issue, reason.clone())?;
+            print_task_session(&session, *json)
+        }
         TaskCommand::Attach { issue } => {
             loopflow::ops::task::task_attach(issue).map_err(Into::into)
         }

--- a/rust/loopflow/src/lf/mod.rs
+++ b/rust/loopflow/src/lf/mod.rs
@@ -1155,6 +1155,14 @@ pub enum TaskCommand {
         #[arg(long)]
         json: bool,
     },
+    /// Recover an abandoned Task as a linked successor on the same worktree
+    Recover {
+        issue: String,
+        #[arg(long)]
+        reason: Option<String>,
+        #[arg(long)]
+        json: bool,
+    },
     /// Attach read-write to the Task Session control terminal
     Attach { issue: String },
     /// Explicitly end a Task Session without merging
@@ -2702,6 +2710,30 @@ mod tests {
             "quota exhausted",
         ])
         .is_err());
+    }
+
+    #[test]
+    fn task_recover_accepts_an_optional_audited_reason() {
+        let cli = Cli::try_parse_from([
+            "lf",
+            "task",
+            "recover",
+            "PRD-9",
+            "--reason",
+            "the abandoned work is still valid",
+            "--json",
+        ])
+        .expect("parse Task recovery");
+        assert!(matches!(
+            cli.command,
+            Some(Commands::Task {
+                cmd: TaskCommand::Recover {
+                    issue,
+                    reason: Some(reason),
+                    json: true,
+                }
+            }) if issue == "PRD-9" && reason == "the abandoned work is still valid"
+        ));
     }
 
     #[test]

--- a/rust/loopflow/src/ops/task.rs
+++ b/rust/loopflow/src/ops/task.rs
@@ -137,6 +137,10 @@ pub struct TaskSessionSnapshot {
     /// historical `project_session_id` is a terminal predecessor and a live
     /// successor now owns its observations, reviews, and reconciliation.
     pub project_route_succeeded: bool,
+    /// Terminal attempt this Session recovered from, when any.
+    pub predecessor_session_id: Option<String>,
+    /// Live successor that recovered this terminal attempt, when any.
+    pub successor_session_id: Option<String>,
     pub current_directive_version: u32,
     pub incorporated_directive_version: u32,
     pub status: TaskSessionStatus,
@@ -4104,6 +4108,10 @@ pub fn task_snapshot(session: &TaskSession) -> OpsResult<TaskSessionSnapshot> {
             local_progress_unsettled: None,
         };
         let actions = derive_task_actions(&action_evidence);
+        let (predecessor_session_id, successor_session_id) = store
+            .task_session_chain_neighbors(&session.id)
+            .await
+            .map_err(|error| task_error(format!("failed to read Task chain: {error}")))?;
         // Resolve the live routing target for this Task's parent Project. The
         // historical project_session_id stays as provenance; the routing target
         // is its non-terminal successor when the historical session is terminal.
@@ -4127,6 +4135,8 @@ pub fn task_snapshot(session: &TaskSession) -> OpsResult<TaskSessionSnapshot> {
             project_session_id: session.project_session_id.to_string(),
             routing_project_session_id,
             project_route_succeeded,
+            predecessor_session_id,
+            successor_session_id,
             current_directive_version: session.current_directive_version,
             incorporated_directive_version: session.incorporated_directive_version,
             status: session.status,
@@ -4432,6 +4442,136 @@ pub fn task_steer(issue: &str, message: String) -> OpsResult<TaskControlResult> 
 
 pub fn task_interrupt(issue: &str, replacement: Option<String>) -> OpsResult<TaskControlResult> {
     queue_command(issue, ChildCommandKind::Interrupt { replacement })
+}
+
+/// Recover an abandoned Task as one linked successor that adopts its worktree,
+/// serial PR history, and current directive.
+pub fn task_recover(issue: &str, reason: Option<String>) -> OpsResult<TaskSession> {
+    let issue = issue.to_string();
+    block_on_task(async move {
+        let store = task_store().await?;
+        _recover_abandoned_task(&store, &issue, reason).await
+    })
+}
+
+async fn _recover_abandoned_task(
+    store: &SharedStore,
+    issue: &str,
+    reason: Option<String>,
+) -> OpsResult<TaskSession> {
+    let reason = reason
+        .map(|value| value.trim().to_string())
+        .map(|value| {
+            if value.is_empty() {
+                Err(task_error("recovery reason cannot be empty"))
+            } else {
+                Ok(value)
+            }
+        })
+        .transpose()?;
+    let predecessor = store
+        .get_task_session_by_issue(issue)
+        .await
+        .map_err(|error| task_error(format!("failed to resolve task: {error}")))?
+        .ok_or_else(|| task_error(format!("no Task Session exists for {issue:?}")))?;
+    command_source(store, &predecessor).await?;
+
+    if predecessor.status != TaskSessionStatus::Abandoned {
+        if predecessor.status == TaskSessionStatus::Completed {
+            return Err(task_error(format!(
+                "Task {} is completed; start a new Task rather than recovering it",
+                predecessor.launch.issue.identifier
+            )));
+        }
+        // A retry after a successful recovery resolves to the live successor.
+        // Return it only when it demonstrably adopted the abandoned attempt's
+        // worktree; an ordinary new attempt uses a different worktree and is not
+        // misreported as recovered.
+        let (prior_id, _) = store
+            .task_session_chain_neighbors(&predecessor.id)
+            .await
+            .map_err(|error| task_error(format!("failed to read Task chain: {error}")))?;
+        if let Some(prior_id) = prior_id {
+            let prior_id = TaskSessionId::parse(&prior_id)
+                .map_err(|error| task_error(format!("invalid Task predecessor: {error}")))?;
+            if let Some(prior) = store
+                .get_task_session(&prior_id)
+                .await
+                .map_err(|error| task_error(format!("failed to read Task predecessor: {error}")))?
+            {
+                if prior.status == TaskSessionStatus::Abandoned
+                    && prior.worktree == predecessor.worktree
+                {
+                    return Ok(predecessor);
+                }
+            }
+        }
+        return Err(task_error(format!(
+            "Task {} is {}; resume it with `lf task resume {}`. Recover is only for abandoned Tasks.",
+            predecessor.launch.issue.identifier,
+            predecessor.status.as_str(),
+            predecessor.launch.issue.identifier
+        )));
+    }
+
+    // Refuse every unsafe worktree/branch/PR shape before moving ownership.
+    task_recovery_adoption(store, &predecessor).await?;
+    let carried = store
+        .child_directives(&ChildRef::Task(predecessor.id.clone()))
+        .await
+        .map_err(|error| task_error(error.to_string()))?
+        .into_iter()
+        .find(|directive| directive.version == predecessor.current_directive_version)
+        .ok_or_else(|| task_error("abandoned Task Session has no current directive"))?;
+    let now = time::OffsetDateTime::now_utc();
+    let status_reason = reason.map_or_else(
+        || format!("recovered from {}; resume to continue", predecessor.id),
+        |reason| {
+            format!(
+                "recovered from {}: {reason}; resume to continue",
+                predecessor.id
+            )
+        },
+    );
+    let successor = TaskSession {
+        id: TaskSessionId::new(),
+        launch: predecessor.launch.clone(),
+        pm_writeback: PmWritebackState::Current,
+        wave_id: predecessor.wave_id.clone(),
+        project_session_id: predecessor.project_session_id.clone(),
+        current_directive_version: 1,
+        incorporated_directive_version: 0,
+        status: TaskSessionStatus::Waiting,
+        status_reason,
+        status_at: now,
+        worktree: predecessor.worktree.clone(),
+        workspace_slug: predecessor.workspace_slug.clone(),
+        lifecycle: predecessor.lifecycle.clone(),
+        lifecycle_phase: crate::task::TaskLifecyclePhase::Kickoff,
+        phase_epoch: 1,
+        phase_cursor: 0,
+        phase_iteration: 0,
+        gate_cycle: 0,
+        gate_proposal: None,
+        agent: predecessor.agent.clone(),
+        provider: predecessor.provider.clone(),
+        provider_session_id: None,
+        latest_process: None,
+        abandon_intent: None,
+        created_at: now,
+        updated_at: now,
+        observation: Observation::NotRequired,
+    };
+    let directive = ChildDirective::initial(
+        ChildRef::Task(successor.id.clone()),
+        carried.text,
+        carried.source,
+    );
+    let succession = store
+        .recover_task_session_successor(&predecessor, &successor, &directive)
+        .await
+        .map_err(|error| task_error(format!("failed to recover Task: {error}")))?;
+    Ok(succession.session)
 }
 
 pub fn task_resume(
@@ -4873,20 +5013,20 @@ mod tests {
     use std::time::Duration;
 
     use super::{
-        _defer_task_interactions, cached_github_observation, changes_snapshot,
-        count_recovery_attempts, decide_open_pr_status, derive_workspace_slug, diff_snapshot,
-        ensure_working_pr, ensure_working_pr_with_authority, file_snapshot, next_pr_slug,
-        parse_pr_slug, parse_workspace_slug, project_context, reconcile_process_liveness,
-        reconcile_task_pr, recover_stalled_task_body, recover_stranded_task_body,
-        refuse_dirty_between_prs, refuse_if_canonical_ahead,
+        _defer_task_interactions, _recover_abandoned_task, cached_github_observation,
+        changes_snapshot, count_recovery_attempts, decide_open_pr_status, derive_workspace_slug,
+        diff_snapshot, ensure_working_pr, ensure_working_pr_with_authority, file_snapshot,
+        next_pr_slug, parse_pr_slug, parse_workspace_slug, project_context,
+        reconcile_process_liveness, reconcile_task_pr, recover_stalled_task_body,
+        recover_stranded_task_body, refuse_dirty_between_prs, refuse_if_canonical_ahead,
         require_task_pr_range_nonempty_with_authority, resolve_task_flow, resolve_upstream_base,
         succession_workspace_slug, task_recovery_adoption, verify_task_pr_range_with_authority,
         RotateOptions, TaskControlResult, TaskRecoveryAdoption, TaskWorkspace,
     };
     use crate::child_session::{
         observe, BodyEvidence, BodyIntent, ChildBodyOutcome, ChildCommand, ChildCommandKind,
-        ChildCommandSource, ChildCommandState, ChildLeaseState, ChildProcessGeneration, ChildRef,
-        MAX_RECOVERY_ATTEMPTS,
+        ChildCommandSource, ChildCommandState, ChildDirective, ChildLeaseState,
+        ChildProcessGeneration, ChildRef, MAX_RECOVERY_ATTEMPTS,
     };
     use crate::id::WaveId;
     use crate::pm::{PmKr, PmProject};
@@ -7277,6 +7417,115 @@ mod tests {
             resume_still_pending,
             "the Resume command is still in the queue, not discarded"
         );
+    }
+
+    #[tokio::test]
+    async fn recover_refuses_a_non_abandoned_task() {
+        let repo = TestRepo::new();
+        let base = repo.head_sha();
+        let branch = "jack/task-pr-proof";
+        repo.create_branch(branch);
+        let (_home, store, session, _pr) = rotation_task(&repo, branch, &base).await;
+
+        let error = _recover_abandoned_task(&store, &session.launch.issue.identifier, None)
+            .await
+            .expect_err("a waiting Task resumes instead of recovering");
+        assert!(error.to_string().contains("lf task resume"), "{error}");
+        assert_eq!(
+            store
+                .get_task_session_by_issue(&session.launch.issue.identifier)
+                .await
+                .unwrap()
+                .unwrap()
+                .id,
+            session.id
+        );
+    }
+
+    #[tokio::test]
+    async fn recover_abandoned_task_adopts_existing_worktree_pr_and_direction() {
+        let repo = TestRepo::new();
+        let base = repo.head_sha();
+        let branch = "jack/task-pr-proof";
+        repo.create_branch(branch);
+        repo.create_file("recovery.txt", "work survives abandonment\n");
+        repo.stage_all();
+        repo.commit("task work");
+        let (_home, store, session, pr) = rotation_task(&repo, branch, &base).await;
+
+        let target = ChildRef::Task(session.id.clone());
+        let command = ChildCommand::new(
+            target.clone(),
+            ChildCommandSource::Human,
+            ChildCommandKind::Steer {
+                text: "finish the existing PR".to_string(),
+            },
+        );
+        let directive = ChildDirective::replacement(
+            target,
+            1,
+            "finish the existing PR".to_string(),
+            command.source.clone(),
+            command.id.clone(),
+        );
+        store
+            .create_child_command_with_directive(&command, &directive)
+            .await
+            .expect("record current direction");
+        let mut abandoned = store.get_task_session(&session.id).await.unwrap().unwrap();
+        abandoned.set_status(TaskSessionStatus::Abandoned, "operator stopped the attempt");
+        store.update_task_session(&abandoned).await.unwrap();
+
+        let successor = _recover_abandoned_task(
+            &store,
+            &abandoned.launch.issue.identifier,
+            Some("the work is still valid".to_string()),
+        )
+        .await
+        .expect("recover abandoned Task");
+        assert_ne!(successor.id, abandoned.id);
+        assert_eq!(successor.status, TaskSessionStatus::Waiting);
+        assert_eq!(successor.worktree, abandoned.worktree);
+        assert_eq!(successor.workspace_slug, abandoned.workspace_slug);
+        assert!(successor.latest_process.is_none());
+        assert_eq!(
+            successor.lifecycle_phase,
+            crate::task::TaskLifecyclePhase::Kickoff
+        );
+        assert!(successor.status_reason.contains("the work is still valid"));
+
+        assert!(store.task_prs(&abandoned.id).await.unwrap().is_empty());
+        let adopted_prs = store.task_prs(&successor.id).await.unwrap();
+        assert_eq!(adopted_prs.len(), 1);
+        assert_eq!(adopted_prs[0].id, pr.id);
+        let carried = store
+            .child_directives(&ChildRef::Task(successor.id.clone()))
+            .await
+            .unwrap();
+        assert_eq!(carried.len(), 1);
+        assert_eq!(carried[0].text, directive.text);
+        assert_eq!(carried[0].source, directive.source);
+
+        let repeated = _recover_abandoned_task(
+            &store,
+            &successor.launch.issue.identifier,
+            Some("the work is still valid".to_string()),
+        )
+        .await
+        .expect("recovery retry converges");
+        assert_eq!(repeated.id, successor.id);
+
+        let mut completed = repeated;
+        completed.set_status(TaskSessionStatus::Completed, "recovered work landed");
+        store.update_task_session(&completed).await.unwrap();
+        let error = _recover_abandoned_task(
+            &store,
+            &completed.launch.issue.identifier,
+            Some("try again".to_string()),
+        )
+        .await
+        .expect_err("a completed recovered Task cannot be recovered again");
+        assert!(error.to_string().contains("is completed"), "{error}");
     }
 
     // ── Task recovery adoption preconditions (W2-251) ───────────────────────

--- a/rust/loopflow/src/store/child_sessions.rs
+++ b/rust/loopflow/src/store/child_sessions.rs
@@ -64,6 +64,23 @@ impl Store {
         .await
     }
 
+    /// Recover an abandoned Task by atomically adopting its worktree and PR
+    /// history onto one linked successor.
+    pub async fn recover_task_session_successor(
+        &self,
+        predecessor: &TaskSession,
+        successor: &TaskSession,
+        directive: &ChildDirective,
+    ) -> StoreResult<TaskSessionSuccession> {
+        let predecessor = predecessor.clone();
+        let successor = successor.clone();
+        let directive = directive.clone();
+        run_sqlite(&self.sqlite, move |store| {
+            store.recover_task_session_successor(&predecessor, &successor, &directive)
+        })
+        .await
+    }
+
     pub async fn update_task_session(&self, session: &TaskSession) -> StoreResult<()> {
         let session = session.clone();
         run_sqlite(&self.sqlite, move |store| {
@@ -232,6 +249,17 @@ impl Store {
     ) -> StoreResult<Option<TaskSession>> {
         let session_id = session_id.clone();
         run_sqlite(&self.sqlite, move |store| store.task_session(&session_id)).await
+    }
+
+    pub async fn task_session_chain_neighbors(
+        &self,
+        session_id: &TaskSessionId,
+    ) -> StoreResult<(Option<String>, Option<String>)> {
+        let session_id = session_id.clone();
+        run_sqlite(&self.sqlite, move |store| {
+            store.task_session_chain_neighbors(&session_id)
+        })
+        .await
     }
 
     pub async fn get_task_session_by_issue(&self, issue: &str) -> StoreResult<Option<TaskSession>> {

--- a/rust/loopflow/src/store/mod.rs
+++ b/rust/loopflow/src/store/mod.rs
@@ -3287,6 +3287,90 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn abandoned_task_recovery_atomically_adopts_its_pr_and_direction() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = open_store(&StorageConfig::sqlite(dir.path().join("registry.db")))
+            .await
+            .unwrap();
+        let wave = make_wave("/repo");
+        store.create_wave(&wave).await.unwrap();
+        let project = make_project_session(&wave);
+        store.create_project_session(&project).await.unwrap();
+
+        let mut predecessor = make_task_session(&wave, &project);
+        predecessor.current_directive_version = 1;
+        let pr = make_task_pr(&predecessor);
+        let initial = ChildDirective::initial(
+            ChildRef::Task(predecessor.id.clone()),
+            "preserve the existing work and PR".to_string(),
+            ChildCommandSource::Human,
+        );
+        store
+            .reserve_task_session_with_directive(&predecessor, &pr, &initial)
+            .await
+            .unwrap();
+        predecessor.set_status(TaskSessionStatus::Abandoned, "stopped explicitly");
+        store.update_task_session(&predecessor).await.unwrap();
+
+        let mut successor = predecessor.clone();
+        successor.id = TaskSessionId::new();
+        successor.status = TaskSessionStatus::Waiting;
+        successor.status_reason = "recovered; resume to continue".to_string();
+        successor.status_at = OffsetDateTime::now_utc();
+        successor.incorporated_directive_version = 0;
+        successor.latest_process = None;
+        successor.created_at = OffsetDateTime::now_utc();
+        successor.updated_at = successor.created_at;
+        let carried = ChildDirective::initial(
+            ChildRef::Task(successor.id.clone()),
+            initial.text.clone(),
+            initial.source.clone(),
+        );
+
+        let created = store
+            .recover_task_session_successor(&predecessor, &successor, &carried)
+            .await
+            .unwrap();
+        assert!(created.created);
+        assert_eq!(created.session.id, successor.id);
+        assert_eq!(
+            store
+                .get_task_session_by_issue("INF-123")
+                .await
+                .unwrap()
+                .unwrap()
+                .id,
+            successor.id
+        );
+        assert!(store.task_prs(&predecessor.id).await.unwrap().is_empty());
+        let adopted = store.task_prs(&successor.id).await.unwrap();
+        assert_eq!(adopted.len(), 1);
+        assert_eq!(adopted[0].id, pr.id);
+        assert_eq!(
+            store
+                .child_directives(&ChildRef::Task(successor.id.clone()))
+                .await
+                .unwrap()[0]
+                .text,
+            initial.text
+        );
+        assert_eq!(
+            store
+                .task_session_chain_neighbors(&successor.id)
+                .await
+                .unwrap(),
+            (Some(predecessor.id.to_string()), None)
+        );
+
+        let repeated = store
+            .recover_task_session_successor(&predecessor, &successor, &carried)
+            .await
+            .unwrap();
+        assert!(!repeated.created);
+        assert_eq!(repeated.session.id, successor.id);
+    }
+
+    #[tokio::test]
     async fn task_session_resolution_fails_actionably_on_multiple_live_successors() {
         let dir = tempfile::tempdir().unwrap();
         let store = open_store(&StorageConfig::sqlite(dir.path().join("registry.db")))

--- a/rust/loopflow/src/store/sqlite/child_sessions.rs
+++ b/rust/loopflow/src/store/sqlite/child_sessions.rs
@@ -114,30 +114,111 @@ impl SqliteStore {
         )?;
         insert_task_pr(&transaction, pr)?;
         insert_child_directive(&transaction, directive)?;
-        // Re-key the cursor: move the predecessor's single row onto the
-        // successor. No successor cursor row exists yet (the successor was not
-        // seeded), so the UPDATE cannot collide on the PRIMARY KEY.
+        _carry_task_session_state(&transaction, predecessor, successor)?;
+        transaction.commit()?;
+        Ok(TaskSessionSuccession {
+            session: successor.clone(),
+            created: true,
+        })
+    }
+
+    /// Recover an abandoned Task by creating one linked successor that adopts
+    /// the predecessor's worktree and complete serial PR history.
+    ///
+    /// Unlike [`Self::reserve_task_session_successor`], this does not create a
+    /// new worktree or sequence-1 PR. It re-keys the existing PR rows together
+    /// with the Linear observation state, so the ownership move is atomic and a
+    /// crash cannot leave two partial attempts. A repeated or concurrent call
+    /// converges on the one live successor.
+    pub fn recover_task_session_successor(
+        &self,
+        predecessor: &TaskSession,
+        successor: &TaskSession,
+        directive: &ChildDirective,
+    ) -> StoreResult<TaskSessionSuccession> {
+        if predecessor.status != TaskSessionStatus::Abandoned {
+            return Err(StoreError::InvalidData(format!(
+                "Task Session {} is {}; only abandoned Tasks can be recovered",
+                predecessor.id,
+                predecessor.status.as_str()
+            )));
+        }
+        if successor.launch != predecessor.launch
+            || successor.wave_id != predecessor.wave_id
+            || successor.project_session_id != predecessor.project_session_id
+        {
+            return Err(StoreError::InvalidData(
+                "a recovered Task successor must keep its predecessor's launch and ownership"
+                    .to_string(),
+            ));
+        }
+        if successor.worktree != predecessor.worktree
+            || successor.workspace_slug != predecessor.workspace_slug
+        {
+            return Err(StoreError::InvalidData(
+                "a recovered Task successor must adopt its predecessor's worktree and workspace"
+                    .to_string(),
+            ));
+        }
+        if successor.status != TaskSessionStatus::Waiting
+            || successor.latest_process.is_some()
+            || successor.provider_session_id.is_some()
+            || successor.abandon_intent.is_some()
+        {
+            return Err(StoreError::InvalidData(
+                "a recovered Task successor must begin waiting without a live body".to_string(),
+            ));
+        }
+        ensure_directive_target(directive, "task", successor.id.as_str())?;
+        validate_task_session(successor)?;
+        let issue_id = successor.launch.issue.id.as_str().to_string();
+        let mut conn = self.conn.lock().expect("store mutex poisoned");
+        let transaction = conn.transaction_with_behavior(TransactionBehavior::Immediate)?;
+        if let Some(existing) =
+            non_terminal_successor_for_issue(&transaction, predecessor.id.as_str(), &issue_id)?
+        {
+            if existing.worktree != predecessor.worktree {
+                return Err(StoreError::InvalidData(format!(
+                    "Task {} already has successor {} on {}; recovery cannot also adopt {}",
+                    predecessor.launch.issue.identifier,
+                    existing.id,
+                    existing.worktree.display(),
+                    predecessor.worktree.display()
+                )));
+            }
+            transaction.commit()?;
+            return Ok(TaskSessionSuccession {
+                session: existing,
+                created: false,
+            });
+        }
+        validate_task_project_session(&transaction, successor)?;
+        let parameters = task_session_params(successor);
         transaction.execute(
-            "UPDATE task_linear_observations SET session_id=?2 WHERE session_id=?1",
-            params![predecessor.id.as_str(), successor.id.as_str()],
+            TASK_SESSION_INSERT,
+            rusqlite::params_from_iter(parameters.iter().map(|value| value.as_ref())),
         )?;
-        // Seed-if-absent: a predecessor without a cursor (e.g. one predating
-        // the cursor migration) leaves the successor with no row to move, so
-        // seed from the launch snapshot. INSERT OR IGNORE is a no-op when the
-        // re-key moved a row.
-        seed_task_linear_observation(&transaction, successor)?;
-        // Re-key the comment ledger so an already-delivered comment cannot
-        // become a second follow-up on the successor.
-        transaction.execute(
-            "UPDATE task_linear_ingested_comments SET session_id=?2 WHERE session_id=?1",
-            params![predecessor.id.as_str(), successor.id.as_str()],
+        let moved = transaction.execute(
+            "UPDATE task_prs SET task_session_id=?1, updated_at=?2 WHERE task_session_id=?3",
+            params![successor.id.as_str(), now_unix(), predecessor.id.as_str()],
         )?;
-        // Soft-link the successor to its predecessor. Receipts stay on the
-        // predecessor; this column is the attributable-history link.
-        transaction.execute(
-            "UPDATE task_sessions SET predecessor_session_id=?2 WHERE id=?1",
-            params![successor.id.as_str(), predecessor.id.as_str()],
+        if moved == 0 {
+            return Err(StoreError::InvalidData(format!(
+                "abandoned Task Session {} has no PR history to recover",
+                predecessor.id
+            )));
+        }
+        insert_child_directive(&transaction, directive)?;
+        insert_task_event_in(
+            &transaction,
+            successor,
+            &TaskEventKind::DirectiveChanged {
+                directive_id: directive.id.clone(),
+                version: directive.version,
+                directive_kind: directive.kind,
+            },
         )?;
+        _carry_task_session_state(&transaction, predecessor, successor)?;
         transaction.commit()?;
         Ok(TaskSessionSuccession {
             session: successor.clone(),
@@ -691,6 +772,30 @@ impl SqliteStore {
         )
         .optional()
         .map_err(StoreError::from)
+    }
+
+    /// The predecessor and successor ids linked to one Task Session.
+    pub fn task_session_chain_neighbors(
+        &self,
+        session_id: &TaskSessionId,
+    ) -> StoreResult<(Option<String>, Option<String>)> {
+        let conn = self.conn.lock().expect("store mutex poisoned");
+        let predecessor = conn
+            .query_row(
+                "SELECT predecessor_session_id FROM task_sessions WHERE id=?1",
+                params![session_id.as_str()],
+                |row| row.get::<_, Option<String>>(0),
+            )
+            .optional()?
+            .flatten();
+        let successor = conn
+            .query_row(
+                "SELECT id FROM task_sessions WHERE predecessor_session_id=?1",
+                params![session_id.as_str()],
+                |row| row.get::<_, String>(0),
+            )
+            .optional()?;
+        Ok((predecessor, successor))
     }
 
     pub fn task_session_by_issue(&self, issue: &str) -> StoreResult<Option<TaskSession>> {
@@ -3107,6 +3212,36 @@ fn seed_task_linear_observation(conn: &Connection, session: &TaskSession) -> Sto
             session.launch.issue.description,
             now_unix(),
         ],
+    )?;
+    Ok(())
+}
+
+/// Move the live Linear ingress state onto a Task successor and link the
+/// successor back to its terminal predecessor. Historical commands and
+/// directives stay on the predecessor for attribution.
+fn _carry_task_session_state(
+    conn: &Connection,
+    predecessor: &TaskSession,
+    successor: &TaskSession,
+) -> StoreResult<()> {
+    // Move the cursor rather than copying it: an already-applied Linear edit
+    // must not replay when a successor becomes current.
+    conn.execute(
+        "UPDATE task_linear_observations SET session_id=?2 WHERE session_id=?1",
+        params![predecessor.id.as_str(), successor.id.as_str()],
+    )?;
+    // Legacy predecessors may have no cursor. Seed only when the move above
+    // found nothing.
+    seed_task_linear_observation(conn, successor)?;
+    // A previously delivered Linear comment must not become a second follow-up
+    // on the successor.
+    conn.execute(
+        "UPDATE task_linear_ingested_comments SET session_id=?2 WHERE session_id=?1",
+        params![predecessor.id.as_str(), successor.id.as_str()],
+    )?;
+    conn.execute(
+        "UPDATE task_sessions SET predecessor_session_id=?2 WHERE id=?1",
+        params![successor.id.as_str(), predecessor.id.as_str()],
     )?;
     Ok(())
 }


### PR DESCRIPTION
## Usage

```bash
lf task recover INF-123 --reason "the earlier attempt was abandoned by mistake"
lf task resume INF-123
```

## Summary

`abandon` is terminal, which meant a worktree full of real work plus an open PR had no way back — the only option was starting a fresh Task and re-doing everything. `lf task recover` closes that gap by creating exactly one linked Task Session successor that adopts the abandoned attempt's worktree, workspace slug, current directive, and full serial PR history, then hands off to `resume` to start the fresh body.

Recovery refuses unsafe shapes before it moves any ownership: missing, detached, mid-operation, or branch-mismatched worktrees are rejected via the existing `task_recovery_adoption` preconditions, and the store move is atomic so a failure can't leave PRs orphaned between two sessions. A non-abandoned Task is told to `resume` instead; a completed one is told to start a new Task. Retrying `recover` after a successful recovery converges on the live successor rather than forking a second one — but only when that successor demonstrably adopted the abandoned worktree, so an ordinary new attempt on a different worktree isn't misreported as recovered.

## Changes

- New `lf task recover ISSUE [--reason ...] [--json]` command, wired through the CLI to `ops::task::task_recover`
- `TaskSessionSnapshot` gains `predecessor_session_id` / `successor_session_id`, backed by a new `task_session_chain_neighbors` store query, so the succession chain is visible to callers
- New atomic `recover_task_session_successor` store operation: creates the successor, carries the directive forward as version 1, and moves PR history off the terminal predecessor in one transaction
- Successor starts clean — `Waiting`, `Kickoff` phase, no inherited process or provider session — with the reason recorded in `status_reason` for audit
- Tests cover the refusals, the adoption of worktree/PR/directive, retry convergence, and the store-level atomicity; README documents the recover-then-resume flow