### PR TITLE
usage: provider-reported plans and unambiguous window headers

### DIFF
--- a/docs/lf.md
+++ b/docs/lf.md
@@ -353,13 +353,15 @@ lf doctor                       # audit continuity, identity, lineage, coverage,
 lf doctor --json                # machine-readable audit
 ```
 
-`lf usage` leads with each managed account's subscription state — plan, session
-window, weekly window, reset times — from stored observations (harness streams
-report them mid-run) topped up by a live poll when older than 15 minutes.
-`--refresh` polls everything now; `--cached` skips polling. A revoked
-credential shows the fix (`lf auth connect <provider>`), not a blank. The
-spend table below it sums per-boundary delta rows; TOTAL is input+output with
-cache reads their own column, and SHARE is each row's slice of total tokens.
+`lf usage` leads with each managed account's subscription state — provider-
+reported plan, session and weekly windows as percent *used*, reset times —
+from stored observations (harness streams report them mid-run) topped up by a
+live poll when older than 15 minutes. `--refresh` polls everything now;
+`--cached` skips polling. A revoked credential shows the fix
+(`lf auth connect <provider>`), not a blank. The spend table below it sums
+per-boundary delta rows; TOTAL is input+output with cache reads their own
+column, and `% TOKENS` is each row's slice of all tokens in the window — a
+distribution across repos, not a subscription measure.
 
 A run is one agent-backed skill invocation. It owns the context, model, token,
 cost, and outcome evidence. An exec is one `lf` process; nested execs share a

--- a/rust/loopflow/src/lf/commands/usage.rs
+++ b/rust/loopflow/src/lf/commands/usage.rs
@@ -13,7 +13,7 @@ use crate::subscription::{poll_account, SubscriptionError};
 const REPO_WIDTH: usize = 32;
 const PROVIDER_WIDTH: usize = 12;
 const NUM_WIDTH: usize = 14;
-const SHARE_WIDTH: usize = 7;
+const SHARE_WIDTH: usize = 8;
 const ACCOUNT_WIDTH: usize = 30;
 const WINDOW_WIDTH: usize = 14;
 
@@ -100,7 +100,7 @@ async fn account_statuses(refresh: bool, cached: bool) -> Result<Vec<AccountStat
         let mut status = AccountStatus {
             provider: account.provider.clone(),
             label: account_label(account, &profiles),
-            plan: account.plan.clone(),
+            plan: None,
             windows: stored_windows
                 .iter()
                 .map(|row| AccountLimitWindow {
@@ -137,9 +137,14 @@ async fn account_statuses(refresh: bool, cached: bool) -> Result<Vec<AccountStat
             }
             None => {}
         }
-        if status.plan.is_none() {
-            status.plan = status.windows.iter().find_map(|window| window.plan.clone());
-        }
+        // The plan is what the provider reports (poll planType, claude's
+        // subscriptionType), never a hand-entered label; the stored lifecycle
+        // column is only a fallback for accounts never yet observed.
+        status.plan = status
+            .windows
+            .iter()
+            .find_map(|window| window.plan.clone())
+            .or_else(|| account.plan.clone());
         let cooling = account.cooldown_until.filter(|until| *until > now);
         if let Some(until) = cooling {
             let note = format!("cooling until {}", format_reset(until, now));
@@ -200,8 +205,8 @@ fn print_accounts(statuses: &[AccountStatus]) {
         provider = "PROVIDER",
         account = "ACCOUNT",
         plan = "PLAN",
-        session = "SESSION",
-        weekly = "WEEKLY",
+        session = "SESSION USED",
+        weekly = "WEEKLY USED",
     );
     for status in statuses {
         let mut note = status.note.clone().unwrap_or_default();
@@ -417,7 +422,11 @@ fn print_report(rows: &[UsageRow], days: u32) {
     print_row(&provider_lead("TOTAL"), grand.cells(grand_total), true);
 }
 
-const HEADINGS: [&str; 5] = ["INPUT", "OUTPUT", "CACHE READ", "TOTAL", "SHARE"];
+/// `% TOKENS` is each row's slice of all tokens in the window — a relative
+/// distribution across repos, deliberately not a subscription measure (a repo
+/// can burn through many subscriptions' worth; subscription state lives in
+/// the ACCOUNTS section, always as percent *used*).
+const HEADINGS: [&str; 5] = ["INPUT", "OUTPUT", "CACHE READ", "TOTAL", "% TOKENS"];
 
 fn repo_lead(repo: &str, provider: &str) -> String {
     format!("{repo:<REPO_WIDTH$}  {provider:<PROVIDER_WIDTH$}")

--- a/rust/loopflow/src/subscription.rs
+++ b/rust/loopflow/src/subscription.rs
@@ -63,6 +63,18 @@ pub async fn poll_account(
 async fn poll_claude(home: &Path) -> Result<SubscriptionUsage, SubscriptionError> {
     let credentials_path = home.join(".credentials.json");
     let access_token = fresh_claude_token(&credentials_path).await?;
+    // The plan rides in the credential file Claude Code maintains
+    // (`subscriptionType`) — observed at login, never hand-entered.
+    let plan = tokio::fs::read_to_string(&credentials_path)
+        .await
+        .ok()
+        .and_then(|raw| serde_json::from_str::<Value>(&raw).ok())
+        .and_then(|credentials| {
+            credentials
+                .pointer("/claudeAiOauth/subscriptionType")
+                .and_then(Value::as_str)
+                .map(str::to_string)
+        });
     let response = reqwest::Client::new()
         .get(CLAUDE_USAGE_URL)
         .bearer_auth(&access_token)
@@ -87,13 +99,13 @@ async fn poll_claude(home: &Path) -> Result<SubscriptionUsage, SubscriptionError
         .await
         .map_err(|error| SubscriptionError::Unavailable(error.to_string()))?;
     Ok(SubscriptionUsage {
-        windows: claude_windows(&body),
+        windows: claude_windows(&body, plan.as_deref()),
     })
 }
 
 /// Parse the OAuth usage payload's `limits` array: one entry per rate-limit
-/// window, each with a percent, a reset time, and an optional model scope.
-fn claude_windows(body: &Value) -> Vec<AccountLimitWindow> {
+/// window, each with a percent used, a reset time, and an optional model scope.
+fn claude_windows(body: &Value, plan: Option<&str>) -> Vec<AccountLimitWindow> {
     let Some(limits) = body.get("limits").and_then(Value::as_array) else {
         return Vec::new();
     };
@@ -119,7 +131,7 @@ fn claude_windows(body: &Value) -> Vec<AccountLimitWindow> {
                     .and_then(Value::as_str)
                     .and_then(|value| OffsetDateTime::parse(value, &Rfc3339).ok())
                     .map(|value| value.unix_timestamp()),
-                plan: None,
+                plan: plan.map(str::to_string),
             })
         })
         .collect()
@@ -344,11 +356,12 @@ mod tests {
                  "scope": {"model": {"id": null, "display_name": "Fable"}}}
             ]
         });
-        let windows = claude_windows(&body);
+        let windows = claude_windows(&body, Some("max"));
         assert_eq!(windows.len(), 3);
         assert_eq!(windows[0].window, "session");
         assert_eq!(windows[0].used_percent, 22);
         assert!(windows[0].resets_at.is_some());
+        assert_eq!(windows[0].plan.as_deref(), Some("max"));
         assert_eq!(windows[1].window, "weekly");
         assert_eq!(windows[2].window, "weekly:fable");
         assert_eq!(windows[2].used_percent, 11);


### PR DESCRIPTION
## What

Three display truths from first live use of the new `lf usage`:

- **PLAN is observed, not declared.** Codex `planType` rides every rate-limit snapshot; claude's `subscriptionType` lives in the credential file Claude Code maintains. Display now prefers those; the hand-entered `lf auth set --plan` value is only a fallback for accounts never yet observed. (Live symptom: a codex account labeled `max` by hand while the provider says `pro`.)
- **Used vs remaining is now explicit.** Columns read `SESSION USED` / `WEEKLY USED` — `0% → Jul 23` means a fresh window, not an exhausted one.
- **`SHARE` → `% TOKENS`.** It is each row's slice of all tokens in the window — a distribution across repos, deliberately not a subscription measure (one repo can burn many subscriptions' worth; subscription state lives in the ACCOUNTS section).

## Verified
- 1502 unit tests green; fmt + `clippy --all-targets -D warnings` clean.
- Claude plan captured in the window rows in the parser test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)