### PR TITLE
lfd: bound daemon log storage

### DIFF
--- a/docs/ops.md
+++ b/docs/ops.md
@@ -304,7 +304,8 @@ repository contains work created outside Loopflow.
 `lfd` runs a lossless sweep on startup and every 15 minutes. It removes only
 clean landed, remotely deleted, or terminal Task worktrees, prunes stale Git
 registrations, and deletes abandoned `.lf/logs/.tmp*` directories after 24
-hours. Nonterminal Task Sessions and any worktree currently owned by a live
+hours. Its own log is capped at one 8 MiB current file plus one predecessor.
+Nonterminal Task Sessions and any worktree currently owned by a live
 process are protected even when their branch is merged or remotely deleted.
 Disable the fallback sweep explicitly:
 

--- a/rust/loopflow/src/bin/lfd.rs
+++ b/rust/loopflow/src/bin/lfd.rs
@@ -246,6 +246,20 @@ fn main() -> anyhow::Result<()> {
     }
 }
 
+/// Read Linear webhook config from env. `None` when either the secret or the
+/// viewer id is unset/empty — the daemon runs but `/linear/webhook` returns 503.
+fn read_linear_config() -> Option<lfd::LinearConfig> {
+    let secret = std::env::var("LF_LINEAR_WEBHOOK_SECRET").ok()?;
+    let viewer_id = std::env::var("LF_LINEAR_VIEWER_ID").ok()?;
+    if secret.is_empty() || viewer_id.is_empty() {
+        return None;
+    }
+    Some(lfd::LinearConfig {
+        secret: std::sync::Arc::new(secret.into_bytes()),
+        viewer_id: std::sync::Arc::new(viewer_id),
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::{MakeWriter, RotatingLog};
@@ -269,18 +283,4 @@ mod tests {
             b"next"
         );
     }
-}
-
-/// Read Linear webhook config from env. `None` when either the secret or the
-/// viewer id is unset/empty — the daemon runs but `/linear/webhook` returns 503.
-fn read_linear_config() -> Option<lfd::LinearConfig> {
-    let secret = std::env::var("LF_LINEAR_WEBHOOK_SECRET").ok()?;
-    let viewer_id = std::env::var("LF_LINEAR_VIEWER_ID").ok()?;
-    if secret.is_empty() || viewer_id.is_empty() {
-        return None;
-    }
-    Some(lfd::LinearConfig {
-        secret: std::sync::Arc::new(secret.into_bytes()),
-        viewer_id: std::sync::Arc::new(viewer_id),
-    })
 }

--- a/rust/loopflow/src/bin/lfd.rs
+++ b/rust/loopflow/src/bin/lfd.rs
@@ -1,8 +1,132 @@
 use clap::{Parser, Subcommand};
+use std::fs::{File, OpenOptions};
+use std::io::{self, Write};
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+use tracing_subscriber::fmt::MakeWriter;
 use tracing_subscriber::EnvFilter;
 
 use loopflow::lfd;
 use loopflow::store;
+
+const MAX_LOG_BYTES: u64 = 8 * 1024 * 1024;
+
+#[derive(Debug, Clone)]
+struct RotatingLog {
+    state: Arc<Mutex<RotatingLogState>>,
+}
+
+#[derive(Debug)]
+struct RotatingLogState {
+    path: PathBuf,
+    file: Option<File>,
+    bytes: u64,
+    max_bytes: u64,
+}
+
+#[derive(Debug)]
+struct RotatingLogWriter {
+    state: Arc<Mutex<RotatingLogState>>,
+}
+
+impl RotatingLog {
+    fn open(path: PathBuf, max_bytes: u64) -> io::Result<Self> {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let file = OpenOptions::new().create(true).append(true).open(&path)?;
+        let bytes = file.metadata()?.len();
+        Ok(Self {
+            state: Arc::new(Mutex::new(RotatingLogState {
+                path,
+                file: Some(file),
+                bytes,
+                max_bytes,
+            })),
+        })
+    }
+}
+
+impl RotatingLogState {
+    fn rotate_before(&mut self, incoming_bytes: usize) -> io::Result<()> {
+        if self.bytes == 0 || self.bytes.saturating_add(incoming_bytes as u64) <= self.max_bytes {
+            return Ok(());
+        }
+
+        self.file.take();
+        let previous = self.path.with_extension("log.previous");
+        if previous.exists() {
+            std::fs::remove_file(&previous)?;
+        }
+        if self.path.exists() {
+            std::fs::rename(&self.path, previous)?;
+        }
+        self.file = Some(
+            OpenOptions::new()
+                .create(true)
+                .append(true)
+                .open(&self.path)?,
+        );
+        self.bytes = 0;
+        Ok(())
+    }
+}
+
+impl Write for RotatingLogWriter {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        let mut state = self
+            .state
+            .lock()
+            .map_err(|_| io::Error::other("lfd log lock poisoned"))?;
+        state.rotate_before(buf.len())?;
+        let written = state
+            .file
+            .as_mut()
+            .expect("rotating log always owns an open file")
+            .write(buf)?;
+        state.bytes = state.bytes.saturating_add(written as u64);
+        Ok(written)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.state
+            .lock()
+            .map_err(|_| io::Error::other("lfd log lock poisoned"))?
+            .file
+            .as_mut()
+            .expect("rotating log always owns an open file")
+            .flush()
+    }
+}
+
+impl<'a> MakeWriter<'a> for RotatingLog {
+    type Writer = RotatingLogWriter;
+
+    fn make_writer(&'a self) -> Self::Writer {
+        RotatingLogWriter {
+            state: Arc::clone(&self.state),
+        }
+    }
+}
+
+fn daemon_log_path() -> anyhow::Result<PathBuf> {
+    let home = std::env::var_os("LF_HOME")
+        .map(PathBuf::from)
+        .or_else(|| dirs::home_dir().map(|path| path.join(".lf")))
+        .ok_or_else(|| anyhow::anyhow!("cannot resolve Loopflow home for lfd logs"))?;
+    Ok(home.join("logs/lfd.log"))
+}
+
+fn init_tracing() -> anyhow::Result<()> {
+    let filter = EnvFilter::try_from_default_env()
+        .unwrap_or_else(|_| EnvFilter::new("lfd=info,loopflow=info"));
+    let writer = RotatingLog::open(daemon_log_path()?, MAX_LOG_BYTES)?;
+    tracing_subscriber::fmt()
+        .with_env_filter(filter)
+        .with_writer(writer)
+        .init();
+    Ok(())
+}
 
 #[derive(Parser)]
 #[command(name = "lfd")]
@@ -48,13 +172,7 @@ enum Commands {
 }
 
 fn main() -> anyhow::Result<()> {
-    let filter = EnvFilter::try_from_default_env()
-        .unwrap_or_else(|_| EnvFilter::new("lfd=info,loopflow=info"));
-    tracing_subscriber::fmt()
-        .with_env_filter(filter)
-        .with_writer(std::io::stderr)
-        .without_time()
-        .init();
+    init_tracing()?;
 
     let cli = Cli::parse();
     let rt = tokio::runtime::Runtime::new()?;
@@ -125,6 +243,31 @@ fn main() -> anyhow::Result<()> {
             println!("removed lfd service file: {}", path.display());
             Ok(())
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{MakeWriter, RotatingLog};
+    use std::io::Write;
+
+    #[test]
+    fn daemon_log_keeps_only_one_bounded_predecessor() {
+        let directory = tempfile::tempdir().expect("create temp directory");
+        let path = directory.path().join("lfd.log");
+        let log = RotatingLog::open(path.clone(), 8).expect("open log");
+
+        log.make_writer().write_all(b"12345678").expect("write log");
+        log.make_writer().write_all(b"next").expect("rotate log");
+        log.make_writer()
+            .write_all(b"56789")
+            .expect("rotate log again");
+
+        assert_eq!(std::fs::read(&path).expect("read current log"), b"56789");
+        assert_eq!(
+            std::fs::read(path.with_extension("log.previous")).expect("read previous log"),
+            b"next"
+        );
     }
 }
 

--- a/rust/loopflow/src/lfd/service.rs
+++ b/rust/loopflow/src/lfd/service.rs
@@ -63,7 +63,8 @@ fn shell_escape(value: &str) -> String {
 }
 
 /// Render the launchd plist for macOS. `RunAtLoad` + `KeepAlive` keep the daemon
-/// up; `ThrottleInterval` bounds restart churn; logs go to `~/.lf/logs/lfd.log`.
+/// up; `ThrottleInterval` bounds restart churn. `lfd` owns its bounded log;
+/// launchd output is discarded so the service manager cannot duplicate it.
 pub fn render_launchd_plist(spec: &ServiceSpec) -> String {
     let program_args = [
         spec.lfd_path.to_string_lossy().to_string(),
@@ -102,12 +103,6 @@ pub fn render_launchd_plist(spec: &ServiceSpec) -> String {
     } else {
         format!("    <key>EnvironmentVariables</key>\n    <dict>\n{env}    </dict>\n")
     };
-    let log_path = xml_escape(&format!(
-        "{}/.lf/logs/lfd.log",
-        dirs::home_dir()
-            .map(|h| h.to_string_lossy().to_string())
-            .unwrap_or_else(|| "$HOME".to_string())
-    ));
     format!(
         r#"<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -126,9 +121,9 @@ pub fn render_launchd_plist(spec: &ServiceSpec) -> String {
     <key>ThrottleInterval</key>
     <integer>10</integer>
     <key>StandardOutPath</key>
-    <string>{log_path}</string>
+    <string>/dev/null</string>
     <key>StandardErrorPath</key>
-    <string>{log_path}</string>
+    <string>/dev/null</string>
 </dict>
 </plist>
 "#,
@@ -164,18 +159,12 @@ pub fn render_systemd_unit(spec: &ServiceSpec) -> String {
          Restart=on-failure\n\
          RestartSec=5\n\
          {env_lines}\
-         StandardOutput=append:{log_path}\n\
-         StandardError=append:{log_path}\n\n\
+         StandardOutput=null\n\
+         StandardError=null\n\n\
          [Install]\n\
          WantedBy=default.target\n",
         addr = shell_escape(&spec.addr),
         repo = shell_escape(&spec.repo_root.to_string_lossy()),
-        log_path = shell_escape(&format!(
-            "{}/.lf/logs/lfd.log",
-            dirs::home_dir()
-                .map(|h| h.to_string_lossy().to_string())
-                .unwrap_or_else(|| "$HOME".to_string())
-        ))
     )
 }
 
@@ -360,6 +349,7 @@ mod tests {
         assert!(plist.contains("/home/op/src/loopflow</string>"));
         assert!(plist.contains("<key>PATH</key>"));
         assert!(plist.contains("/opt/homebrew/bin:/usr/bin:/bin"));
+        assert_eq!(plist.matches("<string>/dev/null</string>").count(), 2);
         // Secrets must never appear in the file.
         assert!(!plist.contains("WEBHOOK_SECRET"));
         assert!(!plist.contains("VIEWER_ID"));
@@ -374,6 +364,8 @@ mod tests {
         ));
         assert!(unit.contains("Restart=on-failure"));
         assert!(unit.contains("RestartSec=5"));
+        assert!(unit.contains("StandardOutput=null"));
+        assert!(unit.contains("StandardError=null"));
         assert!(unit.contains("Environment=LF_HOME=/home/op/.lf"));
         assert!(unit.contains("Environment=PATH=/opt/homebrew/bin:/usr/bin:/bin"));
         assert!(unit.contains("WantedBy=default.target"));

--- a/scratch/daemon-log-rotation.md
+++ b/scratch/daemon-log-rotation.md
@@ -1,0 +1,9 @@
+# Bound daemon logs
+
+The first live install found `~/.lf/logs/lfd.log` at 385 MiB. launchd and
+systemd were configured to append stdout and stderr forever, so worktree
+recovery itself carried an unbounded file.
+
+Make `lfd` own one 8 MiB current log and one predecessor. Service managers send
+their duplicate stdout/stderr streams to the null sink. Rotation stays inside
+the process, works identically under launchd and systemd, and honors `LF_HOME`.

--- a/scratch/daemon-log-rotation.md
+++ b/scratch/daemon-log-rotation.md
@@ -1,9 +1,0 @@
-# Bound daemon logs
-
-The first live install found `~/.lf/logs/lfd.log` at 385 MiB. launchd and
-systemd were configured to append stdout and stderr forever, so worktree
-recovery itself carried an unbounded file.
-
-Make `lfd` own one 8 MiB current log and one predecessor. Service managers send
-their duplicate stdout/stderr streams to the null sink. Rotation stays inside
-the process, works identically under launchd and systemd, and honors `LF_HOME`.


### PR DESCRIPTION
## Usage

```bash
lfd install --repo /path/to/repo
```

## Summary

Keep daemon logs from becoming another source of disk pressure. `lfd` now owns a bounded 8 MiB current log plus one predecessor, while launchd and systemd stop duplicating output into unbounded service files.

## Changes

- rotate `lfd.log` at 8 MiB and retain one predecessor
- honor `LF_HOME` for the log location
- send launchd/systemd stdout and stderr to the null sink
- cover rotation and service rendering with tests

## Verification

- `cargo test -p loopflow --bin lfd daemon_log_keeps_only_one_bounded_predecessor`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --all -- --check`