### PR TITLE
auth: exec a provider CLI on a managed account's home

### DIFF
--- a/docs/lf.md
+++ b/docs/lf.md
@@ -353,6 +353,16 @@ lf doctor                       # audit continuity, identity, lineage, coverage,
 lf doctor --json                # machine-readable audit
 ```
 
+```bash
+lf auth exec codex engineering            # interactive codex on the managed account
+lf auth exec claude jack@loopflow.studio  # provider CLI shares the routed session
+```
+
+`lf auth exec` replaces the process with the provider's CLI running on the
+managed account's credential home. Logging into a managed account with a bare
+`codex login`/`claude` creates a second session and evicts the managed one
+("needs re-login"); exec is how direct use and lf routing share one session.
+
 `lf usage` leads with each managed account's subscription state — provider-
 reported plan, session and weekly windows as percent *used*, reset times —
 from stored observations (harness streams report them mid-run) topped up by a

--- a/rust/loopflow/src/lf/commands/auth.rs
+++ b/rust/loopflow/src/lf/commands/auth.rs
@@ -15,6 +15,7 @@ use sha2::{Digest, Sha256};
 use time::OffsetDateTime;
 
 use crate::engine::platform::open_url;
+use crate::lf::commands::profile::find_provider_account;
 use crate::lf::AuthCommand;
 use crate::profile::{EmailAddress, HostId, LocalChromeProfile, ProfileId, ProfileProviderAccount};
 use crate::provider_account::{
@@ -108,6 +109,11 @@ async fn run_async(cmd: &AuthCommand) -> Result<()> {
             .await
         }
         AuthCommand::Reset { provider, account } => reset_account(provider, account).await,
+        AuthCommand::Exec {
+            provider,
+            account,
+            args,
+        } => exec_account(provider, account, args).await,
         AuthCommand::External(args) => {
             let provider = args
                 .first()
@@ -830,6 +836,52 @@ fn parse_paid_through(value: &str) -> Result<time::Date> {
     let format = time::format_description::parse_borrowed::<2>("[year]-[month]-[day]")?;
     time::Date::parse(value.trim(), &format)
         .map_err(|_| anyhow!("invalid paid-through date '{value}': expected YYYY-MM-DD"))
+}
+
+/// Replace this process with the provider's CLI running on the managed
+/// account's credential home, so direct use shares the session lf routes
+/// through instead of evicting it with a fresh ambient login.
+async fn exec_account(raw_provider: &str, raw_account: &str, args: &[String]) -> Result<()> {
+    let provider = parse_managed_provider(raw_provider)?;
+    let store = open_account_store().await?;
+    let account = find_provider_account(&store, provider, raw_account).await?;
+    let home = account
+        .home
+        .clone()
+        .ok_or_else(|| anyhow!("account '{}' has no managed credential home", raw_account))?;
+    let mut command = Command::new(provider.as_str());
+    command.args(args);
+    match provider {
+        Provider::Claude => {
+            command
+                .env("CLAUDE_CONFIG_DIR", &home)
+                .env_remove("CLAUDE_CODE_OAUTH_TOKEN")
+                .env_remove("ANTHROPIC_API_KEY");
+        }
+        Provider::Codex => {
+            command
+                .env("CODEX_HOME", &home)
+                .env_remove("CODEX_ACCESS_TOKEN")
+                .env_remove("OPENAI_API_KEY");
+        }
+        _ => unreachable!("parse_managed_provider admits Claude and Codex only"),
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt;
+        Err(anyhow!(
+            "failed to exec {}: {}",
+            provider.as_str(),
+            command.exec()
+        ))
+    }
+    #[cfg(not(unix))]
+    {
+        let status = command
+            .status()
+            .with_context(|| format!("failed to run {}", provider.as_str()))?;
+        std::process::exit(status.code().unwrap_or(1));
+    }
 }
 
 async fn reset_account(raw_provider: &str, raw_account: &str) -> Result<()> {

--- a/rust/loopflow/src/lf/commands/profile.rs
+++ b/rust/loopflow/src/lf/commands/profile.rs
@@ -257,7 +257,7 @@ async fn show_repo_route(
     Ok(())
 }
 
-async fn find_provider_account(
+pub(crate) async fn find_provider_account(
     store: &SharedStore,
     provider: Provider,
     raw_account: &str,

--- a/rust/loopflow/src/lf/mod.rs
+++ b/rust/loopflow/src/lf/mod.rs
@@ -1585,6 +1585,15 @@ pub enum AuthCommand {
     },
     /// Clear observed utilization and cooldown for an account
     Reset { provider: String, account: String },
+    /// Run the provider's CLI on a managed account's credential home
+    Exec {
+        provider: String,
+        /// Managed account id or login email
+        account: String,
+        /// Arguments passed through to the provider CLI
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        args: Vec<String>,
+    },
     /// External: provider name (so `lf auth linear` works)
     #[command(external_subcommand)]
     External(Vec<String>),


### PR DESCRIPTION
## What

`lf auth exec <provider> <account> [args…]` — replaces the process with the vendor CLI (codex/claude) running on the managed account's credential home, with ambient token env vars cleared.

Why: logging into a managed account with a bare `codex login` mints a fresh session and **evicts the managed one** (observed today: loopflow-eng went "needs re-login" hours after reconnecting because of a direct login). One account should have one credential home; exec makes direct interactive use share the session lf routes through.

```bash
lf auth exec codex engineering                       # interactive codex, managed session
lf auth exec codex manabot-eng@loopflow.studio -- login status   # accepts login email too
```

## Verified
- Live: `lf auth exec codex manabot-eng@loopflow.studio -- login status` → "Logged in using ChatGPT" against the managed home.
- 1511 unit tests green; fmt + clippy --all-targets clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)