### PR TITLE
lf --account: run any invocation as a named managed account

### DIFF
--- a/docs/lf.md
+++ b/docs/lf.md
@@ -354,14 +354,18 @@ lf doctor --json                # machine-readable audit
 ```
 
 ```bash
-lf auth exec codex engineering            # interactive codex on the managed account
-lf auth exec claude jack@loopflow.studio  # provider CLI shares the routed session
+lf -m codex --account manabot-eng : "fix the tests"   # this account, this run
+lf -m codex --account manabot-eng --tui               # interactive codex, same session
+LF_ACCOUNT=jack@loopflow.studio lf implement          # exported form, inherited by children
 ```
 
-`lf auth exec` replaces the process with the provider's CLI running on the
-managed account's credential home. Logging into a managed account with a bare
-`codex login`/`claude` creates a second session and evicts the managed one
-("needs re-login"); exec is how direct use and lf routing share one session.
+`--account <email|id>` (or `LF_ACCOUNT=`) makes every provider resolution in
+the invocation — and its child lf processes — use the named managed account,
+bypassing the repo route and cooldown gating. The credential is still
+verified, so a revoked account errors with the re-login fix. Use it for
+interactive vendor sessions too (`--tui`): logging into a managed account
+with a bare `codex login` creates a second session and evicts the managed
+one ("needs re-login"); entering through lf shares one session.
 
 `lf usage` leads with each managed account's subscription state — provider-
 reported plan, session and weekly windows as percent *used*, reset times —

--- a/rust/loopflow/src/bin/lf.rs
+++ b/rust/loopflow/src/bin/lf.rs
@@ -1369,6 +1369,14 @@ fn main() -> anyhow::Result<()> {
             wave.name().to_string(),
         )
     });
+    // Explicit account selection rides the environment so every provider
+    // resolution in this invocation — and its child lf processes — honors it.
+    let _explicit_account_env = cli.account.as_deref().map(|account| {
+        EnvGuard::set(
+            loopflow::provider_account::PROVIDER_ACCOUNT_ENV,
+            account.to_string(),
+        )
+    });
     debug!(?cli, "parsed CLI arguments");
 
     // Route repo/PR/release/PM commands to the Wave's execution home before local

--- a/rust/loopflow/src/lf/commands/auth.rs
+++ b/rust/loopflow/src/lf/commands/auth.rs
@@ -15,7 +15,6 @@ use sha2::{Digest, Sha256};
 use time::OffsetDateTime;
 
 use crate::engine::platform::open_url;
-use crate::lf::commands::profile::find_provider_account;
 use crate::lf::AuthCommand;
 use crate::profile::{EmailAddress, HostId, LocalChromeProfile, ProfileId, ProfileProviderAccount};
 use crate::provider_account::{
@@ -109,11 +108,6 @@ async fn run_async(cmd: &AuthCommand) -> Result<()> {
             .await
         }
         AuthCommand::Reset { provider, account } => reset_account(provider, account).await,
-        AuthCommand::Exec {
-            provider,
-            account,
-            args,
-        } => exec_account(provider, account, args).await,
         AuthCommand::External(args) => {
             let provider = args
                 .first()
@@ -836,52 +830,6 @@ fn parse_paid_through(value: &str) -> Result<time::Date> {
     let format = time::format_description::parse_borrowed::<2>("[year]-[month]-[day]")?;
     time::Date::parse(value.trim(), &format)
         .map_err(|_| anyhow!("invalid paid-through date '{value}': expected YYYY-MM-DD"))
-}
-
-/// Replace this process with the provider's CLI running on the managed
-/// account's credential home, so direct use shares the session lf routes
-/// through instead of evicting it with a fresh ambient login.
-async fn exec_account(raw_provider: &str, raw_account: &str, args: &[String]) -> Result<()> {
-    let provider = parse_managed_provider(raw_provider)?;
-    let store = open_account_store().await?;
-    let account = find_provider_account(&store, provider, raw_account).await?;
-    let home = account
-        .home
-        .clone()
-        .ok_or_else(|| anyhow!("account '{}' has no managed credential home", raw_account))?;
-    let mut command = Command::new(provider.as_str());
-    command.args(args);
-    match provider {
-        Provider::Claude => {
-            command
-                .env("CLAUDE_CONFIG_DIR", &home)
-                .env_remove("CLAUDE_CODE_OAUTH_TOKEN")
-                .env_remove("ANTHROPIC_API_KEY");
-        }
-        Provider::Codex => {
-            command
-                .env("CODEX_HOME", &home)
-                .env_remove("CODEX_ACCESS_TOKEN")
-                .env_remove("OPENAI_API_KEY");
-        }
-        _ => unreachable!("parse_managed_provider admits Claude and Codex only"),
-    }
-    #[cfg(unix)]
-    {
-        use std::os::unix::process::CommandExt;
-        Err(anyhow!(
-            "failed to exec {}: {}",
-            provider.as_str(),
-            command.exec()
-        ))
-    }
-    #[cfg(not(unix))]
-    {
-        let status = command
-            .status()
-            .with_context(|| format!("failed to run {}", provider.as_str()))?;
-        std::process::exit(status.code().unwrap_or(1));
-    }
 }
 
 async fn reset_account(raw_provider: &str, raw_account: &str) -> Result<()> {

--- a/rust/loopflow/src/lf/commands/profile.rs
+++ b/rust/loopflow/src/lf/commands/profile.rs
@@ -257,7 +257,7 @@ async fn show_repo_route(
     Ok(())
 }
 
-pub(crate) async fn find_provider_account(
+async fn find_provider_account(
     store: &SharedStore,
     provider: Provider,
     raw_account: &str,

--- a/rust/loopflow/src/lf/mod.rs
+++ b/rust/loopflow/src/lf/mod.rs
@@ -1592,15 +1592,6 @@ pub enum AuthCommand {
     },
     /// Clear observed utilization and cooldown for an account
     Reset { provider: String, account: String },
-    /// Run the provider's CLI on a managed account's credential home
-    Exec {
-        provider: String,
-        /// Managed account id or login email
-        account: String,
-        /// Arguments passed through to the provider CLI
-        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
-        args: Vec<String>,
-    },
     /// External: provider name (so `lf auth linear` works)
     #[command(external_subcommand)]
     External(Vec<String>),

--- a/rust/loopflow/src/lf/mod.rs
+++ b/rust/loopflow/src/lf/mod.rs
@@ -43,6 +43,11 @@ pub struct Cli {
     #[arg(short = 'm', long = "model", short_alias = 'M')]
     pub model: Option<String>,
 
+    /// Run as this managed provider account (login email or account id),
+    /// overriding the repo's profile route for this invocation and its children
+    #[arg(long = "account", alias = "profile")]
+    pub account: Option<String>,
+
     /// Skip permission prompts
     #[arg(long)]
     pub yolo: bool,

--- a/rust/loopflow/src/lf/mod.rs
+++ b/rust/loopflow/src/lf/mod.rs
@@ -44,8 +44,10 @@ pub struct Cli {
     pub model: Option<String>,
 
     /// Run as this managed provider account (login email or account id),
-    /// overriding the repo's profile route for this invocation and its children
-    #[arg(long = "account", alias = "profile")]
+    /// overriding the repo's route for this invocation and its children.
+    /// Accounts spend; a profile is only the Chrome venue accounts log in
+    /// through, so it is never a run-time selector.
+    #[arg(long = "account")]
     pub account: Option<String>,
 
     /// Skip permission prompts

--- a/rust/loopflow/src/provider_account.rs
+++ b/rust/loopflow/src/provider_account.rs
@@ -24,10 +24,11 @@ use crate::store::{CredentialState, RoutingState};
 pub const FORWARDED_PROFILE_BUNDLE_ENV: &str = "LF_FORWARDED_PROFILE_BUNDLE";
 pub const FORWARDED_PROFILE_STORE_ENV: &str = "LF_FORWARDED_PROFILE_STORE";
 pub const PROFILE_REPO_ID_ENV: &str = "LF_PROFILE_REPO_ID";
-/// Explicit account selection (`lf --account <email|id>`): every provider
-/// resolution in this process and its children uses the named account,
-/// bypassing the repo route and health gating — an explicit human choice.
-pub const PROVIDER_ACCOUNT_ENV: &str = "LF_PROVIDER_ACCOUNT";
+/// Explicit account selection (`lf --account <email|id>`, or exported as
+/// `LF_ACCOUNT=<email|id>`): every provider resolution in this process and
+/// its children uses the named account, bypassing the repo route and health
+/// gating — an explicit human choice.
+pub const PROVIDER_ACCOUNT_ENV: &str = "LF_ACCOUNT";
 const DEFAULT_COOLDOWN_SECS: i64 = 15 * 60;
 const RESET_GRACE_SECS: i64 = 5;
 const LEGACY_CHROME_PROFILE_FILE: &str = ".loopflow-chrome-profile.json";
@@ -683,19 +684,48 @@ pub async fn resolve_provider_account(
     }
 }
 
-/// An explicit selector names an account by login email (case-insensitive)
-/// or by exact account id.
-fn match_account<'a>(
-    accounts: &'a [ProviderAccount],
-    selector: &str,
-) -> Option<&'a ProviderAccount> {
-    accounts.iter().find(|account| {
+#[derive(Debug)]
+enum AccountMatch<'a> {
+    One(&'a ProviderAccount),
+    Ambiguous(Vec<&'a ProviderAccount>),
+    None,
+}
+
+/// An explicit selector names an account by login email or account id —
+/// exactly, or by any prefix that matches exactly one known account
+/// (`manabot` reaches `manabot-eng`). Matching is case-insensitive.
+fn match_account<'a>(accounts: &'a [ProviderAccount], selector: &str) -> AccountMatch<'a> {
+    let selector_lower = selector.to_ascii_lowercase();
+    let exact = accounts.iter().find(|account| {
         account
             .login_email
             .as_ref()
             .is_some_and(|email| email.as_str().eq_ignore_ascii_case(selector))
-            || account.account_id.as_str() == selector
-    })
+            || account.account_id.as_str().eq_ignore_ascii_case(selector)
+    });
+    if let Some(account) = exact {
+        return AccountMatch::One(account);
+    }
+    let prefixed: Vec<&ProviderAccount> = accounts
+        .iter()
+        .filter(|account| {
+            account.login_email.as_ref().is_some_and(|email| {
+                email
+                    .as_str()
+                    .to_ascii_lowercase()
+                    .starts_with(&selector_lower)
+            }) || account
+                .account_id
+                .as_str()
+                .to_ascii_lowercase()
+                .starts_with(&selector_lower)
+        })
+        .collect();
+    match prefixed.as_slice() {
+        [] => AccountMatch::None,
+        [account] => AccountMatch::One(account),
+        _ => AccountMatch::Ambiguous(prefixed),
+    }
 }
 
 /// Resolve `lf --account <email|id>`: the named account, verified live, with
@@ -711,11 +741,24 @@ async fn resolve_explicit_account(
     let accounts = store
         .list_provider_accounts(Some(provider.as_str()))
         .await?;
-    let account = match_account(&accounts, selector).ok_or_else(|| {
-        ProviderAccountError::Runtime(format!(
-            "no managed {provider} account matches '{selector}'; see `lf auth accounts`"
-        ))
-    })?;
+    let account = match match_account(&accounts, selector) {
+        AccountMatch::One(account) => account,
+        AccountMatch::Ambiguous(candidates) => {
+            return Err(ProviderAccountError::Runtime(format!(
+                "'{selector}' matches several {provider} accounts: {}",
+                candidates
+                    .iter()
+                    .map(|account| account.account_id.as_str())
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            )));
+        }
+        AccountMatch::None => {
+            return Err(ProviderAccountError::Runtime(format!(
+                "no managed {provider} account matches '{selector}'; see `lf auth accounts`"
+            )));
+        }
+    };
     let home = account.home.clone().ok_or_else(|| {
         ProviderAccountError::Runtime(format!(
             "{provider} account '{}' has no managed credential home",
@@ -1039,7 +1082,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn explicit_account_selector_matches_email_case_insensitively_or_id() {
+    fn explicit_account_selector_matches_exactly_or_by_unique_prefix() {
         let temp = tempdir().unwrap();
         let accounts = vec![
             new_account(
@@ -1054,23 +1097,33 @@ mod tests {
                 temp.path().join("manabot-eng"),
                 None,
             ),
+            new_account(
+                Provider::Codex,
+                parse_account_id("manabot-ops").unwrap(),
+                temp.path().join("manabot-ops"),
+                None,
+            ),
         ];
+        let one = |selector: &str| match match_account(&accounts, selector) {
+            AccountMatch::One(account) => account.account_id.as_str().to_string(),
+            other => panic!("expected one match for '{selector}', got {other:?}"),
+        };
 
-        assert_eq!(
-            match_account(&accounts, "LoopFlow-Eng@loopflow.studio")
-                .expect("email match")
-                .account_id
-                .as_str(),
-            "engineering"
-        );
-        assert_eq!(
-            match_account(&accounts, "manabot-eng")
-                .expect("id match")
-                .account_id
-                .as_str(),
-            "manabot-eng"
-        );
-        assert!(match_account(&accounts, "nobody@example.com").is_none());
+        assert_eq!(one("LoopFlow-Eng@loopflow.studio"), "engineering");
+        assert_eq!(one("manabot-eng"), "manabot-eng");
+        // A unique prefix reaches its account; email prefixes count too.
+        assert_eq!(one("manabot-e"), "manabot-eng");
+        assert_eq!(one("loopflow-eng@"), "engineering");
+        // An exact id wins even when it prefixes nothing else and another
+        // account's id shares its prefix.
+        assert!(matches!(
+            match_account(&accounts, "manabot"),
+            AccountMatch::Ambiguous(candidates) if candidates.len() == 2
+        ));
+        assert!(matches!(
+            match_account(&accounts, "nobody@example.com"),
+            AccountMatch::None
+        ));
     }
 
     #[test]

--- a/rust/loopflow/src/provider_account.rs
+++ b/rust/loopflow/src/provider_account.rs
@@ -24,6 +24,10 @@ use crate::store::{CredentialState, RoutingState};
 pub const FORWARDED_PROFILE_BUNDLE_ENV: &str = "LF_FORWARDED_PROFILE_BUNDLE";
 pub const FORWARDED_PROFILE_STORE_ENV: &str = "LF_FORWARDED_PROFILE_STORE";
 pub const PROFILE_REPO_ID_ENV: &str = "LF_PROFILE_REPO_ID";
+/// Explicit account selection (`lf --account <email|id>`): every provider
+/// resolution in this process and its children uses the named account,
+/// bypassing the repo route and health gating — an explicit human choice.
+pub const PROVIDER_ACCOUNT_ENV: &str = "LF_PROVIDER_ACCOUNT";
 const DEFAULT_COOLDOWN_SECS: i64 = 15 * 60;
 const RESET_GRACE_SECS: i64 = 5;
 const LEGACY_CHROME_PROFILE_FILE: &str = ".loopflow-chrome-profile.json";
@@ -549,6 +553,11 @@ pub async fn resolve_provider_account(
     provider_session_id: Option<&str>,
 ) -> Result<Option<ProviderAccountRoute>, ProviderAccountError> {
     ensure_supported(provider)?;
+    if let Ok(selector) = std::env::var(PROVIDER_ACCOUNT_ENV) {
+        if !selector.trim().is_empty() {
+            return resolve_explicit_account(provider, selector.trim()).await;
+        }
+    }
     let forwarded_bundle = match std::env::var(FORWARDED_PROFILE_BUNDLE_ENV) {
         Ok(value) if !value.trim().is_empty() => Some(decode_forwarded_profile_bundle(&value)?),
         _ => None,
@@ -672,6 +681,89 @@ pub async fn resolve_provider_account(
             store,
         }));
     }
+}
+
+/// An explicit selector names an account by login email (case-insensitive)
+/// or by exact account id.
+fn match_account<'a>(
+    accounts: &'a [ProviderAccount],
+    selector: &str,
+) -> Option<&'a ProviderAccount> {
+    accounts.iter().find(|account| {
+        account
+            .login_email
+            .as_ref()
+            .is_some_and(|email| email.as_str().eq_ignore_ascii_case(selector))
+            || account.account_id.as_str() == selector
+    })
+}
+
+/// Resolve `lf --account <email|id>`: the named account, verified live, with
+/// no route lookup and no cooldown gating — refusing an explicit human choice
+/// helps nobody; a dead credential still errors with the re-login fix.
+async fn resolve_explicit_account(
+    provider: Provider,
+    selector: &str,
+) -> Result<Option<ProviderAccountRoute>, ProviderAccountError> {
+    let store = route_store(true).await?.ok_or_else(|| {
+        ProviderAccountError::Runtime("account store unavailable for --account".to_string())
+    })?;
+    let accounts = store
+        .list_provider_accounts(Some(provider.as_str()))
+        .await?;
+    let account = match_account(&accounts, selector).ok_or_else(|| {
+        ProviderAccountError::Runtime(format!(
+            "no managed {provider} account matches '{selector}'; see `lf auth accounts`"
+        ))
+    })?;
+    let home = account.home.clone().ok_or_else(|| {
+        ProviderAccountError::Runtime(format!(
+            "{provider} account '{}' has no managed credential home",
+            account.account_id
+        ))
+    })?;
+    let operator_home = dirs::home_dir().unwrap_or_else(|| PathBuf::from("."));
+    ensure_account_profile_at(&operator_home, &home, provider)?;
+    let status = provider_account_auth_status(provider, home.clone())
+        .await
+        .map_err(|error| {
+            ProviderAccountError::Runtime(format!(
+                "check {provider} account '{}': {error}",
+                account.account_id
+            ))
+        })?;
+    if !retain_authenticated_account(&store, account, &status).await? {
+        return Err(ProviderAccountError::NoAuthenticatedAccount {
+            provider,
+            accounts: format!("'{}' with `lf auth connect {provider}`", account.account_id),
+        });
+    }
+    let profile_id = store
+        .list_profile_provider_accounts(None)
+        .await?
+        .into_iter()
+        .find(|mapping| mapping.provider == provider && mapping.account_id == account.account_id)
+        .map(|mapping| mapping.profile_id)
+        .or_else(|| {
+            account
+                .login_email
+                .as_ref()
+                .and_then(|email| ProfileId::parse(email.as_str()).ok())
+        })
+        .ok_or_else(|| {
+            ProviderAccountError::Runtime(format!(
+                "{provider} account '{}' has no profile or login email to record the session under",
+                account.account_id
+            ))
+        })?;
+    Ok(Some(ProviderAccountRoute {
+        provider,
+        profile_id,
+        account_id: account.account_id.clone(),
+        credential: AccountCredential::NativeHome(home),
+        resume_requested_session: false,
+        store,
+    }))
 }
 
 async fn retain_authenticated_account(
@@ -945,6 +1037,41 @@ mod tests {
     use tempfile::tempdir;
 
     use super::*;
+
+    #[test]
+    fn explicit_account_selector_matches_email_case_insensitively_or_id() {
+        let temp = tempdir().unwrap();
+        let accounts = vec![
+            new_account(
+                Provider::Codex,
+                parse_account_id("engineering").unwrap(),
+                temp.path().join("engineering"),
+                Some(crate::profile::EmailAddress::parse("loopflow-eng@loopflow.studio").unwrap()),
+            ),
+            new_account(
+                Provider::Codex,
+                parse_account_id("manabot-eng").unwrap(),
+                temp.path().join("manabot-eng"),
+                None,
+            ),
+        ];
+
+        assert_eq!(
+            match_account(&accounts, "LoopFlow-Eng@loopflow.studio")
+                .expect("email match")
+                .account_id
+                .as_str(),
+            "engineering"
+        );
+        assert_eq!(
+            match_account(&accounts, "manabot-eng")
+                .expect("id match")
+                .account_id
+                .as_str(),
+            "manabot-eng"
+        );
+        assert!(match_account(&accounts, "nobody@example.com").is_none());
+    }
 
     #[test]
     fn account_ids_are_shell_and_path_safe() {


### PR DESCRIPTION
## What

Explicit account selection for any lf invocation:

```bash
lf -m codex --account manabot-eng : "fix the tests"    # this account, this run
lf -m codex --account manabot --tui                    # unique prefix works; interactive too
LF_ACCOUNT=jack@loopflow.studio lf implement           # exported form, inherited by children
```

- `--account <selector>` / `LF_ACCOUNT=<selector>`: every provider resolution in the invocation and its child lf processes uses the named managed account, bypassing the repo route and cooldown gating (an explicit human choice). The credential is still verified live — a revoked account errors with the `lf auth connect` fix rather than silently running ambient.
- Selectors match an exact login email or account id, or **any prefix that reaches exactly one known account**; ambiguity errors with the candidate list.
- No `--profile` spelling: an account spends; a profile is the Chrome venue accounts log in through, never a run-time selector.
- **Removes `lf auth exec`** (from #1027): `lf auth …` is for ceremonies, not for running agents. Interactive vendor use on a managed account rides the same selection through the front door (`--tui`), which resolves and applies the account route like every other launch.

## Verified
- 1512 unit tests green (selector exact/prefix/ambiguous/none cases); fmt + clippy --all-targets clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)