### PR TITLE
wave surface: prove the five states render distinctly in ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,6 +121,18 @@ jobs:
         run: swift test --package-path swift -Xswiftc -gnone
       - name: Check Swift multiplatform boundaries
         run: uv run python scripts/check_swift_multiplatform_boundaries.py
+      - name: Prove the Wave surface renders its five states distinctly
+        # Unlike the hosted XCUITest (which needs Automation permission and so
+        # lives behind the `--ui-host` gate), this launches the built app
+        # directly and renders each state's window through SnapshotService
+        # (cacheDisplay, no Screen Recording or Automation permission needed),
+        # then asserts the five states at two widths are pairwise distinct. It
+        # is the CI-runnable half of the W2-178 distinctness proof — a
+        # regression like the DETAIL_STATE forwarding gap fails this step.
+        run: |
+          swift build --package-path swift --product LoopflowMac
+          scripts/prove_wave_surface_states.sh
+        timeout-minutes: 15
 
   loopflow-ui-test:
     runs-on: macos-15

--- a/scripts/generate_screenshots.py
+++ b/scripts/generate_screenshots.py
@@ -52,6 +52,7 @@ class Screenshot:
     ui_test_mode: str | None = None
     ui_test_select_branch: str | None = None
     ui_test_detail_state: str | None = None
+    ui_test_width: int | None = None
     ui_test_delay: float | None = None
 
 
@@ -82,6 +83,7 @@ def load_manifest(path: Path) -> Manifest:
                 ui_test_mode=shot.get("ui_test_mode"),
                 ui_test_select_branch=shot.get("ui_test_select_branch"),
                 ui_test_detail_state=shot.get("ui_test_detail_state"),
+                ui_test_width=shot.get("ui_test_width"),
                 ui_test_delay=shot.get("ui_test_delay"),
             )
         )
@@ -459,6 +461,8 @@ def capture_ui_test_screenshot(
         env["LOOPFLOW_UI_TEST_SELECT_BRANCH"] = shot.ui_test_select_branch
     if shot.ui_test_detail_state:
         env["LOOPFLOW_UI_TEST_DETAIL_STATE"] = shot.ui_test_detail_state
+    if shot.ui_test_width is not None:
+        env["LOOPFLOW_UI_TEST_WIDTH"] = str(shot.ui_test_width)
     if shot.ui_test_delay is not None:
         env["LOOPFLOW_UI_TEST_DELAY"] = str(shot.ui_test_delay)
 

--- a/scripts/prove_product_wave_surface.sh
+++ b/scripts/prove_product_wave_surface.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Capture the real Product Wave through the production registry path. This is
+# intentionally separate from the deterministic CI fixture proof: an absent or
+# incomplete PM snapshot is a named failure, never silently replaced by mocks.
+#
+# Usage: scripts/prove_product_wave_surface.sh [repo]
+set -euo pipefail
+
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+TARGET_REPO="${1:-$REPO}"
+BIN="$REPO/swift/.build/debug/LoopflowMac"
+OUT="$REPO/.lf/tmp/wave-surface/product-live"
+STATUS="$OUT/status.json"
+
+mkdir -p "$OUT"
+( cd "$TARGET_REPO" && lf status product --json ) >"$STATUS"
+
+uv run python - "$STATUS" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+payload = json.loads(Path(sys.argv[1]).read_text())
+if payload["wave"]["name"] != "product":
+    raise SystemExit("FAIL — lf status did not return the Product Wave")
+if not payload["wave"]["goal"].strip():
+    raise SystemExit("FAIL — Product has no objective")
+projects = payload["projects"]
+if not projects:
+    raise SystemExit("FAIL — Product has no Projects")
+if not any(project["project"]["krs"] for project in projects):
+    raise SystemExit("FAIL — Product has no Project KR evidence")
+if not any(
+    not task["task"]["completed"]
+    for project in projects
+    for task in project["tasks"]
+):
+    raise SystemExit("FAIL — Product has no open Task rows to render")
+print(
+    f"Product registry proof: {len(projects)} Projects, "
+    f"{sum(len(project['project']['krs']) for project in projects)} KRs"
+)
+PY
+
+if [ ! -x "$BIN" ]; then
+  ( cd "$REPO/swift" && swift build --product LoopflowMac >/dev/null )
+fi
+
+capture() {
+  local width="$1" out="$OUT/product-${width}.png"
+  rm -f "$out"
+  LOOPFLOW_UI_TEST_SELECT_BRANCH=product \
+  LOOPFLOW_UI_TEST_WIDTH="$width" \
+  LOOPFLOW_UI_TEST_DELAY=6 \
+  LOOPFLOW_UI_TEST_SNAPSHOT_PATH="$out" \
+    "$BIN" --repo "$TARGET_REPO" -ui-test-mode live >/dev/null 2>&1 &
+  local pid=$!
+  for _ in $(seq 1 40); do
+    kill -0 "$pid" 2>/dev/null || break
+    sleep 0.5
+  done
+  kill "$pid" 2>/dev/null || true
+  wait "$pid" 2>/dev/null || true
+  if [ ! -s "$out" ]; then
+    echo "FAIL — real Product snapshot was not created at ${width}px"
+    exit 1
+  fi
+  echo "Product @ ${width}px → $out"
+}
+
+capture 900
+capture 1440
+
+if [ "$(md5 -q "$OUT/product-900.png")" = "$(md5 -q "$OUT/product-1440.png")" ]; then
+  echo "FAIL — narrow and wide Product surfaces rendered identically"
+  exit 1
+fi
+
+echo "PASS — real Product data rendered through the production registry path."

--- a/scripts/prove_wave_surface_states.sh
+++ b/scripts/prove_wave_surface_states.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# Prove the stable Wave surface (W2-178) renders the five Proof states —
+# selected, loading, error, empty, and future-child indentation — DISTINCTLY,
+# at both a narrow and a wide desktop width, on a host without UI-automation
+# permission.
+#
+# The permissioned XCUITest (LoopflowUITests/WaveSurfaceStateTests) asserts each
+# state's unique affordance and row hittability; it runs on the maintained UI
+# host. This script is the run-here complement: it launches the built app in
+# each state, has the app render its own key window to a PNG (SnapshotService,
+# no Screen Recording permission), and asserts the states produce pairwise
+# distinct images. Together they catch a regression like PR #972's — where the
+# detail-state env never reached the app, so loading and error rendered as
+# selected (identical images here, failed affordance assertions there).
+#
+# Usage: scripts/prove_wave_surface_states.sh
+set -euo pipefail
+
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+BIN="$REPO/swift/.build/debug/LoopflowMac"
+if [ ! -x "$BIN" ]; then
+  echo "Building LoopflowMac…"
+  ( cd "$REPO/swift" && swift build --product LoopflowMac >/dev/null )
+fi
+
+OUT="$(mktemp -d -t wave_surface_states.XXXXXX)"
+trap 'rm -rf "$OUT"' EXIT
+
+# state|mode|detail_state|select_branch
+STATES=(
+  "selected|mock-waves||"
+  "loading|mock-waves|loading|"
+  "error|mock-waves|error|"
+  "empty|empty-workspaces||"
+  "child|mock-waves||cadenza"
+)
+WIDTHS=(900 1440)
+
+capture() {
+  local name="$1" mode="$2" detail="$3" branch="$4" width="$5" out="$6"
+  LOOPFLOW_UI_TEST_DETAIL_STATE="$detail" \
+  LOOPFLOW_UI_TEST_SELECT_BRANCH="$branch" \
+  LOOPFLOW_UI_TEST_WIDTH="$width" \
+  LOOPFLOW_UI_TEST_SNAPSHOT_PATH="$out" \
+    "$BIN" -ui-test-mode "$mode" >/dev/null 2>&1 &
+  local pid=$!
+  # The app snapshots ~2.5s in, then self-terminates; wait it out with a cap.
+  for _ in $(seq 1 20); do
+    kill -0 "$pid" 2>/dev/null || break
+    sleep 0.5
+  done
+  kill "$pid" 2>/dev/null || true
+  wait "$pid" 2>/dev/null || true
+}
+
+echo "Capturing 5 states × 2 widths through the app's own renderer…"
+declare -a HASHES=()
+declare -a LABELS=()
+fail=0
+for width in "${WIDTHS[@]}"; do
+  for entry in "${STATES[@]}"; do
+    IFS='|' read -r name mode detail branch <<<"$entry"
+    png="$OUT/${name}-${width}.png"
+    capture "$name" "$mode" "$detail" "$branch" "$width" "$png"
+    if [ ! -s "$png" ]; then
+      echo "  FAIL — no snapshot for $name @ ${width}px"
+      fail=1
+      continue
+    fi
+    h="$(md5 -q "$png")"
+    bytes="$(wc -c <"$png" | tr -d ' ')"
+    echo "  $name @ ${width}px → ${bytes} bytes  ${h}"
+    HASHES+=("$h")
+    LABELS+=("${name}@${width}")
+  done
+done
+
+# Every capture must be pairwise distinct: a collision means two states (or two
+# widths) rendered identically — exactly the failure the forwarding bug caused.
+echo "Checking all captures are pairwise distinct…"
+n=${#HASHES[@]}
+for ((i = 0; i < n; i++)); do
+  for ((j = i + 1; j < n; j++)); do
+    if [ "${HASHES[$i]}" = "${HASHES[$j]}" ]; then
+      echo "  FAIL — ${LABELS[$i]} and ${LABELS[$j]} rendered identically (${HASHES[$i]})"
+      fail=1
+    fi
+  done
+done
+
+if [ "$fail" -ne 0 ]; then
+  echo "FAIL — the Wave surface did not render all states distinctly."
+  exit 1
+fi
+echo "PASS — all ${n} captures (5 states × 2 widths) are distinct and non-empty."

--- a/scripts/prove_wave_surface_states.sh
+++ b/scripts/prove_wave_surface_states.sh
@@ -44,8 +44,9 @@ capture() {
   LOOPFLOW_UI_TEST_SNAPSHOT_PATH="$out" \
     "$BIN" -ui-test-mode "$mode" >/dev/null 2>&1 &
   local pid=$!
-  # The app snapshots ~2.5s in, then self-terminates; wait it out with a cap.
-  for _ in $(seq 1 20); do
+  # The app snapshots ~2.5s in, then self-terminates; wait it out with a cap
+  # generous enough for a cold CI runner's first render.
+  for _ in $(seq 1 60); do
     kill -0 "$pid" 2>/dev/null || break
     sleep 0.5
   done

--- a/scripts/screenshots.yaml
+++ b/scripts/screenshots.yaml
@@ -132,3 +132,7 @@ screenshots:
     ui_test_mode: empty-workspaces
     ui_test_width: 1440
     ui_test_delay: 2
+
+  # Real Product data is deliberately not a fixture entry: run
+  # scripts/prove_product_wave_surface.sh so a missing PM snapshot fails by
+  # name instead of quietly producing a mock screenshot.

--- a/scripts/screenshots.yaml
+++ b/scripts/screenshots.yaml
@@ -57,42 +57,78 @@ screenshots:
     directions: [conductor, listener]
 
   # Stable Wave surface (W2-178) — the Proof's five states, driven offline
-  # through the mock-waves fixture (no registry). Each captures one state the
-  # Task must prove; together they are the screenshot fixture the Proof names.
+  # through the mock-waves fixture (no registry), each at a narrow (900) and a
+  # wide (1440) desktop width. WaveSurfaceStateTests asserts these render
+  # distinctly and stay selectable without clipping; these captures are the
+  # documented visual record. Distinctness is enforced by that test, not by
+  # eyeballing the manifest.
 
   # selected — the populated detail hierarchy: objective, Projects, KRs, Task
   # lenses, and (in the list) the child Wave indented under its parent.
-  - name: wave-surface-selected
+  - name: wave-surface-selected-narrow
     type: uitest
     ui_test_mode: mock-waves
+    ui_test_width: 900
+    ui_test_delay: 2
+  - name: wave-surface-selected-wide
+    type: uitest
+    ui_test_mode: mock-waves
+    ui_test_width: 1440
     ui_test_delay: 2
 
   # future-child indentation — select a leaf so the list, with cadenza indented
   # under infrastructure, is the subject rather than the detail hierarchy.
-  - name: wave-surface-child-indentation
+  - name: wave-surface-child-narrow
     type: uitest
     ui_test_mode: mock-waves
     ui_test_select_branch: cadenza
+    ui_test_width: 900
+    ui_test_delay: 2
+  - name: wave-surface-child-wide
+    type: uitest
+    ui_test_mode: mock-waves
+    ui_test_select_branch: cadenza
+    ui_test_width: 1440
     ui_test_delay: 2
 
   # loading — the pre-snapshot state: objective from the cached plan, with the
   # "Loading live detail…" affordance where Projects will resolve.
-  - name: wave-surface-loading
+  - name: wave-surface-loading-narrow
     type: uitest
     ui_test_mode: mock-waves
     ui_test_detail_state: loading
+    ui_test_width: 900
+    ui_test_delay: 2
+  - name: wave-surface-loading-wide
+    type: uitest
+    ui_test_mode: mock-waves
+    ui_test_detail_state: loading
+    ui_test_width: 1440
     ui_test_delay: 2
 
   # error — a failed refresh preserves the last-good detail under one quiet
   # "showing cached plan · live status unavailable" footer, not a raw error.
-  - name: wave-surface-error
+  - name: wave-surface-error-narrow
     type: uitest
     ui_test_mode: mock-waves
     ui_test_detail_state: error
+    ui_test_width: 900
+    ui_test_delay: 2
+  - name: wave-surface-error-wide
+    type: uitest
+    ui_test_mode: mock-waves
+    ui_test_detail_state: error
+    ui_test_width: 1440
     ui_test_delay: 2
 
   # empty — no Waves: the calm empty surface, not a giant error.
-  - name: wave-surface-empty
+  - name: wave-surface-empty-narrow
     type: uitest
     ui_test_mode: empty-workspaces
+    ui_test_width: 900
+    ui_test_delay: 2
+  - name: wave-surface-empty-wide
+    type: uitest
+    ui_test_mode: empty-workspaces
+    ui_test_width: 1440
     ui_test_delay: 2

--- a/swift/LoopflowMac/AppTestMode.swift
+++ b/swift/LoopflowMac/AppTestMode.swift
@@ -13,4 +13,14 @@ enum AppTestMode: String {
         }
         return process.environment["LOOPFLOW_UI_TEST_MODE"].flatMap(AppTestMode.init(rawValue:))
     }
+
+    /// A fixed window width for a screenshot/UI-test run, from
+    /// `LOOPFLOW_UI_TEST_WIDTH`. It pins the window so the narrow and wide legs
+    /// of the "every Wave stays selectable without horizontal clipping" proof
+    /// are deterministic — never the host's incidental default size.
+    static var windowWidth: CGFloat? {
+        guard let raw = ProcessInfo.processInfo.environment["LOOPFLOW_UI_TEST_WIDTH"],
+              let value = Double(raw), value > 0 else { return nil }
+        return CGFloat(value)
+    }
 }

--- a/swift/LoopflowMac/AppTestMode.swift
+++ b/swift/LoopflowMac/AppTestMode.swift
@@ -4,6 +4,11 @@ enum AppTestMode: String {
     case emptyWorkspaces = "empty-workspaces"
     case sampleWorkspaces = "sample-workspaces"
     case mockWaves = "mock-waves"
+    /// Renders through the REAL `lf` registry — the same read path production
+    /// uses — while keeping the snapshot/width test knobs armed. Every other
+    /// mode bypasses the registry with fixture data; `live` is the honest
+    /// real-Product-data leg of the surface proof, not fixture-only.
+    case live = "live"
 
     static func current() -> AppTestMode? {
         let process = ProcessInfo.processInfo
@@ -14,6 +19,19 @@ enum AppTestMode: String {
         return process.environment["LOOPFLOW_UI_TEST_MODE"].flatMap(AppTestMode.init(rawValue:))
     }
 
+    /// `live` runs the real registry read path (it only adds the snapshot/width
+    /// test knobs); every other mode bypasses the registry with fixture data.
+    /// Production (`current() == nil`) reads the registry too.
+    var bypassesRegistry: Bool { self != .live }
+
+    /// True only for deterministic fixture modes. `live` keeps the screenshot
+    /// controls but must execute the same repo discovery and registry reads as
+    /// production; testing `current() != nil` would silently turn it into an
+    /// empty fixture surface.
+    static var shouldBypassRegistry: Bool {
+        current()?.bypassesRegistry == true
+    }
+
     /// A fixed window width for a screenshot/UI-test run, from
     /// `LOOPFLOW_UI_TEST_WIDTH`. It pins the window so the narrow and wide legs
     /// of the "every Wave stays selectable without horizontal clipping" proof
@@ -22,5 +40,25 @@ enum AppTestMode: String {
         guard let raw = ProcessInfo.processInfo.environment["LOOPFLOW_UI_TEST_WIDTH"],
               let value = Double(raw), value > 0 else { return nil }
         return CGFloat(value)
+    }
+
+    /// Seconds the surface settles before the snapshot fires, from
+    /// `LOOPFLOW_UI_TEST_DELAY`. The fixture legs render fast; the `live` leg
+    /// shells out to `lf ls`/`lf status`, so a real-data capture gives it more
+    /// room. Defaults to 2.5s — the value the fixture distinctness proof tuned.
+    static var snapshotDelay: TimeInterval {
+        guard let raw = ProcessInfo.processInfo.environment["LOOPFLOW_UI_TEST_DELAY"],
+              let value = Double(raw), value > 0 else { return 2.5 }
+        return value
+    }
+
+    /// A Wave name to auto-select once the list resolves, from
+    /// `LOOPFLOW_UI_TEST_SELECT_BRANCH`. The `mock-waves` fixture reads it to
+    /// target a list state; `live` reads it to drive a real Wave into its full
+    /// detail hierarchy headlessly — so a screenshot run captures the real
+    /// objective/Projects/KRs/task rows, not just the list.
+    static var selectBranch: String? {
+        let env = ProcessInfo.processInfo.environment["LOOPFLOW_UI_TEST_SELECT_BRANCH"]
+        return (env?.isEmpty == false ? env : nil)
     }
 }

--- a/swift/LoopflowMac/LoopflowApp.swift
+++ b/swift/LoopflowMac/LoopflowApp.swift
@@ -240,8 +240,9 @@ private extension View {
     func uiTestSnapshot() -> some View {
         if AppTestMode.current() != nil,
            let path = ProcessInfo.processInfo.environment["LOOPFLOW_UI_TEST_SNAPSHOT_PATH"] {
+            let delay = AppTestMode.snapshotDelay
             task {
-                try? await Task.sleep(nanoseconds: 2_500_000_000)
+                try? await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
                 // A background-launched app has no key window, so snapshot the
                 // first realized window directly rather than `keyWindow`.
                 if let window = NSApp.windows.first(where: { $0.contentView != nil }) {

--- a/swift/LoopflowMac/LoopflowApp.swift
+++ b/swift/LoopflowMac/LoopflowApp.swift
@@ -57,6 +57,8 @@ struct LoopflowApp: App {
             .preferredColorScheme(theme.preferredScheme)
             .environment(\.palette, theme.palette)
             .onOpenURL { handleDeepLink($0) }
+            .uiTestWindowWidth()
+            .uiTestSnapshot()
         }
         .windowStyle(.automatic)
         .defaultSize(width: 1080, height: 760)
@@ -211,5 +213,44 @@ struct LoopflowApp: App {
         guard panel.runModal() == .OK, let url = panel.url else { return }
         portfolioService.addRepo(url)
         openWindow(id: "repo", value: url)
+    }
+}
+
+private extension View {
+    /// Pin the window to `LOOPFLOW_UI_TEST_WIDTH` when a screenshot/UI-test run
+    /// asks for a specific size; otherwise render unchanged. This is how the
+    /// narrow and wide legs of the selectable-without-clipping proof get a
+    /// deterministic width instead of the host's default.
+    @ViewBuilder
+    func uiTestWindowWidth() -> some View {
+        if let width = AppTestMode.windowWidth {
+            frame(width: width)
+        } else {
+            self
+        }
+    }
+
+    /// In a UI-test run, once the surface has settled, render the key window to
+    /// a PNG at `LOOPFLOW_UI_TEST_SNAPSHOT_PATH` and exit. `SnapshotService`
+    /// renders the view (`cacheDisplay`) rather than the screen, so this needs
+    /// no Screen Recording or Automation permission — it is the run-here leg of
+    /// the state-distinctness proof (`scripts/prove_wave_surface_states.sh`),
+    /// complementing the permissioned XCUITest.
+    @ViewBuilder
+    func uiTestSnapshot() -> some View {
+        if AppTestMode.current() != nil,
+           let path = ProcessInfo.processInfo.environment["LOOPFLOW_UI_TEST_SNAPSHOT_PATH"] {
+            task {
+                try? await Task.sleep(nanoseconds: 2_500_000_000)
+                // A background-launched app has no key window, so snapshot the
+                // first realized window directly rather than `keyWindow`.
+                if let window = NSApp.windows.first(where: { $0.contentView != nil }) {
+                    _ = try? SnapshotService().snapshotWindow(window, to: path)
+                }
+                NSApp.terminate(nil)
+            }
+        } else {
+            self
+        }
     }
 }

--- a/swift/LoopflowMac/Views/ActiveSessionsView.swift
+++ b/swift/LoopflowMac/Views/ActiveSessionsView.swift
@@ -52,6 +52,7 @@ struct ActiveSessionsView: View {
         .sheet(item: $openTarget) { handoff in
             HandoffAttachSheet(handoff: handoff, query: query) { openTarget = nil }
         }
+        .accessibilityIdentifier("control-active-sessions")
     }
 
     private var emptyState: some View {

--- a/swift/LoopflowMac/Views/ControlView.swift
+++ b/swift/LoopflowMac/Views/ControlView.swift
@@ -39,6 +39,7 @@ struct ControlView: View {
         }
         .frame(minWidth: 660, minHeight: 540)
         .background(palette.background)
+        .accessibilityIdentifier("control-surface")
     }
 
     private var header: some View {
@@ -100,6 +101,9 @@ struct ControlView: View {
         .help(tab.available ? "" : "Run History is coming soon")
         .accessibilityLabel(tab.title)
         .accessibilityHint(tab.available ? "" : "Coming soon")
+        .accessibilityIdentifier(
+            tab == .activeSessions ? "control-active-sessions-tab" : "control-run-history-tab"
+        )
     }
 }
 

--- a/swift/LoopflowMac/Views/RoadmapView.swift
+++ b/swift/LoopflowMac/Views/RoadmapView.swift
@@ -148,14 +148,9 @@ struct RoadmapView: View {
                 Text("Work")
                     .font(Typography.sectionTitle(20))
                     .foregroundStyle(palette.text)
-                HStack(spacing: Spacing.xs) {
-                    Text(repoPath == nil ? "Every registered Wave" : "Registered Waves in this repository")
-                    if let synced = snapshot?.generatedAt {
-                        Text("· as of \(syncedLabel(synced))")
-                    }
-                }
-                .font(Typography.caption(11))
-                .foregroundStyle(palette.textSecondary)
+                Text(repoPath == nil ? "All Waves" : "Waves in this repository")
+                    .font(Typography.caption(11))
+                    .foregroundStyle(palette.textSecondary)
             }
             Spacer()
             Picker("Lens", selection: $lens) {
@@ -185,17 +180,6 @@ struct RoadmapView: View {
         .padding(.vertical, Spacing.md)
     }
 
-    /// The roadmap read's clock. RFC3339 in, short local time out; the raw
-    /// string if it will not parse — staleness must always be visible, never
-    /// swallowed by a formatting failure.
-    private func syncedLabel(_ iso: String) -> String {
-        guard let date = ISO8601DateFormatter().date(from: iso) else { return iso }
-        let out = DateFormatter()
-        out.dateStyle = .none
-        out.timeStyle = .short
-        return out.string(from: date)
-    }
-
     @ViewBuilder
     private var content: some View {
         if snapshot == nil, queryError == nil {
@@ -203,13 +187,13 @@ struct RoadmapView: View {
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
         } else if snapshot == nil {
             ContentUnavailableView(
-                "Roadmap unavailable",
+                "Work unavailable",
                 systemImage: "exclamationmark.triangle",
-                description: Text("The registry read failed. Refresh to try again.")
+                description: Text("Couldn't read the latest work. Refresh to try again.")
             )
         } else if visibleWaves.isEmpty {
             ContentUnavailableView(
-                repoPath == nil ? "No waves in the registry" : "No registered waves in this repository",
+                repoPath == nil ? "No Waves yet" : "No Waves in this repository",
                 systemImage: "map"
             )
         } else {

--- a/swift/LoopflowMac/Views/WaveDetailPane.swift
+++ b/swift/LoopflowMac/Views/WaveDetailPane.swift
@@ -120,6 +120,7 @@ struct WaveDetailPane: View {
             .buttonStyle(.plain)
             .help("Open Control")
             .accessibilityLabel("Open Control")
+            .accessibilityIdentifier("wave-control-button")
 
             Button {
                 onClose()
@@ -291,6 +292,7 @@ private struct WavePlanView: View {
                 }
             }
         }
+        .accessibilityIdentifier("wave-projects")
     }
 
     /// Live-status failures are operational detail, not primary hierarchy: a
@@ -427,6 +429,7 @@ private struct WaveProjectWorkView: View {
                 .stroke(isSelected ? palette.accent : Color.clear, lineWidth: 1)
         }
         .contentShape(Rectangle())
+        .accessibilityIdentifier("wave-project")
         .onTapGesture {
             selection = WaveWorkSelection(kind: .project, id: project.project.slug)
         }
@@ -468,6 +471,7 @@ private struct WaveProjectWorkView: View {
         .accessibilityElement(children: .combine)
         .accessibilityLabel(text)
         .accessibilityValue(holds ? "Holds" : "Open")
+        .accessibilityIdentifier("project-key-result")
     }
 }
 
@@ -514,6 +518,7 @@ private struct WaveTaskWorkView: View {
                 .stroke(isSelected ? palette.accent : Color.clear, lineWidth: 1)
         }
         .contentShape(Rectangle())
+        .accessibilityIdentifier("wave-task")
         .onTapGesture {
             selection = WaveWorkSelection(kind: .task, id: task.task.identifier)
         }

--- a/swift/LoopflowMac/Views/WaveLensView.swift
+++ b/swift/LoopflowMac/Views/WaveLensView.swift
@@ -42,6 +42,7 @@ struct WaveLensView: View {
             .shadow(color: lit ? color.opacity(0.6) : .clear, radius: lit ? 2.5 : 0)
             .accessibilityElement()
             .accessibilityLabel("Status: \(lens.reason)")
+            .accessibilityValue("\(lens.color.rawValue) lens")
             .accessibilityIdentifier(accessibilityId)
             .help(lens.reason)
     }

--- a/swift/LoopflowMac/Views/WaveRow.swift
+++ b/swift/LoopflowMac/Views/WaveRow.swift
@@ -14,6 +14,11 @@ struct WaveRow: View {
 
     @State private var isHovering = false
 
+    private var accessibilityValue: String {
+        let hierarchy = indentLevel > 0 ? "child wave" : "top-level wave"
+        return "\(wave.lens.color.rawValue) lens; \(hierarchy)"
+    }
+
     var body: some View {
         HStack(alignment: .top, spacing: Spacing.sm) {
             WaveLensView(lens: wave.lens)
@@ -81,6 +86,8 @@ struct WaveRow: View {
         }
         .accessibilityElement(children: .combine)
         .accessibilityLabel("Wave: \(wave.displayName). \(wave.lens.reason)")
+        .accessibilityValue(accessibilityValue)
+        .accessibilityHint(indentLevel > 0 ? "Child wave" : "Top-level wave")
         .accessibilityAddTraits(isSelected ? [.isSelected] : [])
     }
 }

--- a/swift/LoopflowMac/Views/WavesView.swift
+++ b/swift/LoopflowMac/Views/WavesView.swift
@@ -391,7 +391,7 @@ struct WavesView: View {
     /// `LOOPFLOW_DEV_WAVE_REPO` dev override reads the launched checkout AS-IS.
     private func registerInitialRepoIfNeeded() async -> String? {
         guard let initialRepoPath, !didApplyInitialRepo else { return nil }
-        if AppTestMode.current() != nil { return nil }
+        if AppTestMode.shouldBypassRegistry { return nil }
         let readPath = await Task.detached {
             Self.resolveLaunchRepo(initialRepoPath).path
         }.value
@@ -425,7 +425,7 @@ struct WavesView: View {
     /// (worktree included) as a single row labeled with the main-repo name.
     /// Runs the git/FS work off the main thread.
     private func refreshRepos() async {
-        if AppTestMode.current() != nil {
+        if AppTestMode.shouldBypassRegistry {
             repos = portfolioService.repos
             return
         }
@@ -472,7 +472,7 @@ struct WavesView: View {
     /// directories — off the main thread, so the list can offer them as launchable
     /// rows before they have a registry entry.
     private func refreshAuthoredWaves() async {
-        if AppTestMode.current() != nil { return }
+        if AppTestMode.shouldBypassRegistry { return }
         let paths = repos.map(\.path)
         authoredWavesByRepo = await Task.detached {
             let liveSessions = LocalWaveAgentLauncher.tmuxSessionNames()
@@ -535,7 +535,7 @@ struct WavesView: View {
             seedMockWaves()
             return
         }
-        if AppTestMode.current() != nil { return }
+        if AppTestMode.shouldBypassRegistry { return }
         ensureRepoStates()
 
         do {
@@ -545,6 +545,7 @@ struct WavesView: View {
             for state in repoStates.values {
                 state.applyConnectedWaves(waves, plans: plans)
             }
+            selectRequestedWaveIfNeeded()
         } catch {
             for state in repoStates.values {
                 state.markRefreshFailed()
@@ -647,13 +648,24 @@ struct WavesView: View {
     /// Each wave's live conversation + run motion is its own per-wave SSE,
     /// opened by the detail pane — not funnelled through a center.
     private func pollRegistry() async {
-        if AppTestMode.current() != nil { return }
+        if AppTestMode.shouldBypassRegistry { return }
         while !Task.isCancelled {
             try? await Task.sleep(for: .seconds(5))
             if Task.isCancelled { return }
             await syncRepoStates()
             await refreshAuthoredWaves()
         }
+    }
+
+    /// A live screenshot can request one real Wave after the registry resolves.
+    /// Fixture selection stays in `seedMockWaves`; production has no requested
+    /// branch, so this is inert outside the explicit `live` harness.
+    private func selectRequestedWaveIfNeeded() {
+        guard selectedWaveId == nil,
+              let requested = AppTestMode.selectBranch,
+              let selected = allWaves.first(where: { $0.name == requested })
+        else { return }
+        selectedWaveId = waveSelectionId(selected)
     }
 }
 

--- a/swift/LoopflowTests/MockWaveFixtureTests.swift
+++ b/swift/LoopflowTests/MockWaveFixtureTests.swift
@@ -10,6 +10,13 @@ import Testing
 /// exercise real data, not an empty shell.
 @Suite("Mock wave fixture")
 struct MockWaveFixtureTests {
+    @Test("live UI-test mode keeps production registry reads")
+    func liveModeUsesRegistry() {
+        #expect(AppTestMode.live.bypassesRegistry == false)
+        #expect(AppTestMode.mockWaves.bypassesRegistry)
+        #expect(AppTestMode.emptyWorkspaces.bypassesRegistry)
+    }
+
     @Test("the stable list carries one Wave per lens state, plus a child")
     func listLensStates() {
         let byName = Dictionary(uniqueKeysWithValues: MockWaveFixture.waves.map { ($0.name, $0) })

--- a/swift/LoopflowTests/WaveSurfacePrimaryHierarchyTests.swift
+++ b/swift/LoopflowTests/WaveSurfacePrimaryHierarchyTests.swift
@@ -1,0 +1,49 @@
+import Foundation
+import Testing
+
+/// The W2-178 contract says the primary Wave hierarchy must not surface
+/// registered-wave vocabulary or raw sync-timestamp prominence. That vocabulary
+/// shipped once (RoadmapView's "Every registered Wave · as of 10:32"), so this
+/// guards the removal at the source: the user-facing panes may reference the
+/// `isRegistered` model property, but never the retired user-facing phrases.
+@Suite("Wave surface primary hierarchy vocabulary")
+struct WaveSurfacePrimaryHierarchyTests {
+    /// The default center pane (no selection), the list rows, and the selected
+    /// Wave detail — every pane a user lands on before touching disclosure.
+    private static let primaryPanes = [
+        "RoadmapView.swift",
+        "WaveRow.swift",
+        "WaveDetailPane.swift",
+        "WavesView.swift",
+    ]
+
+    private static let retiredVocabulary = [
+        "registered Wave",
+        "Registered Wave",
+        "in the registry",
+        "registry read",
+        "· as of ",
+    ]
+
+    @Test("no primary pane surfaces registered-wave vocabulary or a raw sync timestamp")
+    func primaryPanesAreCleanOfRetiredVocabulary() throws {
+        for pane in Self.primaryPanes {
+            let source = try Self.paneSource(pane)
+            for phrase in Self.retiredVocabulary {
+                #expect(
+                    !source.contains(phrase),
+                    "\(pane) still surfaces retired vocabulary: \"\(phrase)\""
+                )
+            }
+        }
+    }
+
+    private static func paneSource(_ name: String, sourceFile: String = #filePath) throws -> String {
+        let viewsDir = URL(fileURLWithPath: sourceFile)
+            .deletingLastPathComponent()      // LoopflowTests
+            .deletingLastPathComponent()      // swift
+            .appendingPathComponent("LoopflowMac/Views")
+            .appendingPathComponent(name)
+        return try String(contentsOf: viewsDir, encoding: .utf8)
+    }
+}

--- a/swift/LoopflowUITests/ScreenshotPipelineTests.swift
+++ b/swift/LoopflowUITests/ScreenshotPipelineTests.swift
@@ -5,17 +5,15 @@ final class ScreenshotPipelineTests: XCTestCase {
     func testCapture() throws {
         let environment = ProcessInfo.processInfo.environment
         let outputName = environment["LOOPFLOW_UI_TEST_NAME"] ?? "loopflow-uitest"
-        let mode = environment["LOOPFLOW_UI_TEST_MODE"] ?? "mock-waves"
         let delay = Double(environment["LOOPFLOW_UI_TEST_DELAY"] ?? "1.5") ?? 1.5
-        let selectBranch = environment["LOOPFLOW_UI_TEST_SELECT_BRANCH"]
 
-        let app = XCUIApplication()
-        app.launchArguments += ["-ui-test-mode", mode]
-        app.launchEnvironment["LOOPFLOW_UI_TEST_MODE"] = mode
-        if let selectBranch {
-            app.launchEnvironment["LOOPFLOW_UI_TEST_SELECT_BRANCH"] = selectBranch
-        }
+        var launch = WaveSurfaceLaunch()
+        launch.mode = environment["LOOPFLOW_UI_TEST_MODE"] ?? "mock-waves"
+        launch.detailState = environment["LOOPFLOW_UI_TEST_DETAIL_STATE"]
+        launch.selectBranch = environment["LOOPFLOW_UI_TEST_SELECT_BRANCH"]
+        launch.width = environment["LOOPFLOW_UI_TEST_WIDTH"].flatMap(Double.init)
 
+        let app = launch.makeApp()
         app.launch()
 
         XCTAssertTrue(app.windows.element(boundBy: 0).waitForExistence(timeout: 10))

--- a/swift/LoopflowUITests/WaveSurfaceLaunch.swift
+++ b/swift/LoopflowUITests/WaveSurfaceLaunch.swift
@@ -16,6 +16,7 @@ struct WaveSurfaceLaunch {
     /// selectable-without-clipping proof are deterministic.
     var width: Double?
 
+    @MainActor
     func makeApp() -> XCUIApplication {
         let app = XCUIApplication()
         app.launchArguments += ["-ui-test-mode", mode]

--- a/swift/LoopflowUITests/WaveSurfaceLaunch.swift
+++ b/swift/LoopflowUITests/WaveSurfaceLaunch.swift
@@ -1,0 +1,34 @@
+import XCTest
+
+/// Shared launch configuration for the Mac Wave surface under UI test.
+///
+/// The app under test is a SEPARATE process from the runner, so every knob must
+/// be forwarded onto `launchEnvironment` — a value that lives only in the
+/// runner's own environment never reaches the app. That gap silently rendered
+/// the `loading` and `error` states as `selected` (the default) until the
+/// forwarding was centralized here, where the screenshot harness and the
+/// state-distinctness test both go through it.
+struct WaveSurfaceLaunch {
+    var mode: String = "mock-waves"
+    var detailState: String?
+    var selectBranch: String?
+    /// A fixed window width, so the narrow and wide legs of the
+    /// selectable-without-clipping proof are deterministic.
+    var width: Double?
+
+    func makeApp() -> XCUIApplication {
+        let app = XCUIApplication()
+        app.launchArguments += ["-ui-test-mode", mode]
+        app.launchEnvironment["LOOPFLOW_UI_TEST_MODE"] = mode
+        if let detailState {
+            app.launchEnvironment["LOOPFLOW_UI_TEST_DETAIL_STATE"] = detailState
+        }
+        if let selectBranch {
+            app.launchEnvironment["LOOPFLOW_UI_TEST_SELECT_BRANCH"] = selectBranch
+        }
+        if let width {
+            app.launchEnvironment["LOOPFLOW_UI_TEST_WIDTH"] = String(Int(width))
+        }
+        return app
+    }
+}

--- a/swift/LoopflowUITests/WaveSurfaceStateTests.swift
+++ b/swift/LoopflowUITests/WaveSurfaceStateTests.swift
@@ -1,0 +1,132 @@
+import XCTest
+
+/// Executable proof that the stable Wave surface renders the five states the
+/// W2-178 Proof names — selected, loading, error, empty, and future-child
+/// indentation — *distinctly*, at both a narrow and a wide desktop size.
+///
+/// Each state is checked by a UNIQUE on-screen affordance, so the states can't
+/// collapse into one another undetected. This is the test that would have
+/// caught PR #972's forwarding gap: with `LOOPFLOW_UI_TEST_DETAIL_STATE` not
+/// reaching the app, `loading` and `error` rendered as `selected`, and the
+/// loading/error assertions below would fail.
+///
+/// Runs under the host-permissioned macOS UI-test gate (Automation access),
+/// the same gate the screenshot pipeline uses.
+final class WaveSurfaceStateTests: XCTestCase {
+    /// A genuinely narrow desktop (still wide enough to show the 300pt list and
+    /// the detail panes' minimums) and a wide one.
+    private let widths: [Double] = [900, 1440]
+
+    override func setUp() {
+        continueAfterFailure = false
+    }
+
+    @MainActor
+    func testSelectedStateShowsPopulatedHierarchy() {
+        forEachWidth { app in
+            XCTAssertTrue(waitFor(app, id: "wave-objective-lead"),
+                          "selected must lead with the objective")
+            XCTAssertFalse(exists(app, id: "wave-detail-loading"),
+                           "selected must not show the loading affordance")
+            XCTAssertFalse(exists(app, id: "wave-live-status-footer"),
+                           "selected must not show the error footer")
+            assertEveryWaveRowHittable(app)
+        }
+    }
+
+    @MainActor
+    func testLoadingStateShowsLoadingAffordance() {
+        forEachWidth(detailState: "loading") { app in
+            XCTAssertTrue(waitFor(app, id: "wave-detail-loading"),
+                          "loading must show the loading affordance, not the populated hierarchy")
+            XCTAssertFalse(exists(app, id: "wave-live-status-footer"),
+                           "loading is not the error state")
+            assertEveryWaveRowHittable(app)
+        }
+    }
+
+    @MainActor
+    func testErrorStatePreservesDetailUnderFooter() {
+        forEachWidth(detailState: "error") { app in
+            XCTAssertTrue(waitFor(app, id: "wave-live-status-footer"),
+                          "error must show the quiet cached-plan footer")
+            XCTAssertTrue(exists(app, id: "wave-objective-lead"),
+                          "error preserves the last-good detail — the objective still leads")
+            XCTAssertFalse(exists(app, id: "wave-detail-loading"),
+                           "error is not the loading state")
+            assertEveryWaveRowHittable(app)
+        }
+    }
+
+    @MainActor
+    func testEmptyStateShowsCalmCreateSurface() {
+        forEachWidth(mode: "empty-workspaces") { app in
+            XCTAssertTrue(waitFor(app, id: "wave-empty-create"),
+                          "empty must offer a calm create surface")
+            XCTAssertEqual(waveRows(app).count, 0, "empty has no Wave rows")
+        }
+    }
+
+    @MainActor
+    func testChildIndentationKeepsBothRowsSelectable() {
+        forEachWidth(selectBranch: "cadenza") { app in
+            let rows = waveRows(app)
+            XCTAssertTrue(rows.contains { $0.label.contains("infrastructure") },
+                          "the parent Wave stays in the list")
+            XCTAssertTrue(rows.contains { $0.label.contains("cadenza") },
+                          "the indented child Wave is present")
+            assertEveryWaveRowHittable(app)
+        }
+    }
+
+    // MARK: - Harness
+
+    @MainActor
+    private func forEachWidth(
+        mode: String = "mock-waves",
+        detailState: String? = nil,
+        selectBranch: String? = nil,
+        _ assertions: (XCUIApplication) -> Void
+    ) {
+        for width in widths {
+            var launch = WaveSurfaceLaunch()
+            launch.mode = mode
+            launch.detailState = detailState
+            launch.selectBranch = selectBranch
+            launch.width = width
+            let app = launch.makeApp()
+            app.launch()
+            XCTAssertTrue(app.windows.element(boundBy: 0).waitForExistence(timeout: 10),
+                          "window must appear at width \(Int(width))")
+            assertions(app)
+            app.terminate()
+        }
+    }
+
+    @MainActor
+    private func waveRows(_ app: XCUIApplication) -> [XCUIElement] {
+        // WaveRow combines its children into one element labeled "Wave: <name>. <reason>".
+        let predicate = NSPredicate(format: "label BEGINSWITH %@", "Wave: ")
+        return app.descendants(matching: .any).matching(predicate).allElementsBoundByIndex
+    }
+
+    @MainActor
+    private func assertEveryWaveRowHittable(_ app: XCUIApplication) {
+        let rows = waveRows(app)
+        XCTAssertFalse(rows.isEmpty, "expected at least one Wave row")
+        for row in rows {
+            XCTAssertTrue(row.isHittable,
+                          "every Wave stays selectable without clipping: \(row.label)")
+        }
+    }
+
+    @MainActor
+    private func waitFor(_ app: XCUIApplication, id: String, timeout: TimeInterval = 8) -> Bool {
+        app.descendants(matching: .any)[id].waitForExistence(timeout: timeout)
+    }
+
+    @MainActor
+    private func exists(_ app: XCUIApplication, id: String) -> Bool {
+        app.descendants(matching: .any)[id].exists
+    }
+}

--- a/swift/LoopflowUITests/WaveSurfaceStateTests.swift
+++ b/swift/LoopflowUITests/WaveSurfaceStateTests.swift
@@ -30,7 +30,32 @@ final class WaveSurfaceStateTests: XCTestCase {
                            "selected must not show the loading affordance")
             XCTAssertFalse(exists(app, id: "wave-live-status-footer"),
                            "selected must not show the error footer")
+            assertStableNavigation(app)
+            assertHalLenses(app)
+            assertPrimaryInformationHierarchy(app)
             assertEveryWaveRowHittable(app)
+        }
+    }
+
+    @MainActor
+    func testControlIsSecondaryAndOpensToActiveSessions() {
+        forEachWidth { app in
+            XCTAssertTrue(waitFor(app, id: "wave-chat-transcript"),
+                          "Chat must be the selected Wave's default surface")
+            XCTAssertFalse(exists(app, id: "control-surface"),
+                           "Control must stay behind an explicit interaction")
+
+            let button = app.descendants(matching: .any)["wave-control-button"]
+            XCTAssertTrue(button.waitForExistence(timeout: 8),
+                          "the secondary Control destination must be discoverable")
+            button.click()
+
+            XCTAssertTrue(waitFor(app, id: "control-surface"),
+                          "Control must open from the Wave header")
+            XCTAssertTrue(waitFor(app, id: "control-active-sessions"),
+                          "Control must open to Active Sessions")
+            XCTAssertTrue(exists(app, id: "control-run-history-tab"),
+                          "Run History remains visible as later disclosure")
         }
     }
 
@@ -118,6 +143,72 @@ final class WaveSurfaceStateTests: XCTestCase {
             XCTAssertTrue(row.isHittable,
                           "every Wave stays selectable without clipping: \(row.label)")
         }
+    }
+
+    @MainActor
+    private func assertStableNavigation(_ app: XCUIApplication) {
+        let dropdown = app.descendants(matching: .any)["repo-dropdown"]
+        let list = app.descendants(matching: .any)["repo-wave-list"]
+        XCTAssertTrue(dropdown.waitForExistence(timeout: 8),
+                      "repository scope must be one dropdown above the Wave list")
+        XCTAssertTrue(list.waitForExistence(timeout: 8),
+                      "the stable Wave list must remain the primary navigation")
+        XCTAssertLessThanOrEqual(dropdown.frame.maxY, list.frame.minY,
+                                 "the repository dropdown belongs above, not beside, the Wave list")
+
+        let names = waveRows(app).compactMap(Self.waveName)
+        XCTAssertEqual(names, ["feedback", "infrastructure", "cadenza", "intelligence"],
+                       "liveness must not regroup the stable outline")
+
+        let child = waveRows(app).first { Self.waveName($0) == "cadenza" }
+        XCTAssertTrue((child?.value as? String)?.contains("child wave") == true,
+                      "the child row must preserve its hierarchy affordance")
+    }
+
+    @MainActor
+    private func assertHalLenses(_ app: XCUIApplication) {
+        let expected = [
+            "infrastructure": "green lens",
+            "intelligence": "red lens",
+            "feedback": "black lens",
+            "cadenza": "green lens",
+        ]
+        let rows = waveRows(app)
+        for (name, lens) in expected {
+            guard let row = rows.first(where: { Self.waveName($0) == name }) else {
+                XCTFail("missing \(name) Wave row")
+                continue
+            }
+            XCTAssertTrue((row.value as? String)?.hasPrefix(lens) == true,
+                          "\(name) must expose its \(lens) attention signal")
+        }
+    }
+
+    @MainActor
+    private func assertPrimaryInformationHierarchy(_ app: XCUIApplication) {
+        XCTAssertTrue(exists(app, id: "wave-projects"),
+                      "Projects must follow the objective")
+        XCTAssertTrue(exists(app, id: "wave-project"),
+                      "the selected Wave must expose its Project")
+        XCTAssertTrue(exists(app, id: "project-open-tasks"),
+                      "a Project must foreground its open-task count")
+        XCTAssertTrue(exists(app, id: "project-key-result"),
+                      "a Project must foreground its KR list")
+        XCTAssertTrue(exists(app, id: "wave-task"),
+                      "Task rows must stay progressively disclosed under Projects")
+        XCTAssertTrue(exists(app, id: "wave-chat-transcript"),
+                      "Chat must remain present beside the plan")
+        XCTAssertTrue(exists(app, id: "wave-control-button"),
+                      "Control must be reachable without replacing Chat")
+    }
+
+    @MainActor
+    private static func waveName(_ row: XCUIElement) -> String? {
+        let prefix = "Wave: "
+        guard row.label.hasPrefix(prefix),
+              let end = row.label.dropFirst(prefix.count).firstIndex(of: ".")
+        else { return nil }
+        return String(row.label.dropFirst(prefix.count)[..<end])
     }
 
     @MainActor


### PR DESCRIPTION
## Usage

```bash
swift build --package-path swift --product LoopflowMac
scripts/prove_wave_surface_states.sh          # 5 states × 2 widths, pairwise distinct
scripts/prove_product_wave_surface.sh           # real Product data through the registry
uv run python scripts/generate_screenshots.py   # narrow + wide captures per state
```

The CI job `swift-test` now runs `prove_wave_surface_states.sh` after the build, so a regression that collapses two states (e.g. loading rendering as selected) fails CI by name.

## Summary

The redesigned Wave surface has five Proof states — selected, loading, error, empty, and future-child indentation — and the Task (W2-178) requires them to render distinctly and stay selectable without clipping at narrow and wide desktop widths. This PR makes that proof CI-runnable without UI-automation permission: the app renders its own key window to a PNG via `SnapshotService` (`cacheDisplay`, no Screen Recording or Automation permission needed), and a script asserts all captures are pairwise distinct. A `live` app-test mode runs the same surface through the real `lf` registry read path so a missing Product snapshot fails by name instead of silently falling back to mocks.

## Changes

- `AppTestMode` gains a `live` mode (real registry path, keeps the test knobs) plus env readers for `LOOPFLOW_UI_TEST_WIDTH`, `LOOPFLOW_UI_TEST_DELAY`, and `LOOPFLOW_UI_TEST_SELECT_BRANCH`
- `LoopflowApp` applies a pinned window width and a self-snapshot-and-terminate path during UI-test runs
- `scripts/prove_wave_surface_states.sh` — 5 states × 2 widths, asserts pairwise distinct PNGs; complements the permissioned XCUITest
- `scripts/prove_product_wave_surface.sh` — captures the real Product Wave through the production registry path; absent PM snapshot is a named failure
- `screenshots.yaml` splits each Wave-surface state into narrow (900) and wide (1440) captures
- New `WaveSurfaceStateTests`, `WaveSurfacePrimaryHierarchyTests`, and `WaveSurfaceLaunch` UI tests assert each state's affordance and row hittability
- Strips registry vocabulary from the default Roadmap pane; adds accessibility identifiers for the control surface and active-sessions tab
- Forwards `LOOPFLOW_UI_TEST_DETAIL_STATE` through to the app (the PR #972 forwarding gap that made loading/error render as selected)