### PR TITLE
ci: require a serviced ci-fix wake before counting autonomy

### DIFF
--- a/rust/loopflow/src/lf/commands/ci.rs
+++ b/rust/loopflow/src/lf/commands/ci.rs
@@ -247,12 +247,14 @@ fn summarize(incidents: &[CiIncidentDto]) -> CiSummaryDto {
             .filter(|incident| incident.outcome == "blocked")
             .count(),
         // `!human_assisted` alone only says nobody was seen intervening, which is
-        // also true of a green that no `ci-fix` wake repaired.
+        // also true of a green that no `ci-fix` wake repaired. A wake that was
+        // persisted but never serviced did not own the repair either.
         autonomous: incidents
             .iter()
             .filter(|incident| {
                 matches!(incident.outcome.as_str(), "green" | "merged")
                     && incident.trigger_command_id.is_some()
+                    && incident.responded_at.is_some()
                     && !incident.human_assisted
             })
             .count(),
@@ -361,7 +363,7 @@ mod tests {
     use super::{parse_since, percentile, summarize, CiIncidentDto};
     use time::{Duration, OffsetDateTime};
 
-    fn green_incident(trigger: Option<&str>) -> CiIncidentDto {
+    fn green_incident(trigger: Option<&str>, responded: Option<&str>) -> CiIncidentDto {
         CiIncidentDto {
             identity: "github:ci:loopflow:1034".to_string(),
             repo: "loopflow".to_string(),
@@ -378,7 +380,7 @@ mod tests {
             observed_at: "2026-07-16T00:00:00Z".to_string(),
             observer: "poll".to_string(),
             trigger_command_id: trigger.map(str::to_string),
-            responded_at: None,
+            responded_at: responded.map(str::to_string),
             green_at: Some("2026-07-16T00:10:00Z".to_string()),
             merged_at: None,
             blocked_at: None,
@@ -393,17 +395,40 @@ mod tests {
         }
     }
 
-    /// PR #1034: a normal Task body pushed the fix, so no `ci-fix` wake owned the
-    /// repair. Dropping the `trigger_command_id` clause makes this go red; the
-    /// triggered case below still passes, so this is the guard of the pair.
+    /// The first row is PR #1034: a normal Task body pushed the fix, so no `ci-fix`
+    /// wake owned the repair. The second is a green answered by something outside
+    /// the ledger, and it is what pins the `trigger_command_id` clause — #1034 alone
+    /// is excluded by the `responded_at` clause too, so it would pass without it.
     #[test]
     fn an_untriggered_green_is_not_autonomous() {
-        assert_eq!(summarize(&[green_incident(None)]).autonomous, 0);
+        let summary = summarize(&[
+            green_incident(None, None),
+            green_incident(None, Some("2026-07-16T00:05:00Z")),
+        ]);
+        assert_eq!(summary.autonomous, 0);
+    }
+
+    /// A wake persisted but never serviced did not repair anything.
+    #[test]
+    fn a_triggered_but_unanswered_green_is_not_autonomous() {
+        assert_eq!(
+            summarize(&[green_incident(Some("cc_1018"), None)]).autonomous,
+            0
+        );
+    }
+
+    /// A serviced wake still does not own a repair a human was in the loop for.
+    #[test]
+    fn a_human_assisted_green_is_not_autonomous() {
+        let mut incident = green_incident(Some("cc_1018"), Some("2026-07-16T00:05:00Z"));
+        incident.human_assisted = true;
+        assert_eq!(summarize(&[incident]).autonomous, 0);
     }
 
     #[test]
-    fn a_triggered_green_is_autonomous() {
-        assert_eq!(summarize(&[green_incident(Some("cc_1018"))]).autonomous, 1);
+    fn a_triggered_and_answered_green_is_autonomous() {
+        let incident = green_incident(Some("cc_1018"), Some("2026-07-16T00:05:00Z"));
+        assert_eq!(summarize(&[incident]).autonomous, 1);
     }
 
     #[test]


### PR DESCRIPTION
Follow-up to #1042, which landed the `trigger_command_id` clause while this correction was in flight.

## What

`trigger_command_id.is_some()` proves a ci-fix wake was *persisted*, not that it ever *ran*. A wake enqueued and never serviced did not own the repair. The autonomy predicate now requires the wake to have been answered:

```rust
matches!(incident.outcome.as_str(), "green" | "merged")
    && incident.trigger_command_id.is_some()
    && incident.responded_at.is_some()
    && !incident.human_assisted
```

No schema or DTO change — `responded_at` is already on `CiIncidentDto`.

## Each clause is pinned by exactly one test

Verified by sabotaging each clause independently:

| Sabotage | Test that goes red |
|---|---|
| drop `trigger_command_id.is_some()` | `an_untriggered_green_is_not_autonomous` |
| drop `responded_at.is_some()` | `a_triggered_but_unanswered_green_is_not_autonomous` |

One test fails per sabotage — no redundancy, no gaps.

The untriggered case deliberately asserts **two** rows: the literal #1034 shape `(trigger=None, responded=None)`, plus a responded-but-untriggered row `(None, Some)`. The second is load-bearing. Once `responded_at` joined the predicate, #1034's shape alone became excluded by the `responded_at` clause, so it would have passed with the trigger clause deleted and stopped guarding it. The `(None, Some)` row is the ledger-bypass the DTO comment already names, and it isolates the trigger clause.

## Measured

Against a `sqlite3 .backup` snapshot of the live store (a dev build is walled off from the production store, so the snapshot is what lets the real binary read real rows):

```
0 autonomous · 2 human-assisted
```

Unchanged from #1042 on today's data: the only incident carrying a serviced trigger (#1018) is human-assisted, so it stays excluded either way. This clause is a correctness guard against future data, not a mover of the current number.

`cargo fmt --check`, `clippy -D warnings`, and focused tests all clean.