### PR TITLE
task ci-fix: prove a crashed ci-fix repair resumes on its own wake

### DIFF
--- a/rust/loopflow/src/task/runner/ci_fix_lifecycle_tests.rs
+++ b/rust/loopflow/src/task/runner/ci_fix_lifecycle_tests.rs
@@ -1075,40 +1075,6 @@ async fn a_ci_fix_wake_mints_no_directive() {
     );
 }
 
-/// The state contract of a wake, pinned so a future edit cannot quietly
-/// reintroduce the `Uncertain`/`NeedsInput` strand. `Delivering` means a provider
-/// call is in flight; a wake makes none, so it must never be reachable.
-#[tokio::test]
-async fn a_ci_fix_wake_never_enters_delivering() {
-    let mut harness = Harness::new().await;
-    harness.head("h1");
-    harness.checks_failing();
-    let (wake_id, _) = harness.observe().await.expect("a red head mints a wake");
-
-    for state in [
-        harness.command_state(&wake_id).await,
-        {
-            harness.arm().await.expect("the wake arms");
-            harness.command_state(&wake_id).await
-        },
-        {
-            harness.crash_and_relaunch().await;
-            harness.arm().await.expect("the successor rearms");
-            harness.command_state(&wake_id).await
-        },
-    ] {
-        assert!(
-            matches!(
-                state,
-                ChildCommandState::Persisted | ChildCommandState::Claimed
-            ),
-            "a wake occupies only Persisted or Claimed before settlement, got {state:?}"
-        );
-        assert_ne!(state, ChildCommandState::Delivering);
-        assert_ne!(state, ChildCommandState::Uncertain);
-    }
-}
-
 /// The Project runner's seam, through the real entry point.
 ///
 /// `queue_ci_fix_command` is what the observation calls now; the direct

--- a/rust/loopflow/src/task/runner/ci_fix_lifecycle_tests.rs
+++ b/rust/loopflow/src/task/runner/ci_fix_lifecycle_tests.rs
@@ -554,6 +554,76 @@ impl Harness {
         Some((command.id, created))
     }
 
+    /// Kill this generation's body and boot its successor, as recovery does.
+    ///
+    /// Revokes and finishes the live process, then reserves and activates the
+    /// next generation, replacing the harness lease. A real succession, not a
+    /// re-arm: `arm()` alone reuses one lease, and `claim_child_commands_in`
+    /// skips rows already claimed by the asking generation, so re-arming can
+    /// never prove that a *successor* reclaims. Returns the new generation.
+    async fn crash_and_relaunch(&mut self) -> u32 {
+        let revoked = self
+            .store
+            .revoke_task_process(
+                &self.task.id,
+                &crate::child_session::ChildBodyOutcome::Lost {
+                    reason: "body died mid-repair".to_string(),
+                },
+            )
+            .await
+            .expect("revoke the live generation");
+        self.store
+            .finish_revoked_task_process(&self.task.id, revoked.generation)
+            .await
+            .expect("finish the revoked generation");
+
+        let mut successor = self
+            .store
+            .get_task_session(&self.task.id)
+            .await
+            .expect("read task")
+            .expect("task exists");
+        successor.set_status(TaskSessionStatus::Waiting, "body died; recovering");
+        self.store
+            .update_task_session(&successor)
+            .await
+            .expect("park the session for recovery");
+        let generation = successor.begin_generation("lf-ci-fix-successor".to_string());
+        successor.status = TaskSessionStatus::Running;
+        successor.status_reason = "ci-fix successor body".to_string();
+        let lease = self
+            .store
+            .reserve_task_process(&successor, TaskSessionStatus::Waiting)
+            .await
+            .expect("reserve the successor process")
+            .expect("a waiting task reserves its next generation");
+        // A reserved lease cannot write; the body activates it before touching
+        // anything, exactly as the first generation did.
+        if let Some(process) = successor.latest_process.as_mut() {
+            process.state = ChildLeaseState::Active;
+        }
+        self.store
+            .activate_task_process(&successor, &lease)
+            .await
+            .expect("activate the successor process");
+        self.lease = lease;
+        self.task = self
+            .store
+            .get_task_session(&self.task.id)
+            .await
+            .expect("read task")
+            .expect("task exists");
+        generation
+    }
+
+    async fn command(&self, id: &ChildCommandId) -> ChildCommand {
+        self.store
+            .get_child_command(id)
+            .await
+            .expect("read command")
+            .expect("command exists")
+    }
+
     /// What a body's boot does: claim, then select the flow from the claimed wake.
     /// Returns the armed wake, if this generation has one.
     async fn arm(&self) -> Option<super::CiFixWake> {
@@ -882,6 +952,161 @@ async fn a_changed_failing_set_on_the_same_head_rearms() {
             .any(|check| check.name == "rust-test"),
         "the body repairs the failure that woke it, including the newly broken check"
     );
+}
+
+/// The window the whole `Claimed`-through-the-turn decision exists for, and the
+/// executable form of the argument for it.
+///
+/// A body dies mid-repair. Its successor must land back on the *same* wake and
+/// run ci-fix again. That works only because the command is still `Claimed`:
+/// `claim_child_commands_in` reassigns `persisted`/`claimed` rows to the asking
+/// generation and skips terminal ones.
+///
+/// Both rejected alternatives fail here, which is the point of the test:
+/// - **Accept at arm** — the wake would be terminal, the successor would claim
+///   nothing, `arm` would return `None`, the body would fall through to its
+///   lifecycle phase, and the PR would stay red with nobody repairing it. A
+///   silent strand.
+/// - **Deliver at arm** — `reconcile_stale_deliveries` would flip the dead
+///   generation's `Delivering` to `Uncertain`, and `plan_body_recovery` returns
+///   `NeedsInput`, stranding an *automatic* wake on a human.
+#[tokio::test]
+async fn a_crash_after_arm_reclaims_the_same_command_and_reselects_ci_fix() {
+    let mut harness = Harness::new().await;
+    harness.head("h1");
+    harness.checks_failing();
+    let (wake, _) = harness.observe().await.expect("a red head mints a wake");
+
+    // Generation 1 arms it and is servicing the repair.
+    let armed = harness.arm().await.expect("the first body arms the wake");
+    assert_eq!(armed.command_id, wake);
+    assert_eq!(harness.command(&wake).await.claimed_by_generation, Some(1));
+    assert_eq!(
+        harness.command_state(&wake).await,
+        ChildCommandState::Claimed,
+        "held for the repair turn, not settled at arm"
+    );
+
+    // The body dies mid-repair and recovery boots its successor.
+    let generation = harness.crash_and_relaunch().await;
+    assert_eq!(generation, 2, "a real succession, not a re-arm");
+
+    let resumed = harness.arm().await.expect(
+        "the successor reselects ci-fix rather than falling through to its lifecycle phase",
+    );
+    assert_eq!(
+        resumed.command_id, wake,
+        "the successor services the same command, not a new one"
+    );
+    assert_eq!(
+        resumed.head_sha, "h1",
+        "seeded from that same command's payload"
+    );
+
+    let command = harness.command(&wake).await;
+    assert_eq!(
+        command.claimed_by_generation,
+        Some(generation),
+        "the wake is reassigned to the successor generation"
+    );
+    assert_eq!(
+        command.state,
+        ChildCommandState::Claimed,
+        "still Claimed across the crash — never Accepted, never Uncertain"
+    );
+    assert_eq!(
+        harness.ci_fix_commands().await.len(),
+        1,
+        "a crash mints no second wake"
+    );
+    assert_eq!(
+        harness.incidents().await.len(),
+        1,
+        "and opens no second incident"
+    );
+}
+
+/// A wake is a command, not a direction — the sharpest trap in the change.
+///
+/// Minting a `ChildDirective` would bump `current_directive_version`, and
+/// `has_pending_directive` gates `task_completion_gate` on
+/// `current > incorporated`. A wake that minted one would block Task completion
+/// until a body acknowledged a direction no human ever gave.
+#[tokio::test]
+async fn a_ci_fix_wake_mints_no_directive() {
+    let mut harness = Harness::new().await;
+    let before = harness
+        .store
+        .get_task_session(&harness.task.id)
+        .await
+        .expect("read task")
+        .expect("task exists");
+
+    harness.head("h1");
+    harness.checks_failing();
+    harness.observe().await.expect("a red head mints a wake");
+    harness.arm().await.expect("the wake arms a body");
+
+    let after = harness
+        .store
+        .get_task_session(&harness.task.id)
+        .await
+        .expect("read task")
+        .expect("task exists");
+    assert_eq!(
+        after.current_directive_version, before.current_directive_version,
+        "a wake must not version a direction nobody gave"
+    );
+    assert_eq!(
+        after.incorporated_directive_version, before.incorporated_directive_version,
+        "so nothing is left pending incorporation, and completion stays reachable"
+    );
+    let wake_id = harness.ci_fix_commands().await[0].id.clone();
+    let directives = harness
+        .store
+        .child_directives(&ChildRef::Task(harness.task.id.clone()))
+        .await
+        .expect("read directives");
+    assert!(
+        directives
+            .iter()
+            .all(|directive| directive.command_id.as_ref() != Some(&wake_id)),
+        "no directive is bound to the wake command"
+    );
+}
+
+/// The state contract of a wake, pinned so a future edit cannot quietly
+/// reintroduce the `Uncertain`/`NeedsInput` strand. `Delivering` means a provider
+/// call is in flight; a wake makes none, so it must never be reachable.
+#[tokio::test]
+async fn a_ci_fix_wake_never_enters_delivering() {
+    let mut harness = Harness::new().await;
+    harness.head("h1");
+    harness.checks_failing();
+    let (wake_id, _) = harness.observe().await.expect("a red head mints a wake");
+
+    for state in [
+        harness.command_state(&wake_id).await,
+        {
+            harness.arm().await.expect("the wake arms");
+            harness.command_state(&wake_id).await
+        },
+        {
+            harness.crash_and_relaunch().await;
+            harness.arm().await.expect("the successor rearms");
+            harness.command_state(&wake_id).await
+        },
+    ] {
+        assert!(
+            matches!(
+                state,
+                ChildCommandState::Persisted | ChildCommandState::Claimed
+            ),
+            "a wake occupies only Persisted or Claimed before settlement, got {state:?}"
+        );
+        assert_ne!(state, ChildCommandState::Delivering);
+        assert_ne!(state, ChildCommandState::Uncertain);
+    }
 }
 
 /// The Project runner's seam, through the real entry point.


### PR DESCRIPTION
## Try it

```bash
cargo test -p loopflow ci_fix_lifecycle
```

## Summary

Adds the test that justifies holding a ci-fix wake in `Claimed` through the repair turn. A body arms the wake, dies mid-repair, and its successor generation must land back on the *same* command and reselect ci-fix. That only works because the command is still `Claimed` — `claim_child_commands_in` reassigns `persisted`/`claimed` rows to the asking generation and skips terminal ones. Both rejected designs fail this test, which is the point: accepting at arm makes the wake terminal and the PR stays red with nobody repairing it; delivering at arm lets `reconcile_stale_deliveries` flip the dead generation to `Uncertain`, stranding an automatic wake on a human via `NeedsInput`.

A second test pins the wake-is-a-command boundary: minting a `ChildDirective` would bump `current_directive_version`, and `has_pending_directive` would then gate `task_completion_gate` on a direction no human ever gave — blocking Task completion.

## Changes

- `crash_and_relaunch` harness helper performs a real succession (revoke, finish, reserve, activate) rather than re-arming one lease, since re-arming can never prove a *successor* reclaims
- Crash test asserts the successor reclaims the same command with the same head payload, and that the crash mints no second wake or incident
- Directive test asserts a wake leaves both directive versions untouched and binds no directive to the wake command
- Drops a redundant wake-state test now covered by the above