### PR TITLE
task review: name the review authority boundary by session id alone

### DIFF
--- a/rust/loopflow/src/bin/lf.rs
+++ b/rust/loopflow/src/bin/lf.rs
@@ -1325,11 +1325,6 @@ fn run_task_command(repo: &Path, command: &TaskCommand) -> anyhow::Result<()> {
 }
 
 fn main() -> anyhow::Result<()> {
-    // Snapshot inherited session identity before any journaling can mint
-    // LF_RUN_ID/LF_PROCESS_ID into this process's own environment — human
-    // review authority is decided by what the process was launched with.
-    loopflow::ops::task::capture_review_authority_at_entry();
-
     // Ensure Ctrl+C terminates lf and the child agent. Without this,
     // child.wait() retries on EINTR and hangs while the agent catches
     // SIGINT and keeps running. SIGTERM the agent first so it doesn't

--- a/rust/loopflow/src/ops/task.rs
+++ b/rust/loopflow/src/ops/task.rs
@@ -4874,35 +4874,17 @@ pub fn task_review_reply(review_id: &str, text: String) -> OpsResult<Interaction
     })
 }
 
-static ENTRY_SESSION_MARKERS: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
-
-fn session_markers_present() -> bool {
-    [
-        "LF_TASK_SESSION_ID",
-        "LF_PROJECT_SESSION_ID",
-        "LF_RUN_ID",
-        "LF_PROCESS_ID",
-    ]
-    .iter()
-    .any(|variable| std::env::var_os(variable).is_some())
-}
-
-/// Record, before anything else runs, whether this process was *launched
-/// inside* an agent session. The journal exports `LF_RUN_ID`/`LF_PROCESS_ID`
-/// into the process's own environment when a run starts, so reading the
-/// environment at review time sees the id the process just minted for itself
-/// and refuses every human invocation. Authority is about what the process
-/// inherited, so it must be read at entry.
-pub fn capture_review_authority_at_entry() {
-    let _ = ENTRY_SESSION_MARKERS.set(session_markers_present());
-}
-
+/// An agent session is named by its session id, and only by that. `LF_RUN_ID`
+/// and `LF_PROCESS_ID` name a *run* — the journal mints both into this
+/// process's own environment when any top-level `lf` command starts, so a guard
+/// that reads them refuses the human CLI it exists to serve, whenever it reads.
 fn _require_human_review_authority() -> OpsResult<()> {
-    let inherited = *ENTRY_SESSION_MARKERS.get_or_init(session_markers_present);
-    if inherited {
-        return Err(task_error(
-            "human review commands cannot run inside a Task, Project, or Wave agent session",
-        ));
+    for variable in ["LF_TASK_SESSION_ID", "LF_PROJECT_SESSION_ID", "LF_WAVE_ID"] {
+        if std::env::var_os(variable).is_some() {
+            return Err(task_error(
+                "human review commands cannot run inside a Task, Project, or Wave agent session",
+            ));
+        }
     }
     Ok(())
 }
@@ -5067,38 +5049,6 @@ mod tests {
     use std::process::Command;
     use std::sync::Arc;
     use std::time::Duration;
-
-    /// Review authority is decided by what the process inherited at entry —
-    /// the run id the journal mints into this process's own environment later
-    /// must not revoke it (it did: every human `lf task review` was refused).
-    #[test]
-    fn self_minted_run_identity_does_not_revoke_review_authority() {
-        let _lock = crate::journal::test_env_lock();
-        let saved: Vec<(&str, Option<std::ffi::OsString>)> = [
-            "LF_TASK_SESSION_ID",
-            "LF_PROJECT_SESSION_ID",
-            "LF_RUN_ID",
-            "LF_PROCESS_ID",
-        ]
-        .iter()
-        .map(|name| (*name, std::env::var_os(name)))
-        .collect();
-        for (name, _) in &saved {
-            std::env::remove_var(name);
-        }
-
-        super::capture_review_authority_at_entry();
-        std::env::set_var("LF_RUN_ID", "run_self_minted");
-        let verdict = super::_require_human_review_authority();
-
-        for (name, value) in saved {
-            match value {
-                Some(value) => std::env::set_var(name, value),
-                None => std::env::remove_var(name),
-            }
-        }
-        verdict.expect("entry snapshot grants authority despite self-minted run id");
-    }
 
     use super::{
         _defer_task_interactions, _recover_abandoned_task, cached_github_observation,

--- a/rust/loopflow/tests/task_review_authority_tests.rs
+++ b/rust/loopflow/tests/task_review_authority_tests.rs
@@ -1,0 +1,92 @@
+//! W2-287 — top-level `lf task review` must pass its own authority check.
+//!
+//! The human review commands refuse to run inside a managed agent session, so a
+//! Task cannot answer the review it is the subject of. That boundary is named by
+//! the session id vars alone. `with_runtime` mints `LF_RUN_ID`/`LF_PROCESS_ID`
+//! for **every** top-level `lf` command before the command body runs, so a guard
+//! keyed on them refuses the human CLI it exists to serve.
+//!
+//! These tests pin both directions: a top-level invocation reaches the review
+//! lookup, and a managed session is still refused.
+
+mod support;
+
+use loopflow::interaction_review::InteractionReviewId;
+use loopflow::ops::task::{task_review_complete, task_review_message};
+use loopflow::store::{open_store, StorageConfig};
+use support::EnvGuard;
+use tempfile::TempDir;
+
+const AUTHORITY_REFUSAL: &str = "cannot run inside a Task, Project, or Wave agent session";
+
+/// A guarded home with a **materialized** registry, plus the runtime identity
+/// `with_runtime` exports before dispatching any command.
+///
+/// The registry must exist: against an empty home every review command fails at
+/// store resolution ("no Loopflow registry on this machine"), which is not the
+/// authority error either — so the top-level proof would pass without ever
+/// reaching the guard's far side.
+fn top_level_cli(home: &TempDir) -> EnvGuard {
+    let guard = EnvGuard::with_lf_home(&[], home.path());
+    let runtime = tokio::runtime::Runtime::new().expect("test runtime");
+    runtime
+        .block_on(open_store(&StorageConfig::sqlite(
+            home.path().join("loopflow.db"),
+        )))
+        .expect("materialize the review registry");
+    std::env::set_var("LF_RUN_ID", "run_w2287");
+    std::env::set_var("LF_PROCESS_ID", "process_w2287");
+    guard
+}
+
+#[test]
+fn top_level_review_commands_pass_authority_and_reach_the_review_lookup() {
+    let home = TempDir::new().expect("temp lf home");
+    let _guard = top_level_cli(&home);
+
+    // A well-formed id for a review that does not exist. Reaching "not found"
+    // means the call cleared the authority boundary and queried the registry —
+    // the far side of the guard is the whole subject here.
+    let absent = InteractionReviewId::new();
+
+    let message = task_review_message(absent.as_str(), "ship it".to_string())
+        .expect_err("no such review exists");
+    assert!(
+        message.to_string().contains("not found"),
+        "a top-level `lf task review message` must reach the review lookup, not \
+         be refused by its own authority guard: {message}"
+    );
+
+    let complete = task_review_complete(absent.as_str(), "approved", "looks right".to_string())
+        .expect_err("no such review exists");
+    assert!(
+        !complete.to_string().contains(AUTHORITY_REFUSAL),
+        "a top-level `lf task review complete` must not be refused by its own \
+         authority guard: {complete}"
+    );
+}
+
+#[test]
+fn a_managed_task_session_is_still_refused() {
+    let home = TempDir::new().expect("temp lf home");
+    // EnvGuard clears the ambient Task identity and restores it on drop, so the
+    // session id set here is the only one in play.
+    let _guard = top_level_cli(&home);
+    std::env::set_var("LF_TASK_SESSION_ID", "ts_w2287");
+
+    let absent = InteractionReviewId::new();
+
+    let message = task_review_message(absent.as_str(), "approve my own review".to_string())
+        .expect_err("a Task body cannot answer its own review");
+    assert!(
+        message.to_string().contains(AUTHORITY_REFUSAL),
+        "a Task session must be refused before the review is read: {message}"
+    );
+
+    let complete = task_review_complete(absent.as_str(), "approved", "self-approval".to_string())
+        .expect_err("a Task body cannot complete its own review");
+    assert!(
+        complete.to_string().contains(AUTHORITY_REFUSAL),
+        "a Task session must be refused before the review is read: {complete}"
+    );
+}


### PR DESCRIPTION
## Usage

```bash
# top-level human CLI — reaches the review, no longer refused
lf task review message <review-id> "ship it"
lf task review complete <review-id> approved "looks right"

cargo test -p loopflow --test task_review_authority_tests
```

## Summary

Human review commands refuse to run inside a managed agent session, so a Task can't answer the review it is the subject of. The guard was checking `LF_RUN_ID`/`LF_PROCESS_ID` alongside the session id vars — but those name a *run*, not a session, and `with_runtime` mints both into the process's own environment before any top-level `lf` command body runs. The result was that every human `lf task review` refused itself.

The previous fix worked around this by snapshotting the environment at `main()` entry, before journaling could mint the run ids. That kept a process-global `OnceLock` and an ordering constraint in `main()` alive to defend a check that was looking at the wrong variables in the first place. This drops the entry snapshot and names the boundary directly: an agent session is identified by `LF_TASK_SESSION_ID`, `LF_PROJECT_SESSION_ID`, or `LF_WAVE_ID`, and by nothing else. Read at any time, the guard now gives the same answer.

## Changes

- `_require_human_review_authority` keys on session id vars only; `capture_review_authority_at_entry`, the `OnceLock`, and its `main()` call site are gone
- New integration test `task_review_authority_tests.rs` pins both directions with the runtime identity actually exported: a top-level invocation clears the guard and reaches the review lookup (against a materialized registry, so "not found" is real proof rather than an earlier store failure), and a Task session is still refused before the review is read