### PR TITLE
wave chat: make journal delivery failure atomic

### DIFF
--- a/rust/loopflow/src/wave/journal.rs
+++ b/rust/loopflow/src/wave/journal.rs
@@ -685,6 +685,24 @@ pub struct Journal {
     file: File,
     next_seq: u64,
     narrator: Narrator,
+    #[cfg(test)]
+    next_append_failure: Option<JournalAppendStage>,
+}
+
+/// A journal append failed before it became durable.
+#[derive(Debug, thiserror::Error)]
+#[error("journal append at seq {seq} failed during {operation}: {source}")]
+pub struct JournalAppendError {
+    seq: u64,
+    operation: &'static str,
+    #[source]
+    source: std::io::Error,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum JournalAppendStage {
+    Write,
+    Flush,
 }
 
 impl Journal {
@@ -753,6 +771,8 @@ impl Journal {
                 file,
                 next_seq,
                 narrator: Narrator::default(),
+                #[cfg(test)]
+                next_append_failure: None,
             },
             events,
         ))
@@ -766,31 +786,111 @@ impl Journal {
         self.next_seq
     }
 
-    /// Append one event, building its kind from the seq it will get (so ids
-    /// like `"turn-<seq>"` live inside the event that mints them). Flushes the
-    /// line. A write failure is logged, not propagated — the in-memory state
-    /// stays live and the fault is loud in the logs.
+    /// Append one event, stopping the process if persistence fails.
+    ///
+    /// Most runtime paths cannot recover locally: their next action projects
+    /// the event into memory, so continuing would split the live view from
+    /// restart truth. Request paths that can report failure use
+    /// [`Self::try_append`] directly instead.
     pub fn append(&mut self, build: impl FnOnce(u64) -> EventKind) -> Event {
+        self.try_append(build)
+            .expect("journal truth must persist before projecting an event in memory")
+    }
+
+    /// Append and flush one event before advancing its sequence or narrating
+    /// it. A failed write is rolled back to the prior byte boundary so the
+    /// same runtime can retry without leaving a torn tail or consuming an id.
+    ///
+    /// # Errors
+    /// Serialization, file inspection, write, flush, or rollback failure.
+    pub fn try_append(
+        &mut self,
+        build: impl FnOnce(u64) -> EventKind,
+    ) -> Result<Event, JournalAppendError> {
         let event = Event {
             v: FORMAT_VERSION,
             seq: self.next_seq,
             at: OffsetDateTime::now_utc(),
             kind: build(self.next_seq),
         };
-        self.next_seq += 1;
-        match serde_json::to_string(&event) {
-            Ok(line) => {
-                if let Err(err) = writeln!(self.file, "{line}").and_then(|_| self.file.flush()) {
-                    tracing::error!(seq = event.seq, error = %err, "failed to append journal event");
-                } else {
-                    self.narrator.narrate(&event.kind);
-                }
-            }
-            Err(err) => {
-                tracing::error!(seq = event.seq, error = %err, "failed to serialize journal event");
-            }
+        let mut line = serde_json::to_vec(&event).map_err(|source| JournalAppendError {
+            seq: event.seq,
+            operation: "serialization",
+            source: std::io::Error::new(std::io::ErrorKind::InvalidData, source),
+        })?;
+        line.push(b'\n');
+        let checkpoint = self
+            .file
+            .metadata()
+            .map_err(|source| JournalAppendError {
+                seq: event.seq,
+                operation: "file inspection",
+                source,
+            })?
+            .len();
+
+        let write_result = match self.take_injected_failure(JournalAppendStage::Write) {
+            Some(source) => Err(source),
+            None => self.file.write_all(&line),
+        };
+        if let Err(source) = write_result {
+            return Err(self.rollback(event.seq, checkpoint, "write", source));
         }
-        event
+
+        let flush_result = match self.take_injected_failure(JournalAppendStage::Flush) {
+            Some(source) => Err(source),
+            None => self.file.flush(),
+        };
+        if let Err(source) = flush_result {
+            return Err(self.rollback(event.seq, checkpoint, "flush", source));
+        }
+
+        self.next_seq += 1;
+        self.narrator.narrate(&event.kind);
+        Ok(event)
+    }
+
+    fn rollback(
+        &mut self,
+        seq: u64,
+        checkpoint: u64,
+        operation: &'static str,
+        source: std::io::Error,
+    ) -> JournalAppendError {
+        match self.file.set_len(checkpoint) {
+            Ok(()) => JournalAppendError {
+                seq,
+                operation,
+                source,
+            },
+            Err(rollback) => JournalAppendError {
+                seq,
+                operation: "write rollback",
+                source: std::io::Error::new(
+                    source.kind(),
+                    format!(
+                        "{operation} failed: {source}; truncating to byte {checkpoint} also failed: {rollback}"
+                    ),
+                ),
+            },
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn fail_next_append(&mut self, failure: JournalAppendStage) {
+        self.next_append_failure = Some(failure);
+    }
+
+    fn take_injected_failure(
+        &mut self,
+        #[cfg_attr(not(test), allow(unused_variables))] expected: JournalAppendStage,
+    ) -> Option<std::io::Error> {
+        #[cfg(test)]
+        if self.next_append_failure == Some(expected) {
+            self.next_append_failure = None;
+            return Some(std::io::Error::other("injected journal append failure"));
+        }
+        None
     }
 }
 

--- a/rust/loopflow/src/wave/runtime.rs
+++ b/rust/loopflow/src/wave/runtime.rs
@@ -37,9 +37,12 @@ use crate::receipt::Receipt;
 use crate::security::sanitize_fs_component;
 use crate::task::TaskObservation;
 use crate::wave::channel::matches_prefix;
+#[cfg(test)]
+use crate::wave::journal::JournalAppendStage;
 use crate::wave::journal::{
     fold_thread, journal_path, project_observation_message, restore_pending,
-    task_observation_message, EventKind, Journal, MessageId, MessageOp, PendingMessage, Usage,
+    task_observation_message, EventKind, Journal, JournalAppendError, MessageId, MessageOp,
+    PendingMessage, Usage,
 };
 use crate::wave::memory::Memory;
 use crate::wave::playhead::{
@@ -915,28 +918,51 @@ impl WaveRuntime {
     /// and appends no turn — `None`; every other delivery journals a
     /// `UserMessage`, commits the user turn, and queues for the loop.
     pub fn deliver(&self, op: MessageOp, text: String) -> Option<ChatTurn> {
+        self.try_deliver(op, text)
+            .expect("journal truth must accept a message before runtime delivery")
+    }
+
+    /// Deliver one human op only after its journal row is durable.
+    ///
+    /// The HTTP door uses this form so a failed write returns a non-success
+    /// response and leaves the transcript, pending queue, and live broadcasts
+    /// untouched. The caller may retry the same message.
+    ///
+    /// # Errors
+    /// The message's journal append could not be written and flushed.
+    pub fn try_deliver(
+        &self,
+        op: MessageOp,
+        text: String,
+    ) -> Result<Option<ChatTurn>, JournalAppendError> {
         if op == MessageOp::Interrupt && text.trim().is_empty() {
             self.deliver_interrupt();
-            return None;
+            return Ok(None);
         }
-        Some(self.deliver_message(text, op, None))
+        self.try_deliver_message(text, op, None).map(Some)
     }
 
     /// Deliver an attributed emission folded off the bus — a worker report,
     /// child-wave escalation, or CLI FYI. Same journal row, thread commit, and
     /// inbox path as any user message; the byline rides along.
     pub fn deliver_say(&self, text: String, from: String) -> ChatTurn {
-        self.deliver_message(text, MessageOp::Say, Some(from))
+        self.try_deliver_message(text, MessageOp::Say, Some(from))
+            .expect("journal truth must accept a bus report before runtime delivery")
     }
 
-    fn deliver_message(&self, text: String, op: MessageOp, from: Option<String>) -> ChatTurn {
+    fn try_deliver_message(
+        &self,
+        text: String,
+        op: MessageOp,
+        from: Option<String>,
+    ) -> Result<ChatTurn, JournalAppendError> {
         let mut inner = self.inner();
-        let event = inner.journal.append(|seq| EventKind::UserMessage {
+        let event = inner.journal.try_append(|seq| EventKind::UserMessage {
             id: MessageId(format!("msg-{seq}")),
             op,
             text: text.clone(),
             from: from.clone(),
-        });
+        })?;
         let id = MessageId(format!("msg-{}", event.seq));
         let mut turn = ChatTurn::user(format!("turn-{}", event.seq), text.clone());
         turn.created_at = event.at_rfc3339();
@@ -951,7 +977,12 @@ impl WaveRuntime {
         // order — sending after release lets two deliveries invert. A send
         // error just means no live subscribers; the pending fold has it.
         let _ = self.inbox_tx.send(InboxItem::Message(pending));
-        turn
+        Ok(turn)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn fail_next_journal_append(&self, failure: JournalAppendStage) {
+        self.inner().journal.fail_next_append(failure);
     }
 
     /// Deliver a bare interrupt (no text). Nothing is journaled here — the

--- a/rust/loopflow/src/wave/server.rs
+++ b/rust/loopflow/src/wave/server.rs
@@ -528,7 +528,7 @@ async fn conversation_handler(
 /// The door is opaque on resident ops: this handler validates SHAPE only —
 /// `from` rides `say` and nothing else; `text` may be empty only for
 /// `interrupt` — then hands the op to the runtime uninterpreted
-/// ([`WaveRuntime::deliver`]). What steer or interrupt *means* lives with the
+/// ([`WaveRuntime::try_deliver`]). What steer or interrupt *means* lives with the
 /// resident, not the ear. Honest partial: the `{turn, state}` echo still
 /// leaks that a bare interrupt appends nothing (`turn: null`), but that fact
 /// comes back from the runtime's return, not from the door interpreting.
@@ -560,7 +560,15 @@ async fn messages_handler(
             "text is required for every op but interrupt".to_string(),
         ));
     }
-    let turn = state.runtime.deliver(body.op, body.text);
+    let turn = state
+        .runtime
+        .try_deliver(body.op, body.text)
+        .map_err(|err| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("message was not accepted: {err}"),
+            )
+        })?;
     Ok(Json(PostMessageResponse {
         turn,
         state: state.runtime.loop_state().name().to_string(),
@@ -947,6 +955,7 @@ pub fn remove_resident_token(repo_root: &Path, wave: &str, own_token: &str) {
 mod tests {
     use super::*;
     use crate::chat::turns::ChatTurn;
+    use crate::wave::journal::{journal_path, read_events, EventKind, JournalAppendStage};
 
     fn whole_broadcast(id: &str) -> TurnBroadcast {
         let turn = ChatTurn::user(id.to_string(), "hi".to_string());
@@ -1064,6 +1073,85 @@ mod tests {
         assert_eq!(response.status(), reqwest::StatusCode::ACCEPTED);
         requested.wait().await;
         server.abort();
+    }
+
+    #[tokio::test]
+    async fn message_write_failures_are_not_accepted_and_can_be_retried() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let runtime = WaveRuntime::open("ship".into(), tmp.path().to_path_buf()).expect("open");
+        let app = router(
+            runtime.clone(),
+            ResidentDoor::new("resident"),
+            None,
+            None,
+            ShutdownDoor::new(),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind");
+        let addr = listener.local_addr().expect("address");
+        let server = tokio::spawn(async move {
+            axum::serve(listener, app).await.ok();
+        });
+        let client = reqwest::Client::new();
+        let url = format!("http://{addr}/messages");
+        let body = serde_json::json!({"op": "message", "text": "keep this"});
+        let mut turn_rx = runtime.subscribe_turns();
+        let mut inbox_rx = runtime.subscribe_inbox();
+
+        for failure in [JournalAppendStage::Write, JournalAppendStage::Flush] {
+            runtime.fail_next_journal_append(failure);
+            let response = client
+                .post(&url)
+                .json(&body)
+                .send()
+                .await
+                .expect("failed append response");
+            assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+            assert!(response
+                .text()
+                .await
+                .expect("error body")
+                .contains("message was not accepted"));
+            assert!(runtime.thread_snapshot().is_empty());
+            assert!(runtime.pending_messages().is_empty());
+            assert!(read_events(&journal_path(tmp.path(), "ship")).is_empty());
+            assert!(matches!(
+                turn_rx.try_recv(),
+                Err(broadcast::error::TryRecvError::Empty)
+            ));
+            assert!(matches!(
+                inbox_rx.try_recv(),
+                Err(broadcast::error::TryRecvError::Empty)
+            ));
+        }
+
+        let response = client
+            .post(&url)
+            .json(&body)
+            .send()
+            .await
+            .expect("retry response");
+        assert_eq!(response.status(), StatusCode::OK);
+        let accepted: serde_json::Value = response.json().await.expect("accepted body");
+        assert_eq!(accepted["turn"]["id"], "turn-1");
+        assert_eq!(accepted["turn"]["role"], "user");
+        assert_eq!(accepted["turn"]["text"], "keep this");
+        assert_eq!(runtime.thread_snapshot().len(), 1);
+        assert_eq!(runtime.pending_messages().len(), 1);
+
+        let events = read_events(&journal_path(tmp.path(), "ship"));
+        assert_eq!(events.len(), 1);
+        assert!(matches!(events[0].kind, EventKind::UserMessage { .. }));
+        server.abort();
+        let _ = server.await;
+        drop(runtime);
+
+        let reopened = WaveRuntime::open("ship".into(), tmp.path().to_path_buf()).expect("reopen");
+        let transcript = reopened.thread_snapshot();
+        assert_eq!(transcript.len(), 1);
+        assert_eq!(transcript[0].id, "turn-1");
+        assert_eq!(transcript[0].text, "keep this");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Usage

```bash
cargo test -p loopflow wave::server
```

## Summary

A journal append that failed used to be logged and swallowed: the runtime still minted the message id, committed the turn to the transcript, queued it as pending, and broadcast it live. The wave looked like it had accepted the message, but on restart the journal had no record of it — the live view and restart truth silently diverged, and the sender got a 200 for a message that no longer existed.

Appends now persist before anything projects them. `Journal::try_append` serializes, records the file's byte length, writes, and flushes — and only then advances the sequence and narrates. If the write or flush fails, the file is truncated back to the checkpoint, so no torn tail is left behind and no id is burned; the same runtime can retry the same message. `Journal::append` keeps the old infallible shape for the runtime paths that can't report failure, but it now panics rather than continuing on a split brain.

The HTTP door takes the fallible path. `WaveRuntime::try_deliver` returns the append error, and `messages_handler` maps it to a 500 with `message was not accepted`, leaving the transcript, pending queue, and turn/inbox broadcasts untouched. A retry of the identical POST then succeeds and lands as `turn-1`.

## Changes

- New `JournalAppendError` carrying the seq and the stage that failed (serialization, file inspection, write, flush, or rollback), with rollback failure folded into the message
- `try_append` / `try_deliver` / `try_deliver_message` fallible variants; `append`, `deliver`, and `deliver_say` expect on them
- Test-only failure injection (`fail_next_journal_append`) at the write and flush stages, gated behind `#[cfg(test)]`
- Server test proves both failure stages are rejected with nothing observable left behind, that a retry is accepted, and that the message survives reopening the wave