### PR TITLE
ops: resolve Actions run/job ids in lf wt ci --logs

### DIFF
--- a/rust/loopflow/src/lf/commands/ops/mod.rs
+++ b/rust/loopflow/src/lf/commands/ops/mod.rs
@@ -1716,34 +1716,133 @@ fn wt_ci(watch: bool, logs: bool) -> Result<()> {
         .status()?;
 
     if !status.success() && logs {
-        println!("\n--- Failed check logs ---\n");
-        let output = Command::new("gh")
-            .args([
-                "pr",
-                "view",
-                &branch,
-                "--json",
-                "statusCheckRollup",
-                "-q",
-                ".statusCheckRollup[] | select(.conclusion == \"FAILURE\" or .conclusion == \"failure\") | .detailsUrl",
-            ])
-            .current_dir(&repo_root)
-            .output()?;
-        if output.status.success() {
-            let urls = String::from_utf8_lossy(&output.stdout);
-            for url in urls.lines().filter(|line| !line.trim().is_empty()) {
-                let _ = Command::new("gh")
-                    .args(["run", "view", url])
-                    .current_dir(&repo_root)
-                    .status();
-            }
-        }
+        print_failed_check_logs(&repo_root, &branch)?;
     }
 
     if status.success() {
         Ok(())
     } else {
         Err(anyhow!("ci checks failed"))
+    }
+}
+
+/// A GitHub Actions run reference extracted from a `detailsUrl` or bare id.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct RunRef {
+    run_id: String,
+    job_id: Option<String>,
+}
+
+/// Parse a GitHub Actions `detailsUrl`, run/job URL, or bare numeric run id
+/// into a [`RunRef`]. Returns `None` for non-Actions URLs (external CI
+/// services) or unparseable input.
+fn parse_run_ref(value: &str) -> Option<RunRef> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    if trimmed.chars().all(|c| c.is_ascii_digit()) {
+        return Some(RunRef {
+            run_id: trimmed.to_string(),
+            job_id: None,
+        });
+    }
+    let marker = "/actions/runs/";
+    let idx = trimmed.find(marker)?;
+    let after = &trimmed[idx + marker.len()..];
+    let mut parts = after.split('/');
+    let run_id = parts.next()?;
+    if !is_numeric(run_id) {
+        return None;
+    }
+    let job_id = match parts.next() {
+        Some("jobs") => parts.next().filter(|j| is_numeric(j)),
+        _ => None,
+    };
+    Some(RunRef {
+        run_id: run_id.to_string(),
+        job_id: job_id.map(str::to_string),
+    })
+}
+
+fn is_numeric(s: &str) -> bool {
+    !s.is_empty() && s.chars().all(|c| c.is_ascii_digit())
+}
+
+/// Fetch and print logs for every failed check on `branch`, with attribution.
+/// Non-Actions checks and missing/expired/private logs are reported actionably
+/// rather than silently dropped.
+fn print_failed_check_logs(repo_root: &Path, branch: &str) -> Result<()> {
+    println!("\n--- Failed check logs ---\n");
+
+    let output = Command::new("gh")
+        .args([
+            "pr",
+            "view",
+            branch,
+            "--json",
+            "statusCheckRollup",
+            "-q",
+            r#".statusCheckRollup[] | select(.conclusion == "FAILURE" or .conclusion == "failure") | [.name, (.detailsUrl // "")] | @tsv"#,
+        ])
+        .current_dir(repo_root)
+        .output()?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        eprintln!("Couldn't list failed checks: {stderr}");
+        return Ok(());
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    for line in stdout.lines().map(str::trim).filter(|l| !l.is_empty()) {
+        let (name, url) = line.split_once('\t').unwrap_or((line, ""));
+        print_single_check_logs(repo_root, name, url);
+    }
+
+    Ok(())
+}
+
+fn print_single_check_logs(repo_root: &Path, name: &str, url: &str) {
+    let Some(run_ref) = parse_run_ref(url) else {
+        if url.is_empty() {
+            eprintln!("### {name}\nNo details URL for this check; open the PR checks tab.\n");
+        } else {
+            eprintln!("### {name}\nLogs not available via gh for this check. Open: {url}\n");
+        }
+        return;
+    };
+
+    let mut args: Vec<&str> = vec!["run", "view", &run_ref.run_id, "--log"];
+    if let Some(job_id) = &run_ref.job_id {
+        args.extend(["--job", job_id]);
+    }
+
+    let output = Command::new("gh")
+        .args(&args)
+        .current_dir(repo_root)
+        .output();
+
+    match output {
+        Ok(out) if out.status.success() => {
+            let logs = String::from_utf8_lossy(&out.stdout);
+            print!("### {name}\n\n{logs}");
+            if !logs.ends_with('\n') {
+                println!();
+            }
+            println!();
+        }
+        Ok(out) => {
+            let stderr = String::from_utf8_lossy(&out.stderr).trim().to_string();
+            eprintln!(
+                "### {name}\nCouldn't fetch logs (run {}): {stderr}\n\
+                 The run may be missing, expired (>90 days), or private. Open: {url}\n",
+                run_ref.run_id
+            );
+        }
+        Err(err) => {
+            eprintln!("### {name}\nFailed to invoke gh: {err}\n");
+        }
     }
 }
 
@@ -2187,6 +2286,71 @@ mod telemetry_tests {
             porcelain(repo),
             "",
             "recording telemetry must not dirty a clean worktree"
+        );
+    }
+}
+
+#[cfg(test)]
+mod wt_ci_tests {
+    use super::{parse_run_ref, RunRef};
+
+    #[test]
+    fn parse_run_ref_handles_job_url() {
+        let url =
+            "https://github.com/loopflowstudio/loopflow/actions/runs/978123456/jobs/111222333";
+        let r = parse_run_ref(url).expect("job URL parses");
+        assert_eq!(r.run_id, "978123456");
+        assert_eq!(r.job_id, Some("111222333".to_string()));
+    }
+
+    #[test]
+    fn parse_run_ref_handles_run_url() {
+        let url = "https://github.com/loopflowstudio/loopflow/actions/runs/983654321";
+        let r = parse_run_ref(url).expect("run URL parses");
+        assert_eq!(r.run_id, "983654321");
+        assert_eq!(r.job_id, None);
+    }
+
+    #[test]
+    fn parse_run_ref_handles_bare_numeric_id() {
+        let r = parse_run_ref("978123456").expect("numeric id parses");
+        assert_eq!(
+            r,
+            RunRef {
+                run_id: "978123456".to_string(),
+                job_id: None
+            }
+        );
+    }
+
+    #[test]
+    fn parse_run_ref_trims_whitespace() {
+        let r = parse_run_ref("  978123456  ").expect("trimmed numeric id parses");
+        assert_eq!(r.run_id, "978123456");
+    }
+
+    #[test]
+    fn parse_run_ref_rejects_non_actions_url() {
+        assert_eq!(
+            parse_run_ref("https://example.com/build/123"),
+            None,
+            "external CI URLs are not Actions runs"
+        );
+    }
+
+    #[test]
+    fn parse_run_ref_rejects_empty_and_garbage() {
+        assert_eq!(parse_run_ref(""), None);
+        assert_eq!(parse_run_ref("   "), None);
+        assert_eq!(parse_run_ref("not-a-url"), None);
+    }
+
+    #[test]
+    fn parse_run_ref_rejects_non_numeric_run_id() {
+        assert_eq!(
+            parse_run_ref("https://github.com/o/r/actions/runs/abc"),
+            None,
+            "non-numeric run id is not a valid ref"
         );
     }
 }

--- a/rust/loopflow/tests/wt_ci_logs_tests.rs
+++ b/rust/loopflow/tests/wt_ci_logs_tests.rs
@@ -1,0 +1,283 @@
+mod support;
+
+use std::process::Command;
+
+use loopflow_test_support::TestRepo;
+use support::EnvGuard;
+
+/// Fake `gh` that fails `pr checks`, returns two failed checks with PR 978
+/// (job URL) and PR 983 (run URL) shapes, and records every `run view`
+/// invocation. `run view` with a URL arg exits 404; with a numeric run id it
+/// prints log lines. The record file is the proof artifact: it should contain
+/// only numeric run ids, never full URLs.
+fn gh_script_for_url_shapes(record: &std::path::Path) -> String {
+    format!(
+        r#"#!/bin/sh
+if [ "$1" = "--version" ]; then
+  echo 'gh version 2.40.0'
+  exit 0
+fi
+case "$1 $2" in
+  'pr checks')
+    exit 1
+    ;;
+  'pr view')
+    printf 'build\thttps://github.com/loopflowstudio/loopflow/actions/runs/978123456/jobs/111222333\n'
+    printf 'test\thttps://github.com/loopflowstudio/loopflow/actions/runs/983654321\n'
+    exit 0
+    ;;
+  'run view')
+    echo "$@" >> '{record}'
+    for arg in "$@"; do
+      case "$arg" in
+        */*)
+          echo "HTTP 404: Not Found" >&2
+          exit 1
+          ;;
+      esac
+    done
+    echo "log line 1 for run $3"
+    echo "log line 2 for run $3"
+    exit 0
+    ;;
+esac
+echo "unexpected gh invocation: $@" >&2
+exit 1
+"#,
+        record = record.display()
+    )
+}
+
+/// Fake `gh` whose `run view --log` always fails, simulating missing, expired,
+/// or private logs.
+fn gh_script_for_failing_logs() -> &'static str {
+    r#"#!/bin/sh
+if [ "$1" = "--version" ]; then
+  echo 'gh version 2.40.0'
+  exit 0
+fi
+case "$1 $2" in
+  'pr checks')
+    exit 1
+    ;;
+  'pr view')
+    printf 'build\thttps://github.com/loopflowstudio/loopflow/actions/runs/978123456/jobs/111222333\n'
+    exit 0
+    ;;
+  'run view')
+    echo "could not find workflow run" >&2
+    exit 1
+    ;;
+esac
+echo "unexpected gh invocation: $@" >&2
+exit 1
+"#
+}
+
+/// Fake `gh` that returns a non-Actions (external CI) `detailsUrl`. The code
+/// should skip `gh run view` and print an actionable message instead.
+fn gh_script_for_external_ci() -> &'static str {
+    r#"#!/bin/sh
+if [ "$1" = "--version" ]; then
+  echo 'gh version 2.40.0'
+  exit 0
+fi
+case "$1 $2" in
+  'pr checks')
+    exit 1
+    ;;
+  'pr view')
+    printf 'external-ci\thttps://ci.example.com/build/12345\n'
+    exit 0
+    ;;
+esac
+echo "unexpected gh invocation: $@" >&2
+exit 1
+"#
+}
+
+/// Fake `gh` that returns a bare numeric run id as the `detailsUrl`, covering
+/// the numeric-id variant. Records `run view` invocations.
+fn gh_script_for_numeric_id(record: &std::path::Path) -> String {
+    format!(
+        r#"#!/bin/sh
+if [ "$1" = "--version" ]; then
+  echo 'gh version 2.40.0'
+  exit 0
+fi
+case "$1 $2" in
+  'pr checks')
+    exit 1
+    ;;
+  'pr view')
+    printf 'lint\t555666777\n'
+    exit 0
+    ;;
+  'run view')
+    echo "$@" >> '{record}'
+    for arg in "$@"; do
+      case "$arg" in
+        */*)
+          echo "HTTP 404: Not Found" >&2
+          exit 1
+          ;;
+      esac
+    done
+    echo "log line 1 for run $3"
+    echo "log line 2 for run $3"
+    exit 0
+    ;;
+esac
+echo "unexpected gh invocation: $@" >&2
+exit 1
+"#,
+        record = record.display()
+    )
+}
+
+fn run_wt_ci_logs(repo: &TestRepo) -> std::process::Output {
+    Command::new(env!("CARGO_BIN_EXE_lf"))
+        .args(["wt", "ci", "--logs"])
+        .current_dir(repo.path())
+        .env("RUST_LOG", "off")
+        .output()
+        .expect("run lf wt ci --logs")
+}
+
+/// Reproduces the PR 978 (job URL) and PR 983 (run URL) shapes that caused
+/// `gh run view <full-url>` to produce malformed API paths and HTTP 404.
+/// Proves the fix extracts numeric run/job ids and never passes a URL.
+#[test]
+fn wt_ci_logs_extracts_run_ids_from_pr_shaped_urls() {
+    let record_dir = tempfile::TempDir::new().expect("record dir");
+    let record = record_dir.path().join("run_view_calls.txt");
+    let script = gh_script_for_url_shapes(&record);
+    let _env = EnvGuard::new(&[("gh", script.as_str())]);
+    let repo = TestRepo::new();
+
+    let output = run_wt_ci_logs(&repo);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(!output.status.success(), "ci checks should fail");
+
+    // Attribution headers for both failed checks.
+    assert!(
+        stdout.contains("### build"),
+        "stdout should attribute build: {stdout}"
+    );
+    assert!(
+        stdout.contains("### test"),
+        "stdout should attribute test: {stdout}"
+    );
+
+    // Log content — proves gh run view was called with numeric run ids, not
+    // full URLs (the fake gh returns 404 for any arg containing "/").
+    assert!(
+        stdout.contains("log line 1 for run 978123456"),
+        "should print logs for PR 978 shaped job URL: {stdout}"
+    );
+    assert!(
+        stdout.contains("log line 2 for run 983654321"),
+        "should print logs for PR 983 shaped run URL: {stdout}"
+    );
+
+    // No malformed API requests leaked to stderr.
+    assert!(
+        !stderr.contains("404") && !stderr.contains("Not Found"),
+        "no malformed API errors in stderr: {stderr}"
+    );
+
+    // The record file is the direct proof: gh run view received numeric run
+    // ids with --log and --job, never full URLs.
+    let calls = std::fs::read_to_string(&record).expect("record file");
+    assert!(
+        calls.contains("run view 978123456 --log --job 111222333"),
+        "PR 978 job URL → numeric run id + job id: {calls}"
+    );
+    assert!(
+        calls.contains("run view 983654321 --log"),
+        "PR 983 run URL → numeric run id: {calls}"
+    );
+    assert!(
+        !calls.contains("http") && !calls.contains("/actions/runs/"),
+        "no full URLs passed to gh run view: {calls}"
+    );
+}
+
+/// Missing, expired, or private logs produce an actionable error with the run
+/// id and a hint — not a silent `let _ =` drop.
+#[test]
+fn wt_ci_logs_reports_unavailable_logs_actionably() {
+    let script = gh_script_for_failing_logs();
+    let _env = EnvGuard::new(&[("gh", script)]);
+    let repo = TestRepo::new();
+
+    let output = run_wt_ci_logs(&repo);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(!output.status.success(), "ci checks should fail");
+    assert!(
+        stderr.contains("Couldn't fetch logs"),
+        "should report actionable error: {stderr}"
+    );
+    assert!(
+        stderr.contains("missing, expired"),
+        "should hint at possible causes: {stderr}"
+    );
+    assert!(
+        stderr.contains("978123456"),
+        "should include the run id so the user can look it up: {stderr}"
+    );
+}
+
+/// Non-Actions `detailsUrl` (external CI) is skipped with an actionable
+/// message and the original URL — not passed to `gh run view` as garbage.
+#[test]
+fn wt_ci_logs_skips_non_actions_urls() {
+    let script = gh_script_for_external_ci();
+    let _env = EnvGuard::new(&[("gh", script)]);
+    let repo = TestRepo::new();
+
+    let output = run_wt_ci_logs(&repo);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(!output.status.success(), "ci checks should fail");
+    assert!(
+        stderr.contains("### external-ci"),
+        "should attribute the external check: {stderr}"
+    );
+    assert!(
+        stderr.contains("Logs not available via gh"),
+        "should explain why logs aren't fetched: {stderr}"
+    );
+    assert!(
+        stderr.contains("ci.example.com"),
+        "should include the URL for manual inspection: {stderr}"
+    );
+}
+
+/// A bare numeric run id in `detailsUrl` is passed through correctly — the
+/// numeric-id variant.
+#[test]
+fn wt_ci_logs_handles_numeric_id_details_url() {
+    let record_dir = tempfile::TempDir::new().expect("record dir");
+    let record = record_dir.path().join("run_view_calls.txt");
+    let script = gh_script_for_numeric_id(&record);
+    let _env = EnvGuard::new(&[("gh", script.as_str())]);
+    let repo = TestRepo::new();
+
+    let output = run_wt_ci_logs(&repo);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert!(!output.status.success(), "ci checks should fail");
+    assert!(
+        stdout.contains("log line 1 for run 555666777"),
+        "should print logs for numeric id detailsUrl: {stdout}"
+    );
+    let calls = std::fs::read_to_string(&record).expect("record file");
+    assert!(
+        calls.contains("run view 555666777 --log"),
+        "numeric id should be passed through as-is: {calls}"
+    );
+}


### PR DESCRIPTION
## Summary

`lf wt ci --logs` passed full GitHub Actions job URLs as the run identifier to `gh run view`, producing malformed API paths like `/actions/runs/https://github.com/...` and HTTP 404 (seen on PRs #978 and #983).

- Parse the check `detailsUrl` (job URL, run URL) or a bare numeric run id into a run/job id before calling `gh run view --log [--job ...]`.
- Print each failed check's logs under a `### <name>` attribution header.
- Report missing/expired/private logs and non-Actions (external CI) URLs actionably with the run id and a link, instead of silently dropping them.
- Integration test reproduces the PR 978 (job URL) and PR 983 (run URL) shapes plus the numeric-id variant, and proves no full URL ever reaches `gh run view`.