### PR TITLE
review: decide human authority from inherited identity, not self-minted run ids

### DIFF
--- a/rust/loopflow/src/bin/lf.rs
+++ b/rust/loopflow/src/bin/lf.rs
@@ -1317,6 +1317,11 @@ fn run_task_command(repo: &Path, command: &TaskCommand) -> anyhow::Result<()> {
 }
 
 fn main() -> anyhow::Result<()> {
+    // Snapshot inherited session identity before any journaling can mint
+    // LF_RUN_ID/LF_PROCESS_ID into this process's own environment — human
+    // review authority is decided by what the process was launched with.
+    loopflow::ops::task::capture_review_authority_at_entry();
+
     // Ensure Ctrl+C terminates lf and the child agent. Without this,
     // child.wait() retries on EINTR and hangs while the agent catches
     // SIGINT and keeps running. SIGTERM the agent first so it doesn't

--- a/rust/loopflow/src/ops/task.rs
+++ b/rust/loopflow/src/ops/task.rs
@@ -4695,18 +4695,35 @@ pub fn task_review_reply(review_id: &str, text: String) -> OpsResult<Interaction
     })
 }
 
-fn _require_human_review_authority() -> OpsResult<()> {
-    for variable in [
+static ENTRY_SESSION_MARKERS: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+
+fn session_markers_present() -> bool {
+    [
         "LF_TASK_SESSION_ID",
         "LF_PROJECT_SESSION_ID",
         "LF_RUN_ID",
         "LF_PROCESS_ID",
-    ] {
-        if std::env::var_os(variable).is_some() {
-            return Err(task_error(
-                "human review commands cannot run inside a Task, Project, or Wave agent session",
-            ));
-        }
+    ]
+    .iter()
+    .any(|variable| std::env::var_os(variable).is_some())
+}
+
+/// Record, before anything else runs, whether this process was *launched
+/// inside* an agent session. The journal exports `LF_RUN_ID`/`LF_PROCESS_ID`
+/// into the process's own environment when a run starts, so reading the
+/// environment at review time sees the id the process just minted for itself
+/// and refuses every human invocation. Authority is about what the process
+/// inherited, so it must be read at entry.
+pub fn capture_review_authority_at_entry() {
+    let _ = ENTRY_SESSION_MARKERS.set(session_markers_present());
+}
+
+fn _require_human_review_authority() -> OpsResult<()> {
+    let inherited = *ENTRY_SESSION_MARKERS.get_or_init(session_markers_present);
+    if inherited {
+        return Err(task_error(
+            "human review commands cannot run inside a Task, Project, or Wave agent session",
+        ));
     }
     Ok(())
 }
@@ -4871,6 +4888,38 @@ mod tests {
     use std::process::Command;
     use std::sync::Arc;
     use std::time::Duration;
+
+    /// Review authority is decided by what the process inherited at entry —
+    /// the run id the journal mints into this process's own environment later
+    /// must not revoke it (it did: every human `lf task review` was refused).
+    #[test]
+    fn self_minted_run_identity_does_not_revoke_review_authority() {
+        let _lock = crate::journal::test_env_lock();
+        let saved: Vec<(&str, Option<std::ffi::OsString>)> = [
+            "LF_TASK_SESSION_ID",
+            "LF_PROJECT_SESSION_ID",
+            "LF_RUN_ID",
+            "LF_PROCESS_ID",
+        ]
+        .iter()
+        .map(|name| (*name, std::env::var_os(name)))
+        .collect();
+        for (name, _) in &saved {
+            std::env::remove_var(name);
+        }
+
+        super::capture_review_authority_at_entry();
+        std::env::set_var("LF_RUN_ID", "run_self_minted");
+        let verdict = super::_require_human_review_authority();
+
+        for (name, value) in saved {
+            match value {
+                Some(value) => std::env::set_var(name, value),
+                None => std::env::remove_var(name),
+            }
+        }
+        verdict.expect("entry snapshot grants authority despite self-minted run id");
+    }
 
     use super::{
         _defer_task_interactions, cached_github_observation, changes_snapshot,


### PR DESCRIPTION
## What

`lf task review message|reply|complete` was refused from every human terminal with "human review commands cannot run inside a Task, Project, or Wave agent session" — because the guard reads `LF_RUN_ID`/`LF_PROCESS_ID` from the environment, and by the time it runs, the journal has already minted this process's *own* run id into those variables (`journal::ensure_run_context` → `set_var`). The guard could never pass under `with_runtime`; it was checking the id it just created for itself.

Fix: snapshot the session markers at the very top of `main`, before any journaling, and decide authority from that snapshot. Agent sessions (which *inherit* the markers from their parent) are still refused; humans are not. Fallback to a live env read remains for in-process callers that never pass through `main` (lfd).

Found while shepherding W2-280: its headless kickoff requested a design review that no human could dispose from the CLI.

## Verified
- New test: capture at entry with clean env, then self-mint `LF_RUN_ID` — authority holds.
- 1536 unit tests green; fmt + clippy --all-targets clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)