### PR TITLE
supervision: recover replay-safe stalled task bodies

### DIFF
--- a/rust/loopflow/src/child_session.rs
+++ b/rust/loopflow/src/child_session.rs
@@ -733,6 +733,57 @@ pub struct BodyEvidence {
 /// this is the honest coarse bound the read model can prove.
 pub const DEFAULT_STALL_AFTER: Duration = Duration::from_secs(30 * 60);
 
+/// Age of the freshest durable progress evidence, clamped at zero so clock
+/// skew never turns a future event into a negative duration.
+pub(crate) fn body_progress_age(
+    latest_event_at: Option<OffsetDateTime>,
+    status_at: OffsetDateTime,
+    now: OffsetDateTime,
+) -> Duration {
+    let progress_at = latest_event_at.map_or(status_at, |event_at| event_at.max(status_at));
+    let seconds = (now - progress_at).whole_seconds().max(0);
+    Duration::from_secs(seconds as u64)
+}
+
+/// What supervision may do after observing a stalled body.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum BodyRecoveryPlan {
+    /// The observation is not a stall, so recovery has no work.
+    LeaveAlone,
+    /// No provider delivery is ambiguous; revoke, reap, and start generation+1.
+    Restart,
+    /// Delivery began without a recorded outcome. Reap the body, preserve these
+    /// commands as uncertain, and wait for a human instead of replaying them.
+    NeedsInput { commands: Vec<ChildCommandId> },
+}
+
+pub(crate) fn plan_body_recovery(
+    observation: &BodyObservation,
+    commands: &[ChildCommand],
+    generation: u32,
+) -> BodyRecoveryPlan {
+    if observation.category != BodyCategory::Stalled {
+        return BodyRecoveryPlan::LeaveAlone;
+    }
+    let uncertain = commands
+        .iter()
+        .filter(|command| {
+            matches!(
+                command.state,
+                ChildCommandState::Delivering | ChildCommandState::Uncertain
+            ) && command.claimed_by_generation == Some(generation)
+        })
+        .map(|command| command.id.clone())
+        .collect::<Vec<_>>();
+    if uncertain.is_empty() {
+        BodyRecoveryPlan::Restart
+    } else {
+        BodyRecoveryPlan::NeedsInput {
+            commands: uncertain,
+        }
+    }
+}
+
 /// Derive the observed body state from durable intent and body evidence.
 ///
 /// Liveness (a body exists) and progress (it advanced) are separate inputs;
@@ -842,9 +893,11 @@ pub fn observe(evidence: &BodyEvidence, stall_after: Duration) -> BodyObservatio
 #[cfg(test)]
 mod tests {
     use super::{
-        observe, unincorporated_directive_version, BodyCategory, BodyControl, BodyEvidence,
-        BodyIntent, BodyOwner, ChildCommandId, ChildDecisionId, ChildDirectiveId, ChildLeaseState,
-        ChildLeaseToken, ChildProcessGeneration, ChildWriteLease, Duration, DEFAULT_STALL_AFTER,
+        body_progress_age, observe, plan_body_recovery, unincorporated_directive_version,
+        BodyCategory, BodyControl, BodyEvidence, BodyIntent, BodyOwner, BodyRecoveryPlan,
+        ChildCommand, ChildCommandId, ChildCommandKind, ChildCommandSource, ChildCommandState,
+        ChildDecisionId, ChildDirectiveId, ChildLeaseState, ChildLeaseToken,
+        ChildProcessGeneration, ChildRef, ChildWriteLease, Duration, DEFAULT_STALL_AFTER,
     };
 
     fn evidence(intent: BodyIntent, alive: bool, progress: Duration) -> BodyEvidence {
@@ -910,6 +963,108 @@ mod tests {
             )
             .category,
             BodyCategory::Stalled,
+        );
+    }
+
+    #[test]
+    fn progress_age_uses_the_freshest_durable_evidence() {
+        let status_at = time::OffsetDateTime::UNIX_EPOCH + time::Duration::seconds(10);
+        let event_at = status_at + time::Duration::seconds(5);
+        let now = status_at + time::Duration::seconds(20);
+
+        assert_eq!(
+            body_progress_age(Some(event_at), status_at, now),
+            Duration::from_secs(15)
+        );
+        assert_eq!(
+            body_progress_age(Some(now + time::Duration::seconds(5)), status_at, now),
+            Duration::ZERO,
+        );
+    }
+
+    #[test]
+    fn stalled_recovery_refuses_to_replay_an_ambiguous_delivery() {
+        let observation = observe(
+            &evidence(BodyIntent::Active, true, Duration::from_secs(31 * 60)),
+            DEFAULT_STALL_AFTER,
+        );
+        let target = ChildRef::Task(crate::task::TaskSessionId::new());
+        let mut delivering = ChildCommand::new(
+            target.clone(),
+            ChildCommandSource::Human,
+            ChildCommandKind::Steer {
+                text: "ship it".to_string(),
+            },
+        );
+        delivering.state = ChildCommandState::Delivering;
+        delivering.claimed_by_generation = Some(7);
+        let mut claimed = ChildCommand::new(
+            target,
+            ChildCommandSource::Human,
+            ChildCommandKind::FollowUp {
+                text: "then verify".to_string(),
+            },
+        );
+        claimed.state = ChildCommandState::Claimed;
+        claimed.claimed_by_generation = Some(7);
+
+        assert_eq!(
+            plan_body_recovery(&observation, &[delivering.clone(), claimed], 7),
+            BodyRecoveryPlan::NeedsInput {
+                commands: vec![delivering.id],
+            }
+        );
+    }
+
+    #[test]
+    fn stalled_recovery_restarts_only_from_a_replay_safe_boundary() {
+        let stalled = observe(
+            &evidence(BodyIntent::Active, true, Duration::from_secs(31 * 60)),
+            DEFAULT_STALL_AFTER,
+        );
+        let working = observe(
+            &evidence(BodyIntent::Active, true, Duration::from_secs(1)),
+            DEFAULT_STALL_AFTER,
+        );
+        let mut claimed = ChildCommand::new(
+            ChildRef::Task(crate::task::TaskSessionId::new()),
+            ChildCommandSource::Human,
+            ChildCommandKind::FollowUp {
+                text: "safe to reclaim".to_string(),
+            },
+        );
+        claimed.state = ChildCommandState::Claimed;
+        claimed.claimed_by_generation = Some(7);
+
+        assert_eq!(
+            plan_body_recovery(&stalled, &[claimed.clone()], 7),
+            BodyRecoveryPlan::Restart,
+        );
+        assert_eq!(
+            plan_body_recovery(&working, &[claimed], 7),
+            BodyRecoveryPlan::LeaveAlone,
+        );
+    }
+
+    #[test]
+    fn uncertainty_from_an_older_generation_does_not_poison_its_successor() {
+        let stalled = observe(
+            &evidence(BodyIntent::Active, true, Duration::from_secs(31 * 60)),
+            DEFAULT_STALL_AFTER,
+        );
+        let mut old = ChildCommand::new(
+            ChildRef::Task(crate::task::TaskSessionId::new()),
+            ChildCommandSource::Human,
+            ChildCommandKind::Steer {
+                text: "already adjudicated".to_string(),
+            },
+        );
+        old.state = ChildCommandState::Uncertain;
+        old.claimed_by_generation = Some(6);
+
+        assert_eq!(
+            plan_body_recovery(&stalled, &[old], 7),
+            BodyRecoveryPlan::Restart,
         );
     }
 

--- a/rust/loopflow/src/lf/commands/waves.rs
+++ b/rust/loopflow/src/lf/commands/waves.rs
@@ -18,8 +18,8 @@ use anyhow::{anyhow, Result};
 use serde::{Deserialize, Serialize};
 
 use crate::child_session::{
-    observe, BodyEvidence, BodyObservation, ChildRef, DirectiveKind, ObservationRecipient,
-    DEFAULT_STALL_AFTER,
+    body_progress_age, observe, BodyEvidence, BodyObservation, ChildRef, DirectiveKind,
+    ObservationRecipient, DEFAULT_STALL_AFTER,
 };
 #[cfg(test)]
 use crate::child_session::{BodyCategory, BodyControl, BodyOwner};
@@ -1002,20 +1002,6 @@ async fn snapshot_wave(store: &SharedStore, wave: &Wave) -> Result<WaveSnapshot>
     })
 }
 
-/// Seconds of no durable progress, measured from the freshest of the last event
-/// and the last status change. Clamped at zero so clock skew never reads as
-/// negative age. This is the signal that separates a working body from a stalled
-/// one (G3): a live body silent past its deadline is stalled, not working.
-fn progress_age(
-    latest_event_at: Option<time::OffsetDateTime>,
-    status_at: time::OffsetDateTime,
-    now: time::OffsetDateTime,
-) -> std::time::Duration {
-    let progress_at = latest_event_at.map_or(status_at, |event_at| event_at.max(status_at));
-    let seconds = (now - progress_at).whole_seconds().max(0);
-    std::time::Duration::from_secs(seconds as u64)
-}
-
 async fn snapshot_task_runtime(
     store: &SharedStore,
     task: &TaskSession,
@@ -1035,7 +1021,7 @@ async fn snapshot_task_runtime(
         intent: task.status.body_intent(),
         observable: liveness.liveness() == Liveness::Observable,
         process_alive,
-        progress_age: progress_age(latest_event_at, task.status_at, now),
+        progress_age: body_progress_age(latest_event_at, task.status_at, now),
         step: Some(task.lifecycle_phase.as_str().to_string()),
         reason: task.status_reason.clone(),
     };
@@ -1077,7 +1063,7 @@ async fn snapshot_project_runtime(
         intent: project.status.body_intent(),
         observable: liveness.liveness() == Liveness::Observable,
         process_alive,
-        progress_age: progress_age(latest_event_at, project.status_at, now),
+        progress_age: body_progress_age(latest_event_at, project.status_at, now),
         step: Some(format!("iteration {}", project.iteration)),
         reason: project.status_reason.clone(),
     };

--- a/rust/loopflow/src/ops/child.rs
+++ b/rust/loopflow/src/ops/child.rs
@@ -60,6 +60,14 @@ pub(crate) async fn revoke_and_reap_child_body(
             .await
             .map_err(child_error)?,
     };
+    reap_revoked_child_body(store, target, revoked).await
+}
+
+pub(crate) async fn reap_revoked_child_body(
+    store: &SharedStore,
+    target: &ChildRef,
+    revoked: ChildProcessGeneration,
+) -> OpsResult<ChildProcessGeneration> {
     crate::engine::process::reap_child_process(&revoked, Duration::from_secs(2))
         .await
         .map_err(child_error)?;

--- a/rust/loopflow/src/ops/task.rs
+++ b/rust/loopflow/src/ops/task.rs
@@ -5,9 +5,10 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use crate::child_session::{
-    task_write_lease_from_env, ChildCommandEffect, ChildCommandId, ChildCommandKind,
-    ChildCommandSource, ChildCommandState, ChildDecisionId, ChildDirective, ChildProcessGeneration,
-    ChildRef, ChildWriteLease,
+    body_progress_age, observe, plan_body_recovery, task_write_lease_from_env, BodyEvidence,
+    BodyRecoveryPlan, ChildBodyOutcome, ChildCommandEffect, ChildCommandId, ChildCommandKind,
+    ChildCommandSource, ChildCommandState, ChildDecisionId, ChildDirective, ChildLeaseState,
+    ChildProcessGeneration, ChildRef, ChildWriteLease, DEFAULT_STALL_AFTER,
 };
 use crate::engine::config::{load_config_or_default, parse_agent};
 use crate::engine::git::{
@@ -15,7 +16,10 @@ use crate::engine::git::{
     push_with_upstream, ref_exists, rev_parse,
 };
 use crate::engine::naming::sanitize_for_branch;
-use crate::engine::process::{start_lf_session_with_env, tmux_session_exists, tmux_session_slug};
+use crate::engine::process::{
+    start_lf_session_with_env, tmux_installed, tmux_live_sessions, tmux_session_exists,
+    tmux_session_slug,
+};
 use crate::engine::worktrees::{
     create_from_placement_plan, plan_placement, PlacementStrategy, WorktreeSegment,
 };
@@ -1760,6 +1764,234 @@ pub(crate) async fn reconcile_process_liveness(
     record_task_failure(store, session, reason, reason.to_string()).await
 }
 
+/// Let one live Project body supervise the progress leases of its Task bodies.
+///
+/// This is deliberately parent-driven: Project and Task Sessions do not grow a
+/// second watchdog process. A live Project runner calls this on its existing
+/// control tick and recovers only children whose durable progress deadline has
+/// passed on a machine that can still observe their tmux body.
+pub(crate) async fn supervise_project_task_bodies(
+    store: &SharedStore,
+    project: &crate::project_session::ProjectSession,
+) -> OpsResult<usize> {
+    if !tmux_installed() {
+        return Ok(0);
+    }
+    let live_sessions = tmux_live_sessions()
+        .await
+        .map_err(|error| task_error(format!("failed to observe Task bodies: {error}")))?;
+    let tasks = store
+        .list_task_sessions(Some(&project.wave_id))
+        .await
+        .map_err(|error| task_error(format!("failed to list supervised Tasks: {error}")))?;
+    let now = time::OffsetDateTime::now_utc();
+    let mut recovered = 0;
+    for task in tasks.into_iter().filter(|task| {
+        task.project_session_id == project.id
+            && task.status.is_process_active()
+            && task.latest_process.as_ref().is_some_and(|process| {
+                process.state == ChildLeaseState::Active
+                    && live_sessions.contains(&process.tmux_name)
+            })
+    }) {
+        let latest_event = store
+            .latest_task_event(&task.id)
+            .await
+            .map_err(|error| task_error(format!("failed to read Task progress: {error}")))?;
+        let observation = observe(
+            &BodyEvidence {
+                intent: task.status.body_intent(),
+                observable: true,
+                process_alive: true,
+                progress_age: body_progress_age(
+                    latest_event.as_ref().map(|event| event.created_at),
+                    task.status_at,
+                    now,
+                ),
+                step: Some(task.lifecycle_phase.as_str().to_string()),
+                reason: task.status_reason.clone(),
+            },
+            DEFAULT_STALL_AFTER,
+        );
+        match recover_stalled_task_body(
+            store,
+            task,
+            &observation,
+            latest_event.as_ref().map(|event| event.id),
+        )
+        .await
+        {
+            Ok(true) => recovered += 1,
+            Ok(false) => {}
+            Err(error) => {
+                tracing::warn!(
+                    project_session = %project.id,
+                    error = %error,
+                    "Task body recovery failed"
+                );
+            }
+        }
+    }
+    Ok(recovered)
+}
+
+async fn recover_stalled_task_body(
+    store: &SharedStore,
+    task: TaskSession,
+    observation: &crate::child_session::BodyObservation,
+    latest_event_id: Option<i64>,
+) -> OpsResult<bool> {
+    let commands = store
+        .list_child_commands(&ChildRef::Task(task.id.clone()))
+        .await
+        .map_err(|error| task_error(format!("failed to inspect Task commands: {error}")))?;
+    let generation = task
+        .latest_process
+        .as_ref()
+        .map(|process| process.generation)
+        .ok_or_else(|| task_error("stalled Task has no process generation"))?;
+    let plan = plan_body_recovery(observation, &commands, generation);
+    if plan == BodyRecoveryPlan::LeaveAlone {
+        return Ok(false);
+    }
+    let active_pr = store
+        .active_task_pr(&task.id)
+        .await
+        .map_err(|error| task_error(format!("failed to inspect Task PR: {error}")))?;
+    if let Some(reason) = task.supervisor_restart_bar(active_pr.as_ref()) {
+        tracing::info!(task = %task.launch.issue.identifier, "not recovering Task body: {reason}");
+        return Ok(false);
+    }
+    let progress_age = observation.progress_age_secs.unwrap_or_default();
+    let uncertain = match &plan {
+        BodyRecoveryPlan::NeedsInput { commands } => Some(commands.clone()),
+        BodyRecoveryPlan::Restart => None,
+        BodyRecoveryPlan::LeaveAlone => unreachable!("leave-alone plan returned above"),
+    };
+    let reason = uncertain.as_ref().map_or_else(
+        || {
+            format!(
+                "body generation {generation} stalled after {progress_age}s without durable progress; recovering the same Task Session"
+            )
+        },
+        |commands| {
+            let commands = commands
+                .iter()
+                .map(ToString::to_string)
+                .collect::<Vec<_>>()
+                .join(", ");
+            format!(
+                "body generation {generation} stalled after {progress_age}s during provider delivery ({commands}); delivery outcome is uncertain, inspect the transcript and resume explicitly"
+            )
+        },
+    );
+    let outcome = if uncertain.is_some() {
+        ChildBodyOutcome::Lost {
+            reason: reason.clone(),
+        }
+    } else {
+        ChildBodyOutcome::Superseded {
+            reason: reason.clone(),
+        }
+    };
+    let Some(revoked) = store
+        .revoke_task_process_if_unchanged(
+            &task.id,
+            generation,
+            task.status_at,
+            latest_event_id,
+            &outcome,
+        )
+        .await
+        .map_err(|error| task_error(format!("failed to claim stalled Task body: {error}")))?
+    else {
+        return Ok(false);
+    };
+    if let Err(error) =
+        super::child::reap_revoked_child_body(store, &ChildRef::Task(task.id.clone()), revoked)
+            .await
+    {
+        let mut current = store
+            .get_task_session(&task.id)
+            .await
+            .map_err(|store_error| task_error(store_error.to_string()))?
+            .ok_or_else(|| task_error("Task Session disappeared during recovery"))?;
+        let failure = format!(
+            "body generation {generation} lease was revoked after a stall but its process group could not be reaped: {error}; manual cleanup is required"
+        );
+        record_task_failure(store, &mut current, failure.clone(), failure).await?;
+        return Err(error);
+    }
+
+    let mut current = store
+        .get_task_session(&task.id)
+        .await
+        .map_err(|error| task_error(error.to_string()))?
+        .ok_or_else(|| task_error("Task Session disappeared during recovery"))?;
+    if uncertain.is_some() {
+        let successor_generation = generation
+            .checked_add(1)
+            .ok_or_else(|| task_error("Task process generation overflow"))?;
+        let changed = store
+            .mark_stale_child_deliveries_uncertain(
+                &ChildRef::Task(task.id.clone()),
+                successor_generation,
+            )
+            .await
+            .map_err(|error| {
+                task_error(format!("failed to preserve uncertain delivery: {error}"))
+            })?;
+        for command in changed {
+            store
+                .append_task_event(
+                    &task.id,
+                    &TaskEventKind::CommandChanged {
+                        command_id: command.id,
+                        state: ChildCommandState::Uncertain,
+                        effect: command.effect,
+                        error: command.error,
+                    },
+                )
+                .await
+                .map_err(|error| task_error(error.to_string()))?;
+        }
+    }
+    let from = current.status;
+    current.set_status(TaskSessionStatus::Waiting, reason);
+    store
+        .update_task_session(&current)
+        .await
+        .map_err(|error| task_error(error.to_string()))?;
+    store
+        .append_task_event(
+            &current.id,
+            &TaskEventKind::StatusChanged {
+                from,
+                to: TaskSessionStatus::Waiting,
+                reason: current.status_reason.clone(),
+            },
+        )
+        .await
+        .map_err(|error| task_error(error.to_string()))?;
+    if uncertain.is_none() {
+        if let Err(error) = relaunch_inactive_process(store, &mut current).await {
+            let mut persisted = store
+                .get_task_session(&task.id)
+                .await
+                .map_err(|store_error| task_error(store_error.to_string()))?
+                .ok_or_else(|| task_error("Task Session disappeared during relaunch"))?;
+            if persisted.status == TaskSessionStatus::Waiting {
+                let failure = format!(
+                    "body generation {generation} was reaped after a stall but its successor could not start: {error}"
+                );
+                record_task_failure(store, &mut persisted, failure.clone(), failure).await?;
+            }
+            return Err(error);
+        }
+    }
+    Ok(true)
+}
+
 pub(crate) async fn reconcile_task_pr(
     store: &SharedStore,
     session: &mut TaskSession,
@@ -3207,19 +3439,24 @@ pub fn task_attach(issue: &str) -> OpsResult<()> {
 
 #[cfg(test)]
 mod tests {
+    use std::io::{BufRead, BufReader};
+    use std::os::unix::process::CommandExt;
     use std::path::Path;
     use std::process::Command;
     use std::sync::Arc;
+    use std::time::Duration;
 
     use super::{
         _defer_task_interactions, changes_snapshot, command_source_for_wave, derive_workspace_slug,
         diff_snapshot, ensure_working_pr, ensure_working_pr_with_authority, file_snapshot,
         parse_pr_slug, parse_workspace_slug, project_context, reconcile_process_liveness,
-        refuse_if_canonical_ahead, resolve_task_flow, resolve_upstream_base,
-        verify_task_pr_range_with_authority, RotateOptions, TaskControlResult, TaskWorkspace,
+        recover_stalled_task_body, refuse_if_canonical_ahead, resolve_task_flow,
+        resolve_upstream_base, verify_task_pr_range_with_authority, RotateOptions,
+        TaskControlResult, TaskWorkspace,
     };
     use crate::child_session::{
-        ChildCommand, ChildCommandKind, ChildCommandSource, ChildProcessGeneration, ChildRef,
+        observe, BodyEvidence, BodyIntent, ChildBodyOutcome, ChildCommand, ChildCommandKind,
+        ChildCommandSource, ChildCommandState, ChildLeaseState, ChildProcessGeneration, ChildRef,
     };
     use crate::id::WaveId;
     use crate::pm::{PmKr, PmProject};
@@ -3230,8 +3467,8 @@ mod tests {
     };
     use crate::store::{open_store, SharedStore, StorageConfig};
     use crate::task::{
-        AfterMerge, GithubPr, PmWritebackState, PrPhase, PrPublication, TaskPr, TaskPrId,
-        TaskSession, TaskSessionId, TaskSessionStatus,
+        AfterMerge, GithubPr, PmWritebackState, PrPhase, PrPublication, TaskEventKind, TaskPr,
+        TaskPrId, TaskSession, TaskSessionId, TaskSessionStatus,
     };
     use crate::wave::Wave;
     use loopflow_test_support::TestRepo;
@@ -3667,6 +3904,161 @@ mod tests {
             Some(crate::child_session::ChildLeaseState::Finished)
         );
         assert_eq!(persisted.status, TaskSessionStatus::Failed);
+    }
+
+    #[tokio::test]
+    async fn stalled_delivery_is_reaped_and_waits_without_replay() {
+        let repo = TestRepo::new();
+        let base = repo.head_sha();
+        let (_home, store, mut session, _pr) =
+            rotation_task(&repo, "jack/stalled-delivery", &base).await;
+        session.begin_generation(format!("stalled-body-{}", session.id));
+        let lease = store
+            .reserve_task_process(&session, TaskSessionStatus::Waiting)
+            .await
+            .unwrap()
+            .expect("reserve stalled body");
+
+        let mut child = std::process::Command::new("/bin/sh")
+            .arg("-c")
+            .arg("sleep 60 & echo $!; wait")
+            .process_group(0)
+            .stdout(std::process::Stdio::piped())
+            .spawn()
+            .expect("spawn stalled process group");
+        let group = child.id();
+        let stdout = child.stdout.take().expect("capture grandchild pid");
+        let mut line = String::new();
+        BufReader::new(stdout)
+            .read_line(&mut line)
+            .expect("read grandchild pid");
+        let grandchild: u32 = line.trim().parse().expect("grandchild pid");
+        let waiter = std::thread::spawn(move || child.wait().expect("reap shell"));
+
+        let process = session.latest_process.as_mut().expect("reserved process");
+        process.pid = Some(group);
+        process.process_group_id = Some(group);
+        process.state = ChildLeaseState::Active;
+        session.set_status(TaskSessionStatus::Running, "fake provider is alive");
+        store.activate_task_process(&session, &lease).await.unwrap();
+
+        let mut command = ChildCommand::new(
+            ChildRef::Task(session.id.clone()),
+            ChildCommandSource::Human,
+            ChildCommandKind::Steer {
+                text: "do the external thing".to_string(),
+            },
+        );
+        store.create_child_command(&command).await.unwrap();
+        let claimed = store
+            .claim_child_commands_for_lease(&command.target, &lease)
+            .await
+            .unwrap();
+        command = claimed.into_iter().next().expect("claimed command");
+        store
+            .mark_child_command_delivering_for_lease(
+                &command.target,
+                &lease,
+                &command.id,
+                crate::child_session::ChildCommandEffect::LiveSteer,
+            )
+            .await
+            .unwrap();
+        session = store.get_task_session(&session.id).await.unwrap().unwrap();
+
+        let observation = observe(
+            &BodyEvidence {
+                intent: BodyIntent::Active,
+                observable: true,
+                process_alive: true,
+                progress_age: Duration::from_secs(31 * 60),
+                step: Some("task_pursue".to_string()),
+                reason: "fake provider is alive".to_string(),
+            },
+            Duration::from_secs(30 * 60),
+        );
+        let latest_event_id = store
+            .latest_task_event(&session.id)
+            .await
+            .unwrap()
+            .map(|event| event.id);
+        assert!(
+            recover_stalled_task_body(&store, session.clone(), &observation, latest_event_id,)
+                .await
+                .unwrap()
+        );
+        waiter.join().unwrap();
+
+        // SAFETY: signal 0 is an existence probe and uses no pointers.
+        assert_ne!(unsafe { libc::kill(group as i32, 0) }, 0);
+        // SAFETY: signal 0 is an existence probe and uses no pointers.
+        assert_ne!(unsafe { libc::kill(grandchild as i32, 0) }, 0);
+        let persisted = store.get_task_session(&session.id).await.unwrap().unwrap();
+        assert_eq!(persisted.status, TaskSessionStatus::Waiting);
+        assert_eq!(
+            persisted.latest_process.map(|process| process.state),
+            Some(ChildLeaseState::Finished)
+        );
+        assert!(persisted.status_reason.contains(command.id.as_str()));
+        let receipt = store.get_child_command(&command.id).await.unwrap().unwrap();
+        assert_eq!(receipt.state, ChildCommandState::Uncertain);
+    }
+
+    #[tokio::test]
+    async fn progress_wins_the_race_against_stall_recovery() {
+        let repo = TestRepo::new();
+        let base = repo.head_sha();
+        let (_home, store, mut session, _pr) =
+            rotation_task(&repo, "jack/progress-race", &base).await;
+        session.begin_generation(format!("progress-race-{}", session.id));
+        let lease = store
+            .reserve_task_process(&session, TaskSessionStatus::Waiting)
+            .await
+            .unwrap()
+            .expect("reserve body");
+        session
+            .latest_process
+            .as_mut()
+            .expect("reserved process")
+            .state = ChildLeaseState::Active;
+        session.set_status(TaskSessionStatus::Running, "provider is alive");
+        store.activate_task_process(&session, &lease).await.unwrap();
+        session = store.get_task_session(&session.id).await.unwrap().unwrap();
+        let observed_event_id = store
+            .latest_task_event(&session.id)
+            .await
+            .unwrap()
+            .map(|event| event.id);
+
+        store
+            .append_task_event(
+                &session.id,
+                &TaskEventKind::Progress {
+                    summary: "body advanced before revocation".to_string(),
+                },
+            )
+            .await
+            .unwrap();
+        let revoked = store
+            .revoke_task_process_if_unchanged(
+                &session.id,
+                1,
+                session.status_at,
+                observed_event_id,
+                &ChildBodyOutcome::Superseded {
+                    reason: "stale observation".to_string(),
+                },
+            )
+            .await
+            .unwrap();
+
+        assert!(revoked.is_none());
+        let persisted = store.get_task_session(&session.id).await.unwrap().unwrap();
+        assert_eq!(
+            persisted.latest_process.map(|process| process.state),
+            Some(ChildLeaseState::Active),
+        );
+        assert_eq!(persisted.status, TaskSessionStatus::Running);
     }
 
     #[test]

--- a/rust/loopflow/src/project_session/runner.rs
+++ b/rust/loopflow/src/project_session/runner.rs
@@ -31,6 +31,8 @@ use crate::wave::playhead::{
 };
 use crate::wave::Wave;
 
+const TASK_SUPERVISION_INTERVAL: Duration = Duration::from_secs(5);
+
 pub async fn run_project_session(session_id: ProjectSessionId, generation: u32) -> Result<()> {
     let lease = project_write_lease_from_env().map_err(|error| anyhow!(error))?;
     if lease.generation != generation {
@@ -177,6 +179,8 @@ async fn run_project_session_inner(
     );
     let mut poll = tokio::time::interval(Duration::from_millis(200));
     poll.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+    let mut task_supervision = tokio::time::interval(TASK_SUPERVISION_INTERVAL);
+    task_supervision.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
     let mut last_text = String::new();
     loop {
         tokio::select! {
@@ -202,6 +206,18 @@ async fn run_project_session_inner(
                     &mut pending,
                 ).await? {
                     return finish_command_stop(&store, &mut session, lease, harness.as_mut(), stop).await;
+                }
+            }
+            _ = task_supervision.tick() => {
+                if let Err(error) = crate::ops::task::supervise_project_task_bodies(
+                    &store,
+                    &session,
+                ).await {
+                    tracing::warn!(
+                        project_session = %session.id,
+                        error = %error,
+                        "could not supervise Task progress leases"
+                    );
                 }
             }
             event = event_rx.recv() => {

--- a/rust/loopflow/src/store/child_sessions.rs
+++ b/rust/loopflow/src/store/child_sessions.rs
@@ -119,6 +119,28 @@ impl Store {
         .await
     }
 
+    pub(crate) async fn revoke_task_process_if_unchanged(
+        &self,
+        session_id: &TaskSessionId,
+        generation: u32,
+        status_at: OffsetDateTime,
+        latest_event_id: Option<i64>,
+        outcome: &ChildBodyOutcome,
+    ) -> StoreResult<Option<ChildProcessGeneration>> {
+        let session_id = session_id.clone();
+        let outcome = outcome.clone();
+        run_sqlite(&self.sqlite, move |store| {
+            store.revoke_task_process_if_unchanged(
+                &session_id,
+                generation,
+                status_at,
+                latest_event_id,
+                &outcome,
+            )
+        })
+        .await
+    }
+
     pub(crate) async fn finish_revoked_task_process(
         &self,
         session_id: &TaskSessionId,
@@ -270,6 +292,17 @@ impl Store {
         let session_id = session_id.clone();
         run_sqlite(&self.sqlite, move |store| {
             store.latest_task_event_at(&session_id)
+        })
+        .await
+    }
+
+    pub async fn latest_task_event(
+        &self,
+        session_id: &TaskSessionId,
+    ) -> StoreResult<Option<TaskEvent>> {
+        let session_id = session_id.clone();
+        run_sqlite(&self.sqlite, move |store| {
+            store.latest_task_event(&session_id)
         })
         .await
     }

--- a/rust/loopflow/src/store/sqlite/child_sessions.rs
+++ b/rust/loopflow/src/store/sqlite/child_sessions.rs
@@ -275,6 +275,79 @@ impl SqliteStore {
         Ok(process)
     }
 
+    /// Revoke a body only if the progress evidence a supervisor observed is
+    /// still current. The immediate transaction closes the gap between the
+    /// final progress check and lease revocation: a body that completed or
+    /// appended an event in that gap wins, and supervision leaves it alone.
+    pub(crate) fn revoke_task_process_if_unchanged(
+        &self,
+        session_id: &TaskSessionId,
+        generation: u32,
+        status_at: OffsetDateTime,
+        latest_event_id: Option<i64>,
+        outcome: &ChildBodyOutcome,
+    ) -> StoreResult<Option<ChildProcessGeneration>> {
+        let mut conn = self.conn.lock().expect("store mutex poisoned");
+        let transaction = conn.transaction_with_behavior(TransactionBehavior::Immediate)?;
+        let mut session = transaction
+            .query_row(
+                TASK_SESSION_SELECT,
+                params![session_id.as_str()],
+                map_task_session_row,
+            )
+            .optional()?
+            .ok_or(StoreError::NotFound)?;
+        let current_event_id: Option<i64> = transaction.query_row(
+            "SELECT MAX(id) FROM task_events WHERE session_id = ?1",
+            params![session_id.as_str()],
+            |row| row.get(0),
+        )?;
+        if session.status_at != status_at
+            || current_event_id != latest_event_id
+            || !session.status.is_process_active()
+        {
+            transaction.commit()?;
+            return Ok(None);
+        }
+        let Some(process) = session.latest_process.as_mut() else {
+            transaction.commit()?;
+            return Ok(None);
+        };
+        if process.generation != generation || process.state != ChildLeaseState::Active {
+            transaction.commit()?;
+            return Ok(None);
+        }
+        process.state = ChildLeaseState::Revoked;
+        process.outcome = Some(outcome.clone());
+        let outcome_json = serde_json::to_string(outcome)?;
+        if transaction.execute(
+            "UPDATE task_sessions
+             SET process_lease_state='revoked', process_outcome_json=?3
+             WHERE id=?1 AND process_generation=?2
+               AND process_lease_state='active' AND status_at=?4",
+            params![
+                session_id.as_str(),
+                i64::from(generation),
+                outcome_json,
+                status_at.unix_timestamp(),
+            ],
+        )? == 0
+        {
+            transaction.commit()?;
+            return Ok(None);
+        }
+        let process = process.clone();
+        insert_task_event_in(
+            &transaction,
+            &session,
+            &TaskEventKind::BodyLeaseChanged {
+                process: process.clone(),
+            },
+        )?;
+        transaction.commit()?;
+        Ok(Some(process))
+    }
+
     pub(crate) fn finish_revoked_task_process(
         &self,
         session_id: &TaskSessionId,
@@ -1715,6 +1788,18 @@ impl SqliteStore {
             |row| row.get(0),
         )?;
         Ok(seconds.map(crate::store::rows::unix_to_datetime))
+    }
+
+    pub fn latest_task_event(&self, session_id: &TaskSessionId) -> StoreResult<Option<TaskEvent>> {
+        let conn = self.conn.lock().expect("store mutex poisoned");
+        conn.query_row(
+            "SELECT id, session_id, kind_json, created_at
+             FROM task_events WHERE session_id = ?1 ORDER BY id DESC LIMIT 1",
+            params![session_id.as_str()],
+            map_task_event_row,
+        )
+        .optional()
+        .map_err(StoreError::from)
     }
 
     // Project Sessions are durable KR-pursuit children. They share the same


### PR DESCRIPTION
## Usage

```bash
# A live Project Session runner supervises its Task bodies automatically.
# Trigger: a Task body with an Active lease goes 30 min without durable progress.
lf project run <wave>/<project>
```

Recovery runs on the Project runner's existing control tick — no new watchdog process. When a Task body stalls, supervision revokes its lease, reaps the tmux process group, and either restarts the same Task Session at generation+1 or parks it for human input.

## Summary

Task bodies could stall silently (live tmux pane, no durable progress) with no owner to recover them. This adds parent-driven supervision: a live Project runner observes each Task body's progress lease and recovers stalled ones. The critical safety property is replay-safety — if any command was mid-delivery when the body stalled, supervision refuses to replay it (which could double-execute a steer or follow-up). Instead it marks those commands `Uncertain`, records the loss, and waits for a human to inspect the transcript and resume explicitly. Only when delivery state is unambiguous does it restart cleanly.

## Changes

- `body_progress_age` and `BodyRecoveryPlan` (`LeaveAlone` / `Restart` / `NeedsInput`) move into `child_session` so both the read model and supervision share one definition of progress and recovery
- `plan_body_recovery` classifies a stalled body: ambiguous deliveries (Delivering/Uncertain, same generation) become `NeedsInput`; otherwise `Restart` — uncertainty from older generations never poisons a successor
- `reap_revoked_child_body` split out of `revoke_and_reap_child_body` so supervision can reap an already-revoked generation
- `supervise_project_task_bodies` walks a Project's live Task bodies, observes each, and recovers stalled ones via `recover_stalled_task_body`, which records `Superseded` (restart) or `Lost` (needs input) outcomes
- `mark_stale_child_deliveries_uncertain` + `revoke_task_process_if_unchanged` make the recovery compare-and-set: a body that advanced between observation and revocation is left alone
- `TaskSession::supervisor_restart_bar` gates recovery when a Task has an active PR or other reason not to restart