### PR TITLE
task: settle an abandoned PR idempotently across observation replays

### DIFF
--- a/rust/loopflow/src/ops/task.rs
+++ b/rust/loopflow/src/ops/task.rs
@@ -2868,7 +2868,12 @@ async fn reconcile_task_pr_with_authority(
             })
         }
         "closed" => {
-            pr.abandoned_at = Some(now);
+            // A PR the flow already abandoned settles again when GitHub's
+            // `closed` is observed. Re-stamping the time makes the second
+            // settle differ from the first and wedges the session on
+            // "already settled differently" — the first abandonment is the
+            // fact; observation only confirms it.
+            pr.abandoned_at = pr.abandoned_at.or(Some(now));
             pr.ci_observation = None;
             if !session.status.is_process_active() {
                 session.set_status(

--- a/rust/loopflow/src/store/mod.rs
+++ b/rust/loopflow/src/store/mod.rs
@@ -3655,6 +3655,41 @@ mod tests {
         );
     }
 
+    /// The settle equality includes `abandoned_at`, so a re-settle must carry
+    /// the original abandonment time. GitHub-observation reconcile once
+    /// re-stamped it with `now` on every `lf task status`, and the session
+    /// wedged permanently on "already settled differently" (live: W2-283).
+    #[tokio::test]
+    async fn re_settling_an_abandoned_pr_is_idempotent_only_at_its_original_time() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = open_store(&StorageConfig::sqlite(dir.path().join("registry.db")))
+            .await
+            .unwrap();
+        let wave = make_wave("/repo");
+        store.create_wave(&wave).await.unwrap();
+        let project = make_project_session(&wave);
+        store.create_project_session(&project).await.unwrap();
+        let session = make_task_session(&wave, &project);
+        let mut pr = make_task_pr(&session);
+        store.create_task_session(&session, &pr).await.unwrap();
+
+        let first_abandonment = OffsetDateTime::now_utc();
+        pr.abandoned_at = Some(first_abandonment);
+        pr.updated_at = first_abandonment;
+        store.settle_task_pr(&pr, None).await.unwrap();
+        store
+            .settle_task_pr(&pr, None)
+            .await
+            .expect("same settle is idempotent");
+
+        let mut restamped = pr.clone();
+        restamped.abandoned_at = Some(first_abandonment + time::Duration::seconds(30));
+        assert!(
+            store.settle_task_pr(&restamped, None).await.is_err(),
+            "a drifted abandonment time is a different settle and must refuse"
+        );
+    }
+
     #[tokio::test]
     async fn separate_task_worktree_tracks_and_collapses_its_parent_pr() {
         let dir = tempfile::tempdir().unwrap();

--- a/rust/loopflow/src/store/sqlite/child_sessions.rs
+++ b/rust/loopflow/src/store/sqlite/child_sessions.rs
@@ -4027,7 +4027,18 @@ fn same_task_pr(left: &TaskPr, right: &TaskPr) -> bool {
         && left.base_commit == right.base_commit
         && left.publication == right.publication
         && left.merge_commit == right.merge_commit
-        && left.abandoned_at == right.abandoned_at
+        && same_settle_instant(left.abandoned_at, right.abandoned_at)
+}
+
+/// The column stores unix seconds, so a settle re-presented with the same
+/// wall-clock instant but nanosecond precision is the same settle, not a
+/// conflicting one.
+fn same_settle_instant(
+    left: Option<time::OffsetDateTime>,
+    right: Option<time::OffsetDateTime>,
+) -> bool {
+    left.map(time::OffsetDateTime::unix_timestamp)
+        == right.map(time::OffsetDateTime::unix_timestamp)
 }
 
 fn invalid_column(


### PR DESCRIPTION
## What

W2-283 wedged with `Task PR pr_8b1b… is already settled differently` on every `lf task status`/`resume`. Two layers, both fixed:

1. **Reconcile re-stamped the abandonment.** The GitHub `closed` observation arm sets `pr.abandoned_at = Some(now)` unconditionally — a fresh timestamp per call — so a PR the flow had already abandoned could never re-settle equal. Now the first abandonment time is preserved; observation confirms the fact rather than restating it.
2. **The settle equality compared at the wrong grain.** `abandoned_at` is stored as unix seconds; comparing `OffsetDateTime`s at nanosecond precision means even an identical in-memory re-settle differs from the read-back row. The new test caught this second layer after the first fix. Equality now compares at the persisted grain.

## Verified
- New store test pins both halves: identical re-settle is idempotent; a drifted (+30s) abandonment time still refuses as a genuine conflict.
- 1551 unit tests green; fmt + clippy --all-targets clean.

Unblocks W2-283 (account-first inversion) once deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)