### PR TITLE
auth: adopt stored codex logins and stop opening the loopback listener

### DIFF
--- a/rust/loopflow/src/lf/commands/auth.rs
+++ b/rust/loopflow/src/lf/commands/auth.rs
@@ -1225,6 +1225,9 @@ mod tests {
         assert_eq!(format_relative_delta(172_800), "2d");
     }
 
+    // The env lock must span the awaited import so no parallel test swaps
+    // LF_HOME mid-flight; the single-threaded test runtime makes that safe.
+    #[allow(clippy::await_holding_lock)]
     #[tokio::test]
     async fn codex_import_without_stored_credentials_names_the_ambient_limit() {
         // Codex import adopts an existing auth.json in the account home; with

--- a/rust/loopflow/src/lf/commands/auth.rs
+++ b/rust/loopflow/src/lf/commands/auth.rs
@@ -465,11 +465,6 @@ async fn import_account(
     raw_chrome_profile: Option<&str>,
 ) -> Result<()> {
     let provider = parse_managed_provider(raw_provider)?;
-    if provider != Provider::Claude {
-        return Err(anyhow!(
-            "existing login import is supported for Claude only"
-        ));
-    }
     let account_id = parse_account_id(raw_account)?;
     let provider_profile = ensure_account_profile(provider, &account_id)?;
     let profile_id = raw_profile
@@ -482,7 +477,12 @@ async fn import_account(
         .and_then(|profile| profile.login.as_deref())
         .map(String::from);
 
-    let login = if provider_profile.join(".credentials.json").is_file() {
+    let credentials_file = match provider {
+        Provider::Claude => ".credentials.json",
+        Provider::Codex => "auth.json",
+        _ => unreachable!("parse_managed_provider admits Claude and Codex only"),
+    };
+    let login = if provider_profile.join(credentials_file).is_file() {
         match provider_account_auth_status(provider, provider_profile.clone()).await? {
             AuthStatus::Active { login } => login,
             other => {
@@ -495,6 +495,13 @@ async fn import_account(
             }
         }
     } else {
+        if provider != Provider::Claude {
+            return Err(anyhow!(
+                "no stored {} login at {}; importing the ambient login is supported for Claude only",
+                provider.display_name(),
+                provider_profile.display()
+            ));
+        }
         let ambient = read_ambient_claude_status()?;
         if !ambient.logged_in {
             return Err(anyhow!("the ambient Claude CLI is not logged in"));
@@ -1219,14 +1226,23 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn codex_login_cannot_be_created_by_importing_ambient_credentials() {
-        let error = import_account("codex", "engineering", None, None)
-            .await
-            .expect_err("Codex imports must require a direct login");
+    async fn codex_import_without_stored_credentials_names_the_ambient_limit() {
+        // Codex import adopts an existing auth.json in the account home; with
+        // none present there is no ambient fallback (that path is Claude's).
+        let _lock = crate::journal::test_env_lock();
+        let home = tempfile::tempdir().unwrap();
+        let previous = std::env::var_os("LF_HOME");
+        std::env::set_var("LF_HOME", home.path());
+        let result = import_account("codex", "engineering", None, None).await;
+        match previous {
+            Some(value) => std::env::set_var("LF_HOME", value),
+            None => std::env::remove_var("LF_HOME"),
+        }
 
+        let error = result.expect_err("Codex imports must require a stored login");
         assert!(error
             .to_string()
-            .contains("existing login import is supported for Claude only"));
+            .contains("importing the ambient login is supported for Claude only"));
     }
 
     #[test]

--- a/rust/loopflow/src/provider_auth/mod.rs
+++ b/rust/loopflow/src/provider_auth/mod.rs
@@ -2092,8 +2092,20 @@ fn parse_github_auth_line(line: &str, builder: &mut AuthFlowBuilder) {
     }
 }
 
+/// A loopback URL is the provider CLI's local callback listener, never the
+/// page a human authorizes on. codex prints its `localhost:1455` server line
+/// before the real authorization URL, and the first URL parsed wins the flow —
+/// treating loopback as a verification URL opened a dead "Not Found" tab and
+/// returned before the real URL was ever read.
+fn is_loopback_url(url: &str) -> bool {
+    Url::parse(url).is_ok_and(|url| {
+        matches!(url.host_str(), Some("localhost" | "127.0.0.1" | "[::1]"))
+            || url.host_str().is_some_and(|host| host == "::1")
+    })
+}
+
 fn parse_generic_auth_line(line: &str, builder: &mut AuthFlowBuilder) {
-    let url = extract_url(line);
+    let url = extract_url(line).filter(|url| !is_loopback_url(url));
     if let Some(url) = &url {
         if builder.verification_uri_complete.is_none() {
             builder.verification_uri_complete = Some(url.clone());
@@ -3780,6 +3792,36 @@ mod tests {
             Some("https://example.com/device?user_code=QWER-9876".to_string())
         );
         assert_eq!(response.user_code, Some("QWER-9876".to_string()));
+    }
+
+    /// `codex login` announces its localhost callback server before printing
+    /// the real authorization URL. The listener is not a page a human can
+    /// authorize on — taking it as the verification URL opened a dead
+    /// "Not Found" tab and ended the flow before the real URL arrived.
+    #[test]
+    fn generic_parser_waits_past_the_loopback_callback_listener() {
+        let mut builder = AuthFlowBuilder::default();
+        parse_generic_auth_line(
+            "Starting local login server on http://localhost:1455.",
+            &mut builder,
+        );
+        assert!(
+            build_flow_response(Provider::Codex, &builder).is_none(),
+            "a loopback URL alone must not complete the flow"
+        );
+
+        parse_generic_auth_line(
+            "If your browser did not open, navigate to https://auth.openai.com/oauth/authorize?client_id=abc&state=xyz",
+            &mut builder,
+        );
+        let response = build_flow_response(Provider::Codex, &builder).expect("response");
+        assert_eq!(
+            response.verification_uri,
+            "https://auth.openai.com/oauth/authorize"
+        );
+        assert!(!is_loopback_url("https://auth.openai.com/oauth/authorize"));
+        assert!(is_loopback_url("http://localhost:1455"));
+        assert!(is_loopback_url("http://127.0.0.1:1455/callback"));
     }
 
     #[test]


### PR DESCRIPTION
## What

Two `lf auth connect`/`import` UX bugs observed reconnecting accounts today:

1. **Dead localhost tab on codex connect.** `codex login` announces its local callback server (`http://localhost:1455`) before printing the real authorization URL. The generic auth-line parser took the *first* URL as the verification URL, so `lf` opened a "Not Found" tab at the listener root and completed the flow before ever reading the real URL (the correct page only appeared because codex opens it itself — macOS ignores `BROWSER=echo`). Loopback URLs are now never verification URLs; the flow waits for the real one, which `lf` then opens in the bound Chrome profile.

2. **`lf auth import codex` refused.** The claude-only guard predated codex support in the underlying machinery (broker status check, token extraction, registration all handle codex). Import now adopts an existing `auth.json` in the account home — so a login that already lives under `~/.lf/accounts/codex/<account>` (e.g. `manabot-eng`, whose stored credential is valid) registers without a fresh browser dance. The ambient-login fallback stays Claude-only and the error says so.

## Verified
- New parser test replays the codex login line sequence: loopback line alone must not complete the flow; the following real URL wins.
- New import test: codex import with no stored credential errors with the ambient-limit message (isolated `LF_HOME`).
- 1495 unit tests green; fmt + clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)