### PR TITLE
task: make repeated closed-PR reconciliation idempotent

### DIFF
--- a/rust/loopflow/src/ops/task.rs
+++ b/rust/loopflow/src/ops/task.rs
@@ -2868,7 +2868,9 @@ async fn reconcile_task_pr_with_authority(
             })
         }
         "closed" => {
-            pr.abandoned_at = Some(now);
+            // Re-confirming a close is not a second abandonment: a fresh `now` here
+            // settles the row differently on every read, which the store rejects.
+            pr.abandoned_at.get_or_insert(now);
             pr.ci_observation = None;
             if !session.status.is_process_active() {
                 session.set_status(

--- a/rust/loopflow/src/task/runner/ci_fix_lifecycle_tests.rs
+++ b/rust/loopflow/src/task/runner/ci_fix_lifecycle_tests.rs
@@ -1361,6 +1361,42 @@ async fn a_reopened_pr_is_restored_red_woken_once_and_mints_no_successor() {
     assert_eq!(prs[0].id, original.id);
 }
 
+/// Re-reading a PR GitHub still reports closed re-confirms the abandonment it
+/// already recorded; it does not re-abandon it.
+#[tokio::test]
+async fn a_repeat_reconcile_of_a_closed_pr_keeps_its_first_abandonment() {
+    let mut harness = Harness::new().await;
+
+    harness.gh.set_pr(harness.pr_number, "closed", "h1");
+    harness.reconcile().await;
+    let first = harness
+        .store
+        .task_prs(&harness.task.id)
+        .await
+        .expect("read task prs")
+        .pop()
+        .expect("the fixture Task has a PR")
+        .abandoned_at
+        .expect("the closed PR is abandoned");
+
+    // `reconcile` expires the read cache, so this really re-reads the same close.
+    let second = harness.reconcile().await.expect("reconcile still answers");
+
+    assert_eq!(second.phase(), PrPhase::Abandoned);
+    assert_eq!(second.abandoned_at, Some(first));
+    assert_eq!(
+        harness
+            .store
+            .task_prs(&harness.task.id)
+            .await
+            .expect("read task prs")
+            .pop()
+            .expect("the fixture Task has a PR")
+            .abandoned_at,
+        Some(first)
+    );
+}
+
 /// A predecessor GitHub could not be re-read is not a settled predecessor: under
 /// an outage the stale `abandoned_at` stands, and rotating on it would mint the
 /// same empty successor.


### PR DESCRIPTION
## Usage

```bash
cargo test -p loopflow a_repeat_reconcile_of_a_closed_pr_keeps_its_first_abandonment
```

## Summary

Reconciling a PR that GitHub still reports as `closed` stamped a fresh `abandoned_at` on every read. Re-confirming a close isn't a second abandonment — but each pass settled the row with a different timestamp, and `same_task_pr` compares `abandoned_at`, so the store rejected the second reading as a different settlement.

That rejection has one production site (`store/sqlite/child_sessions.rs:3963`), and it is what makes a Task's status **fail outright** rather than degrade — every command that funnels through reconcile errors:

```
$ lf task status W2-283
Error: invalid data: Task PR pr_8b1b5d4ccb554486b4ec6818c6b649ed is already settled differently
```

So this is the fix for the defect behind W2-283's unreadable status, which the Project has been carrying as an unexplained wedge — not only an idempotency tidy-up. W2-283 is the evidence, not the scope: this PR repairs no rows and touches no session. The fleet runs release `lf` 0.11.3, so W2-283 becomes readable once this is released and installed, not on merge.

## Changes

- `reconcile_task_pr_with_authority` uses `get_or_insert` for `abandoned_at` on the `closed` branch, so the first abandonment stands. No schema, no new lifecycle state.
- New ci-fix lifecycle test re-reads the same close and asserts both the returned PR and the **stored row** keep the original `abandoned_at`.

## Proof

Sabotaging the fix (`get_or_insert(now)` → `= Some(now)`) fails the test with the exact production error above, so it guards the behavior rather than pinning a fixture. It reaches the closed arm on the second pass because `harness.reconcile()` expires the read cache first — and that helper resolves the newest row rather than `active_task_pr`, which returns `None` for an abandoned row and would otherwise serve a cached reading.
