### PR TITLE
task ci-fix: settle one bounded ci-fix turn at its exit

### DIFF
--- a/rust/loopflow/src/child_control.rs
+++ b/rust/loopflow/src/child_control.rs
@@ -120,7 +120,7 @@ impl<'a> ChildTarget<'a> {
             .await
     }
 
-    async fn accept_command(
+    pub(crate) async fn accept_command(
         self,
         store: &SharedStore,
         command_id: ChildCommandId,
@@ -157,7 +157,7 @@ impl<'a> ChildTarget<'a> {
         .await
     }
 
-    async fn fail_command(
+    pub(crate) async fn fail_command(
         self,
         store: &SharedStore,
         command_id: ChildCommandId,

--- a/rust/loopflow/src/task/runner.rs
+++ b/rust/loopflow/src/task/runner.rs
@@ -142,7 +142,10 @@ async fn run_task_session_inner(session_id: TaskSessionId, lease: &ChildWriteLea
         // parks the parent without ever starting the provider.
         if reconcile_interactive_rendezvous_at_birth(&store, &mut session, lease, &mut flow).await?
         {
-            return finish_parked(&store, &mut session, lease, None).await;
+            let outcome = ChildBodyOutcome::Interrupted {
+                reason: session.status_reason.clone(),
+            };
+            return finish_parked(&store, &mut session, lease, None, outcome).await;
         }
         flow
     };
@@ -401,11 +404,15 @@ The durable reviewer outcome is:\n{}",
                                 "interactive handoff open; waiting for a human",
                             )
                             .await?;
+                            let outcome = ChildBodyOutcome::Interrupted {
+                                reason: session.status_reason.clone(),
+                            };
                             return finish_parked(
                                 &store,
                                 &mut session,
                                 lease,
                                 Some(harness.as_mut()),
+                                outcome,
                             )
                             .await;
                         }
@@ -655,6 +662,23 @@ The durable reviewer outcome is:\n{}",
                             iteration_start_head = observed_pr
                                 .as_ref()
                                 .and_then(|pr| pr.head_sha().map(str::to_string));
+                            // A ci-fix body is one bounded turn, and this is its
+                            // exit. It leaves before rotation, before the gate,
+                            // and before any successor step: those advance the
+                            // Task, and a repair is not Task progress.
+                            if let Some(wake) = ci_fix_wake.as_ref() {
+                                let _ = harness.stop().await;
+                                return settle_ci_fix_turn(
+                                    &store,
+                                    &mut session,
+                                    lease,
+                                    wake,
+                                    observed_pr.as_ref(),
+                                    head_before_turn.as_deref(),
+                                    status,
+                                )
+                                .await;
+                            }
                             // Merged, not merely settled: the branch below reports
                             // this PR as merged and waits on its review gate, which
                             // is false of an abandoned one.
@@ -1434,23 +1458,22 @@ async fn parked_on_interactive_handoff(store: &SharedStore, session: &TaskSessio
     Ok(interactive_rendezvous::pending(&handoffs).is_some())
 }
 
-/// End a parked body: the session status is already `Waiting` or `Blocked`, so
-/// only the process is settled. The parent stays non-terminal and resumes when a
-/// later body reconciles the handoff outcome.
+/// End a parked body: the session status is already `Waiting` or `Blocked`, so only
+/// the process is settled and the parent stays non-terminal. The caller supplies
+/// `outcome` — only it knows whether the turn finished or was cut short.
 async fn finish_parked(
     store: &SharedStore,
     session: &mut TaskSession,
     lease: &ChildWriteLease,
     harness: Option<&mut dyn Harness>,
+    outcome: ChildBodyOutcome,
 ) -> Result<()> {
     if let Some(harness) = harness {
         let _ = harness.stop().await;
     }
     if let Some(process) = &mut session.latest_process {
         process.state = ChildLeaseState::Finished;
-        process.outcome = Some(ChildBodyOutcome::Interrupted {
-            reason: "interactive handoff; waiting on a human".to_string(),
-        });
+        process.outcome = Some(outcome);
     }
     store.finish_task_process(session, lease).await?;
     Ok(())
@@ -2072,13 +2095,10 @@ async fn finish_command_stop(
 pub(crate) struct CiFixWake {
     /// Which durable command this body is repairing.
     ///
-    /// Read by the tests that prove the entry contract — that a body services the
-    /// wake naming the PR's *current* failure, and the same one again after a
-    /// crash. No production reader yet: settling this command is ENG-19's, and
-    /// this PR deliberately changes no settlement behaviour. Deleting it would
-    /// make the contract unassertable, and re-adding it is the whole of ENG-19's
-    /// entry-side dependency.
-    #[allow(dead_code)]
+    /// The turn's whole span: claimed at the arm, settled by `settle_ci_fix_turn`
+    /// at the exit, and nothing in between transitions it. Naming the command —
+    /// rather than re-deriving the identity at the exit — is what makes the body
+    /// settle the wake it actually serviced, even if the PR moved on underneath.
     pub command_id: ChildCommandId,
     pub pr_number: u32,
     pub head_sha: String,
@@ -2208,6 +2228,130 @@ async fn arm_ci_fix_wake(
         }),
         remaining,
     ))
+}
+
+/// What a finished ci-fix turn does to the wake that started it. Named apart from
+/// the writes so the verdict is decided before anything is durable.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CiFixVerdict {
+    /// The turn left the PR in a good place.
+    Accept,
+    /// The turn ran and the PR is still blocked, or the reading was too degraded
+    /// to tell. Either way the failure is a human's now, not a retry loop's.
+    Fail,
+    /// The PR settled or went away; the repair stopped mattering.
+    Supersede,
+    /// Not an outcome — the turn never reached one, so recovery re-runs it.
+    LeaveClaimed,
+}
+
+/// End a bounded ci-fix turn: park the body, then settle the wake that started it.
+///
+/// The exit half of [`arm_ci_fix_wake`], and the only place a `CiFix` command goes
+/// terminal by running. It settles `wake.command_id` — the command this body was
+/// born for — rather than re-deriving the identity from a PR that may since name a
+/// different failure. The verdict rides [`decide_open_pr_status`], which already
+/// reads an open PR the way the lifecycle does: `Waiting` accepts, `Blocked` fails
+/// with the same operator-facing reason, a settled or vanished PR supersedes.
+///
+/// Any terminal state spends the incident identity for good — `ensure_` mints no
+/// second wake for an identity that already has one, however it settled. That is
+/// the bound: one failing head, one automatic repair; a *new* failure is a new
+/// identity and wakes again.
+///
+/// **The invariant.** The park and the settlement are two writes with no
+/// transaction around them, so their order is the whole crash contract: park the
+/// Session *before* terminalizing the wake. A death in that window then leaves the
+/// wake `Claimed`, which is what [`relaunch_on_duplicate`] documents as recovery's
+/// job. The reverse order would spend the identity while the Session still read
+/// `Running`, and the successor — finding no claimable wake — would silently
+/// resume the generic lifecycle and leave the PR red with nobody repairing it.
+/// Interruption is the same case reached deliberately: no outcome, so no
+/// settlement.
+///
+/// The body parks: no gate, no successor step, no PR rotation. A repair pushes to
+/// an existing branch; advancing the Task on its behalf would credit a repair as
+/// progress the Task never made.
+async fn settle_ci_fix_turn(
+    store: &SharedStore,
+    session: &mut TaskSession,
+    lease: &ChildWriteLease,
+    wake: &CiFixWake,
+    observed_pr: Option<&crate::task::TaskPr>,
+    head_before_turn: Option<&str>,
+    status: Lifecycle,
+) -> Result<()> {
+    let (verdict, settled_status, reason) = match observed_pr
+        .filter(|pr| pr.phase() == PrPhase::Open)
+    {
+        Some(pr) if status != Lifecycle::Interrupted => {
+            let head_advanced = match (head_before_turn, pr.head_sha()) {
+                // No baseline: this body never saw a head to move.
+                (None, _) => false,
+                (Some(start), Some(current)) => start != current,
+                (Some(_), None) => false,
+            };
+            // Reconcile names a degraded read on the session; for a turn that just
+            // ran, that reading could not have verified a repair.
+            let degraded = match &session.observation {
+                Observation::Degraded { reason, .. } => Some(reason.as_str()),
+                _ => None,
+            };
+            let (settled_status, reason) =
+                crate::ops::task::decide_open_pr_status(pr, degraded, head_advanced);
+            let verdict = match settled_status {
+                TaskSessionStatus::Blocked => CiFixVerdict::Fail,
+                _ => CiFixVerdict::Accept,
+            };
+            (verdict, settled_status, reason)
+        }
+        Some(_) => (
+            CiFixVerdict::LeaveClaimed,
+            TaskSessionStatus::Waiting,
+            format!(
+                "ci-fix turn on pull request #{} was interrupted; the repair resumes on resume",
+                wake.pr_number
+            ),
+        ),
+        None => (
+            CiFixVerdict::Supersede,
+            TaskSessionStatus::Waiting,
+            format!(
+                "pull request #{} settled or is no longer attached; the ci-fix wake no longer applies",
+                wake.pr_number
+            ),
+        ),
+    };
+
+    set_and_record_status(store, session, lease, settled_status, &reason).await?;
+    let target = ChildTarget::Task(&session.id, lease);
+    match verdict {
+        CiFixVerdict::Accept => {
+            target
+                .accept_command(store, wake.command_id.clone(), None)
+                .await?
+        }
+        CiFixVerdict::Fail => {
+            target
+                .fail_command(store, wake.command_id.clone(), None, &reason)
+                .await?
+        }
+        CiFixVerdict::Supersede => {
+            target
+                .supersede_command(store, wake.command_id.clone(), &reason)
+                .await?
+        }
+        CiFixVerdict::LeaveClaimed => {}
+    }
+    // The body's outcome describes this turn, not the wake's verdict: a repair
+    // that ran to the end Completed, whatever it found. Only a turn cut short was
+    // Interrupted — and that is the one that leaves the wake reclaimable.
+    let outcome = if status == Lifecycle::Interrupted {
+        ChildBodyOutcome::Interrupted { reason }
+    } else {
+        ChildBodyOutcome::Completed
+    };
+    finish_parked(store, session, lease, None, outcome).await
 }
 
 /// The seed for a `ci-fix` turn: the PR the skill must repair plus the failing
@@ -3565,7 +3709,10 @@ mod tests {
             .await
             .unwrap();
 
-        super::finish_parked(&store, &mut session, &lease, None)
+        let outcome = crate::child_session::ChildBodyOutcome::Interrupted {
+            reason: session.status_reason.clone(),
+        };
+        super::finish_parked(&store, &mut session, &lease, None, outcome)
             .await
             .unwrap();
 

--- a/rust/loopflow/src/task/runner/ci_fix_lifecycle_tests.rs
+++ b/rust/loopflow/src/task/runner/ci_fix_lifecycle_tests.rs
@@ -25,6 +25,7 @@ use loopflow_test_support::TestRepo;
 use tempfile::TempDir;
 use time::OffsetDateTime;
 
+use crate::chat::types::Lifecycle;
 use crate::child_session::{
     ChildCommand, ChildCommandId, ChildCommandKind, ChildCommandSource, ChildCommandState,
     ChildLeaseState, ChildProcessGeneration, ChildRef, ChildWriteLease,
@@ -741,6 +742,28 @@ exit 1
 "#,
         );
     }
+
+    /// What the runner's exit does: reconcile the PR the turn just acted on, then
+    /// settle the wake and park the body. Mirrors the production call site.
+    async fn settle(
+        &mut self,
+        wake: &super::CiFixWake,
+        head_before_turn: Option<&str>,
+        status: Lifecycle,
+    ) {
+        let observed_pr = self.reconcile().await;
+        super::settle_ci_fix_turn(
+            &self.store,
+            &mut self.task,
+            &self.lease,
+            wake,
+            observed_pr.as_ref(),
+            head_before_turn,
+            status,
+        )
+        .await
+        .expect("settle the ci-fix turn");
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -1375,4 +1398,217 @@ async fn a_degraded_read_refuses_to_rotate_past_an_abandoned_pr() {
         .await
         .expect("read task prs");
     assert_eq!(prs.len(), 1, "a refused rotation mints no successor");
+}
+
+// ---------------------------------------------------------------------------
+// The exit: settlement and parking
+// ---------------------------------------------------------------------------
+
+/// The repair worked: the body pushed a new head, so the wake it was born for is
+/// accepted and the Task waits on CI again. Nothing about the Task advances — a
+/// repair is not Task progress.
+#[tokio::test]
+async fn a_repaired_head_accepts_the_wake_and_parks_without_a_gate() {
+    let mut harness = Harness::new().await;
+    harness.head("h1");
+    harness.checks_failing();
+    let (command, _) = harness.observe().await.expect("a red head mints a wake");
+    let wake = harness.arm().await.expect("a red head wakes a body");
+    let phase = harness.task.lifecycle_phase;
+    let gate_cycle = harness.task.gate_cycle;
+
+    // The repair turn's push: the head moves, and the new head is not yet red.
+    harness.head("h2");
+    harness.checks_pending();
+    harness
+        .settle(&wake, Some("h1"), Lifecycle::Completed)
+        .await;
+
+    assert_eq!(
+        harness.command_state(&command).await,
+        ChildCommandState::Accepted,
+        "a repair that moved the head settles the exact wake it was born for"
+    );
+    let session = harness
+        .store
+        .get_task_session(&harness.task.id)
+        .await
+        .expect("read task")
+        .expect("task exists");
+    assert_eq!(
+        session.status,
+        TaskSessionStatus::Waiting,
+        "and the Task durably waits on CI for the head it just pushed"
+    );
+    assert_eq!(
+        session.lifecycle_phase, phase,
+        "a ci-fix body must not advance the Task's lifecycle phase"
+    );
+    assert_eq!(session.gate_cycle, gate_cycle, "nor open a gate cycle");
+    assert!(
+        session.gate_proposal.is_none(),
+        "nor propose a Task outcome"
+    );
+    let process = session.latest_process.expect("a generation");
+    assert_eq!(
+        process.state,
+        ChildLeaseState::Finished,
+        "the body is over and the Session is reservable again"
+    );
+    assert_eq!(
+        process.outcome,
+        Some(crate::child_session::ChildBodyOutcome::Completed),
+        "a repair that ran to the end is Completed; reporting it as Interrupted \
+         would file finished work as abandoned"
+    );
+    assert_eq!(
+        harness
+            .store
+            .task_prs(&harness.task.id)
+            .await
+            .expect("read task prs")
+            .len(),
+        1,
+        "a repair pushes to the branch it was given; it never rotates to a successor PR"
+    );
+}
+
+/// The repair ran and the head is still red: the wake fails with the reason a
+/// human needs, and that failure is final. One failing head earns one automatic
+/// repair — the bound that keeps a broken PR from spinning bodies.
+#[tokio::test]
+async fn an_unrepaired_head_fails_the_wake_and_never_rearms_the_same_failure() {
+    let mut harness = Harness::new().await;
+    harness.head("h1");
+    harness.checks_failing();
+    let (command, _) = harness.observe().await.expect("a red head mints a wake");
+    let wake = harness.arm().await.expect("a red head wakes a body");
+
+    // The turn ends with the head exactly where it started, still red.
+    harness
+        .settle(&wake, Some("h1"), Lifecycle::Completed)
+        .await;
+
+    let settled = harness.command(&command).await;
+    assert_eq!(
+        settled.state,
+        ChildCommandState::Failed,
+        "a repair that did not move the head is a failure, not a success"
+    );
+    let error = settled.error.as_deref().expect("a failed wake names why");
+    assert!(
+        error.contains("did not repair the head"),
+        "the wake carries the operator-facing reason: {error}"
+    );
+    assert_eq!(
+        harness.task.status,
+        TaskSessionStatus::Blocked,
+        "and the Task blocks for a human rather than looping"
+    );
+    assert_eq!(harness.task.status_reason, error, "saying the same thing");
+
+    // The bound. The head is still red, and the next supervision pass tries to
+    // wake a body for it. (Only `enqueue`: the park finished this body's lease,
+    // so nothing may reconcile under it any more — which is itself the shape of a
+    // parked body.)
+    let (again, created) = harness.enqueue().await.expect("the failure still stands");
+    assert_eq!(again, command, "the observation lands on the spent wake");
+    assert!(
+        !created,
+        "a settled identity mints no second wake, however it settled — so no body \
+         can launch, and this failure is a human's now"
+    );
+    assert_eq!(harness.ci_fix_commands().await.len(), 1);
+}
+
+/// An interrupted turn reached no outcome, so it reports none: the wake stays
+/// `Claimed`, the same state a crash leaves and recovered the same way (see
+/// `a_crash_after_arm_reclaims_the_same_command_and_reselects_ci_fix`).
+#[tokio::test]
+async fn an_interrupted_turn_leaves_the_wake_claimed() {
+    let mut harness = Harness::new().await;
+    harness.head("h1");
+    harness.checks_failing();
+    let (command, _) = harness.observe().await.expect("a red head mints a wake");
+    let wake = harness.arm().await.expect("a red head wakes a body");
+
+    harness
+        .settle(&wake, Some("h1"), Lifecycle::Interrupted)
+        .await;
+
+    assert_eq!(
+        harness.command_state(&command).await,
+        ChildCommandState::Claimed,
+        "an interrupted repair reports no outcome, so a successor can still run it"
+    );
+    assert_eq!(
+        harness.task.status,
+        TaskSessionStatus::Waiting,
+        "the body still parks; it just settles nothing"
+    );
+    assert!(
+        matches!(
+            harness
+                .task
+                .latest_process
+                .as_ref()
+                .expect("a generation")
+                .outcome,
+            Some(crate::child_session::ChildBodyOutcome::Interrupted { .. })
+        ),
+        "a turn cut short is Interrupted — the outcome and the unsettled wake have \
+         to tell the same story"
+    );
+}
+
+/// The park-before-terminalize invariant (argued on `settle_ci_fix_turn`), read
+/// off the durable record: both writes append to the event stream in the order
+/// they land, so a settlement that ever preceded its park would show here.
+#[tokio::test]
+async fn the_wake_never_settles_while_the_session_still_reads_running() {
+    let mut harness = Harness::new().await;
+    harness.head("h1");
+    harness.checks_failing();
+    let (command, _) = harness.observe().await.expect("a red head mints a wake");
+    let wake = harness.arm().await.expect("a red head wakes a body");
+    assert_eq!(
+        harness.task.status,
+        TaskSessionStatus::Running,
+        "the body is running as the turn ends"
+    );
+
+    harness
+        .settle(&wake, Some("h1"), Lifecycle::Completed)
+        .await;
+
+    let events = harness
+        .store
+        .task_events_after(&harness.task.id, 0)
+        .await
+        .expect("read task events");
+    let parked = events
+        .iter()
+        .position(|event| {
+            matches!(
+                &event.kind,
+                crate::task::TaskEventKind::StatusChanged { to, .. }
+                    if *to == TaskSessionStatus::Blocked
+            )
+        })
+        .expect("the body records its park");
+    let settled = events
+        .iter()
+        .position(|event| {
+            matches!(
+                &event.kind,
+                crate::task::TaskEventKind::CommandChanged { command_id, state, .. }
+                    if *command_id == command && state.is_terminal()
+            )
+        })
+        .expect("the body records its settlement");
+    assert!(
+        parked < settled,
+        "the Session must park before the wake goes terminal: a death in that window \
+         has to leave a Claimed wake, not a spent one under a Running Session"
+    );
 }


### PR DESCRIPTION
Settles one bounded ci-fix turn at its exit, and parks.

`settle_ci_fix_turn` is the exit half of `arm_ci_fix_wake` (#1024/#1026): the only
place a `CiFix` command goes terminal by running. It settles the exact wake the
body was born for — `CiFixWake.command_id` — rather than re-deriving the identity
from a PR that may since name a different failure. The verdict rides the existing
`decide_open_pr_status`, which already reads an open PR the way the lifecycle
does: `Waiting` accepts, `Blocked` fails with the same operator-facing reason, a
settled or vanished PR supersedes, and an interrupted turn settles nothing.

The body then parks — no gate, no successor step, no PR rotation. A repair pushes
to an existing branch; advancing the Task on its behalf would credit a repair as
progress the Task never made.

**The ordering is the crash contract.** The park and the settlement are two writes
with no transaction around them, so the Session is parked *before* the wake goes
terminal. A death in that window leaves the wake `Claimed` — what
`relaunch_on_duplicate` documents as recovery's job. The reverse order would spend
the incident identity while the Session still read `Running`; `ensure_` mints no
second wake for a spent identity, so the successor would find nothing, silently
resume the generic lifecycle, and leave the PR red with nobody repairing it.

Also fixes an outcome lie: `finish_parked` recorded `Interrupted` for every parked
body, filing a repair that ran to the end as abandoned work. The outcome is now an
explicit parameter the caller supplies.

No schema, no migration, no lifecycle phase, no new command API — the wake ledger
and `child_commands` already carry this. Three files.

Proofs (extending the #1026 suite): a repaired head accepts its wake and parks
without phase/gate/rotation and reports `Completed`; an unrepaired head fails with
an actionable reason and the same identity never re-arms; an interrupted turn stays
`Claimed` and reports `Interrupted`; and the park event durably precedes the
terminal command event. Each was verified by sabotaging the code it names — the
ordering proof and the outcome proof both fail against the reversed/old behavior.
