### PR TITLE
lf ssh: forward account authority through a fixed lease broker

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ corpus at [/llms-full.txt](https://loopflow.studio/llms-full.txt).
 | [Conducting](docs/conducting.md) | Monitoring and steering many agents; the Mac podium |
 | [Authoring](docs/authoring.md) | Writing skills, flows, directions, and goals |
 | [Architecture](docs/architecture.md) | No server: the store, the journal, Homes, `lf ssh`, `lfd` |
+| [Security](docs/security.md) | Execution boundaries, permissions, credentials, and account authority |
 | [`lf` reference](docs/lf.md) | Every command, PR/planning/release operations, the builtin catalog |
 | [Configuration](docs/config.md) · [Troubleshooting](docs/troubleshooting.md) | Reference |
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -328,30 +328,30 @@ summaries:
 
 ### Accounts and Profiles
 
-Connect providers once, then route each repository through personal profiles:
+Connect providers once, then route each repository through managed accounts:
 
 ```bash
 lf auth status                   # GitHub / Claude / Codex / OpenCode Zen / Linear
 lf auth github                   # connect a provider in your browser
-lf auth connect claude --profile primary@example.com
+lf auth connect claude primary --chrome-profile primary@example.com
 lf auth accounts claude          # list connected accounts
 
-lf profile create primary@example.com --chrome-profile primary@example.com
-lf profile route set \
-  --default primary@example.com \
-  --backup engineering@example.com
-lf profile route show
+lf profile create --chrome-profile primary@example.com --as primary
+lf auth access set claude primary --profile primary
+lf route set claude primary engineering
+lf route show
 ```
 
 Each provider account keeps independent auth and session state under
-`~/.lf/accounts/`. Profiles reuse those accounts and give each repository a
-default plus ordered backups; a provider child stays pinned to its selected
-profile and account for its lifetime. Shared accounts are tried once and share
-one cooldown. Profiles, bindings, and repo routes live in the local database —
-Loopflow ships no account topology.
+`~/.lf/accounts/`. Access profiles record the Chrome venues that can authenticate
+an account; repository routes record the ordered accounts a provider may use. A
+provider child stays pinned to its selected account for its lifetime. Shared
+accounts are tried once and share one cooldown. Profiles, bindings, and repo
+routes live in the local database — Loopflow sends no account topology to a
+central service.
 
-`auth connect --profile` reuses a matching account or creates one, opens the
-profile's bound Chrome directory, and binds the account to the profile. Codex
+`auth connect <provider> <account> --chrome-profile` opens the selected Chrome
+directory and binds the verified login to the managed account. Codex
 verifies the login email from its ID token; Claude uses the selected Chrome
 profile email. `auth import` adopts an existing isolated credential — or the
 current macOS Keychain login when the account home is empty — without another
@@ -369,18 +369,24 @@ lf auth disconnect claude --account <account-id>
 Once `paid-through` passes, automatic routing treats the account as
 `explicit-only` until cleared.
 
-Force one account for a single invocation (children inherit it):
+Prefer accounts for one invocation, or restrict the process tree to exactly the
+selected accounts:
 
 ```bash
 lf -m codex --account eng@example.com : "fix the tests"
-LF_ACCOUNT=jack@example.com lf implement
+lf --account claude=personal --account codex=reserve implement
+lf --only-account codex=reserve review
 ```
 
-`lf ssh <host> -- <cmd>` forwards the repository's ordered profile route and
-each referenced credential once, for the life of that foreground command; it
-writes no credential files on the remote host. Detached remote sessions are
-rejected — their credentials would vanish when SSH exits — so authenticate on
-the remote host for long-running work.
+`--account` keeps the normal provider route as fallback; `--only-account`
+removes every unselected account and provider. Both accept repeatable
+`claude=<selector>` and `codex=<selector>` forms.
+
+`lf ssh <host> -- <cmd>` resolves the selected route locally and forwards an
+opaque handle to a foreground credential broker. It writes no managed provider
+credential files on the remote host. Detached remote sessions are rejected —
+their lease would vanish when SSH exits — so authenticate on the remote host
+for long-running work.
 
 ### External Skills
 

--- a/docs/lf.md
+++ b/docs/lf.md
@@ -456,18 +456,21 @@ lf doctor --json                # machine-readable audit
 ```
 
 ```bash
-lf -m codex --account manabot-eng : "fix the tests"   # this account, this run
-lf -m codex --account manabot-eng --tui               # interactive codex, same session
-LF_ACCOUNT=jack@loopflow.studio lf implement          # exported form, inherited by children
+lf -m codex --account manabot-eng : "fix the tests"   # prefer this account, then route
+lf --account claude=personal --account codex=reserve implement
+lf --only-account codex=reserve review                # no fallback account
 ```
 
-`--account <email|id>` (or `LF_ACCOUNT=`) makes every provider resolution in
-the invocation — and its child lf processes — use the named managed account,
-bypassing the repo route and cooldown gating. The credential is still
-verified, so a revoked account errors with the re-login fix. Use it for
-interactive vendor sessions too (`--tui`): logging into a managed account
-with a bare `codex login` creates a second session and evicts the managed
-one ("needs re-login"); entering through lf shares one session.
+`--account <email|id>` prefers each matching managed account before its
+provider's normal route. The first preferred attempt bypasses stored health;
+a missing credential continues through the healthy fallback route.
+`--only-account` restricts the invocation and its children to exactly the
+selected provider accounts. Both flags are repeatable and accept
+`claude=<selector>` or `codex=<selector>`. They cannot be combined.
+
+Use the flags for interactive vendor sessions too (`--tui`): logging into a
+managed account with a bare `codex login` creates a second session and evicts
+the managed one ("needs re-login"); entering through lf shares one session.
 
 `lf usage` leads with each managed account's subscription state — provider-
 reported plan, session and weekly windows as percent *used*, reset times —
@@ -478,6 +481,10 @@ live poll when older than 15 minutes. `--refresh` polls everything now;
 per-boundary delta rows; TOTAL is input+output with cache reads their own
 column, and `% TOKENS` is each row's slice of all tokens in the window — a
 distribution across repos, not a subscription measure.
+
+Under forwarded account authority, subscription polling is unavailable so the
+remote account store is never consulted. `lf usage` still prints process token
+spend from the local execution ledger.
 
 A run is one agent-backed skill invocation. It owns the context, model, token,
 cost, and outcome evidence. An exec is one `lf` process; nested execs share a

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,0 +1,192 @@
+---
+layout: default
+title: Security
+---
+
+# Security
+
+Run trusted personal work directly:
+
+```bash
+lf implement
+```
+
+Put unattended or untrusted work behind an OS boundary you control:
+
+```bash
+# The remote user, container, or VM owns the filesystem and network boundary.
+lf ssh agent@build-vm -- lf task pursue
+```
+
+For sensitive infrastructure, combine that boundary with narrow mounts, network
+policy, and scoped credentials. `lf ssh` enters the environment; it does not
+create a sandbox around it.
+
+Four controls answer different questions:
+
+1. **Execution boundary:** which files, processes, and networks the OS permits.
+2. **Action policy:** which vendor tools run automatically or ask first.
+3. **Identity:** which accounts and external systems the process tree can use.
+4. **Workflow review:** when kickoff, iterate, and gate sessions involve a human.
+
+Only the first is general containment. Review and shipping decisions make work
+legible; they do not contain hostile code.
+
+## Choose the execution boundary
+
+Loopflow launches vendor agents and ordinary host processes with the authority
+of the user running `lf`. The useful boundary is therefore a laptop account, a
+dedicated Unix user, a container, or a VM. Apply filesystem mounts, network
+rules, process limits, and credential access at that boundary.
+
+A Git worktree separates changes but is not a security sandbox. Claude and
+Codex worktree sessions also receive write access to the main repository's Git
+metadata so normal Git operations work.
+
+The same boundary covers subprocesses, repository hooks, MCP servers, plugins,
+skills, browser tools, and commands an agent launches. Run repository
+instructions and extensions as code from sources you trust.
+
+## Know the effective action policy
+
+Loopflow chooses an automation floor for headless work:
+
+- Codex gets `workspace-write`; non-interactive runs also get approval policy
+  `never`.
+- Non-interactive Claude runs skip permission prompts.
+- Non-interactive OpenCode receives `permission: allow`.
+- More-permissive vendor configuration remains more permissive.
+- Less-permissive vendor configuration is raised to this floor with a warning.
+
+Interactive launches retain the vendor's interactive approval behavior where
+possible. `yolo: true` selects the vendor's full bypass mode; for Codex that
+also disables its sandbox. See [Configuration](/docs/config#yolo) for the exact
+vendor flags.
+
+These modes govern vendor tool behavior. They do not narrow the OS user,
+network, browser, MCP, or credential boundary around the whole process tree.
+
+Skills can edit, commit, push, land a PR, deploy, or update GitHub and Linear
+when the matching tool and credential are present. A gate may decide that work
+is ready to ship. The LLM session still performs the merge or release action;
+the GitHub merge button is not a separate lifecycle authority.
+
+## Select local accounts for remote work
+
+Prefer an account without removing the normal provider route:
+
+```bash
+lf --account reserve ssh mini -- lf task pursue
+
+lf --account claude=personal \
+  --account codex=reserve \
+  ssh mini \
+  -- lf task pursue
+```
+
+`--account` tries each matching managed account once before that provider's
+normal local route. An unqualified selector matches account IDs or login emails
+independently for Claude and Codex. Providers with no match keep their normal
+routes.
+
+Restrict the process tree to exact accounts:
+
+```bash
+lf --only-account claude=personal \
+  --only-account codex=reserve \
+  ssh mini \
+  -- lf task pursue
+```
+
+`--only-account` removes every unselected account. A provider without a
+selected account is unavailable. The two flags cannot be combined. The same
+flags apply to local invocations:
+
+```bash
+lf --account codex=reserve implement
+lf --only-account claude=personal review
+```
+
+### What crosses SSH
+
+Loopflow resolves managed Claude and Codex accounts on the origin machine. The
+remote process receives an opaque, short-lived lease handle. SSH
+reverse-forwards an owner-only Unix socket to a broker owned by the foreground
+`lf ssh` process. A provider launch receives only its selected credential.
+
+When no managed route exists, `lf ssh` preserves the ambient-login fallback:
+it forwards the extracted Claude or Codex access token in the remote process
+environment. Configure a managed route or pass `--only-account` when provider
+authority must stay behind the broker.
+
+Nested `lf` processes inherit the same fixed grant through the handle. They
+cannot widen, narrow, or reorder it; nested `--account` and `--only-account`
+flags fail. A resumed provider session stays on its recorded account when that
+account belongs to the grant.
+
+Broker failure, a missing credential, and an expired handle fail closed. During
+a lease, remote managed accounts and routes are not consulted. `lf auth
+accounts` and `lf route show` display only the forwarded view. Access-profile
+inspection and all authentication, account, and route edits are rejected.
+`lf usage` skips subscription polling and still reports process token spend.
+Before the target command starts, the remote `lf` proves it understands the
+lease and can reach the broker; an incompatible binary fails closed.
+
+The broker closes with the foreground SSH process. Common detached forms such
+as `tmux`, `screen`, `nohup`, `systemd-run`, and `--detach` are rejected, and a
+lease inherited by a child cannot be re-forwarded over SSH. Put `lf ssh` on the
+outer account-selected invocation; this also rules out a second SSH hop. A
+background process that survives the outer command loses broker access when SSH
+exits. Provider credentials are not placed in argv, logs, remote account homes,
+keychains, or durable Loopflow stores. Temporary sockets are removed during
+normal cleanup.
+
+The remote host and processes running as the same remote OS user are inside the
+lease trust boundary. They can use its handle while it lives. Use a dedicated
+user, container, VM, or credential-free home when same-user code must not reach
+ambient remote credentials.
+
+## Forward other credentials deliberately
+
+`lf ssh` forwards the current GitHub credential for HTTPS Git operations and the
+managed Linear credential used by `lf pm`. They are process-environment
+capabilities available inside the remote user boundary; same-user code can copy
+or retain them. SSH agent forwarding stays off unless `--forward-agent` is
+explicit.
+
+Forward one Doppler secret by name:
+
+```bash
+lf ssh mini --secret SENTRY_AUTH_TOKEN -- lf release check
+```
+
+The Doppler CLI resolves that value on the origin machine. Only the requested
+secret crosses SSH. The Doppler master credential never does.
+
+Managed provider tokens are encrypted in the local store. The key uses the
+macOS Keychain or Linux secret service when available, with an owner-only local
+file fallback.
+
+## Account for stored and transmitted data
+
+Prompts, selected repository context, tool results, and conversation data go to
+the configured model provider as part of an agent run. Browser tools, MCP
+servers, GitHub, Linear, and other integrations receive the data sent to them by
+their commands.
+
+Loopflow keeps a local execution ledger plus prompt and conversation artifacts.
+Trace directories are owner-only (`0700`) and artifact files are `0600`.
+`lf trace --content` deliberately reads the exact captured prompt and
+conversation. Provider or tool output can contain sensitive material, so treat
+the trace store as sensitive even though it is local.
+
+## Keep network services inside their intended boundary
+
+`lfd` listens on `127.0.0.1` by default and uses a machine-local capability
+token. It is not a remote multi-user identity system. Use SSH for remote
+operation. A non-loopback bind is an explicit local-network experiment and
+requires a bearer token; see [lfd](/docs/lfd).
+
+Repository instructions, skills, plugins, MCP servers, browser connections,
+hooks, and installers can all extend what an agent can reach. Review their
+source and configuration before adding them to a high-authority environment.

--- a/rust/loopflow/src/bin/lf.rs
+++ b/rust/loopflow/src/bin/lf.rs
@@ -560,6 +560,28 @@ impl Drop for EnvGuard {
     }
 }
 
+/// Build a local, in-process account-lease broker for a non-`ssh` command that
+/// carries `--account`/`--only-account`, exporting the opaque `LF_ACCOUNT_LEASE`
+/// handle so this process and its children resolve one credential through it.
+/// Returns `None` when the selection resolves to no grant. The returned broker
+/// and env guard must outlive the command.
+fn build_local_account_lease(
+    selection: &loopflow::provider_account::lease::AccountSelection,
+) -> anyhow::Result<
+    Option<(
+        loopflow::provider_account::lease::AccountLeaseBroker,
+        EnvGuard,
+    )>,
+> {
+    use loopflow::provider_account::lease;
+    let runtime = tokio::runtime::Runtime::new()?;
+    let Some(broker) = runtime.block_on(lease::AccountLeaseBroker::start_root(selection))? else {
+        return Ok(None);
+    };
+    let guard = EnvGuard::set(lease::ACCOUNT_LEASE_ENV, broker.local_env_value()?);
+    Ok(Some((broker, guard)))
+}
+
 fn parse_duration(value: &str) -> anyhow::Result<std::time::Duration> {
     let value = value.trim();
     let (number, multiplier) = if let Some(number) = value.strip_suffix('s') {
@@ -1377,14 +1399,18 @@ fn main() -> anyhow::Result<()> {
             wave.name().to_string(),
         )
     });
-    // Explicit account selection rides the environment so every provider
-    // resolution in this invocation — and its child lf processes — honors it.
-    let _explicit_account_env = cli.account.as_deref().map(|account| {
-        EnvGuard::set(
-            loopflow::provider_account::PROVIDER_ACCOUNT_ENV,
-            account.to_string(),
-        )
-    });
+    // `--account`/`--only-account` are resolved once at the outer invocation.
+    // Under an already-forwarded lease the grant is fixed, so a nested
+    // selection is rejected rather than silently re-derived.
+    let account_selection = loopflow::provider_account::lease::AccountSelection::from_flags(
+        &cli.account,
+        &cli.only_account,
+    )?;
+    loopflow::provider_account::lease::validate_account_selection(&account_selection)?;
+    if cli.account_lease_probe {
+        return loopflow::provider_account::lease::probe_forwarded_authority()
+            .map_err(anyhow::Error::from);
+    }
     debug!(?cli, "parsed CLI arguments");
 
     // Global-promotion commands dispatch before home routing, journal emission,
@@ -1402,12 +1428,26 @@ fn main() -> anyhow::Result<()> {
     // dispatch. A remote (SSH) home forwards over `lf ssh`; a local or absent home
     // falls through and runs in-process exactly as before.
     if let Some(command) = &cli.command {
-        if let Some(routed) =
-            loopflow::lf::commands::home::route(command, cli.wave.as_deref(), &args)
-        {
+        if let Some(routed) = loopflow::lf::commands::home::route(
+            command,
+            cli.wave.as_deref(),
+            &account_selection,
+            &args,
+        ) {
             return routed;
         }
     }
+
+    // SSH and remote-Home commands build and forward their broker in the
+    // transport path. Every local command with a selection gets an in-process
+    // broker here, after early install and Home routing have had their chance
+    // to dispatch without opening the ordinary account store.
+    let is_ssh = matches!(cli.command, Some(loopflow::lf::Commands::Ssh { .. }));
+    let _local_account_lease = if is_ssh || account_selection.is_default() {
+        None
+    } else {
+        build_local_account_lease(&account_selection)?
+    };
 
     let result = if cli.list {
         in_repo_runtime(&args, |_| loopflow::lf::commands::list::show_all())
@@ -1702,9 +1742,14 @@ fn main() -> anyhow::Result<()> {
                 secret,
                 forward_agent,
                 cmd,
-            }) => {
-                loopflow::lf::commands::ssh::run(host, repo.as_deref(), secret, *forward_agent, cmd)
-            }
+            }) => loopflow::lf::commands::ssh::run(
+                host,
+                repo.as_deref(),
+                secret,
+                *forward_agent,
+                &account_selection,
+                cmd,
+            ),
             Some(Commands::Flow { name, args: rest }) => {
                 require_target_kind(name, TargetKind::Flow)?;
                 let message = join_args(rest);
@@ -2002,6 +2047,32 @@ mod tests {
         ];
         let result = reorder_args(args);
         assert_eq!(result, vec!["lf", "-m", "codex", "debug"]);
+    }
+
+    #[test]
+    fn reorder_args_repeatable_account_flags_after_skill() {
+        let args = [
+            "lf",
+            "implement",
+            "--account",
+            "claude=personal",
+            "--account",
+            "codex=reserve",
+        ]
+        .map(String::from)
+        .to_vec();
+
+        assert_eq!(
+            reorder_args(args),
+            vec![
+                "lf",
+                "--account",
+                "claude=personal",
+                "--account",
+                "codex=reserve",
+                "implement"
+            ]
+        );
     }
 
     #[test]

--- a/rust/loopflow/src/engine/agent.rs
+++ b/rust/loopflow/src/engine/agent.rs
@@ -944,7 +944,7 @@ pub fn launch_agent(
         .map_err(|error| {
             CoreError::ExecutionFailed(format!("failed to select provider account: {error}"))
         })?
-        .and_then(crate::provider_account::ProviderAccountResolution::into_route);
+        .flatten();
     if account_route
         .as_ref()
         .is_some_and(crate::provider_account::ProviderAccountRoute::uses_native_home)

--- a/rust/loopflow/src/engine/process.rs
+++ b/rust/loopflow/src/engine/process.rs
@@ -677,10 +677,7 @@ pub(crate) async fn start_lf_session_with_env(
     argv: &[String],
     env: &[(&str, &str)],
 ) -> Result<()> {
-    reject_detached_forwarded_account(
-        std::env::var_os(crate::provider_account::FORWARDED_ACCOUNT_BUNDLE_ENV)
-            .is_some_and(|value| !value.is_empty()),
-    )?;
+    reject_detached_forwarded_account(crate::provider_account::lease::account_lease_active())?;
     let context = pinned_execution_context()?;
     let inherited_context = ["LF_RUN_ID", "LF_PROCESS_ID"]
         .into_iter()

--- a/rust/loopflow/src/harness/claude.rs
+++ b/rust/loopflow/src/harness/claude.rs
@@ -99,9 +99,7 @@ impl Harness for ClaudeHarness {
             .expect("claude provider session id lock poisoned")
             .clone();
         let account_route =
-            resolve_provider_account(Provider::Claude, requested_session.as_deref())
-                .await?
-                .into_route();
+            resolve_provider_account(Provider::Claude, requested_session.as_deref()).await?;
         if account_route
             .as_ref()
             .is_some_and(|route| !route.resume_requested_session())

--- a/rust/loopflow/src/harness/codex.rs
+++ b/rust/loopflow/src/harness/codex.rs
@@ -600,9 +600,8 @@ impl Harness for CodexHarness {
         self.launch = Some(config.clone());
         self.should_seed_prompt = true;
         let requested_session = self.resume_provider_session_id.clone();
-        let account_route = resolve_provider_account(Provider::Codex, requested_session.as_deref())
-            .await?
-            .into_route();
+        let account_route =
+            resolve_provider_account(Provider::Codex, requested_session.as_deref()).await?;
         self.resume_provider_session_id = match &account_route {
             Some(route) if route.resume_requested_session() => requested_session,
             Some(_) => None,

--- a/rust/loopflow/src/lf/commands/auth.rs
+++ b/rust/loopflow/src/lf/commands/auth.rs
@@ -64,6 +64,16 @@ pub fn run(cmd: &AuthCommand) -> Result<()> {
 }
 
 async fn run_async(cmd: &AuthCommand) -> Result<()> {
+    if crate::provider_account::lease::account_lease_active() {
+        return match cmd {
+            AuthCommand::Status { provider } | AuthCommand::Accounts { provider } => {
+                forwarded_accounts(provider.as_deref())
+            }
+            _ => Err(anyhow!(
+                "provider account authentication and account edits are unavailable while account authority is fixed by an outer invocation"
+            )),
+        };
+    }
     match cmd {
         AuthCommand::Status { provider } => status(provider.as_deref()).await,
         AuthCommand::Disconnect { provider, account } => match account {
@@ -124,6 +134,32 @@ async fn run_async(cmd: &AuthCommand) -> Result<()> {
             connect(provider).await
         }
     }
+}
+
+fn forwarded_accounts(raw_provider: Option<&str>) -> Result<()> {
+    let provider = raw_provider.map(parse_managed_provider).transpose()?;
+    let client = crate::provider_account::lease::AccountLeaseClient::from_env()?
+        .ok_or_else(|| anyhow!("forwarded account lease is unavailable"))?;
+    let lease = client.describe()?;
+    for grant in lease
+        .grants
+        .iter()
+        .filter(|grant| provider.is_none_or(|provider| provider == grant.provider))
+    {
+        for (position, account_id) in grant.accounts.iter().enumerate() {
+            let mut labels = vec!["forwarded"];
+            if position < grant.preferred {
+                labels.push("preferred");
+            }
+            println!(
+                "{:<12} {} {}",
+                grant.provider,
+                account_id,
+                labels.join(" · ")
+            );
+        }
+    }
+    Ok(())
 }
 
 async fn status(provider: Option<&str>) -> Result<()> {
@@ -1442,14 +1478,13 @@ mod account_first_tests {
     use base64::Engine;
 
     use super::{
-        connect_account, exhausted_access_profiles_error, verify_provider_login,
+        connect_account, exhausted_access_profiles_error, run, verify_provider_login,
         TEST_ACCESS_PROFILE_FAILURES, TEST_OPENED_CHROME_PROFILES,
     };
+    use crate::lf::AuthCommand;
     use crate::profile::{AccessProfile, EmailAddress, ProfileId};
-    use crate::provider_account::{
-        account_home_path, parse_account_id, FORWARDED_ACCOUNT_BUNDLE_ENV,
-        FORWARDED_ACCOUNT_STORE_ENV,
-    };
+    use crate::provider_account::lease::ACCOUNT_LEASE_ENV;
+    use crate::provider_account::{account_home_path, parse_account_id};
     use crate::provider_auth::Provider;
     use crate::store::{open_store, CredentialState, ProviderAccount, RoutingState, StorageConfig};
     use tempfile::tempdir;
@@ -1476,6 +1511,21 @@ mod account_first_tests {
                 }
             }
         }
+    }
+
+    #[test]
+    fn fixed_account_authority_rejects_account_mutation() {
+        let _lock = crate::journal::test_env_lock();
+        let _restore = EnvRestore::capture(&[ACCOUNT_LEASE_ENV]);
+        std::env::set_var(ACCOUNT_LEASE_ENV, "forwarded");
+
+        let error = run(&AuthCommand::Reset {
+            provider: "codex".to_string(),
+            account: "reserve".to_string(),
+        })
+        .unwrap_err();
+
+        assert!(error.to_string().contains("fixed by an outer invocation"));
     }
 
     fn configure_connect_test(temp: &Path, reported_login: &str, fail_first: bool) {
@@ -1526,8 +1576,7 @@ cp "$LF_TEST_CODEX_AUTH_JSON" "$CODEX_HOME/auth.json"
         std::env::set_var("HOME", temp);
         std::env::set_var("LF_HOME", temp);
         std::env::remove_var("LF_DB_PATH");
-        std::env::remove_var(FORWARDED_ACCOUNT_BUNDLE_ENV);
-        std::env::remove_var(FORWARDED_ACCOUNT_STORE_ENV);
+        std::env::remove_var(ACCOUNT_LEASE_ENV);
         std::env::set_var("LF_TEST_CODEX_AUTH_JSON", auth_json);
         std::env::set_var("LF_TEST_CODEX_COUNT", temp.join("codex-count"));
         std::env::set_var("LF_TEST_CODEX_HOMES", temp.join("codex-homes"));
@@ -1601,8 +1650,7 @@ cp "$LF_TEST_CODEX_AUTH_JSON" "$CODEX_HOME/auth.json"
             "LF_HOME",
             "LF_DB_PATH",
             "PATH",
-            FORWARDED_ACCOUNT_BUNDLE_ENV,
-            FORWARDED_ACCOUNT_STORE_ENV,
+            ACCOUNT_LEASE_ENV,
             "LF_TEST_CODEX_AUTH_JSON",
             "LF_TEST_CODEX_COUNT",
             "LF_TEST_CODEX_HOMES",
@@ -1661,8 +1709,7 @@ cp "$LF_TEST_CODEX_AUTH_JSON" "$CODEX_HOME/auth.json"
             "LF_HOME",
             "LF_DB_PATH",
             "PATH",
-            FORWARDED_ACCOUNT_BUNDLE_ENV,
-            FORWARDED_ACCOUNT_STORE_ENV,
+            ACCOUNT_LEASE_ENV,
             "LF_TEST_CODEX_AUTH_JSON",
             "LF_TEST_CODEX_COUNT",
             "LF_TEST_CODEX_HOMES",
@@ -1723,8 +1770,7 @@ cp "$LF_TEST_CODEX_AUTH_JSON" "$CODEX_HOME/auth.json"
             "LF_HOME",
             "LF_DB_PATH",
             "PATH",
-            FORWARDED_ACCOUNT_BUNDLE_ENV,
-            FORWARDED_ACCOUNT_STORE_ENV,
+            ACCOUNT_LEASE_ENV,
             "LF_TEST_CODEX_AUTH_JSON",
             "LF_TEST_CODEX_COUNT",
             "LF_TEST_CODEX_HOMES",

--- a/rust/loopflow/src/lf/commands/home.rs
+++ b/rust/loopflow/src/lf/commands/home.rs
@@ -24,6 +24,7 @@ use crate::engine::wave_home::{
 };
 use crate::lf::commands::util::find_repo_root;
 use crate::lf::{Commands, HomeCommand};
+use crate::provider_account::lease::AccountSelection;
 
 /// `lf home <probe|start>` — the shared Home control path for any surface.
 pub fn run(cmd: &HomeCommand, repo: &Path) -> anyhow::Result<()> {
@@ -108,6 +109,7 @@ fn print_runtime(name: &str, runtime: &HomeRuntimeDto) {
 pub fn route(
     command: &Commands,
     wave: Option<&str>,
+    account_selection: &AccountSelection,
     args: &[String],
 ) -> Option<anyhow::Result<()>> {
     if !is_routable(command) {
@@ -124,6 +126,7 @@ pub fn route(
         &dest,
         home.ssh_port(),
         None,
+        account_selection,
         &remote_argv(args),
     ))
 }
@@ -169,17 +172,35 @@ fn resolve_home(wave: Option<&str>) -> WaveHome {
 
 /// Rebuild the invocation as an `lf` command for the remote shell: the local
 /// `argv[0]` is an absolute path to this machine's binary, so replace it with
-/// bare `lf` (resolved against the remote PATH) and keep every other argument.
+/// bare `lf` (resolved against the remote PATH). Account-selection flags are
+/// consumed at this origin boundary: the remote invocation inherits the fixed
+/// lease handle and must not try to resolve the selectors again.
 fn remote_argv(args: &[String]) -> Vec<String> {
     let mut cmd = Vec::with_capacity(args.len());
     cmd.push("lf".to_string());
-    cmd.extend(args.iter().skip(1).cloned());
+    let mut args = args.iter().skip(1);
+    while let Some(arg) = args.next() {
+        if arg == "--" {
+            cmd.push(arg.clone());
+            cmd.extend(args.cloned());
+            break;
+        }
+        if matches!(arg.as_str(), "--account" | "--only-account") {
+            let _ = args.next();
+            continue;
+        }
+        if arg.starts_with("--account=") || arg.starts_with("--only-account=") {
+            continue;
+        }
+        cmd.push(arg.clone());
+    }
     cmd
 }
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use super::{is_routable, remote_argv};
+    use crate::lf::Commands;
 
     #[test]
     fn remote_argv_swaps_the_binary_path_for_bare_lf() {
@@ -189,6 +210,38 @@ mod tests {
             "open".to_string(),
         ];
         assert_eq!(remote_argv(&args), vec!["lf", "pr", "open"]);
+    }
+
+    #[test]
+    fn remote_argv_consumes_account_selectors_at_the_origin_boundary() {
+        let args = vec![
+            "/local/lf",
+            "--account",
+            "claude=personal",
+            "--only-account=codex=reserve",
+            "commit",
+            "-m",
+            "ship it",
+            "--",
+            "--account",
+            "literal",
+        ]
+        .into_iter()
+        .map(str::to_string)
+        .collect::<Vec<_>>();
+
+        assert_eq!(
+            remote_argv(&args),
+            vec![
+                "lf",
+                "commit",
+                "-m",
+                "ship it",
+                "--",
+                "--account",
+                "literal"
+            ]
+        );
     }
 
     #[test]

--- a/rust/loopflow/src/lf/commands/profile.rs
+++ b/rust/loopflow/src/lf/commands/profile.rs
@@ -14,6 +14,11 @@ use crate::repository::RepoId;
 use crate::store::{ProviderAccount, ProviderAccountId, SharedStore};
 
 pub fn run(cmd: &ProfileCommand, _repo_root: &Path) -> Result<()> {
+    if crate::provider_account::lease::account_lease_active() {
+        return Err(anyhow!(
+            "access-profile inspection and edits are unavailable while account authority is fixed by an outer invocation"
+        ));
+    }
     let runtime = tokio::runtime::Runtime::new().context("failed to create async runtime")?;
     runtime.block_on(run_async(cmd))
 }
@@ -36,6 +41,14 @@ async fn run_async(cmd: &ProfileCommand) -> Result<()> {
 }
 
 async fn run_route_async(cmd: &RouteCommand, repo_root: &Path) -> Result<()> {
+    if crate::provider_account::lease::account_lease_active() {
+        return match cmd {
+            RouteCommand::Show { .. } => show_forwarded_routes(),
+            _ => Err(anyhow!(
+                "provider route edits are unavailable while account authority is fixed by an outer invocation"
+            )),
+        };
+    }
     let store = open_account_store().await?;
     match cmd {
         RouteCommand::Set {
@@ -53,6 +66,24 @@ async fn run_route_async(cmd: &RouteCommand, repo_root: &Path) -> Result<()> {
         },
         RouteCommand::Show { repo } => show_routes(&store, repo_root, repo.as_deref()).await,
     }
+}
+
+fn show_forwarded_routes() -> Result<()> {
+    let client = crate::provider_account::lease::AccountLeaseClient::from_env()?
+        .ok_or_else(|| anyhow!("forwarded account lease is unavailable"))?;
+    let lease = client.describe()?;
+    for grant in lease.grants {
+        println!("{}  (forwarded)", grant.provider);
+        for (position, account_id) in grant.accounts.iter().enumerate() {
+            let preferred = if position < grant.preferred {
+                "  preferred"
+            } else {
+                ""
+            };
+            println!("  {}. {}{preferred}", position + 1, account_id);
+        }
+    }
+    Ok(())
 }
 
 async fn create_profile(
@@ -289,4 +320,49 @@ fn resolve_repo_id(repo_root: &Path, raw_repo: Option<&str>) -> Result<RepoId> {
 
 fn now_unix() -> i64 {
     OffsetDateTime::now_utc().unix_timestamp()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use super::{run, run_route};
+    use crate::lf::{ProfileCommand, RouteCommand};
+    use crate::provider_account::lease::ACCOUNT_LEASE_ENV;
+
+    #[test]
+    fn fixed_account_authority_rejects_profile_and_route_mutation() {
+        let _lock = crate::journal::test_env_lock();
+        let previous = std::env::var_os(ACCOUNT_LEASE_ENV);
+        std::env::set_var(ACCOUNT_LEASE_ENV, "forwarded");
+        let profile = run(
+            &ProfileCommand::Create {
+                chrome_profile: "Profile 1".to_string(),
+                name: None,
+                expects: None,
+            },
+            Path::new("."),
+        );
+        let route = run_route(
+            &RouteCommand::Set {
+                provider: "codex".to_string(),
+                accounts: vec!["reserve".to_string()],
+                repo: None,
+            },
+            Path::new("."),
+        );
+        match previous {
+            Some(value) => std::env::set_var(ACCOUNT_LEASE_ENV, value),
+            None => std::env::remove_var(ACCOUNT_LEASE_ENV),
+        }
+
+        assert!(profile
+            .unwrap_err()
+            .to_string()
+            .contains("fixed by an outer invocation"));
+        assert!(route
+            .unwrap_err()
+            .to_string()
+            .contains("fixed by an outer invocation"));
+    }
 }

--- a/rust/loopflow/src/lf/commands/ssh.rs
+++ b/rust/loopflow/src/lf/commands/ssh.rs
@@ -2,13 +2,12 @@
 //! caller's *local* credentials, resolved per invocation.
 //!
 //! The "bring your auth with you" model: credentials are resolved on this
-//! machine, forwarded into the remote process environment as a stdin preamble
-//! (never in argv, `ps`, or logs), and are NOT persisted on the remote — they
-//! die with the process. The remote host stays a stateless compute surface.
-//! Detached work is rejected when an account bundle is forwarded because it
-//! would outlive that credential lease.
+//! machine. Managed Claude/Codex accounts stay behind a foreground Unix-socket
+//! broker; the remote receives only an opaque lease handle and a provider
+//! process receives only its selected token. Detached work is rejected because
+//! it would outlive that credential lease.
 //!
-//! Forwarded bundle: GitHub (`gh`), Claude/Codex agent OAuth, and — the
+//! Forwarded authority: GitHub (`gh`), Claude/Codex agent OAuth, and — the
 //! capability beyond the shell prototype — the PM/Linear token, which lives in
 //! store rather than the environment. The remote `resolve_pm_token` reads
 //! `LF_FORWARDED_PM_TOKEN` before its (empty) store, so remote `lf pm` works.
@@ -28,9 +27,8 @@ use std::process::{Command, Stdio};
 use anyhow::{anyhow, Context};
 
 use crate::pm::PmProviderKind;
-use crate::provider_account::{
-    encode_forwarded_account_bundle, local_forwarded_account_bundle, ForwardedAccountBundle,
-    FORWARDED_ACCOUNT_BUNDLE_ENV, FORWARDED_ACCOUNT_STORE_ENV, PROVIDER_ACCOUNT_ENV,
+use crate::provider_account::lease::{
+    self, AccountLeaseBroker, AccountLeaseHandle, AccountSelection, PreparedAccountLease,
 };
 use crate::provider_auth::{extract_claude_token, extract_codex_access_token};
 
@@ -39,17 +37,75 @@ pub const DEFAULT_REPO: &str = "src/loopflow";
 
 /// The local credential bundle forwarded to the remote. Absent credentials are
 /// simply not exported — the remote falls back to whatever it can resolve.
-#[derive(Debug, Default, Clone, PartialEq, Eq)]
-pub struct Credentials {
-    pub gh_token: Option<String>,
-    pub claude_token: Option<String>,
-    pub codex_token: Option<String>,
-    pub account_bundle: Option<ForwardedAccountBundle>,
-    pub pm_token: Option<String>,
+#[derive(Default)]
+struct Credentials {
+    gh_token: Option<String>,
+    provider_authority: ProviderAuthority,
+    pm_token: Option<String>,
     /// PM provider the token belongs to (e.g. `linear`).
-    pub pm_provider: Option<String>,
+    pm_provider: Option<String>,
     /// Doppler-backed secrets resolved locally, forwarded as `export NAME=value`.
-    pub secrets: Vec<(String, String)>,
+    secrets: Vec<(String, String)>,
+}
+
+enum ProviderAuthority {
+    Ambient {
+        claude_token: Option<String>,
+        codex_token: Option<String>,
+    },
+    Lease(PreparedAccountLease),
+}
+
+impl Default for ProviderAuthority {
+    fn default() -> Self {
+        Self::Ambient {
+            claude_token: None,
+            codex_token: None,
+        }
+    }
+}
+
+impl Credentials {
+    fn take_account_lease(&mut self) -> Option<PreparedAccountLease> {
+        match std::mem::take(&mut self.provider_authority) {
+            ProviderAuthority::Lease(lease) => Some(lease),
+            ambient @ ProviderAuthority::Ambient { .. } => {
+                self.provider_authority = ambient;
+                None
+            }
+        }
+    }
+}
+
+impl std::fmt::Debug for Credentials {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let provider_authority = match &self.provider_authority {
+            ProviderAuthority::Ambient {
+                claude_token,
+                codex_token,
+            } => format!(
+                "ambient(claude={}, codex={})",
+                claude_token.is_some(),
+                codex_token.is_some()
+            ),
+            ProviderAuthority::Lease(_) => "lease".to_string(),
+        };
+        formatter
+            .debug_struct("Credentials")
+            .field("gh_token", &self.gh_token.is_some())
+            .field("provider_authority", &provider_authority)
+            .field("pm_token", &self.pm_token.is_some())
+            .field("pm_provider", &self.pm_provider)
+            .field(
+                "secrets",
+                &self
+                    .secrets
+                    .iter()
+                    .map(|(name, _)| name)
+                    .collect::<Vec<_>>(),
+            )
+            .finish()
+    }
 }
 
 /// Run `cmd` on `host` in `$HOME/<repo>` with the local credential bundle
@@ -67,6 +123,7 @@ pub fn run(
     repo: Option<&str>,
     secret_names: &[String],
     forward_agent: bool,
+    selection: &AccountSelection,
     cmd: &[String],
 ) -> anyhow::Result<()> {
     if cmd.is_empty() {
@@ -74,7 +131,16 @@ pub fn run(
             "lf ssh needs a command after `--`, e.g. `lf ssh {dest} -- lf pr open`"
         ));
     }
-    run_with_env(dest, None, repo, secret_names, forward_agent, cmd, &[])
+    run_with_env(
+        dest,
+        None,
+        repo,
+        secret_names,
+        forward_agent,
+        selection,
+        cmd,
+        &[],
+    )
 }
 
 /// Run a Wave-home-routed `lf` command on `dest` (an `owner@host` destination)
@@ -86,6 +152,7 @@ pub fn run_routed(
     dest: &str,
     port: Option<u16>,
     repo: Option<&str>,
+    selection: &AccountSelection,
     cmd: &[String],
 ) -> anyhow::Result<()> {
     run_with_env(
@@ -94,6 +161,7 @@ pub fn run_routed(
         repo,
         &[],
         false,
+        selection,
         cmd,
         &[(crate::engine::wave_home::HOME_ROUTED_ENV, "1")],
     )
@@ -109,22 +177,34 @@ pub fn capture_routed(
     port: Option<u16>,
     cmd: &[String],
 ) -> Result<String, SshCaptureError> {
+    if lease::account_lease_active() {
+        return Err(SshCaptureError::Local(
+            "an inherited account lease cannot be re-forwarded over SSH".to_string(),
+        ));
+    }
     let repo = DEFAULT_REPO;
     let runtime = tokio::runtime::Runtime::new()
         .map_err(|error| SshCaptureError::Local(error.to_string()))?;
-    let credentials = runtime
-        .block_on(resolve_credentials(&[]))
+    let mut credentials = runtime
+        .block_on(resolve_credentials(&[], &AccountSelection::default()))
         .map_err(|error| SshCaptureError::Local(error.to_string()))?;
-    reject_detached_account_forwarding(credentials.account_bundle.is_some(), cmd)
+    let account_lease = credentials.take_account_lease();
+    reject_detached_account_forwarding(account_lease.is_some(), cmd)
         .map_err(|error| SshCaptureError::Local(error.to_string()))?;
+    let broker = account_lease
+        .map(AccountLeaseBroker::start)
+        .transpose()
+        .map_err(|error| SshCaptureError::Local(error.to_string()))?;
+    let remote_handle = broker.as_ref().map(AccountLeaseBroker::remote_handle);
     let preamble = build_preamble(
         &credentials,
+        remote_handle.as_ref(),
         dest,
         repo,
         cmd,
         &[(crate::engine::wave_home::HOME_ROUTED_ENV, "1")],
     );
-    run_ssh_capture(dest, port, &preamble)
+    run_ssh_capture(dest, port, broker.as_ref(), &preamble)
 }
 
 /// Why a captured SSH command did not yield usable stdout.
@@ -138,30 +218,87 @@ pub enum SshCaptureError {
     Local(String),
 }
 
+#[allow(clippy::too_many_arguments)]
 fn run_with_env(
     dest: &str,
     port: Option<u16>,
     repo: Option<&str>,
     secret_names: &[String],
     forward_agent: bool,
+    selection: &AccountSelection,
     cmd: &[String],
     extra_env: &[(&str, &str)],
 ) -> anyhow::Result<()> {
+    if lease::account_lease_active() {
+        return Err(anyhow!(
+            "an inherited account lease cannot be re-forwarded over SSH; put `lf ssh` on the outer account-selected invocation"
+        ));
+    }
     let repo = repo.unwrap_or(DEFAULT_REPO);
     let runtime = tokio::runtime::Runtime::new().context("failed to create async runtime")?;
-    let credentials = runtime.block_on(resolve_credentials(secret_names))?;
-    reject_detached_account_forwarding(credentials.account_bundle.is_some(), cmd)?;
-    let preamble = build_preamble(&credentials, dest, repo, cmd, extra_env);
-    run_ssh(dest, port, forward_agent, &preamble)
+    let mut credentials = runtime.block_on(resolve_credentials(secret_names, selection))?;
+    if let ProviderAuthority::Lease(prepared) = &credentials.provider_authority {
+        println!("Account lease: {}", format_account_plan(&prepared.lease));
+    }
+    let account_lease = credentials.take_account_lease();
+    reject_detached_account_forwarding(account_lease.is_some(), cmd)?;
+    let broker = account_lease.map(AccountLeaseBroker::start).transpose()?;
+    let remote_handle = broker.as_ref().map(AccountLeaseBroker::remote_handle);
+    let preamble = build_preamble(
+        &credentials,
+        remote_handle.as_ref(),
+        dest,
+        repo,
+        cmd,
+        extra_env,
+    );
+    let outcome = run_ssh(dest, port, forward_agent, broker.as_ref(), &preamble)?;
+    // `process::exit` skips destructors. Close the broker and remove its local
+    // socket before preserving a nonzero remote command's exact exit code.
+    drop(broker);
+    match outcome {
+        SshOutcome::Success => Ok(()),
+        SshOutcome::CommandFailure(code) => std::process::exit(code),
+        SshOutcome::ConnectionFailure => {
+            unreachable!("run_ssh returns transport failures as errors")
+        }
+    }
+}
+
+fn format_account_plan(lease: &lease::AccountLease) -> String {
+    lease
+        .grants
+        .iter()
+        .map(|grant| {
+            let accounts = grant
+                .accounts
+                .iter()
+                .map(ToString::to_string)
+                .collect::<Vec<_>>();
+            let route = match accounts.as_slice() {
+                [] => "unavailable".to_string(),
+                [account] => account.clone(),
+                [first, rest @ ..] => format!("{first}, then {}", rest.join(", then ")),
+            };
+            format!("{}: {route}", grant.provider.display_name())
+        })
+        .collect::<Vec<_>>()
+        .join("; ")
 }
 
 fn reject_detached_account_forwarding(
-    has_account_bundle: bool,
+    has_account_lease: bool,
     cmd: &[String],
 ) -> anyhow::Result<()> {
-    if has_account_bundle && cmd.first().is_some_and(|program| program == "tmux") {
+    let detached_program = cmd.first().is_some_and(|program| {
+        matches!(
+            program.as_str(),
+            "tmux" | "screen" | "nohup" | "daemon" | "systemd-run"
+        )
+    });
+    if has_account_lease && (detached_program || cmd.iter().any(|arg| arg == "--detach")) {
         return Err(anyhow!(
-            "cannot forward ephemeral provider accounts into a remote tmux command; \
+            "cannot forward ephemeral provider accounts into detached remote work; \
              run the remote command in the foreground or authenticate on the remote host"
         ));
     }
@@ -171,43 +308,26 @@ fn reject_detached_account_forwarding(
 /// Resolve the credential bundle from local sources. Auth tokens that aren't
 /// present resolve to `None`; a `--secret` that can't be resolved is a hard
 /// error (the caller explicitly asked for it). Nothing here prints a value.
-async fn resolve_credentials(secret_names: &[String]) -> anyhow::Result<Credentials> {
+async fn resolve_credentials(
+    secret_names: &[String],
+    selection: &AccountSelection,
+) -> anyhow::Result<Credentials> {
     let home = dirs::home_dir().unwrap_or_else(|| PathBuf::from("."));
     let mut secrets = Vec::with_capacity(secret_names.len());
     for name in secret_names {
         secrets.push((name.clone(), resolve_doppler_secret(name)?));
     }
-    let selector = std::env::var(PROVIDER_ACCOUNT_ENV).ok();
-    if selector
-        .as_deref()
-        .is_some_and(|value| value.trim().is_empty())
-    {
-        return Err(anyhow!(
-            "--account requires a non-empty account id or login email"
-        ));
-    }
-    let account_bundle = match crate::store::open_existing_store().await {
-        Some(store) => {
-            local_forwarded_account_bundle(&std::sync::Arc::new(store), selector.as_deref()).await?
-        }
-        None if selector.is_some() => {
-            return Err(anyhow!("account store unavailable for --account"));
-        }
-        None => None,
-    };
-    let (claude_token, codex_token) = if account_bundle.is_some() {
-        (None, None)
-    } else {
-        (
-            extract_claude_token(&home).map(|token| token.access_token),
-            extract_codex_access_token(&home),
-        )
+    let account_lease = lease::prepare_root_lease(selection).await?;
+    let provider_authority = match account_lease {
+        Some(lease) => ProviderAuthority::Lease(lease),
+        None => ProviderAuthority::Ambient {
+            claude_token: extract_claude_token(&home).map(|token| token.access_token),
+            codex_token: extract_codex_access_token(&home),
+        },
     };
     Ok(Credentials {
         gh_token: resolve_gh_token(),
-        claude_token,
-        codex_token,
-        account_bundle,
+        provider_authority,
         pm_token: resolve_pm_token().await,
         pm_provider: Some(PmProviderKind::Linear.as_str().to_string()),
         secrets,
@@ -283,6 +403,7 @@ fn is_valid_env_name(name: &str) -> bool {
 /// values travel only through this channel, never through argv.
 fn build_preamble(
     credentials: &Credentials,
+    lease_handle: Option<&AccountLeaseHandle>,
     host: &str,
     repo: &str,
     cmd: &[String],
@@ -328,41 +449,50 @@ fn build_preamble(
             sh_quote("!f(){ echo username=x-access-token; echo \"password=$GH_TOKEN\"; };f")
         ));
     }
-    if let Some(token) = nonempty(&credentials.claude_token) {
-        lines.push(format!(
-            "export CLAUDE_CODE_OAUTH_TOKEN={}",
-            sh_quote(token)
-        ));
+    if let ProviderAuthority::Ambient {
+        claude_token,
+        codex_token,
+    } = &credentials.provider_authority
+    {
+        if let Some(token) = nonempty(claude_token) {
+            lines.push(format!(
+                "export CLAUDE_CODE_OAUTH_TOKEN={}",
+                sh_quote(token)
+            ));
+        }
+        if let Some(token) = nonempty(codex_token) {
+            lines.push(format!("export CODEX_ACCESS_TOKEN={}", sh_quote(token)));
+        }
     }
-    if let Some(token) = nonempty(&credentials.codex_token) {
-        lines.push(format!("export CODEX_ACCESS_TOKEN={}", sh_quote(token)));
-    }
-    if let Some(account_bundle) = &credentials.account_bundle {
-        match encode_forwarded_account_bundle(account_bundle) {
-            Ok(bundle) => lines.push(format!(
-                "export {FORWARDED_ACCOUNT_BUNDLE_ENV}={}",
-                sh_quote(&bundle)
+    if let Some(lease_handle) = lease_handle {
+        match lease_handle.encode() {
+            Ok(handle) => lines.push(format!(
+                "export {}={}",
+                lease::ACCOUNT_LEASE_ENV,
+                sh_quote(&handle)
             )),
             Err(error) => lines.push(format!(
                 "echo {} >&2; exit 1",
-                sh_quote(&format!("could not encode provider accounts: {error}"))
+                sh_quote(&format!("could not encode account lease: {error}"))
             )),
         }
-        lines.push(
-            "LF_ACCOUNT_LEASE_DIR=$(mktemp -d \"${TMPDIR:-/tmp}/lf-account.XXXXXX\") || exit 1"
-                .to_string(),
-        );
-        lines.push("export LF_ACCOUNT_LEASE_DIR".to_string());
+        lines.push("unset CLAUDE_CODE_OAUTH_TOKEN ANTHROPIC_API_KEY CLAUDE_CONFIG_DIR".to_string());
+        lines.push("unset CODEX_ACCESS_TOKEN OPENAI_API_KEY CODEX_HOME".to_string());
         lines.push(format!(
-            "export {FORWARDED_ACCOUNT_STORE_ENV}=\"$LF_ACCOUNT_LEASE_DIR/router.db\""
+            "LF_ACCOUNT_LEASE_SOCKET={}",
+            sh_quote(&lease_handle.socket.to_string_lossy())
         ));
         lines.push(
-            "trap 'status=$?; trap - EXIT; rm -rf -- \"$LF_ACCOUNT_LEASE_DIR\"; exit \"$status\"' EXIT"
+            "trap 'status=$?; trap - EXIT; rm -f -- \"$LF_ACCOUNT_LEASE_SOCKET\"; exit \"$status\"' EXIT"
                 .to_string(),
         );
         lines.push("trap 'exit 129' HUP".to_string());
         lines.push("trap 'exit 130' INT".to_string());
         lines.push("trap 'exit 143' TERM".to_string());
+        lines.push(
+            "lf --__account-lease-probe || { echo 'remote lf cannot use the forwarded account lease; install the same loopflow version on both hosts' >&2; exit 1; }"
+                .to_string(),
+        );
     }
     if let Some(token) = nonempty(&credentials.pm_token) {
         lines.push(format!("export LF_FORWARDED_PM_TOKEN={}", sh_quote(token)));
@@ -390,7 +520,9 @@ fn build_preamble(
         .map(|arg| sh_quote(arg))
         .collect::<Vec<_>>()
         .join(" ");
-    lines.push(if credentials.account_bundle.is_some() {
+    // Under a lease the shell must survive the command so its EXIT trap can
+    // remove the forwarded socket; without one, exec saves a process.
+    lines.push(if lease_handle.is_some() {
         remote_cmd
     } else {
         format!("exec {remote_cmd}")
@@ -448,7 +580,12 @@ enum SshOutcome {
 /// `BatchMode=yes` is the primary hang killer: it refuses every interactive
 /// prompt (password, passphrase, unknown host key) rather than blocking on the
 /// tty forever. The timeouts bound the connect handshake and a stalled session.
-fn ssh_args(dest: &str, port: Option<u16>, forward_agent: bool) -> Vec<String> {
+fn ssh_args(
+    dest: &str,
+    port: Option<u16>,
+    forward_agent: bool,
+    broker: Option<&AccountLeaseBroker>,
+) -> Vec<String> {
     let mut args: Vec<String> = Vec::new();
     if forward_agent {
         args.push("-A".to_string());
@@ -456,6 +593,20 @@ fn ssh_args(dest: &str, port: Option<u16>, forward_agent: bool) -> Vec<String> {
     if let Some(port) = port {
         args.push("-p".to_string());
         args.push(port.to_string());
+    }
+    if let Some(broker) = broker {
+        args.push("-R".to_string());
+        args.push(format!(
+            "{}:{}",
+            broker.remote_socket().display(),
+            broker.local_socket().display()
+        ));
+        args.push("-o".to_string());
+        args.push("StreamLocalBindUnlink=yes".to_string());
+        args.push("-o".to_string());
+        args.push("StreamLocalBindMask=0177".to_string());
+        args.push("-o".to_string());
+        args.push("ExitOnForwardFailure=yes".to_string());
     }
     args.push("-o".to_string());
     args.push("BatchMode=yes".to_string());
@@ -492,16 +643,17 @@ fn connection_error(host: &str) -> anyhow::Error {
 }
 
 /// Pipe the preamble into `ssh [-A] <host> bash -s`, streaming stdout/stderr and
-/// propagating the remote exit code. Agent forwarding (`-A`) is opt-in. Bounded
+/// classifying the remote exit code. Agent forwarding (`-A`) is opt-in. Bounded
 /// so an unreachable or misconfigured host fails fast instead of hanging.
 fn run_ssh(
     dest: &str,
     port: Option<u16>,
     forward_agent: bool,
+    broker: Option<&AccountLeaseBroker>,
     preamble: &str,
-) -> anyhow::Result<()> {
+) -> anyhow::Result<SshOutcome> {
     let mut child = Command::new("ssh")
-        .args(ssh_args(dest, port, forward_agent))
+        .args(ssh_args(dest, port, forward_agent, broker))
         .stdin(Stdio::piped())
         .stdout(Stdio::inherit())
         .stderr(Stdio::inherit())
@@ -517,9 +669,8 @@ fn run_ssh(
 
     let status = child.wait().context("ssh did not complete")?;
     match classify_exit(status.code()) {
-        SshOutcome::Success => Ok(()),
+        outcome @ (SshOutcome::Success | SshOutcome::CommandFailure(_)) => Ok(outcome),
         SshOutcome::ConnectionFailure => Err(connection_error(dest)),
-        SshOutcome::CommandFailure(code) => std::process::exit(code),
     }
 }
 
@@ -530,10 +681,11 @@ fn run_ssh(
 fn run_ssh_capture(
     dest: &str,
     port: Option<u16>,
+    broker: Option<&AccountLeaseBroker>,
     preamble: &str,
 ) -> Result<String, SshCaptureError> {
     let mut child = Command::new("ssh")
-        .args(ssh_args(dest, port, false))
+        .args(ssh_args(dest, port, false, broker))
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
@@ -562,121 +714,22 @@ fn run_ssh_capture(
 
 #[cfg(test)]
 mod tests {
-    use std::ffi::OsString;
-    use std::fs;
-
-    use tempfile::tempdir;
-
     use super::*;
-    use crate::provider_account::ForwardedAccountSelection;
 
-    struct EnvRestore(Vec<(&'static str, Option<OsString>)>);
-
-    impl EnvRestore {
-        fn capture(names: &[&'static str]) -> Self {
-            Self(
-                names
-                    .iter()
-                    .map(|name| (*name, std::env::var_os(name)))
-                    .collect(),
-            )
-        }
-    }
-
-    impl Drop for EnvRestore {
-        fn drop(&mut self) {
-            for (name, value) in &self.0 {
-                match value {
-                    Some(value) => std::env::set_var(name, value),
-                    None => std::env::remove_var(name),
-                }
-            }
-        }
-    }
-
-    struct CurrentDirRestore(std::path::PathBuf);
-
-    impl CurrentDirRestore {
-        fn enter(path: &std::path::Path) -> Self {
-            let current = std::env::current_dir().unwrap();
-            std::env::set_current_dir(path).unwrap();
-            Self(current)
-        }
-    }
-
-    impl Drop for CurrentDirRestore {
-        fn drop(&mut self) {
-            std::env::set_current_dir(&self.0).unwrap();
-        }
-    }
-
-    fn full_bundle() -> Credentials {
-        let claude = crate::provider_account::parse_account_id("primary").unwrap();
-        let codex = crate::provider_account::parse_account_id("reserve").unwrap();
+    fn full_credentials() -> Credentials {
         Credentials {
             gh_token: Some("gh-secret".to_string()),
-            claude_token: None,
-            codex_token: None,
-            account_bundle: Some(ForwardedAccountBundle::new(
-                ForwardedAccountSelection::Routed {
-                    repo_id: crate::repository::RepoId::parse("loopflowstudio/loopflow").unwrap(),
-                    routes: vec![
-                        crate::provider_account::ForwardedProviderRoute {
-                            provider: crate::provider_auth::Provider::Claude,
-                            accounts: vec![claude.clone()],
-                        },
-                        crate::provider_account::ForwardedProviderRoute {
-                            provider: crate::provider_auth::Provider::Codex,
-                            accounts: vec![codex.clone()],
-                        },
-                    ],
-                },
-                vec![
-                    crate::provider_account::ForwardedProviderAccount {
-                        provider: crate::provider_auth::Provider::Claude,
-                        account_id: claude.clone(),
-                        login_email: Some(
-                            crate::profile::EmailAddress::parse("personal@example.com").unwrap(),
-                        ),
-                        credential_state: crate::store::CredentialState::Connected,
-                        routing_state: crate::store::RoutingState::Automatic,
-                        plan: Some("max".to_string()),
-                        paid_through: None,
-                        utilization_percent: None,
-                        cooldown_until: None,
-                        cooldown_reason: None,
-                    },
-                    crate::provider_account::ForwardedProviderAccount {
-                        provider: crate::provider_auth::Provider::Codex,
-                        account_id: codex.clone(),
-                        login_email: Some(
-                            crate::profile::EmailAddress::parse("engineering@example.com").unwrap(),
-                        ),
-                        credential_state: crate::store::CredentialState::Connected,
-                        routing_state: crate::store::RoutingState::Automatic,
-                        plan: Some("max".to_string()),
-                        paid_through: None,
-                        utilization_percent: None,
-                        cooldown_until: None,
-                        cooldown_reason: None,
-                    },
-                ],
-                vec![
-                    crate::provider_account::ForwardedProviderCredential::new(
-                        crate::provider_auth::Provider::Claude,
-                        claude,
-                        "claude-primary".to_string(),
-                    ),
-                    crate::provider_account::ForwardedProviderCredential::new(
-                        crate::provider_auth::Provider::Codex,
-                        codex,
-                        "codex-reserve".to_string(),
-                    ),
-                ],
-            )),
+            provider_authority: ProviderAuthority::default(),
             pm_token: Some("linear-secret".to_string()),
             pm_provider: Some("linear".to_string()),
             secrets: vec![("STRIPE_KEY".to_string(), "sk-live-123".to_string())],
+        }
+    }
+
+    fn lease_handle() -> AccountLeaseHandle {
+        AccountLeaseHandle {
+            socket: PathBuf::from("/tmp/lf-account-test.sock"),
+            secret: "test-secret".to_string(),
         }
     }
 
@@ -688,31 +741,60 @@ mod tests {
         assert!(reject_detached_account_forwarding(true, &cmd)
             .unwrap_err()
             .to_string()
-            .contains("remote tmux"));
+            .contains("detached remote work"));
+        assert!(reject_detached_account_forwarding(
+            true,
+            &["lf".to_string(), "wave".to_string(), "--detach".to_string()]
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn inherited_lease_rejects_ssh_before_transport() {
+        let _lock = crate::journal::test_env_lock();
+        let previous = std::env::var_os(lease::ACCOUNT_LEASE_ENV);
+        std::env::set_var(lease::ACCOUNT_LEASE_ENV, "forwarded");
+        let result = run(
+            "must-not-be-reached.invalid",
+            None,
+            &[],
+            false,
+            &AccountSelection::default(),
+            &["true".to_string()],
+        );
+        match previous {
+            Some(value) => std::env::set_var(lease::ACCOUNT_LEASE_ENV, value),
+            None => std::env::remove_var(lease::ACCOUNT_LEASE_ENV),
+        }
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("cannot be re-forwarded over SSH"));
     }
 
     #[test]
     fn preamble_exports_every_credential_and_execs_command() {
         let cmd = vec!["lf".to_string(), "op".to_string(), "pr".to_string()];
-        let preamble = build_preamble(&full_bundle(), "mini-heart", "src/loopflow", &cmd, &[]);
+        let handle = lease_handle();
+        let preamble = build_preamble(
+            &full_credentials(),
+            Some(&handle),
+            "mini-heart",
+            "src/loopflow",
+            &cmd,
+            &[],
+        );
 
         assert!(preamble.contains("export GH_TOKEN='gh-secret'"));
         assert!(!preamble.contains("export CLAUDE_CODE_OAUTH_TOKEN="));
         assert!(!preamble.contains("export CODEX_ACCESS_TOKEN="));
-        let encoded =
-            encode_forwarded_account_bundle(full_bundle().account_bundle.as_ref().unwrap())
-                .unwrap();
-        assert!(preamble.contains(&format!(
-            "export {FORWARDED_ACCOUNT_BUNDLE_ENV}='{}'",
-            encoded
-        )));
+        assert!(preamble.contains(&format!("export {}=", lease::ACCOUNT_LEASE_ENV)));
         assert!(!preamble.contains("claude-primary"));
         assert!(!preamble.contains("codex-reserve"));
         assert!(!preamble.contains("refresh_token"));
         assert!(!preamble.contains("/accounts/"));
-        assert!(preamble.contains("LF_ACCOUNT_LEASE_DIR=$(mktemp -d"));
-        assert!(preamble.contains(&format!("export {FORWARDED_ACCOUNT_STORE_ENV}=")));
-        assert!(preamble.contains("trap - EXIT; rm -rf --"));
+        assert!(preamble.contains("lf --__account-lease-probe"));
+        assert!(preamble.contains("trap - EXIT; rm -f --"));
         assert!(preamble.contains("export LF_FORWARDED_PM_TOKEN='linear-secret'"));
         assert!(preamble.contains("export LF_FORWARDED_PM_PROVIDER='linear'"));
         // Locally-resolved Doppler secret, forwarded by value; no Doppler token.
@@ -730,259 +812,17 @@ mod tests {
         assert!(preamble.trim_end().ends_with("'lf' 'op' 'pr'"));
     }
 
-    #[allow(clippy::await_holding_lock)]
-    #[test]
-    fn foreground_account_lease_removes_its_store_on_command_exit() {
-        let _lock = crate::journal::test_env_lock();
-        let temp = tempdir().unwrap();
-        let bin = temp.path().join("bin");
-        fs::create_dir_all(&bin).unwrap();
-        let ssh = bin.join("ssh");
-        fs::write(&ssh, "#!/bin/sh\nexec bash -s\n").unwrap();
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-
-            let mut permissions = fs::metadata(&ssh).unwrap().permissions();
-            permissions.set_mode(0o755);
-            fs::set_permissions(&ssh, permissions).unwrap();
-        }
-        let _restore = EnvRestore::capture(&["HOME", "PATH"]);
-        std::env::set_var("HOME", temp.path());
-        let path = std::env::var_os("PATH").unwrap_or_default();
-        std::env::set_var(
-            "PATH",
-            std::env::join_paths(std::iter::once(bin).chain(std::env::split_paths(&path))).unwrap(),
-        );
-        let record = temp.path().join("lease-path");
-        let cmd = vec![
-            "sh".to_string(),
-            "-c".to_string(),
-            "printf '%s' \"$LF_ACCOUNT_LEASE_DIR\" > \"$LEASE_RECORD\"; : > \"$LF_FORWARDED_ACCOUNT_STORE\""
-                .to_string(),
-        ];
-        let preamble = build_preamble(
-            &full_bundle(),
-            "host",
-            ".",
-            &cmd,
-            &[("LEASE_RECORD", record.to_str().unwrap())],
-        );
-        run_ssh("host", None, false, &preamble).unwrap();
-        let lease = PathBuf::from(fs::read_to_string(record).unwrap());
-        assert!(!lease.exists());
-        assert!(!lease.join("router.db").exists());
-    }
-
-    #[allow(clippy::await_holding_lock)]
-    #[test]
-    fn explicit_account_reaches_foreground_ssh_outside_a_repository() {
-        let _lock = crate::journal::test_env_lock();
-        let temp = tempdir().unwrap();
-        let bin = temp.path().join("bin");
-        fs::create_dir_all(&bin).unwrap();
-        let transport_input = temp.path().join("ssh-input");
-        let ssh = bin.join("ssh");
-        fs::write(
-            &ssh,
-            format!("#!/bin/sh\ncat > '{}'\n", transport_input.display()),
-        )
-        .unwrap();
-        let codex = bin.join("codex");
-        fs::write(
-            &codex,
-            r#"#!/bin/sh
-IFS= read -r line
-printf '{"id":1,"result":{}}\n'
-IFS= read -r line
-IFS= read -r line
-printf '{"id":2,"result":{"account":null}}\n'
-"#,
-        )
-        .unwrap();
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-
-            for executable in [&ssh, &codex] {
-                let mut permissions = fs::metadata(executable).unwrap().permissions();
-                permissions.set_mode(0o755);
-                fs::set_permissions(executable, permissions).unwrap();
-            }
-        }
-        let _restore = EnvRestore::capture(&[
-            "HOME",
-            "LF_HOME",
-            "LF_DB_PATH",
-            "PATH",
-            crate::provider_account::ACCOUNT_REPO_ID_ENV,
-            PROVIDER_ACCOUNT_ENV,
-            FORWARDED_ACCOUNT_BUNDLE_ENV,
-            FORWARDED_ACCOUNT_STORE_ENV,
-        ]);
-        std::env::set_var("HOME", temp.path());
-        std::env::set_var("LF_HOME", temp.path());
-        let database = temp.path().join("loopflow.db");
-        std::env::set_var("LF_DB_PATH", &database);
-        std::env::remove_var(crate::provider_account::ACCOUNT_REPO_ID_ENV);
-        std::env::remove_var(FORWARDED_ACCOUNT_BUNDLE_ENV);
-        std::env::remove_var(FORWARDED_ACCOUNT_STORE_ENV);
-        std::env::set_var(PROVIDER_ACCOUNT_ENV, "engineering");
-        let path = std::env::var_os("PATH").unwrap_or_default();
-        std::env::set_var(
-            "PATH",
-            std::env::join_paths(std::iter::once(bin).chain(std::env::split_paths(&path))).unwrap(),
-        );
-        let runtime = tokio::runtime::Runtime::new().unwrap();
-        let store = std::sync::Arc::new(
-            runtime
-                .block_on(crate::store::open_store(
-                    &crate::store::StorageConfig::sqlite(database),
-                ))
-                .unwrap(),
-        );
-        let account_home = temp.path().join("accounts/engineering");
-        fs::create_dir_all(&account_home).unwrap();
-        fs::write(
-            account_home.join("auth.json"),
-            r#"{"tokens":{"access_token":"e30.eyJleHAiOjQxMDI0NDQ4MDB9.sig","id_token":"e30.eyJlbWFpbCI6ImVuZ2luZWVyaW5nQGV4YW1wbGUuY29tIn0.sig"}}"#,
-        )
-        .unwrap();
-        let account = crate::provider_account::new_account(
-            crate::provider_auth::Provider::Codex,
-            crate::provider_account::parse_account_id("engineering").unwrap(),
-            account_home,
-            None,
-        );
-        runtime
-            .block_on(store.upsert_provider_account(&account))
-            .unwrap();
-        let outside = temp.path().join("outside");
-        fs::create_dir(&outside).unwrap();
-        let _cwd = CurrentDirRestore::enter(&outside);
-
-        run("host", Some("."), &[], false, &["lf".to_string()]).unwrap();
-
-        let input = fs::read_to_string(transport_input).unwrap();
-        assert!(input.contains(FORWARDED_ACCOUNT_BUNDLE_ENV));
-        assert!(input.trim_end().ends_with("'lf'"));
-    }
-
-    #[allow(clippy::await_holding_lock)]
-    #[test]
-    fn explicit_account_errors_before_ssh_transport() {
-        let _lock = crate::journal::test_env_lock();
-        let temp = tempdir().unwrap();
-        let bin = temp.path().join("bin");
-        fs::create_dir_all(&bin).unwrap();
-        let marker = temp.path().join("ssh-spawned");
-        let ssh = bin.join("ssh");
-        fs::write(
-            &ssh,
-            format!("#!/bin/sh\n: > '{}'\nexit 99\n", marker.display()),
-        )
-        .unwrap();
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-
-            let mut permissions = fs::metadata(&ssh).unwrap().permissions();
-            permissions.set_mode(0o755);
-            fs::set_permissions(&ssh, permissions).unwrap();
-        }
-        let _restore = EnvRestore::capture(&[
-            "HOME",
-            "LF_HOME",
-            "LF_DB_PATH",
-            "PATH",
-            crate::provider_account::ACCOUNT_REPO_ID_ENV,
-            PROVIDER_ACCOUNT_ENV,
-            FORWARDED_ACCOUNT_BUNDLE_ENV,
-            FORWARDED_ACCOUNT_STORE_ENV,
-        ]);
-        std::env::set_var("HOME", temp.path());
-        std::env::set_var("LF_HOME", temp.path());
-        let database = temp.path().join("loopflow.db");
-        std::env::set_var("LF_DB_PATH", &database);
-        std::env::remove_var(crate::provider_account::ACCOUNT_REPO_ID_ENV);
-        let path = std::env::var_os("PATH").unwrap_or_default();
-        std::env::set_var(
-            "PATH",
-            std::env::join_paths(std::iter::once(bin).chain(std::env::split_paths(&path))).unwrap(),
-        );
-        std::env::remove_var(FORWARDED_ACCOUNT_BUNDLE_ENV);
-        std::env::remove_var(FORWARDED_ACCOUNT_STORE_ENV);
-        let runtime = tokio::runtime::Runtime::new().unwrap();
-        let store = std::sync::Arc::new(
-            runtime
-                .block_on(crate::store::open_store(
-                    &crate::store::StorageConfig::sqlite(database),
-                ))
-                .unwrap(),
-        );
-        let command = ["lf".to_string()];
-        let outside = temp.path().join("outside");
-        fs::create_dir(&outside).unwrap();
-        let _cwd = CurrentDirRestore::enter(&outside);
-
-        std::env::set_var(PROVIDER_ACCOUNT_ENV, "   ");
-        let error = run("host", Some("."), &[], false, &command).unwrap_err();
-        assert_eq!(
-            error.to_string(),
-            "--account requires a non-empty account id or login email"
-        );
-        assert!(!marker.exists());
-
-        std::env::set_var(PROVIDER_ACCOUNT_ENV, "missing");
-        let error = run("host", Some("."), &[], false, &command).unwrap_err();
-        assert!(error
-            .to_string()
-            .contains("no managed Claude or Codex account matches 'missing'"));
-        assert!(!marker.exists());
-
-        for account_id in ["engineering-one", "engineering-two"] {
-            let account = crate::provider_account::new_account(
-                crate::provider_auth::Provider::Codex,
-                crate::provider_account::parse_account_id(account_id).unwrap(),
-                temp.path().join("accounts").join(account_id),
-                None,
-            );
-            runtime
-                .block_on(store.upsert_provider_account(&account))
-                .unwrap();
-        }
-        std::env::set_var(PROVIDER_ACCOUNT_ENV, "engineering");
-        let error = run("host", Some("."), &[], false, &command).unwrap_err();
-        assert!(error.to_string().contains(
-            "'engineering' matches several codex accounts: engineering-one, engineering-two"
-        ));
-        assert!(!marker.exists());
-
-        let offline = crate::provider_account::new_account(
-            crate::provider_auth::Provider::Codex,
-            crate::provider_account::parse_account_id("offline").unwrap(),
-            temp.path().join("accounts/offline"),
-            None,
-        );
-        runtime
-            .block_on(store.upsert_provider_account(&offline))
-            .unwrap();
-        std::env::set_var(PROVIDER_ACCOUNT_ENV, "offline");
-        let error = run("host", Some("."), &[], false, &command).unwrap_err();
-        assert!(error.to_string().contains(
-            "no authenticated codex account remains; reconnect 'offline' with `lf auth connect codex offline`"
-        ));
-        assert!(!marker.exists());
-    }
-
     #[test]
     fn preamble_omits_absent_credentials() {
         let creds = Credentials {
-            claude_token: Some("only-claude".to_string()),
+            provider_authority: ProviderAuthority::Ambient {
+                claude_token: Some("only-claude".to_string()),
+                codex_token: None,
+            },
             ..Credentials::default()
         };
         let cmd = vec!["lf".to_string(), "runs".to_string()];
-        let preamble = build_preamble(&creds, "host", "src/loopflow", &cmd, &[]);
+        let preamble = build_preamble(&creds, None, "host", "src/loopflow", &cmd, &[]);
 
         assert!(preamble.contains("export CLAUDE_CODE_OAUTH_TOKEN='only-claude'"));
         assert!(!preamble.contains("GH_TOKEN"));
@@ -997,6 +837,7 @@ printf '{"id":2,"result":{"account":null}}\n'
         let cmd = vec!["lf".to_string(), "pr".to_string(), "open".to_string()];
         let preamble = build_preamble(
             &Credentials::default(),
+            None,
             "mini-heart",
             "src/loopflow",
             &cmd,
@@ -1015,11 +856,21 @@ printf '{"id":2,"result":{"account":null}}\n'
             ..Credentials::default()
         };
         let cmd = vec!["lf".to_string()];
-        let preamble = build_preamble(&creds, "host", "src/loopflow", &cmd, &[]);
+        let preamble = build_preamble(&creds, None, "host", "src/loopflow", &cmd, &[]);
 
         assert!(preamble.contains(r#"export GH_TOKEN='a'\''b; rm -rf ~ #'"#));
         // The dangerous substring never appears unquoted at a statement start.
         assert!(!preamble.contains("\nrm -rf"));
+    }
+
+    #[test]
+    fn credential_debug_output_redacts_values() {
+        let debug = format!("{:?}", full_credentials());
+
+        assert!(!debug.contains("gh-secret"));
+        assert!(!debug.contains("linear-secret"));
+        assert!(!debug.contains("sk-live-123"));
+        assert!(debug.contains("STRIPE_KEY"));
     }
 
     #[test]
@@ -1030,7 +881,7 @@ printf '{"id":2,"result":{"account":null}}\n'
 
     #[test]
     fn ssh_args_bound_the_connection() {
-        let args = ssh_args("jack@mini-heart", None, false);
+        let args = ssh_args("jack@mini-heart", None, false, None);
         // Primary hang killer: never block on an interactive prompt.
         assert!(args.iter().any(|a| a == "BatchMode=yes"));
         // Connect handshake and stalled-session bounds.
@@ -1047,14 +898,14 @@ printf '{"id":2,"result":{"account":null}}\n'
 
     #[test]
     fn ssh_args_pass_an_explicit_port() {
-        let args = ssh_args("jack@host", Some(2222), false);
+        let args = ssh_args("jack@host", Some(2222), false, None);
         let p = args.iter().position(|a| a == "-p").expect("-p present");
         assert_eq!(args[p + 1], "2222");
     }
 
     #[test]
     fn ssh_args_opt_in_agent_forwarding() {
-        let args = ssh_args("host", None, true);
+        let args = ssh_args("host", None, true, None);
         assert_eq!(args.first().unwrap(), "-A");
     }
 

--- a/rust/loopflow/src/lf/commands/usage.rs
+++ b/rust/loopflow/src/lf/commands/usage.rs
@@ -66,6 +66,9 @@ struct AccountStatus {
 /// again when the poll fails. A revoked credential is reported as the fix
 /// (`lf auth connect`), never a blank row.
 async fn account_statuses(refresh: bool, cached: bool) -> Result<Vec<AccountStatus>> {
+    if crate::provider_account::lease::account_lease_active() {
+        anyhow::bail!("subscription usage is unavailable while account authority is fixed by an outer invocation");
+    }
     let store = open_account_store().await?;
     let accounts: Vec<ProviderAccount> = store
         .list_provider_accounts(None)
@@ -447,7 +450,8 @@ fn short_repo(repo: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::{
-        aggregate_spend, format_share, format_window, or_unattributed, short_repo, Totals, UsageRow,
+        account_statuses, aggregate_spend, format_share, format_window, or_unattributed,
+        short_repo, Totals, UsageRow,
     };
     use crate::lf::commands::runs::SpanDto;
     use crate::store::AccountLimitWindow;
@@ -460,6 +464,33 @@ mod tests {
             output_tokens: 1,
             cache_read_tokens: 2,
         }
+    }
+
+    #[test]
+    fn fixed_account_authority_never_reads_ambient_account_usage() {
+        struct RestoreEnv(&'static str, Option<std::ffi::OsString>);
+
+        impl Drop for RestoreEnv {
+            fn drop(&mut self) {
+                if let Some(previous) = &self.1 {
+                    std::env::set_var(self.0, previous);
+                } else {
+                    std::env::remove_var(self.0);
+                }
+            }
+        }
+
+        let _lock = crate::journal::test_env_lock();
+        let name = crate::provider_account::lease::ACCOUNT_LEASE_ENV;
+        let _restore = RestoreEnv(name, std::env::var_os(name));
+        std::env::set_var(name, "forwarded");
+
+        let error = tokio::runtime::Runtime::new()
+            .expect("create test runtime")
+            .block_on(account_statuses(false, true))
+            .err()
+            .expect("fixed account authority must skip ambient account usage");
+        assert!(error.to_string().contains("fixed by an outer invocation"));
     }
 
     #[test]

--- a/rust/loopflow/src/lf/mod.rs
+++ b/rust/loopflow/src/lf/mod.rs
@@ -43,12 +43,21 @@ pub struct Cli {
     #[arg(short = 'm', long = "model", short_alias = 'M')]
     pub model: Option<String>,
 
-    /// Run as this managed provider account (login email or account id),
-    /// overriding the repo's route for this invocation and its children.
+    /// Prefer this managed provider account before the normal route. Repeat to
+    /// select provider-qualified preferences such as `claude=personal`.
     /// Accounts spend; a profile is only the Chrome venue accounts log in
     /// through, so it is never a run-time selector.
-    #[arg(long = "account")]
-    pub account: Option<String>,
+    #[arg(long = "account", conflicts_with = "only_account", global = true)]
+    pub account: Vec<String>,
+
+    /// Restrict this invocation and its children to exactly these managed
+    /// provider accounts. Providers without a selection are unavailable.
+    #[arg(long = "only-account", conflicts_with = "account", global = true)]
+    pub only_account: Vec<String>,
+
+    /// Internal SSH compatibility and broker-connectivity probe.
+    #[arg(long = "__account-lease-probe", hide = true)]
+    pub account_lease_probe: bool,
 
     /// Skip permission prompts
     #[arg(long)]
@@ -539,8 +548,8 @@ pub enum Commands {
     },
     /// Run a command on a remote host carrying your local credentials.
     ///
-    /// Resolves the local credential bundle (GitHub, Claude, PM) and forwards it
-    /// over the ssh channel per-invocation; nothing persists on the remote. The
+    /// Resolves local credentials and forwards a foreground account lease over
+    /// SSH; Loopflow writes no managed provider credential on the remote. The
     /// Doppler token is never forwarded — name specific secrets with `--secret`
     /// to resolve them locally. Example: `lf ssh mini-heart -- lf pr open`.
     Ssh {
@@ -1887,6 +1896,96 @@ mod tests {
                 }
             }) if provider == "claude" && accounts == vec!["loopflow", "primary"]
         ));
+    }
+
+    #[test]
+    fn account_preference_and_restriction_are_distinct_repeatable_flags() {
+        let preferred = Cli::try_parse_from([
+            "lf",
+            "--account",
+            "claude=personal",
+            "--account",
+            "codex=reserve",
+            "skill",
+            "implement",
+        ])
+        .expect("parse account preferences");
+        assert_eq!(preferred.account, vec!["claude=personal", "codex=reserve"]);
+        assert!(preferred.only_account.is_empty());
+
+        let restricted = Cli::try_parse_from([
+            "lf",
+            "--only-account",
+            "claude=personal",
+            "--only-account",
+            "codex=reserve",
+            "skill",
+            "implement",
+        ])
+        .expect("parse account restrictions");
+        assert_eq!(
+            restricted.only_account,
+            vec!["claude=personal", "codex=reserve"]
+        );
+
+        assert!(Cli::try_parse_from([
+            "lf",
+            "--account",
+            "reserve",
+            "--only-account",
+            "reserve",
+            "skill",
+            "implement",
+        ])
+        .is_err());
+    }
+
+    #[test]
+    fn account_lease_probe_is_parseable_but_hidden() {
+        let cli = Cli::try_parse_from(["lf", "--__account-lease-probe"])
+            .expect("parse internal account lease probe");
+        assert!(cli.account_lease_probe);
+        assert!(!Cli::command()
+            .render_long_help()
+            .to_string()
+            .contains("__account-lease-probe"));
+    }
+
+    #[test]
+    fn account_selection_applies_to_ssh_before_or_after_the_host() {
+        let cli = Cli::try_parse_from([
+            "lf",
+            "--account",
+            "reserve",
+            "ssh",
+            "mini",
+            "--",
+            "lf",
+            "task",
+            "pursue",
+        ])
+        .expect("parse SSH account preference");
+
+        assert_eq!(cli.account, vec!["reserve"]);
+        assert!(matches!(
+            cli.command,
+            Some(Commands::Ssh { cmd, .. })
+                if cmd == vec!["lf", "task", "pursue"]
+        ));
+
+        let after_host = Cli::try_parse_from([
+            "lf",
+            "ssh",
+            "mini",
+            "--account",
+            "reserve",
+            "--",
+            "lf",
+            "task",
+            "pursue",
+        ])
+        .expect("parse account preference after SSH host");
+        assert_eq!(after_host.account, vec!["reserve"]);
     }
 
     #[test]

--- a/rust/loopflow/src/ops/task.rs
+++ b/rust/loopflow/src/ops/task.rs
@@ -5660,7 +5660,7 @@ mod tests {
                 "LF_CONTROL_BIN",
                 "LF_CONTROL_HOME",
                 "LF_CONTROL_DB_PATH",
-                crate::provider_account::FORWARDED_ACCOUNT_BUNDLE_ENV,
+                crate::provider_account::lease::ACCOUNT_LEASE_ENV,
             ];
             let previous = keys
                 .into_iter()
@@ -5682,7 +5682,7 @@ mod tests {
             std::env::set_var("LF_CONTROL_BIN", "/usr/bin/true");
             std::env::set_var("LF_CONTROL_HOME", home);
             std::env::set_var("LF_CONTROL_DB_PATH", db);
-            std::env::remove_var(crate::provider_account::FORWARDED_ACCOUNT_BUNDLE_ENV);
+            std::env::remove_var(crate::provider_account::lease::ACCOUNT_LEASE_ENV);
             Self {
                 previous,
                 _bin: bin,

--- a/rust/loopflow/src/provider_account.rs
+++ b/rust/loopflow/src/provider_account.rs
@@ -1,36 +1,35 @@
-//! Host-local provider accounts, selection, and process-lifetime SSH
-//! credential leases for Claude and Codex.
+//! Host-local provider accounts, selection, and process-lifetime credential
+//! leases for Claude and Codex.
 
-use std::collections::{HashMap, HashSet};
+pub mod lease;
+
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::sync::Arc;
 
-use base64::engine::general_purpose::URL_SAFE_NO_PAD;
-use base64::Engine;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
-use crate::profile::{ProviderRoute, RouteScope};
-use crate::provider_auth::{provider_account_auth_status, AuthStatus, Provider};
+use crate::profile::RouteScope;
+use crate::provider_auth::Provider;
 use crate::repository::RepoId;
 use crate::store::{
     open_store, AccountLimitRow, ProviderAccount, ProviderAccountId, SharedStore, StoreError,
 };
 use crate::store::{CredentialState, RoutingState};
 
-pub const FORWARDED_ACCOUNT_BUNDLE_ENV: &str = "LF_FORWARDED_ACCOUNT_BUNDLE";
-pub const FORWARDED_ACCOUNT_STORE_ENV: &str = "LF_FORWARDED_ACCOUNT_STORE";
-pub const ACCOUNT_REPO_ID_ENV: &str = "LF_ACCOUNT_REPO_ID";
-/// Explicit account selection (`lf --account <email|id>`, or exported as
-/// `LF_ACCOUNT=<email|id>`): every provider resolution in this process and
-/// its children uses the named account, bypassing the repo route and health
-/// gating — an explicit human choice.
-pub const PROVIDER_ACCOUNT_ENV: &str = "LF_ACCOUNT";
 const DEFAULT_COOLDOWN_SECS: i64 = 15 * 60;
 const RESET_GRACE_SECS: i64 = 5;
 const STRAINED_UTILIZATION_PERCENT: u8 = 75;
+const PROVIDER_CREDENTIAL_ENV_VARS: [&str; 6] = [
+    "CLAUDE_CODE_OAUTH_TOKEN",
+    "ANTHROPIC_API_KEY",
+    "CLAUDE_CONFIG_DIR",
+    "CODEX_ACCESS_TOKEN",
+    "OPENAI_API_KEY",
+    "CODEX_HOME",
+];
 
 /// The provider-observed limit window that most justifies demoting an account.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -84,21 +83,6 @@ pub(crate) fn order_accounts_by_strain(
         .sort_by_key(|account| is_strained(&account.provider, &account.account_id, limits, now));
 }
 
-/// Bake the same demotion into a forwarded route, so a remote resolver that
-/// cannot see local limit observations still tries healthy accounts first.
-fn order_forwarded_routes_by_strain(
-    routes: &mut [ForwardedProviderRoute],
-    limits: &[AccountLimitRow],
-    now: i64,
-) {
-    for route in routes {
-        let provider = route.provider;
-        route
-            .accounts
-            .sort_by_key(|account_id| is_strained(provider.as_str(), account_id, limits, now));
-    }
-}
-
 #[derive(Debug, Error)]
 pub enum ProviderAccountError {
     #[error("{0}")]
@@ -109,15 +93,15 @@ pub enum ProviderAccountError {
     Store(#[from] StoreError),
     #[error("provider account filesystem failed: {0}")]
     Filesystem(String),
-    #[error("invalid forwarded provider credential bundle: {0}")]
-    ForwardedBundle(String),
+    #[error("invalid forwarded account lease: {0}")]
+    AccountLease(String),
     #[error("cannot forward {provider} account '{account_id}': {reason}")]
     ForwardingCredential {
         provider: Provider,
         account_id: ProviderAccountId,
         reason: String,
     },
-    #[error("provider account runtime failed: {0}")]
+    #[error("{0}")]
     Runtime(String),
     #[error("no authenticated {provider} account remains; reconnect {accounts}")]
     NoAuthenticatedAccount {
@@ -131,97 +115,8 @@ pub enum ProviderAccountError {
     },
 }
 
-#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct ForwardedProviderCredential {
-    pub provider: Provider,
-    pub account_id: ProviderAccountId,
-    access_token: String,
-}
-
-impl std::fmt::Debug for ForwardedProviderCredential {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("ForwardedProviderCredential")
-            .field("provider", &self.provider)
-            .field("account_id", &self.account_id)
-            .field("access_token", &"[REDACTED]")
-            .finish()
-    }
-}
-
-impl ForwardedProviderCredential {
-    pub fn new(provider: Provider, account_id: ProviderAccountId, access_token: String) -> Self {
-        Self {
-            provider,
-            account_id,
-            access_token,
-        }
-    }
-
-    fn access_token(&self) -> &str {
-        &self.access_token
-    }
-}
-
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct ForwardedProviderAccount {
-    pub provider: Provider,
-    pub account_id: ProviderAccountId,
-    pub login_email: Option<crate::profile::EmailAddress>,
-    pub credential_state: CredentialState,
-    pub routing_state: RoutingState,
-    pub plan: Option<String>,
-    pub paid_through: Option<time::Date>,
-    pub utilization_percent: Option<u8>,
-    pub cooldown_until: Option<i64>,
-    pub cooldown_reason: Option<String>,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct ForwardedProviderRoute {
-    pub provider: Provider,
-    pub accounts: Vec<ProviderAccountId>,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct ForwardedProviderPin {
-    pub provider: Provider,
-    pub account_id: ProviderAccountId,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-#[non_exhaustive]
-pub enum ForwardedAccountSelection {
-    Routed {
-        repo_id: RepoId,
-        routes: Vec<ForwardedProviderRoute>,
-    },
-    Pinned(Vec<ForwardedProviderPin>),
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct ForwardedAccountBundle {
-    pub selection: ForwardedAccountSelection,
-    pub accounts: Vec<ForwardedProviderAccount>,
-    credentials: Vec<ForwardedProviderCredential>,
-}
-
-impl ForwardedAccountBundle {
-    pub fn new(
-        selection: ForwardedAccountSelection,
-        accounts: Vec<ForwardedProviderAccount>,
-        credentials: Vec<ForwardedProviderCredential>,
-    ) -> Self {
-        Self {
-            selection,
-            accounts,
-            credentials,
-        }
-    }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct RateLimitSignal {
+pub(crate) struct RateLimitSignal {
     pub utilization_percent: Option<u8>,
     pub resets_at: Option<i64>,
     pub limited: bool,
@@ -232,25 +127,30 @@ pub struct RateLimitSignal {
 }
 
 #[derive(Clone)]
-enum AccountCredential {
-    NativeHome(PathBuf),
-    AccessToken(String),
+enum AccountRouteAuthority {
+    Local {
+        store: SharedStore,
+        home: PathBuf,
+    },
+    Lease {
+        client: lease::AccountLeaseClient,
+        access_token: String,
+    },
 }
 
 #[derive(Clone)]
-pub struct ProviderAccountRoute {
+pub(crate) struct ProviderAccountRoute {
     provider: Provider,
     account_id: ProviderAccountId,
-    credential: AccountCredential,
     resume_requested_session: bool,
-    store: SharedStore,
+    authority: AccountRouteAuthority,
 }
 
 impl std::fmt::Debug for ProviderAccountRoute {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let credential = match self.credential {
-            AccountCredential::NativeHome(_) => "native_home",
-            AccountCredential::AccessToken(_) => "access_token",
+        let credential = match self.authority {
+            AccountRouteAuthority::Local { .. } => "native_home",
+            AccountRouteAuthority::Lease { .. } => "access_token",
         };
         f.debug_struct("ProviderAccountRoute")
             .field("provider", &self.provider)
@@ -262,140 +162,117 @@ impl std::fmt::Debug for ProviderAccountRoute {
 }
 
 impl ProviderAccountRoute {
-    pub fn account_id(&self) -> &ProviderAccountId {
-        &self.account_id
-    }
-
-    pub fn resume_requested_session(&self) -> bool {
+    pub(crate) fn resume_requested_session(&self) -> bool {
         self.resume_requested_session
     }
 
-    pub fn uses_native_home(&self) -> bool {
-        matches!(self.credential, AccountCredential::NativeHome(_))
+    pub(crate) fn uses_native_home(&self) -> bool {
+        matches!(self.authority, AccountRouteAuthority::Local { .. })
     }
 
-    pub fn apply(&self, command: &mut Command) {
-        command.env_remove(FORWARDED_ACCOUNT_BUNDLE_ENV);
-        match (&self.provider, &self.credential) {
-            (Provider::Claude, AccountCredential::NativeHome(home)) => {
+    pub(crate) fn apply(&self, command: &mut Command) {
+        for name in PROVIDER_CREDENTIAL_ENV_VARS {
+            command.env_remove(name);
+        }
+        match (self.provider, &self.authority) {
+            (Provider::Claude, AccountRouteAuthority::Local { home, .. }) => {
                 command.env("CLAUDE_CONFIG_DIR", home);
-                command.env_remove("CLAUDE_CODE_OAUTH_TOKEN");
-                command.env_remove("ANTHROPIC_API_KEY");
             }
-            (Provider::Claude, AccountCredential::AccessToken(token)) => {
-                command.env("CLAUDE_CODE_OAUTH_TOKEN", token);
-                command.env_remove("CLAUDE_CONFIG_DIR");
-                command.env_remove("ANTHROPIC_API_KEY");
+            (Provider::Claude, AccountRouteAuthority::Lease { access_token, .. }) => {
+                command.env("CLAUDE_CODE_OAUTH_TOKEN", access_token);
             }
-            (Provider::Codex, AccountCredential::NativeHome(home)) => {
+            (Provider::Codex, AccountRouteAuthority::Local { home, .. }) => {
                 command.env("CODEX_HOME", home);
-                command.env_remove("CODEX_ACCESS_TOKEN");
-                command.env_remove("OPENAI_API_KEY");
             }
-            (Provider::Codex, AccountCredential::AccessToken(token)) => {
-                command.env("CODEX_ACCESS_TOKEN", token);
-                command.env_remove("CODEX_HOME");
-                command.env_remove("OPENAI_API_KEY");
+            (Provider::Codex, AccountRouteAuthority::Lease { access_token, .. }) => {
+                command.env("CODEX_ACCESS_TOKEN", access_token);
             }
             _ => {}
         }
     }
 
-    pub fn apply_tokio(&self, command: &mut tokio::process::Command) {
-        command.env_remove(FORWARDED_ACCOUNT_BUNDLE_ENV);
-        match (&self.provider, &self.credential) {
-            (Provider::Claude, AccountCredential::NativeHome(home)) => {
-                command.env("CLAUDE_CONFIG_DIR", home);
-                command.env_remove("CLAUDE_CODE_OAUTH_TOKEN");
-                command.env_remove("ANTHROPIC_API_KEY");
-            }
-            (Provider::Claude, AccountCredential::AccessToken(token)) => {
-                command.env("CLAUDE_CODE_OAUTH_TOKEN", token);
-                command.env_remove("CLAUDE_CONFIG_DIR");
-                command.env_remove("ANTHROPIC_API_KEY");
-            }
-            (Provider::Codex, AccountCredential::NativeHome(home)) => {
-                command.env("CODEX_HOME", home);
-                command.env_remove("CODEX_ACCESS_TOKEN");
-                command.env_remove("OPENAI_API_KEY");
-            }
-            (Provider::Codex, AccountCredential::AccessToken(token)) => {
-                command.env("CODEX_ACCESS_TOKEN", token);
-                command.env_remove("CODEX_HOME");
-                command.env_remove("OPENAI_API_KEY");
-            }
-            _ => {}
-        }
+    pub(crate) fn apply_tokio(&self, command: &mut tokio::process::Command) {
+        self.apply(command.as_std_mut());
     }
 
-    pub async fn pin_session(&self, provider_session_id: &str) -> Result<(), ProviderAccountError> {
-        self.store
-            .pin_provider_session_route(self.provider, provider_session_id, &self.account_id)
-            .await?;
+    pub(crate) async fn pin_session(
+        &self,
+        provider_session_id: &str,
+    ) -> Result<(), ProviderAccountError> {
+        match &self.authority {
+            AccountRouteAuthority::Local { store, .. } => {
+                store
+                    .pin_provider_session_route(
+                        self.provider,
+                        provider_session_id,
+                        &self.account_id,
+                    )
+                    .await?;
+            }
+            AccountRouteAuthority::Lease { client, .. } => {
+                client.pin_session(self.provider, provider_session_id, &self.account_id)?;
+            }
+        }
         Ok(())
     }
 
-    pub async fn record_rate_limit(
+    pub(crate) async fn record_rate_limit(
         &self,
         signal: &RateLimitSignal,
     ) -> Result<(), ProviderAccountError> {
-        let cooldown_until = signal.limited.then(|| {
-            let now = now_unix();
-            signal
-                .resets_at
-                .unwrap_or(now + DEFAULT_COOLDOWN_SECS)
-                .max(now)
-                + RESET_GRACE_SECS
-        });
-        self.store
-            .record_provider_account_health(
-                self.provider.as_str(),
-                &self.account_id,
-                signal.utilization_percent,
-                cooldown_until,
-                signal.limited.then_some(signal.reason.as_str()),
-            )
-            .await?;
-        if !signal.windows.is_empty() {
-            self.store
-                .upsert_provider_account_limits(
-                    self.provider.as_str(),
-                    &self.account_id,
-                    &signal.windows,
-                    "stream",
-                )
-                .await?;
+        match &self.authority {
+            AccountRouteAuthority::Local { store, .. } => {
+                record_rate_limit_signal(store, self.provider, &self.account_id, signal, "stream")
+                    .await?;
+            }
+            AccountRouteAuthority::Lease { client, .. } => {
+                client.record_health(self.provider, &self.account_id, signal)?;
+            }
         }
         Ok(())
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum AmbientReason {
-    StoreUnavailable,
-    NoRoutes { repo_id: Option<RepoId> },
-}
-
-#[derive(Debug, Clone)]
-pub enum ProviderAccountResolution {
-    Managed(ProviderAccountRoute),
-    Ambient(AmbientReason),
-}
-
-impl ProviderAccountResolution {
-    pub fn into_route(self) -> Option<ProviderAccountRoute> {
-        match self {
-            Self::Managed(route) => Some(route),
-            Self::Ambient(_) => None,
-        }
+/// Record a provider rate-limit signal against a store: health row plus any
+/// observed limit windows. Shared by the local route and the lease broker so
+/// cooldown policy stays in one place.
+pub(crate) async fn record_rate_limit_signal(
+    store: &SharedStore,
+    provider: Provider,
+    account_id: &ProviderAccountId,
+    signal: &RateLimitSignal,
+    source: &str,
+) -> Result<(), ProviderAccountError> {
+    let cooldown_until = signal.limited.then(|| {
+        let now = now_unix();
+        signal
+            .resets_at
+            .unwrap_or(now + DEFAULT_COOLDOWN_SECS)
+            .max(now)
+            + RESET_GRACE_SECS
+    });
+    store
+        .record_provider_account_health(
+            provider.as_str(),
+            account_id,
+            signal.utilization_percent,
+            cooldown_until,
+            signal.limited.then_some(signal.reason.as_str()),
+        )
+        .await?;
+    if !signal.windows.is_empty() {
+        store
+            .upsert_provider_account_limits(provider.as_str(), account_id, &signal.windows, source)
+            .await?;
     }
+    Ok(())
 }
 
-pub fn parse_account_id(value: &str) -> Result<ProviderAccountId, ProviderAccountError> {
+pub(crate) fn parse_account_id(value: &str) -> Result<ProviderAccountId, ProviderAccountError> {
     ProviderAccountId::parse(value).map_err(ProviderAccountError::InvalidAccountId)
 }
 
-pub fn account_home_path(
+pub(crate) fn account_home_path(
     provider: Provider,
     account_id: &ProviderAccountId,
 ) -> Result<PathBuf, ProviderAccountError> {
@@ -406,7 +283,7 @@ pub fn account_home_path(
         .join(account_id.as_str()))
 }
 
-pub fn ensure_account_home(
+pub(crate) fn ensure_account_home(
     provider: Provider,
     account_id: &ProviderAccountId,
 ) -> Result<PathBuf, ProviderAccountError> {
@@ -416,7 +293,7 @@ pub fn ensure_account_home(
     Ok(home)
 }
 
-pub fn remove_account_home(home: &Path) -> Result<(), ProviderAccountError> {
+pub(crate) fn remove_account_home(home: &Path) -> Result<(), ProviderAccountError> {
     if home.exists() {
         fs::remove_dir_all(home).map_err(|error| {
             ProviderAccountError::Filesystem(format!("remove {}: {error}", home.display()))
@@ -496,163 +373,10 @@ fn link_shared_path(_source: &Path, _target: &Path) -> Result<(), ProviderAccoun
     Ok(())
 }
 
-pub fn encode_forwarded_account_bundle(
-    bundle: &ForwardedAccountBundle,
+pub(crate) async fn prepare_account_access_token(
+    provider: Provider,
+    account: &ProviderAccount,
 ) -> Result<String, ProviderAccountError> {
-    let json = serde_json::to_vec(bundle)
-        .map_err(|error| ProviderAccountError::ForwardedBundle(error.to_string()))?;
-    Ok(URL_SAFE_NO_PAD.encode(json))
-}
-
-pub fn decode_forwarded_account_bundle(
-    encoded: &str,
-) -> Result<ForwardedAccountBundle, ProviderAccountError> {
-    let bytes = URL_SAFE_NO_PAD
-        .decode(encoded.trim())
-        .map_err(|error| ProviderAccountError::ForwardedBundle(error.to_string()))?;
-    serde_json::from_slice(&bytes)
-        .map_err(|error| ProviderAccountError::ForwardedBundle(error.to_string()))
-}
-
-pub async fn local_forwarded_account_bundle(
-    store: &SharedStore,
-    selector: Option<&str>,
-) -> Result<Option<ForwardedAccountBundle>, ProviderAccountError> {
-    if let Some(selector) = selector {
-        return explicit_forwarded_account_bundle(store, selector).await;
-    }
-    let Some(repo_id) = current_repo_id()? else {
-        return Ok(None);
-    };
-    let mut routes = Vec::new();
-    for provider in [Provider::Claude, Provider::Codex] {
-        let route = match store
-            .provider_route(&RouteScope::Repo(repo_id.clone()), provider)
-            .await?
-        {
-            Some(route) => Some(route),
-            None => store.provider_route(&RouteScope::Default, provider).await?,
-        };
-        if let Some(route) = route {
-            routes.push(ForwardedProviderRoute {
-                provider,
-                accounts: route.accounts,
-            });
-        }
-    }
-    if routes.is_empty() {
-        return Ok(None);
-    }
-    // Health lives in the local limit snapshot, so decide the routed order here
-    // and forward the answer rather than the observations behind it.
-    let limits = store.provider_account_limits(None).await?;
-    order_forwarded_routes_by_strain(&mut routes, &limits, now_unix());
-    let routed_accounts = referenced_provider_accounts(store, &routes).await?;
-    let mut accounts = Vec::new();
-    let mut credentials = Vec::new();
-    for (provider, account) in routed_accounts {
-        accounts.push(forwarded_account(provider, &account));
-        if !account.eligible_for_automatic_routing(time::OffsetDateTime::now_utc().date()) {
-            continue;
-        }
-        credentials.push(prepare_forwarding_credential(provider, &account).await?);
-    }
-    Ok(Some(ForwardedAccountBundle::new(
-        ForwardedAccountSelection::Routed { repo_id, routes },
-        accounts,
-        credentials,
-    )))
-}
-
-async fn explicit_forwarded_account_bundle(
-    store: &SharedStore,
-    selector: &str,
-) -> Result<Option<ForwardedAccountBundle>, ProviderAccountError> {
-    let selector = selector.trim();
-    if selector.is_empty() {
-        return Err(ProviderAccountError::Runtime(
-            "--account requires a non-empty account id or login email".to_string(),
-        ));
-    }
-
-    let mut accounts = Vec::new();
-    let mut pins = Vec::new();
-    let mut credentials = Vec::new();
-    for provider in [Provider::Claude, Provider::Codex] {
-        let provider_accounts = store
-            .list_provider_accounts(Some(provider.as_str()))
-            .await?;
-        let account = match match_account(&provider_accounts, selector) {
-            AccountMatch::None => continue,
-            AccountMatch::One(account) => account,
-            AccountMatch::Ambiguous(candidates) => {
-                return Err(ProviderAccountError::Runtime(format!(
-                    "'{selector}' matches several {provider} accounts: {}",
-                    candidates
-                        .iter()
-                        .map(|account| account.account_id.as_str())
-                        .collect::<Vec<_>>()
-                        .join(", ")
-                )));
-            }
-        };
-        let credential = prepare_explicit_forwarding_credential(store, provider, account).await?;
-        accounts.push(forwarded_account(provider, account));
-        pins.push(ForwardedProviderPin {
-            provider,
-            account_id: account.account_id.clone(),
-        });
-        credentials.push(credential);
-    }
-    if pins.is_empty() {
-        return Err(ProviderAccountError::Runtime(format!(
-            "no managed Claude or Codex account matches '{selector}'; see `lf auth accounts`"
-        )));
-    }
-    Ok(Some(ForwardedAccountBundle::new(
-        ForwardedAccountSelection::Pinned(pins),
-        accounts,
-        credentials,
-    )))
-}
-
-async fn prepare_explicit_forwarding_credential(
-    store: &SharedStore,
-    provider: Provider,
-    account: &ProviderAccount,
-) -> Result<ForwardedProviderCredential, ProviderAccountError> {
-    let home = account.home.as_deref().ok_or_else(|| {
-        ProviderAccountError::Runtime(format!(
-            "{provider} account '{}' has no managed credential home",
-            account.account_id
-        ))
-    })?;
-    let operator_home = dirs::home_dir().unwrap_or_else(|| PathBuf::from("."));
-    ensure_account_home_at(&operator_home, home, provider)?;
-    let status = provider_account_auth_status(provider, home.to_path_buf())
-        .await
-        .map_err(|error| {
-            ProviderAccountError::Runtime(format!(
-                "check {provider} account '{}': {error}",
-                account.account_id
-            ))
-        })?;
-    if !retain_authenticated_account(store, account, &status).await? {
-        return Err(ProviderAccountError::NoAuthenticatedAccount {
-            provider,
-            accounts: format!(
-                "'{}' with `lf auth connect {provider} {}`",
-                account.account_id, account.account_id
-            ),
-        });
-    }
-    prepare_forwarding_credential(provider, account).await
-}
-
-async fn prepare_forwarding_credential(
-    provider: Provider,
-    account: &ProviderAccount,
-) -> Result<ForwardedProviderCredential, ProviderAccountError> {
     let home =
         account
             .home
@@ -674,127 +398,43 @@ async fn prepare_forwarding_credential(
             account_id: account.account_id.clone(),
             reason: "provider CLI reports no active OAuth login".to_string(),
         })?;
-    Ok(ForwardedProviderCredential::new(
-        provider,
-        account.account_id.clone(),
-        access_token,
-    ))
+    Ok(access_token)
 }
 
-fn forwarded_account(provider: Provider, account: &ProviderAccount) -> ForwardedProviderAccount {
-    ForwardedProviderAccount {
-        provider,
-        account_id: account.account_id.clone(),
-        login_email: account.login_email.clone(),
-        credential_state: account.credential_state,
-        routing_state: account.routing_state,
-        plan: account.plan.clone(),
-        paid_through: account.paid_through,
-        utilization_percent: account.utilization_percent,
-        cooldown_until: account.cooldown_until,
-        cooldown_reason: account.cooldown_reason.clone(),
-    }
-}
-
-async fn referenced_provider_accounts(
-    store: &SharedStore,
-    routes: &[ForwardedProviderRoute],
-) -> Result<Vec<(Provider, ProviderAccount)>, ProviderAccountError> {
-    let mut accounts = Vec::new();
-    let mut seen_accounts = HashSet::new();
-    for route in routes {
-        for account_id in &route.accounts {
-            if !seen_accounts.insert((route.provider, account_id.clone())) {
-                continue;
-            }
-            let account = store
-                .get_provider_account(route.provider.as_str(), account_id)
-                .await?
-                .ok_or_else(|| {
-                    ProviderAccountError::ForwardedBundle(format!(
-                        "route references missing {}/{}",
-                        route.provider, account_id
-                    ))
-                })?;
-            accounts.push((route.provider, account));
-        }
-    }
-    Ok(accounts)
-}
-
-pub async fn resolve_provider_account(
+pub(crate) async fn resolve_provider_account(
     provider: Provider,
     provider_session_id: Option<&str>,
-) -> Result<ProviderAccountResolution, ProviderAccountError> {
+) -> Result<Option<ProviderAccountRoute>, ProviderAccountError> {
     ensure_supported(provider)?;
-    let forwarded_bundle = match std::env::var(FORWARDED_ACCOUNT_BUNDLE_ENV) {
-        Ok(value) if !value.trim().is_empty() => Some(decode_forwarded_account_bundle(&value)?),
-        _ => None,
-    };
-    if let Some(bundle) = &forwarded_bundle {
-        if matches!(bundle.selection, ForwardedAccountSelection::Pinned(_)) {
-            return resolve_forwarded_pin(bundle, provider).await;
-        }
+    // A forwarded or locally-brokered account lease is the single source of
+    // account authority when active. Descendants never re-resolve a selection;
+    // they resolve one credential from the broker.
+    if let Some(client) = lease::AccountLeaseClient::from_env()? {
+        let resolution = client.resolve(provider, provider_session_id.map(str::to_string))?;
+        return Ok(Some(ProviderAccountRoute {
+            provider,
+            account_id: resolution.account_id.clone(),
+            resume_requested_session: resolution.resume_requested_session,
+            authority: AccountRouteAuthority::Lease {
+                client,
+                access_token: resolution.access_token().to_string(),
+            },
+        }));
     }
-    if let Ok(selector) = std::env::var(PROVIDER_ACCOUNT_ENV) {
-        if !selector.trim().is_empty() {
-            return resolve_explicit_account(provider, selector.trim())
-                .await
-                .map(ProviderAccountResolution::Managed);
-        }
-    }
-    let store = route_store(forwarded_bundle.is_some()).await?;
+    let store = route_store().await?;
     let Some(store) = store else {
-        return Ok(ProviderAccountResolution::Ambient(
-            AmbientReason::StoreUnavailable,
-        ));
+        return Ok(None);
     };
 
-    let mut access_tokens = HashMap::new();
-    let (candidates, routed_repo_id) = if let Some(bundle) = &forwarded_bundle {
-        let ForwardedAccountSelection::Routed { repo_id, routes } = &bundle.selection else {
-            unreachable!("pinned bundles return before routed selection")
-        };
-        let candidates = hydrate_forwarded_route(&store, bundle, repo_id, routes, provider).await?;
-        for credential in bundle
-            .credentials
-            .iter()
-            .filter(|credential| credential.provider == provider)
-        {
-            access_tokens.insert(
-                credential.account_id.clone(),
-                credential.access_token().to_string(),
-            );
-        }
-        (candidates, Some(repo_id.clone()))
-    } else {
-        let repo_id = current_repo_id()?;
-        let route = match &repo_id {
-            Some(repo_id) => {
-                store
-                    .provider_route(&RouteScope::Repo(repo_id.clone()), provider)
-                    .await?
-            }
-            None => None,
-        };
-        let route = match route {
-            Some(route) => Some(route),
-            None => store.provider_route(&RouteScope::Default, provider).await?,
-        };
-        let Some(route) = route else {
-            return Ok(ProviderAccountResolution::Ambient(
-                AmbientReason::NoRoutes { repo_id },
-            ));
-        };
-        (route.accounts, repo_id)
+    let routed_repo_id = current_repo_id()?;
+    let Some(candidates) =
+        provider_route_account_ids(&store, routed_repo_id.as_ref(), provider).await?
+    else {
+        return Ok(None);
     };
 
     if candidates.is_empty() {
-        return Ok(ProviderAccountResolution::Ambient(
-            AmbientReason::NoRoutes {
-                repo_id: routed_repo_id,
-            },
-        ));
+        return Ok(None);
     }
     let selection = store
         .select_provider_account(provider, &candidates, provider_session_id)
@@ -820,108 +460,23 @@ pub async fn resolve_provider_account(
         });
     };
     let account_id = selection.account.account_id.clone();
-    let credential = match access_tokens.remove(&account_id) {
-        Some(access_token) => AccountCredential::AccessToken(access_token),
-        None => match selection.account.home.as_deref() {
-            Some(home) => {
-                let operator_home = dirs::home_dir().unwrap_or_else(|| PathBuf::from("."));
-                ensure_account_home_at(&operator_home, home, provider)?;
-                AccountCredential::NativeHome(home.to_path_buf())
-            }
-            None => {
-                return Err(ProviderAccountError::ForwardedBundle(format!(
-                    "missing access token for {provider}/{account_id}"
-                )))
-            }
-        },
+    let home = match selection.account.home.as_deref() {
+        Some(home) => {
+            let operator_home = dirs::home_dir().unwrap_or_else(|| PathBuf::from("."));
+            ensure_account_home_at(&operator_home, home, provider)?;
+            home.to_path_buf()
+        }
+        None => {
+            return Err(ProviderAccountError::Runtime(format!(
+                "managed {provider}/{account_id} has no credential home"
+            )))
+        }
     };
-    Ok(ProviderAccountResolution::Managed(ProviderAccountRoute {
+    Ok(Some(ProviderAccountRoute {
         provider,
         account_id,
-        credential,
         resume_requested_session: selection.resume_requested_session,
-        store,
-    }))
-}
-
-async fn resolve_forwarded_pin(
-    bundle: &ForwardedAccountBundle,
-    provider: Provider,
-) -> Result<ProviderAccountResolution, ProviderAccountError> {
-    let ForwardedAccountSelection::Pinned(pins) = &bundle.selection else {
-        return Err(ProviderAccountError::ForwardedBundle(
-            "routed bundle cannot resolve an explicit pin".to_string(),
-        ));
-    };
-    let pins = pins
-        .iter()
-        .filter(|pin| pin.provider == provider)
-        .collect::<Vec<_>>();
-    let pin = match pins.as_slice() {
-        [pin] => *pin,
-        [] => {
-            return Err(ProviderAccountError::ForwardedBundle(format!(
-                "explicit forwarded bundle has no {provider} account pin"
-            )));
-        }
-        _ => {
-            return Err(ProviderAccountError::ForwardedBundle(format!(
-                "explicit forwarded bundle has several {provider} account pins"
-            )));
-        }
-    };
-    let store = route_store(true).await?.ok_or_else(|| {
-        ProviderAccountError::ForwardedBundle(
-            "temporary forwarded account store is unavailable".to_string(),
-        )
-    })?;
-    let account = bundle
-        .accounts
-        .iter()
-        .find(|account| account.provider == provider && account.account_id == pin.account_id)
-        .ok_or_else(|| {
-            ProviderAccountError::ForwardedBundle(format!(
-                "pin references missing {provider}/{}",
-                pin.account_id
-            ))
-        })?;
-    if store
-        .get_provider_account(provider.as_str(), &pin.account_id)
-        .await?
-        .is_none()
-    {
-        store
-            .upsert_provider_account(&provider_account_from_forwarded(account))
-            .await?;
-    }
-    let credentials = bundle
-        .credentials
-        .iter()
-        .filter(|credential| {
-            credential.provider == provider && credential.account_id == pin.account_id
-        })
-        .collect::<Vec<_>>();
-    let credential = match credentials.as_slice() {
-        [credential] => *credential,
-        [] => {
-            return Err(ProviderAccountError::ForwardedBundle(format!(
-                "missing access token for {provider}/{}",
-                pin.account_id
-            )));
-        }
-        _ => {
-            return Err(ProviderAccountError::ForwardedBundle(format!(
-                "several access tokens for {provider}/{}",
-                pin.account_id
-            )));
-        }
-    };
-    Ok(ProviderAccountResolution::Managed(ProviderAccountRoute {
-        provider,
-        account_id: account.account_id.clone(),
-        credential: AccountCredential::AccessToken(credential.access_token().to_string()),
-        resume_requested_session: false,
-        store,
+        authority: AccountRouteAuthority::Local { store, home },
     }))
 }
 
@@ -945,7 +500,7 @@ fn account_unavailable_reason(account: &ProviderAccount) -> String {
 }
 
 #[derive(Debug)]
-enum AccountMatch<'a> {
+pub(crate) enum AccountMatch<'a> {
     One(&'a ProviderAccount),
     Ambiguous(Vec<&'a ProviderAccount>),
     None,
@@ -954,9 +509,12 @@ enum AccountMatch<'a> {
 /// An explicit selector names an account by login email or account id —
 /// exactly, or by any prefix that matches exactly one known account
 /// (`manabot` reaches `manabot-eng`). Matching is case-insensitive.
-fn match_account<'a>(accounts: &'a [ProviderAccount], selector: &str) -> AccountMatch<'a> {
+pub(crate) fn match_account<'a>(
+    accounts: &[&'a ProviderAccount],
+    selector: &str,
+) -> AccountMatch<'a> {
     let selector_lower = selector.to_ascii_lowercase();
-    let exact = accounts.iter().find(|account| {
+    let exact = accounts.iter().copied().find(|account| {
         account
             .login_email
             .as_ref()
@@ -968,6 +526,7 @@ fn match_account<'a>(accounts: &'a [ProviderAccount], selector: &str) -> Account
     }
     let prefixed: Vec<&ProviderAccount> = accounts
         .iter()
+        .copied()
         .filter(|account| {
             account.login_email.as_ref().is_some_and(|email| {
                 email
@@ -988,157 +547,38 @@ fn match_account<'a>(accounts: &'a [ProviderAccount], selector: &str) -> Account
     }
 }
 
-/// Resolve `lf --account <email|id>`: the named account, verified live, with
-/// no route lookup and no cooldown gating — refusing an explicit human choice
-/// helps nobody; a dead credential still errors with the re-login fix.
-async fn resolve_explicit_account(
-    provider: Provider,
-    selector: &str,
-) -> Result<ProviderAccountRoute, ProviderAccountError> {
-    let store = route_store(true).await?.ok_or_else(|| {
-        ProviderAccountError::Runtime("account store unavailable for --account".to_string())
-    })?;
-    let accounts = store
-        .list_provider_accounts(Some(provider.as_str()))
-        .await?;
-    let account = match match_account(&accounts, selector) {
-        AccountMatch::One(account) => account,
-        AccountMatch::Ambiguous(candidates) => {
-            return Err(ProviderAccountError::Runtime(format!(
-                "'{selector}' matches several {provider} accounts: {}",
-                candidates
-                    .iter()
-                    .map(|account| account.account_id.as_str())
-                    .collect::<Vec<_>>()
-                    .join(", ")
-            )));
-        }
-        AccountMatch::None => {
-            return Err(ProviderAccountError::Runtime(format!(
-                "no managed {provider} account matches '{selector}'; see `lf auth accounts`"
-            )));
-        }
-    };
-    let home = account.home.clone().ok_or_else(|| {
-        ProviderAccountError::Runtime(format!(
-            "{provider} account '{}' has no managed credential home",
-            account.account_id
-        ))
-    })?;
-    let operator_home = dirs::home_dir().unwrap_or_else(|| PathBuf::from("."));
-    ensure_account_home_at(&operator_home, &home, provider)?;
-    let status = provider_account_auth_status(provider, home.clone())
-        .await
-        .map_err(|error| {
-            ProviderAccountError::Runtime(format!(
-                "check {provider} account '{}': {error}",
-                account.account_id
-            ))
-        })?;
-    if !retain_authenticated_account(&store, account, &status).await? {
-        return Err(ProviderAccountError::NoAuthenticatedAccount {
-            provider,
-            accounts: format!(
-                "'{}' with `lf auth connect {provider} {}`",
-                account.account_id, account.account_id
-            ),
-        });
-    }
-    Ok(ProviderAccountRoute {
-        provider,
-        account_id: account.account_id.clone(),
-        credential: AccountCredential::NativeHome(home),
-        resume_requested_session: false,
-        store,
-    })
-}
-
-async fn retain_authenticated_account(
-    store: &SharedStore,
-    account: &ProviderAccount,
-    status: &AuthStatus,
-) -> Result<bool, ProviderAccountError> {
-    if matches!(status, AuthStatus::Active { .. }) {
-        return Ok(true);
-    }
-    let mut account = account.clone();
-    account.credential_state = CredentialState::Missing;
-    account.updated_at = now_unix();
-    store.upsert_provider_account(&account).await?;
-    Ok(false)
-}
-
-async fn hydrate_forwarded_route(
-    store: &SharedStore,
-    bundle: &ForwardedAccountBundle,
-    repo_id: &RepoId,
-    routes: &[ForwardedProviderRoute],
-    provider: Provider,
-) -> Result<Vec<ProviderAccountId>, ProviderAccountError> {
-    let Some(route) = routes.iter().find(|route| route.provider == provider) else {
-        return Ok(Vec::new());
-    };
-
-    // The route is written last and serves as the initialization marker. A
-    // restarted provider process reuses health accrued in this SSH lease
-    // instead of resetting it from the original local snapshot.
-    let scope = RouteScope::Repo(repo_id.clone());
-    if store.provider_route(&scope, provider).await?.is_none() {
-        let now = now_unix();
-        for account in &bundle.accounts {
-            store
-                .upsert_provider_account(&provider_account_from_forwarded(account))
-                .await?;
-        }
-        store
-            .set_provider_route(&ProviderRoute {
-                scope,
-                provider,
-                accounts: route.accounts.clone(),
-                created_at: now,
-                updated_at: now,
-            })
-            .await?;
-    }
-
-    Ok(route.accounts.clone())
-}
-
-fn provider_account_from_forwarded(account: &ForwardedProviderAccount) -> ProviderAccount {
-    let now = now_unix();
-    ProviderAccount {
-        provider: account.provider.as_str().to_string(),
-        account_id: account.account_id.clone(),
-        home: None,
-        login_email: account.login_email.clone(),
-        credential_state: account.credential_state,
-        routing_state: account.routing_state,
-        plan: account.plan.clone(),
-        paid_through: account.paid_through,
-        utilization_percent: account.utilization_percent,
-        cooldown_until: account.cooldown_until,
-        cooldown_reason: account.cooldown_reason.clone(),
-        last_selected_at: None,
-        created_at: now,
-        updated_at: now,
-    }
-}
-
 fn current_repo_id() -> Result<Option<RepoId>, ProviderAccountError> {
-    if let Ok(value) = std::env::var(ACCOUNT_REPO_ID_ENV) {
-        return RepoId::parse(&value)
-            .map(Some)
-            .map_err(|error| ProviderAccountError::Runtime(error.to_string()));
-    }
     let current = std::env::current_dir()
         .map_err(|error| ProviderAccountError::Runtime(error.to_string()))?;
     Ok(RepoId::discover(&current).ok())
 }
 
-pub fn resolve_provider_account_blocking(
+async fn provider_route_account_ids(
+    store: &SharedStore,
+    repo_id: Option<&RepoId>,
+    provider: Provider,
+) -> Result<Option<Vec<ProviderAccountId>>, ProviderAccountError> {
+    let route = match repo_id {
+        Some(repo_id) => {
+            store
+                .provider_route(&RouteScope::Repo(repo_id.clone()), provider)
+                .await?
+        }
+        None => None,
+    };
+    Ok(match route {
+        Some(route) => Some(route.accounts),
+        None => store
+            .provider_route(&RouteScope::Default, provider)
+            .await?
+            .map(|route| route.accounts),
+    })
+}
+
+pub(crate) fn resolve_provider_account_blocking(
     provider: Provider,
     provider_session_id: Option<String>,
-) -> Result<ProviderAccountResolution, ProviderAccountError> {
+) -> Result<Option<ProviderAccountRoute>, ProviderAccountError> {
     std::thread::Builder::new()
         .name(format!("lf-{}-account-route", provider.as_str()))
         .spawn(move || {
@@ -1156,26 +596,17 @@ pub fn resolve_provider_account_blocking(
         .map_err(|_| ProviderAccountError::Runtime("account resolver panicked".to_string()))?
 }
 
-async fn route_store(create: bool) -> Result<Option<SharedStore>, ProviderAccountError> {
-    if !create {
-        return match crate::store::open_registry_for_authority().await {
-            Ok(store) => Ok(Some(Arc::new(store))),
-            Err(crate::store::RegistryUnavailable::MissingFile { .. }) => Ok(None),
-            Err(error) => Err(ProviderAccountError::Runtime(format!(
-                "open provider account store: {error:?}"
-            ))),
-        };
+async fn route_store() -> Result<Option<SharedStore>, ProviderAccountError> {
+    match crate::store::open_registry_for_authority().await {
+        Ok(store) => Ok(Some(Arc::new(store))),
+        Err(crate::store::RegistryUnavailable::MissingFile { .. }) => Ok(None),
+        Err(error) => Err(ProviderAccountError::Runtime(format!(
+            "open provider account store: {error:?}"
+        ))),
     }
-    let config = match std::env::var_os(FORWARDED_ACCOUNT_STORE_ENV) {
-        Some(path) => crate::store::StorageConfig::sqlite(PathBuf::from(path)),
-        None => crate::store::storage_config_from_env().map_err(|error| {
-            ProviderAccountError::Filesystem(format!("resolve provider account store: {error}"))
-        })?,
-    };
-    Ok(Some(Arc::new(open_store(&config).await?)))
 }
 
-pub async fn open_account_store() -> Result<SharedStore, ProviderAccountError> {
+pub(crate) async fn open_account_store() -> Result<SharedStore, ProviderAccountError> {
     let config = crate::store::storage_config_from_env().map_err(|error| {
         ProviderAccountError::Filesystem(format!("resolve provider account store: {error}"))
     })?;
@@ -1183,7 +614,7 @@ pub async fn open_account_store() -> Result<SharedStore, ProviderAccountError> {
     Ok(store)
 }
 
-pub fn new_account(
+pub(crate) fn new_account(
     provider: Provider,
     account_id: ProviderAccountId,
     home: PathBuf,
@@ -1234,6 +665,7 @@ fn format_reset_time(timestamp: i64) -> String {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
     use std::os::unix::fs::PermissionsExt;
 
     use tempfile::tempdir;
@@ -1243,7 +675,7 @@ mod tests {
     #[test]
     fn explicit_account_selector_matches_exactly_or_by_unique_prefix() {
         let temp = tempdir().unwrap();
-        let accounts = vec![
+        let accounts = [
             new_account(
                 Provider::Codex,
                 parse_account_id("engineering").unwrap(),
@@ -1263,6 +695,7 @@ mod tests {
                 None,
             ),
         ];
+        let accounts = accounts.iter().collect::<Vec<_>>();
         let one = |selector: &str| match match_account(&accounts, selector) {
             AccountMatch::One(account) => account.account_id.as_str().to_string(),
             other => panic!("expected one match for '{selector}', got {other:?}"),
@@ -1379,7 +812,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn routes_apply_only_the_selected_provider_credential() {
+    async fn routes_clear_ambient_provider_credentials() {
         let temp = tempdir().unwrap();
         let store = Arc::new(
             open_store(&crate::store::StorageConfig::sqlite(
@@ -1391,11 +824,14 @@ mod tests {
         let route = ProviderAccountRoute {
             provider: Provider::Codex,
             account_id: parse_account_id("reserve").unwrap(),
-            credential: AccountCredential::AccessToken("codex-secret".to_string()),
             resume_requested_session: false,
-            store,
+            authority: AccountRouteAuthority::Local {
+                store,
+                home: temp.path().join("codex-reserve"),
+            },
         };
         let mut command = Command::new("codex");
+        command.env("CLAUDE_CODE_OAUTH_TOKEN", "ancestor-secret");
         route.apply(&mut command);
         let environment = command
             .get_envs()
@@ -1407,23 +843,31 @@ mod tests {
             })
             .collect::<HashMap<_, _>>();
 
+        assert_eq!(environment.get("CODEX_ACCESS_TOKEN"), Some(&None));
+        assert_eq!(environment.get("OPENAI_API_KEY"), Some(&None));
         assert_eq!(
             environment
-                .get("CODEX_ACCESS_TOKEN")
+                .get("CODEX_HOME")
                 .and_then(|value| value.as_deref()),
-            Some("codex-secret")
+            Some(temp.path().join("codex-reserve").to_str().unwrap())
         );
-        assert_eq!(environment.get("OPENAI_API_KEY"), Some(&None));
-        assert_eq!(environment.get("CODEX_HOME"), Some(&None));
-        assert_eq!(environment.get(FORWARDED_ACCOUNT_BUNDLE_ENV), Some(&None));
-        assert!(!environment.contains_key("CLAUDE_CODE_OAUTH_TOKEN"));
+        // Provider launch carries no account-selection env; descendants inherit
+        // the lease handle, not a re-derivable selection.
+        assert_eq!(
+            environment
+                .get(lease::ACCOUNT_LEASE_ENV)
+                .map(Option::is_some),
+            None
+        );
+        assert_eq!(environment.get("CLAUDE_CODE_OAUTH_TOKEN"), Some(&None));
 
         let mut async_command = tokio::process::Command::new("codex");
+        async_command.env("CLAUDE_CODE_OAUTH_TOKEN", "ancestor-secret");
         route.apply_tokio(&mut async_command);
         assert!(async_command
             .as_std()
             .get_envs()
-            .any(|(name, value)| name == FORWARDED_ACCOUNT_BUNDLE_ENV && value.is_none()));
+            .any(|(name, value)| { name == "CLAUDE_CODE_OAUTH_TOKEN" && value.is_none() }));
     }
 
     #[tokio::test]
@@ -1443,9 +887,11 @@ mod tests {
                 ProviderAccountRoute {
                     provider: Provider::Claude,
                     account_id: parse_account_id("primary").unwrap(),
-                    credential: AccountCredential::NativeHome(claude_home.clone()),
                     resume_requested_session: false,
-                    store: store.clone(),
+                    authority: AccountRouteAuthority::Local {
+                        store: store.clone(),
+                        home: claude_home.clone(),
+                    },
                 },
                 "CLAUDE_CONFIG_DIR",
                 claude_home,
@@ -1454,9 +900,11 @@ mod tests {
                 ProviderAccountRoute {
                     provider: Provider::Codex,
                     account_id: parse_account_id("reserve").unwrap(),
-                    credential: AccountCredential::NativeHome(codex_home.clone()),
                     resume_requested_session: false,
-                    store,
+                    authority: AccountRouteAuthority::Local {
+                        store,
+                        home: codex_home.clone(),
+                    },
                 },
                 "CODEX_HOME",
                 codex_home,
@@ -1473,38 +921,6 @@ mod tests {
                 .map(PathBuf::from);
             assert_eq!(selected_home.as_deref(), Some(expected_home.as_path()));
         }
-    }
-
-    #[tokio::test]
-    async fn expired_live_check_marks_the_credential_missing() {
-        let temp = tempdir().unwrap();
-        let store = Arc::new(
-            open_store(&crate::store::StorageConfig::sqlite(
-                temp.path().join("loopflow.db"),
-            ))
-            .await
-            .unwrap(),
-        );
-        let account_id = parse_account_id("primary").unwrap();
-        let account = new_account(
-            Provider::Claude,
-            account_id.clone(),
-            temp.path().join("primary"),
-            None,
-        );
-        store.upsert_provider_account(&account).await.unwrap();
-
-        let retained = retain_authenticated_account(&store, &account, &AuthStatus::Expired)
-            .await
-            .unwrap();
-
-        assert!(!retained);
-        let account = store
-            .get_provider_account(Provider::Claude.as_str(), &account_id)
-            .await
-            .unwrap()
-            .unwrap();
-        assert_eq!(account.credential_state, CredentialState::Missing);
     }
 
     #[tokio::test]
@@ -1528,9 +944,11 @@ mod tests {
         let route = ProviderAccountRoute {
             provider: Provider::Claude,
             account_id: account_id.clone(),
-            credential: AccountCredential::AccessToken("claude-secret".to_string()),
             resume_requested_session: false,
-            store: store.clone(),
+            authority: AccountRouteAuthority::Local {
+                store: store.clone(),
+                home: temp.path().join("primary"),
+            },
         };
 
         route
@@ -1625,22 +1043,14 @@ mod account_first_tests {
             permissions.set_mode(0o755);
             fs::set_permissions(&claude, permissions).unwrap();
         }
-        let _restore = EnvRestore::capture(&[
-            "LF_HOME",
-            "PATH",
-            PROVIDER_ACCOUNT_ENV,
-            FORWARDED_ACCOUNT_BUNDLE_ENV,
-            FORWARDED_ACCOUNT_STORE_ENV,
-        ]);
+        let _restore = EnvRestore::capture(&["LF_HOME", "PATH", lease::ACCOUNT_LEASE_ENV]);
         std::env::set_var("LF_HOME", temp.path());
         let path = std::env::var_os("PATH").unwrap_or_default();
         std::env::set_var(
             "PATH",
             std::env::join_paths(std::iter::once(bin).chain(std::env::split_paths(&path))).unwrap(),
         );
-        std::env::remove_var(PROVIDER_ACCOUNT_ENV);
-        std::env::remove_var(FORWARDED_ACCOUNT_BUNDLE_ENV);
-        std::env::remove_var(FORWARDED_ACCOUNT_STORE_ENV);
+        std::env::remove_var(lease::ACCOUNT_LEASE_ENV);
         let store = Arc::new(
             open_store(&StorageConfig::sqlite(temp.path().join("loopflow.db")))
                 .await
@@ -1662,10 +1072,9 @@ mod account_first_tests {
         let selection = resolve_provider_account(Provider::Claude, None)
             .await
             .unwrap()
-            .into_route()
             .expect("default route should select a managed account");
 
-        assert_eq!(selection.account_id(), &selected.account_id);
+        assert_eq!(selection.account_id, selected.account_id);
         assert!(store
             .get_provider_account(Provider::Claude.as_str(), &selected.account_id)
             .await
@@ -1673,68 +1082,6 @@ mod account_first_tests {
             .unwrap()
             .last_selected_at
             .is_some());
-    }
-
-    #[allow(clippy::await_holding_lock)]
-    #[tokio::test]
-    async fn explicit_account_bypasses_route_health_but_verifies_live_auth() {
-        let _lock = crate::journal::test_env_lock();
-        let temp = tempdir().unwrap();
-        let bin = temp.path().join("bin");
-        fs::create_dir_all(&bin).unwrap();
-        let claude = bin.join("claude");
-        fs::write(
-            &claude,
-            "#!/bin/sh\n: > \"$AUTH_MARKER\"\nprintf '%s\\n' '{\"loggedIn\":true,\"email\":\"selected@example.com\"}'\n",
-        )
-        .unwrap();
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-
-            let mut permissions = fs::metadata(&claude).unwrap().permissions();
-            permissions.set_mode(0o755);
-            fs::set_permissions(&claude, permissions).unwrap();
-        }
-        let marker = temp.path().join("auth-checked");
-        let _restore = EnvRestore::capture(&[
-            "LF_HOME",
-            "PATH",
-            "AUTH_MARKER",
-            PROVIDER_ACCOUNT_ENV,
-            FORWARDED_ACCOUNT_BUNDLE_ENV,
-            FORWARDED_ACCOUNT_STORE_ENV,
-        ]);
-        std::env::set_var("LF_HOME", temp.path());
-        let path = std::env::var_os("PATH").unwrap_or_default();
-        std::env::set_var(
-            "PATH",
-            std::env::join_paths(std::iter::once(bin).chain(std::env::split_paths(&path))).unwrap(),
-        );
-        std::env::set_var("AUTH_MARKER", &marker);
-        std::env::set_var(PROVIDER_ACCOUNT_ENV, "selected");
-        std::env::remove_var(FORWARDED_ACCOUNT_BUNDLE_ENV);
-        std::env::remove_var(FORWARDED_ACCOUNT_STORE_ENV);
-        let store = Arc::new(
-            open_store(&StorageConfig::sqlite(temp.path().join("loopflow.db")))
-                .await
-                .unwrap(),
-        );
-        let mut selected = account(Provider::Claude, "selected", temp.path());
-        selected.credential_state = CredentialState::Missing;
-        selected.routing_state = RoutingState::Disabled;
-        selected.cooldown_until = Some(now_unix() + 3600);
-        fs::create_dir_all(selected.home.as_ref().unwrap()).unwrap();
-        store.upsert_provider_account(&selected).await.unwrap();
-
-        let selection = resolve_provider_account(Provider::Claude, None)
-            .await
-            .unwrap()
-            .into_route()
-            .expect("explicit account should bypass automatic route gating");
-
-        assert_eq!(selection.account_id(), &selected.account_id);
-        assert!(marker.exists(), "explicit selection must verify live auth");
     }
 
     #[tokio::test]
@@ -1862,38 +1209,27 @@ mod account_first_tests {
 
     #[allow(clippy::await_holding_lock)]
     #[tokio::test]
-    async fn ambient_states_and_an_unusable_configured_route_are_distinct() {
+    async fn missing_routes_are_unmanaged_and_unusable_routes_fail() {
         let _lock = crate::journal::test_env_lock();
         let temp = tempdir().unwrap();
-        let _restore = EnvRestore::capture(&[
-            "LF_HOME",
-            PROVIDER_ACCOUNT_ENV,
-            FORWARDED_ACCOUNT_BUNDLE_ENV,
-            FORWARDED_ACCOUNT_STORE_ENV,
-        ]);
+        let _restore = EnvRestore::capture(&["LF_HOME", lease::ACCOUNT_LEASE_ENV]);
         std::env::set_var("LF_HOME", temp.path());
-        std::env::remove_var(PROVIDER_ACCOUNT_ENV);
-        std::env::remove_var(FORWARDED_ACCOUNT_BUNDLE_ENV);
-        std::env::remove_var(FORWARDED_ACCOUNT_STORE_ENV);
+        std::env::remove_var(lease::ACCOUNT_LEASE_ENV);
 
-        assert!(matches!(
-            resolve_provider_account(Provider::Claude, None)
-                .await
-                .unwrap(),
-            ProviderAccountResolution::Ambient(AmbientReason::StoreUnavailable)
-        ));
+        assert!(resolve_provider_account(Provider::Claude, None)
+            .await
+            .unwrap()
+            .is_none());
 
         let store = Arc::new(
             open_store(&StorageConfig::sqlite(temp.path().join("loopflow.db")))
                 .await
                 .unwrap(),
         );
-        assert!(matches!(
-            resolve_provider_account(Provider::Claude, None)
-                .await
-                .unwrap(),
-            ProviderAccountResolution::Ambient(AmbientReason::NoRoutes { .. })
-        ));
+        assert!(resolve_provider_account(Provider::Claude, None)
+            .await
+            .unwrap()
+            .is_none());
 
         let mut unavailable = account(Provider::Claude, "missing", temp.path());
         unavailable.credential_state = CredentialState::Missing;
@@ -1916,299 +1252,5 @@ mod account_first_tests {
                 .to_string(),
             "configured claude route has no eligible account: 'missing' credential is missing"
         );
-    }
-
-    #[allow(clippy::await_holding_lock)]
-    #[tokio::test]
-    async fn explicit_forwarded_pin_uses_local_account_identity_and_remote_access_token() {
-        let _lock = crate::journal::test_env_lock();
-        let temp = tempdir().unwrap();
-        let bin = temp.path().join("bin");
-        fs::create_dir_all(&bin).unwrap();
-        let codex = bin.join("codex");
-        fs::write(
-            &codex,
-            r#"#!/bin/sh
-IFS= read -r line
-printf '{"id":1,"result":{}}\n'
-IFS= read -r line
-IFS= read -r line
-printf '{"id":2,"result":{"account":null}}\n'
-"#,
-        )
-        .unwrap();
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-
-            let mut permissions = fs::metadata(&codex).unwrap().permissions();
-            permissions.set_mode(0o755);
-            fs::set_permissions(&codex, permissions).unwrap();
-        }
-        let _restore = EnvRestore::capture(&[
-            "PATH",
-            ACCOUNT_REPO_ID_ENV,
-            PROVIDER_ACCOUNT_ENV,
-            FORWARDED_ACCOUNT_BUNDLE_ENV,
-            FORWARDED_ACCOUNT_STORE_ENV,
-        ]);
-        let path = std::env::var_os("PATH").unwrap_or_default();
-        std::env::set_var(
-            "PATH",
-            std::env::join_paths(std::iter::once(bin).chain(std::env::split_paths(&path))).unwrap(),
-        );
-        std::env::set_var(ACCOUNT_REPO_ID_ENV, "loopflowstudio/loopflow");
-        std::env::remove_var(FORWARDED_ACCOUNT_BUNDLE_ENV);
-        std::env::remove_var(FORWARDED_ACCOUNT_STORE_ENV);
-        let source_store = Arc::new(
-            open_store(&StorageConfig::sqlite(temp.path().join("source.db")))
-                .await
-                .unwrap(),
-        );
-        let mut engineering = account(Provider::Codex, "engineering", temp.path());
-        engineering.routing_state = RoutingState::ExplicitOnly;
-        engineering.cooldown_until = Some(now_unix() + 3600);
-        let home = engineering.home.as_ref().unwrap();
-        fs::create_dir_all(home).unwrap();
-        fs::write(
-            home.join("auth.json"),
-            r#"{"tokens":{"access_token":"e30.eyJleHAiOjQxMDI0NDQ4MDB9.sig","id_token":"e30.eyJlbWFpbCI6ImVuZ2luZWVyaW5nQGV4YW1wbGUuY29tIn0.sig"}}"#,
-        )
-        .unwrap();
-        source_store
-            .upsert_provider_account(&engineering)
-            .await
-            .unwrap();
-
-        let bundle = local_forwarded_account_bundle(&source_store, Some("engineering"))
-            .await
-            .unwrap()
-            .expect("explicit account should produce a bundle without a repo route");
-
-        assert_eq!(
-            bundle.selection,
-            ForwardedAccountSelection::Pinned(vec![ForwardedProviderPin {
-                provider: Provider::Codex,
-                account_id: engineering.account_id.clone(),
-            }])
-        );
-        assert_eq!(bundle.accounts.len(), 1);
-        assert_eq!(bundle.credentials.len(), 1);
-        let remote_db = temp.path().join("remote.db");
-        std::env::set_var(
-            FORWARDED_ACCOUNT_BUNDLE_ENV,
-            encode_forwarded_account_bundle(&bundle).unwrap(),
-        );
-        std::env::set_var(FORWARDED_ACCOUNT_STORE_ENV, &remote_db);
-        std::env::set_var(PROVIDER_ACCOUNT_ENV, "some-other-remote-account");
-
-        let route = resolve_provider_account(Provider::Codex, None)
-            .await
-            .unwrap()
-            .into_route()
-            .expect("forwarded explicit pin should resolve");
-
-        assert_eq!(route.account_id(), &engineering.account_id);
-        assert!(!route.uses_native_home());
-        let mut command = Command::new("codex");
-        route.apply(&mut command);
-        assert_eq!(
-            command
-                .get_envs()
-                .find(|(name, _)| *name == std::ffi::OsStr::new("CODEX_ACCESS_TOKEN"))
-                .and_then(|(_, value)| value)
-                .map(|value| value.to_string_lossy()),
-            Some("e30.eyJleHAiOjQxMDI0NDQ4MDB9.sig".into())
-        );
-        let remote_store = open_store(&StorageConfig::sqlite(remote_db)).await.unwrap();
-        assert!(remote_store
-            .get_provider_account(Provider::Codex.as_str(), &engineering.account_id)
-            .await
-            .unwrap()
-            .unwrap()
-            .home
-            .is_none());
-    }
-
-    #[allow(clippy::await_holding_lock)]
-    #[tokio::test]
-    async fn ordinary_forwarded_route_demotes_strain_before_the_bundle_leaves_the_host() {
-        let _lock = crate::journal::test_env_lock();
-        let temp = tempdir().unwrap();
-        let bin = temp.path().join("bin");
-        fs::create_dir_all(&bin).unwrap();
-        let codex = bin.join("codex");
-        fs::write(
-            &codex,
-            r#"#!/bin/sh
-IFS= read -r line
-printf '{"id":1,"result":{}}\n'
-IFS= read -r line
-IFS= read -r line
-printf '{"id":2,"result":{"account":null}}\n'
-"#,
-        )
-        .unwrap();
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-
-            let mut permissions = fs::metadata(&codex).unwrap().permissions();
-            permissions.set_mode(0o755);
-            fs::set_permissions(&codex, permissions).unwrap();
-        }
-        let _restore = EnvRestore::capture(&[
-            "PATH",
-            ACCOUNT_REPO_ID_ENV,
-            PROVIDER_ACCOUNT_ENV,
-            FORWARDED_ACCOUNT_BUNDLE_ENV,
-            FORWARDED_ACCOUNT_STORE_ENV,
-        ]);
-        let path = std::env::var_os("PATH").unwrap_or_default();
-        std::env::set_var(
-            "PATH",
-            std::env::join_paths(std::iter::once(bin).chain(std::env::split_paths(&path))).unwrap(),
-        );
-        std::env::set_var(ACCOUNT_REPO_ID_ENV, "loopflowstudio/loopflow");
-        std::env::remove_var(PROVIDER_ACCOUNT_ENV);
-        std::env::remove_var(FORWARDED_ACCOUNT_BUNDLE_ENV);
-        std::env::remove_var(FORWARDED_ACCOUNT_STORE_ENV);
-        let source_store = Arc::new(
-            open_store(&StorageConfig::sqlite(temp.path().join("source.db")))
-                .await
-                .unwrap(),
-        );
-        let strained = account(Provider::Codex, "strained", temp.path());
-        let healthy = account(Provider::Codex, "healthy", temp.path());
-        for (account, signature) in [(&strained, "strained-sig"), (&healthy, "healthy-sig")] {
-            let home = account.home.as_ref().unwrap();
-            fs::create_dir_all(home).unwrap();
-            fs::write(
-                home.join("auth.json"),
-                format!(
-                    r#"{{"tokens":{{"access_token":"e30.eyJleHAiOjQxMDI0NDQ4MDB9.{signature}","id_token":"e30.eyJlbWFpbCI6ImVuZ2luZWVyaW5nQGV4YW1wbGUuY29tIn0.sig"}}}}"#
-                ),
-            )
-            .unwrap();
-            source_store.upsert_provider_account(account).await.unwrap();
-        }
-        // Declared intent puts the strained account first.
-        source_store
-            .set_provider_route(&ProviderRoute {
-                scope: RouteScope::Default,
-                provider: Provider::Codex,
-                accounts: vec![strained.account_id.clone(), healthy.account_id.clone()],
-                created_at: now_unix(),
-                updated_at: now_unix(),
-            })
-            .await
-            .unwrap();
-        source_store
-            .upsert_provider_account_limits(
-                Provider::Codex.as_str(),
-                &strained.account_id,
-                &[crate::store::AccountLimitWindow {
-                    window: "weekly".to_string(),
-                    used_percent: 80,
-                    resets_at: Some(now_unix() + 3600),
-                    plan: None,
-                }],
-                "poll",
-            )
-            .await
-            .unwrap();
-
-        let bundle = local_forwarded_account_bundle(&source_store, None)
-            .await
-            .unwrap()
-            .expect("a routed repository should produce a bundle");
-
-        assert_eq!(
-            bundle.selection,
-            ForwardedAccountSelection::Routed {
-                repo_id: RepoId::parse("loopflowstudio/loopflow").unwrap(),
-                routes: vec![ForwardedProviderRoute {
-                    provider: Provider::Codex,
-                    accounts: vec![healthy.account_id.clone(), strained.account_id.clone()],
-                }],
-            }
-        );
-
-        std::env::set_var(
-            FORWARDED_ACCOUNT_BUNDLE_ENV,
-            encode_forwarded_account_bundle(&bundle).unwrap(),
-        );
-        std::env::set_var(FORWARDED_ACCOUNT_STORE_ENV, temp.path().join("remote.db"));
-
-        let route = resolve_provider_account(Provider::Codex, None)
-            .await
-            .unwrap()
-            .into_route()
-            .expect("ordinary forwarded route should select its healthy account");
-
-        // The remote store holds no limit observations, so the forwarded order
-        // is the only thing that can carry the demotion this far.
-        assert_eq!(route.account_id(), &healthy.account_id);
-        assert!(!route.uses_native_home());
-        let mut command = Command::new("codex");
-        route.apply(&mut command);
-        assert_eq!(
-            command
-                .get_envs()
-                .find(|(name, _)| *name == std::ffi::OsStr::new("CODEX_ACCESS_TOKEN"))
-                .and_then(|(_, value)| value)
-                .map(|value| value.to_string_lossy()),
-            Some("e30.eyJleHAiOjQxMDI0NDQ4MDB9.healthy-sig".into())
-        );
-    }
-
-    #[test]
-    fn forwarded_account_bundle_round_trips_without_exposing_tokens() {
-        let account_id = parse_account_id("engineering").unwrap();
-        let bundle = ForwardedAccountBundle::new(
-            ForwardedAccountSelection::Pinned(vec![ForwardedProviderPin {
-                provider: Provider::Codex,
-                account_id: account_id.clone(),
-            }]),
-            vec![],
-            vec![ForwardedProviderCredential::new(
-                Provider::Codex,
-                account_id,
-                "secret-token".to_string(),
-            )],
-        );
-
-        let encoded = encode_forwarded_account_bundle(&bundle).unwrap();
-        assert_eq!(decode_forwarded_account_bundle(&encoded).unwrap(), bundle);
-        assert!(!format!("{bundle:?}").contains("secret-token"));
-        let mut missing_selection = serde_json::to_value(&bundle).unwrap();
-        missing_selection
-            .as_object_mut()
-            .unwrap()
-            .remove("selection");
-        assert!(serde_json::from_value::<ForwardedAccountBundle>(missing_selection).is_err());
-    }
-
-    #[test]
-    fn forwarded_routed_selection_requires_repo_id() {
-        let account_id = parse_account_id("engineering").unwrap();
-        let bundle = ForwardedAccountBundle::new(
-            ForwardedAccountSelection::Routed {
-                repo_id: RepoId::parse("loopflowstudio/loopflow").unwrap(),
-                routes: vec![ForwardedProviderRoute {
-                    provider: Provider::Codex,
-                    accounts: vec![account_id],
-                }],
-            },
-            vec![],
-            vec![],
-        );
-        let mut value = serde_json::to_value(bundle).unwrap();
-        value["selection"]["routed"]
-            .as_object_mut()
-            .unwrap()
-            .remove("repo_id");
-
-        assert!(serde_json::from_value::<ForwardedAccountBundle>(value).is_err());
     }
 }

--- a/rust/loopflow/src/provider_account/lease.rs
+++ b/rust/loopflow/src/provider_account/lease.rs
@@ -1,0 +1,1396 @@
+//! Fixed account authority forwarded by `lf ssh` through a foreground broker.
+//!
+//! Descendants receive only an opaque handle and inherit the root grant
+//! unchanged. Provider launches receive one credential, and resumed provider
+//! sessions stay on the account recorded for them.
+
+use std::collections::{HashMap, HashSet};
+use std::fs;
+use std::io::{BufRead, BufReader, Read, Write};
+use std::os::unix::net::{UnixListener, UnixStream};
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::thread;
+use std::time::Duration;
+
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use base64::Engine;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::provider_account::{match_account, AccountMatch, ProviderAccountError, RateLimitSignal};
+use crate::provider_auth::Provider;
+use crate::store::{ProviderAccount, ProviderAccountId, SharedStore};
+
+/// The encoded [`AccountLeaseHandle`] carried across process boundaries.
+pub const ACCOUNT_LEASE_ENV: &str = "LF_ACCOUNT_LEASE";
+
+/// One provider's ordered grant. Preferred (`--account`-selected) ids form the
+/// leading `preferred` entries in `accounts`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct ProviderGrant {
+    pub(crate) provider: Provider,
+    pub(crate) accounts: Vec<ProviderAccountId>,
+    pub(crate) preferred: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct AccountLease {
+    pub(crate) grants: Vec<ProviderGrant>,
+}
+
+impl AccountLease {
+    fn grant(&self, provider: Provider) -> Option<&ProviderGrant> {
+        self.grants.iter().find(|grant| grant.provider == provider)
+    }
+}
+
+/// One `--account claude=work` / `--only-account codex=reserve` token.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ProviderAccountSelector {
+    provider: Option<Provider>,
+    account: String,
+}
+
+impl ProviderAccountSelector {
+    fn parse(value: &str) -> Result<Self, ProviderAccountError> {
+        let value = value.trim();
+        if value.is_empty() {
+            return Err(ProviderAccountError::Runtime(
+                "account selector cannot be empty".to_string(),
+            ));
+        }
+        let Some((provider, account)) = value.split_once('=') else {
+            return Ok(Self {
+                provider: None,
+                account: value.to_string(),
+            });
+        };
+        let provider = provider.parse::<Provider>().map_err(|_| {
+            ProviderAccountError::Runtime(format!(
+                "unknown account selector provider '{}'",
+                provider.trim()
+            ))
+        })?;
+        if !matches!(provider, Provider::Claude | Provider::Codex) {
+            return Err(ProviderAccountError::UnsupportedProvider);
+        }
+        let account = account.trim();
+        if account.is_empty() {
+            return Err(ProviderAccountError::Runtime(format!(
+                "{provider}= requires an account id or login email"
+            )));
+        }
+        Ok(Self {
+            provider: Some(provider),
+            account: account.to_string(),
+        })
+    }
+}
+
+/// The root account selection, resolved once at the outer invocation. This
+/// never crosses a process boundary — descendants inherit the resolved lease,
+/// not the selection.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum SelectionMode {
+    /// No flags: forward the normal healthy local route.
+    Default,
+    /// `--account`: prefer these accounts, keep each provider's route as
+    /// fallback.
+    Prefer(Vec<ProviderAccountSelector>),
+    /// `--only-account`: expose exactly these accounts, no fallback.
+    Restrict(Vec<ProviderAccountSelector>),
+}
+
+/// Root-only account flags before they become one fixed grant.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AccountSelection(SelectionMode);
+
+impl Default for AccountSelection {
+    fn default() -> Self {
+        Self(SelectionMode::Default)
+    }
+}
+
+impl AccountSelection {
+    pub fn from_flags(
+        preferred: &[String],
+        restricted: &[String],
+    ) -> Result<Self, ProviderAccountError> {
+        if !preferred.is_empty() && !restricted.is_empty() {
+            return Err(ProviderAccountError::Runtime(
+                "--account and --only-account are mutually exclusive".to_string(),
+            ));
+        }
+        let parse = |values: &[String]| {
+            values
+                .iter()
+                .map(|value| ProviderAccountSelector::parse(value))
+                .collect::<Result<Vec<_>, _>>()
+        };
+        if !preferred.is_empty() {
+            Ok(Self(SelectionMode::Prefer(parse(preferred)?)))
+        } else if !restricted.is_empty() {
+            Ok(Self(SelectionMode::Restrict(parse(restricted)?)))
+        } else {
+            Ok(Self::default())
+        }
+    }
+
+    pub fn is_default(&self) -> bool {
+        matches!(self.0, SelectionMode::Default)
+    }
+
+    fn is_restricted(&self) -> bool {
+        matches!(self.0, SelectionMode::Restrict(_))
+    }
+
+    fn selectors(&self) -> &[ProviderAccountSelector] {
+        match &self.0 {
+            SelectionMode::Prefer(selectors) | SelectionMode::Restrict(selectors) => selectors,
+            SelectionMode::Default => &[],
+        }
+    }
+}
+
+/// Broker location and request secret, without credentials or account ids.
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct AccountLeaseHandle {
+    pub(crate) socket: PathBuf,
+    pub(crate) secret: String,
+}
+
+impl std::fmt::Debug for AccountLeaseHandle {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("AccountLeaseHandle")
+            .field("socket", &self.socket)
+            .field("secret", &"[REDACTED]")
+            .finish()
+    }
+}
+
+impl AccountLeaseHandle {
+    pub(crate) fn encode(&self) -> Result<String, ProviderAccountError> {
+        let bytes = serde_json::to_vec(self)
+            .map_err(|error| ProviderAccountError::AccountLease(error.to_string()))?;
+        Ok(URL_SAFE_NO_PAD.encode(bytes))
+    }
+
+    fn decode(value: &str) -> Result<Self, ProviderAccountError> {
+        let bytes = URL_SAFE_NO_PAD
+            .decode(value.trim())
+            .map_err(|error| ProviderAccountError::AccountLease(error.to_string()))?;
+        serde_json::from_slice(&bytes)
+            .map_err(|error| ProviderAccountError::AccountLease(error.to_string()))
+    }
+}
+
+/// A resolved root lease plus the broker-private credentials that serve it.
+pub(crate) struct PreparedAccountLease {
+    pub(crate) lease: AccountLease,
+    credentials: HashMap<(Provider, ProviderAccountId), String>,
+    store: SharedStore,
+    restricted: bool,
+}
+
+impl std::fmt::Debug for PreparedAccountLease {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("PreparedAccountLease")
+            .field("lease", &self.lease)
+            .field(
+                "credentials",
+                &format_args!("{} redacted", self.credentials.len()),
+            )
+            .field("restricted", &self.restricted)
+            .finish()
+    }
+}
+
+fn supported_providers() -> [Provider; 2] {
+    [Provider::Claude, Provider::Codex]
+}
+
+#[derive(Debug, Clone)]
+struct ResolvedSelector {
+    provider: Provider,
+    account_id: ProviderAccountId,
+}
+
+fn resolve_selectors(
+    catalog: &[ProviderAccount],
+    selectors: &[ProviderAccountSelector],
+) -> Result<Vec<ResolvedSelector>, ProviderAccountError> {
+    let mut resolved = Vec::new();
+    let mut seen = HashSet::new();
+    for selector in selectors {
+        let mut selector_matches = Vec::new();
+        for provider in supported_providers() {
+            if selector
+                .provider
+                .is_some_and(|selected| selected != provider)
+            {
+                continue;
+            }
+            let accounts = catalog
+                .iter()
+                .filter(|account| account.provider == provider.as_str())
+                .collect::<Vec<_>>();
+            match match_account(&accounts, &selector.account) {
+                AccountMatch::One(account) => selector_matches.push(ResolvedSelector {
+                    provider,
+                    account_id: account.account_id.clone(),
+                }),
+                AccountMatch::Ambiguous(matches) => {
+                    return Err(ProviderAccountError::Runtime(format!(
+                        "'{}' matches several accounts: {}",
+                        selector.account,
+                        matches
+                            .iter()
+                            .map(|account| format!("{}/{}", account.provider, account.account_id))
+                            .collect::<Vec<_>>()
+                            .join(", ")
+                    )));
+                }
+                AccountMatch::None => {}
+            }
+        }
+        if selector_matches.is_empty() {
+            let provider = selector
+                .provider
+                .map(|provider| format!("{provider} "))
+                .unwrap_or_default();
+            return Err(ProviderAccountError::Runtime(format!(
+                "no managed {provider}account matches '{}'; see `lf auth accounts`",
+                selector.account
+            )));
+        }
+        for matched in selector_matches {
+            if !seen.insert((matched.provider, matched.account_id.clone())) {
+                return Err(ProviderAccountError::Runtime(format!(
+                    "account selector duplicates {}/{}",
+                    matched.provider, matched.account_id
+                )));
+            }
+            resolved.push(matched);
+        }
+    }
+    Ok(resolved)
+}
+
+fn grants_for_selection(
+    routes: HashMap<Provider, Vec<ProviderAccountId>>,
+    resolved: &[ResolvedSelector],
+    selection: &AccountSelection,
+) -> Vec<ProviderGrant> {
+    supported_providers()
+        .into_iter()
+        .filter_map(|provider| {
+            let selected = resolved
+                .iter()
+                .filter(|selected| selected.provider == provider)
+                .map(|selected| selected.account_id.clone())
+                .collect::<Vec<_>>();
+            let route = routes.get(&provider).cloned().unwrap_or_default();
+            let (accounts, preferred) = match &selection.0 {
+                SelectionMode::Default => (route, 0),
+                SelectionMode::Prefer(_) => {
+                    let preferred = selected.len();
+                    let mut accounts = selected.clone();
+                    for account_id in route {
+                        if !accounts.contains(&account_id) {
+                            accounts.push(account_id);
+                        }
+                    }
+                    (accounts, preferred)
+                }
+                SelectionMode::Restrict(_) => (selected.clone(), selected.len()),
+            };
+            (!accounts.is_empty()).then_some(ProviderGrant {
+                provider,
+                accounts,
+                preferred,
+            })
+        })
+        .collect()
+}
+
+/// Open the local account store and prepare one fixed root grant. Returns
+/// `None` only when the default selection has no store or route to forward.
+pub(crate) async fn prepare_root_lease(
+    selection: &AccountSelection,
+) -> Result<Option<PreparedAccountLease>, ProviderAccountError> {
+    let store = match crate::store::open_existing_store().await {
+        Some(store) => Arc::new(store),
+        None if selection.is_default() => return Ok(None),
+        None => {
+            return Err(ProviderAccountError::Runtime(
+                "account store unavailable for --account/--only-account".to_string(),
+            ));
+        }
+    };
+    let repo_id = super::current_repo_id()?;
+    let catalog = store.list_provider_accounts(None).await?;
+    let resolved = resolve_selectors(&catalog, selection.selectors())?;
+    let mut routes = HashMap::new();
+    for provider in supported_providers() {
+        routes.insert(
+            provider,
+            super::provider_route_account_ids(&store, repo_id.as_ref(), provider)
+                .await?
+                .unwrap_or_default(),
+        );
+    }
+    let grants = grants_for_selection(routes, &resolved, selection);
+    if grants.is_empty() {
+        if selection.is_default() {
+            return Ok(None);
+        }
+        return Err(ProviderAccountError::Runtime(
+            "account selection produced no provider grant".to_string(),
+        ));
+    }
+    let lease = AccountLease { grants };
+    let selected = lease
+        .grants
+        .iter()
+        .flat_map(|grant| {
+            grant
+                .accounts
+                .iter()
+                .map(move |account_id| (grant.provider, account_id))
+        })
+        .collect::<HashSet<_>>();
+    let mut credentials = HashMap::new();
+    let restricted = selection.is_restricted();
+    for account in catalog.iter().filter(|account| {
+        supported_providers().iter().any(|provider| {
+            account.provider == provider.as_str()
+                && selected.contains(&(*provider, &account.account_id))
+        })
+    }) {
+        let provider = account
+            .provider
+            .parse::<Provider>()
+            .map_err(|error| ProviderAccountError::Runtime(error.to_string()))?;
+        match crate::provider_account::prepare_account_access_token(provider, account).await {
+            Ok(access_token) => {
+                credentials.insert((provider, account.account_id.clone()), access_token);
+            }
+            Err(error) if !restricted => {
+                tracing::warn!(
+                    provider = %provider,
+                    account = %account.account_id,
+                    "skipping unavailable account in fallback grant: {error}"
+                );
+            }
+            Err(error) => return Err(error),
+        }
+    }
+    Ok(Some(PreparedAccountLease {
+        lease,
+        credentials,
+        store,
+        restricted,
+    }))
+}
+
+#[derive(Serialize, Deserialize)]
+struct BrokerRequest {
+    secret: String,
+    operation: BrokerOperation,
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum BrokerOperation {
+    Describe,
+    Resolve {
+        provider: Provider,
+        provider_session_id: Option<String>,
+    },
+    PinSession {
+        provider: Provider,
+        provider_session_id: String,
+        account_id: ProviderAccountId,
+    },
+    RecordHealth {
+        provider: Provider,
+        account_id: ProviderAccountId,
+        signal: RateLimitSignal,
+    },
+}
+
+#[derive(Serialize, Deserialize)]
+pub(crate) struct LeaseResolution {
+    pub(crate) account_id: ProviderAccountId,
+    access_token: String,
+    pub(crate) resume_requested_session: bool,
+}
+
+impl std::fmt::Debug for LeaseResolution {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("LeaseResolution")
+            .field("account_id", &self.account_id)
+            .field("access_token", &"[REDACTED]")
+            .finish()
+    }
+}
+
+impl LeaseResolution {
+    pub(crate) fn access_token(&self) -> &str {
+        &self.access_token
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum BrokerResponse {
+    Lease(AccountLease),
+    Resolution(LeaseResolution),
+    Ok,
+    Error(String),
+}
+
+struct BrokerState {
+    prepared: PreparedAccountLease,
+    secret: String,
+    /// Preferred accounts already served once this run. A preferred account
+    /// gets one attempt bypassing stored demotion; after a rate-limit signal it
+    /// is spent and resolution falls through to the fallback route.
+    spent_preferences: HashSet<(Provider, ProviderAccountId)>,
+}
+
+impl BrokerState {
+    async fn resolve(
+        &mut self,
+        provider: Provider,
+        provider_session_id: Option<&str>,
+    ) -> Result<LeaseResolution, ProviderAccountError> {
+        let grant = self.prepared.lease.grant(provider).ok_or_else(|| {
+            ProviderAccountError::Runtime(format!(
+                "{provider} is unavailable in this forwarded account lease"
+            ))
+        })?;
+        let restricted = self.prepared.restricted;
+        let viable = grant
+            .accounts
+            .iter()
+            .filter(|account_id| {
+                self.prepared
+                    .credentials
+                    .contains_key(&(provider, (*account_id).clone()))
+            })
+            .cloned()
+            .collect::<Vec<_>>();
+        if viable.is_empty() {
+            return Err(ProviderAccountError::NoAuthenticatedAccount {
+                provider,
+                accounts: grant
+                    .accounts
+                    .iter()
+                    .map(|account| format!("'{account}'"))
+                    .collect::<Vec<_>>()
+                    .join(", "),
+            });
+        }
+        // Provider continuation: a resumed session stays on its recorded
+        // account when that account is still within the grant.
+        let resumed = match provider_session_id {
+            Some(session_id) => self
+                .prepared
+                .store
+                .provider_session_account(provider, session_id)
+                .await?
+                .filter(|account_id| viable.contains(account_id)),
+            None => None,
+        };
+        // A continuation already has an account. Do not reserve an unrelated
+        // preferred attempt while honoring that pin; the reservation belongs
+        // only to a new provider session that will actually use it.
+        let preferred = if resumed.is_none() {
+            let preferred = grant
+                .accounts
+                .iter()
+                .take(grant.preferred)
+                .find(|preferred| {
+                    viable.contains(preferred)
+                        && !self
+                            .spent_preferences
+                            .contains(&(provider, (*preferred).clone()))
+                })
+                .cloned();
+            if let Some(account_id) = &preferred {
+                self.spent_preferences
+                    .insert((provider, account_id.clone()));
+            }
+            preferred
+        } else {
+            None
+        };
+        let fallback = if restricted {
+            viable.clone()
+        } else {
+            viable
+                .iter()
+                .filter(|account_id| {
+                    !grant
+                        .accounts
+                        .iter()
+                        .take(grant.preferred)
+                        .any(|id| id == *account_id)
+                })
+                .cloned()
+                .collect::<Vec<_>>()
+        };
+        let (selected, resume_requested_session) = if let Some(account_id) = resumed {
+            (account_id, true)
+        } else if let Some(preferred) = preferred {
+            (preferred, false)
+        } else {
+            (
+                self.prepared
+                    .store
+                    .select_provider_account(provider, &fallback, None)
+                    .await?
+                    .ok_or_else(|| ProviderAccountError::NoEligibleAccount {
+                        provider,
+                        accounts: fallback
+                            .iter()
+                            .map(|account| format!("'{account}'"))
+                            .collect::<Vec<_>>()
+                            .join(", "),
+                    })?
+                    .account
+                    .account_id,
+                false,
+            )
+        };
+        let access_token = self
+            .prepared
+            .credentials
+            .get(&(provider, selected.clone()))
+            .cloned()
+            .ok_or_else(|| {
+                ProviderAccountError::Runtime(format!(
+                    "forwarded grant has no credential for {provider}/{selected}"
+                ))
+            })?;
+        Ok(LeaseResolution {
+            account_id: selected,
+            access_token,
+            resume_requested_session,
+        })
+    }
+
+    fn grant_contains(
+        &self,
+        provider: Provider,
+        account_id: &ProviderAccountId,
+    ) -> Result<(), ProviderAccountError> {
+        let grant = self.prepared.lease.grant(provider).ok_or_else(|| {
+            ProviderAccountError::Runtime(format!(
+                "{provider} is unavailable in this forwarded account lease"
+            ))
+        })?;
+        if grant.accounts.contains(account_id) {
+            Ok(())
+        } else {
+            Err(ProviderAccountError::Runtime(format!(
+                "{provider}/{account_id} is outside the forwarded account lease"
+            )))
+        }
+    }
+
+    async fn handle(
+        &mut self,
+        request: BrokerRequest,
+    ) -> Result<BrokerResponse, ProviderAccountError> {
+        if request.secret != self.secret {
+            return Err(ProviderAccountError::Runtime(
+                "account lease is missing or expired".to_string(),
+            ));
+        }
+        match request.operation {
+            BrokerOperation::Describe => Ok(BrokerResponse::Lease(self.prepared.lease.clone())),
+            BrokerOperation::Resolve {
+                provider,
+                provider_session_id,
+            } => Ok(BrokerResponse::Resolution(
+                self.resolve(provider, provider_session_id.as_deref())
+                    .await?,
+            )),
+            BrokerOperation::PinSession {
+                provider,
+                provider_session_id,
+                account_id,
+            } => {
+                self.grant_contains(provider, &account_id)?;
+                self.spent_preferences
+                    .remove(&(provider, account_id.clone()));
+                self.prepared
+                    .store
+                    .pin_provider_session_route(provider, &provider_session_id, &account_id)
+                    .await?;
+                Ok(BrokerResponse::Ok)
+            }
+            BrokerOperation::RecordHealth {
+                provider,
+                account_id,
+                signal,
+            } => {
+                self.grant_contains(provider, &account_id)?;
+                if signal.limited {
+                    self.spent_preferences
+                        .insert((provider, account_id.clone()));
+                }
+                crate::provider_account::record_rate_limit_signal(
+                    &self.prepared.store,
+                    provider,
+                    &account_id,
+                    &signal,
+                    "forwarded_stream",
+                )
+                .await?;
+                Ok(BrokerResponse::Ok)
+            }
+        }
+    }
+}
+
+pub struct AccountLeaseBroker {
+    secret: String,
+    local_socket: PathBuf,
+    remote_socket: PathBuf,
+    stop: Arc<AtomicBool>,
+    thread: Option<thread::JoinHandle<()>>,
+    _directory: tempfile::TempDir,
+}
+
+impl std::fmt::Debug for AccountLeaseBroker {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("AccountLeaseBroker")
+            .field("local_socket", &self.local_socket)
+            .field("remote_socket", &self.remote_socket)
+            .field("secret", &"[REDACTED]")
+            .finish()
+    }
+}
+
+impl AccountLeaseBroker {
+    pub async fn start_root(
+        selection: &AccountSelection,
+    ) -> Result<Option<Self>, ProviderAccountError> {
+        prepare_root_lease(selection)
+            .await?
+            .map(Self::start)
+            .transpose()
+    }
+
+    pub fn local_env_value(&self) -> Result<String, ProviderAccountError> {
+        self.local_handle().encode()
+    }
+
+    pub(crate) fn start(prepared: PreparedAccountLease) -> Result<Self, ProviderAccountError> {
+        let directory = tempfile::Builder::new()
+            .prefix("lf-account-lease-")
+            .tempdir()
+            .map_err(|error| ProviderAccountError::Filesystem(error.to_string()))?;
+        let local_socket = directory.path().join("broker.sock");
+        let cleanup_directory = directory.path().to_path_buf();
+        crate::engine::agent::register_interrupt_cleanup(move || {
+            let _ = fs::remove_dir_all(&cleanup_directory);
+        });
+        let listener = UnixListener::bind(&local_socket)
+            .map_err(|error| ProviderAccountError::Filesystem(error.to_string()))?;
+        listener
+            .set_nonblocking(true)
+            .map_err(|error| ProviderAccountError::Filesystem(error.to_string()))?;
+        let remote_socket = PathBuf::from(format!("/tmp/lf-account-{}.sock", Uuid::new_v4()));
+        let secret = Uuid::new_v4().to_string();
+        let stop = Arc::new(AtomicBool::new(false));
+        let thread_stop = Arc::clone(&stop);
+        let thread_secret = secret.clone();
+        let thread = thread::Builder::new()
+            .name("lf-account-lease-broker".to_string())
+            .spawn(move || {
+                let runtime = tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                    .expect("account lease broker runtime");
+                let mut state = BrokerState {
+                    prepared,
+                    secret: thread_secret,
+                    spent_preferences: HashSet::new(),
+                };
+                while !thread_stop.load(Ordering::Acquire) {
+                    match listener.accept() {
+                        Ok((mut stream, _)) => {
+                            if stream.set_nonblocking(false).is_err() {
+                                continue;
+                            }
+                            let timeout = Some(Duration::from_secs(5));
+                            if stream.set_read_timeout(timeout).is_err()
+                                || stream.set_write_timeout(timeout).is_err()
+                            {
+                                continue;
+                            }
+                            let mut line = String::new();
+                            let response = match BufReader::new(&mut stream).read_line(&mut line) {
+                                Ok(_) => match serde_json::from_str::<BrokerRequest>(&line) {
+                                    Ok(request) => match runtime.block_on(state.handle(request)) {
+                                        Ok(response) => response,
+                                        Err(error) => BrokerResponse::Error(error.to_string()),
+                                    },
+                                    Err(error) => BrokerResponse::Error(format!(
+                                        "invalid account lease request: {error}"
+                                    )),
+                                },
+                                Err(error) => BrokerResponse::Error(format!(
+                                    "read account lease request: {error}"
+                                )),
+                            };
+                            if let Ok(bytes) = serde_json::to_vec(&response) {
+                                let _ = stream.write_all(&bytes);
+                            }
+                        }
+                        Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                            thread::sleep(Duration::from_millis(10));
+                        }
+                        Err(error) => {
+                            tracing::warn!("account lease broker stopped accepting: {error}");
+                            break;
+                        }
+                    }
+                }
+            })
+            .map_err(|error| ProviderAccountError::Runtime(error.to_string()))?;
+        Ok(Self {
+            secret,
+            local_socket,
+            remote_socket,
+            stop,
+            thread: Some(thread),
+            _directory: directory,
+        })
+    }
+
+    /// Handle a local child inherits: points at the broker's own socket.
+    pub(crate) fn local_handle(&self) -> AccountLeaseHandle {
+        AccountLeaseHandle {
+            socket: self.local_socket.clone(),
+            secret: self.secret.clone(),
+        }
+    }
+
+    /// Handle forwarded over SSH: points at the `-R`-forwarded remote socket.
+    pub(crate) fn remote_handle(&self) -> AccountLeaseHandle {
+        AccountLeaseHandle {
+            socket: self.remote_socket.clone(),
+            secret: self.secret.clone(),
+        }
+    }
+
+    pub(crate) fn local_socket(&self) -> &Path {
+        &self.local_socket
+    }
+
+    pub(crate) fn remote_socket(&self) -> &Path {
+        &self.remote_socket
+    }
+}
+
+impl Drop for AccountLeaseBroker {
+    fn drop(&mut self) {
+        self.stop.store(true, Ordering::Release);
+        let _ = UnixStream::connect(&self.local_socket);
+        if let Some(thread) = self.thread.take() {
+            let _ = thread.join();
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct AccountLeaseClient {
+    handle: AccountLeaseHandle,
+}
+
+impl AccountLeaseClient {
+    pub(crate) fn from_env() -> Result<Option<Self>, ProviderAccountError> {
+        match std::env::var_os(ACCOUNT_LEASE_ENV) {
+            Some(value) if !value.is_empty() => {
+                let value = value.into_string().map_err(|_| {
+                    ProviderAccountError::AccountLease(
+                        "LF_ACCOUNT_LEASE is not valid UTF-8".to_string(),
+                    )
+                })?;
+                Ok(Some(Self {
+                    handle: AccountLeaseHandle::decode(&value)?,
+                }))
+            }
+            _ => Ok(None),
+        }
+    }
+
+    fn request(&self, operation: BrokerOperation) -> Result<BrokerResponse, ProviderAccountError> {
+        let mut stream = UnixStream::connect(&self.handle.socket).map_err(|error| {
+            ProviderAccountError::Runtime(format!(
+                "forwarded account lease is unavailable or expired: {error}"
+            ))
+        })?;
+        let timeout = Some(Duration::from_secs(5));
+        stream
+            .set_read_timeout(timeout)
+            .and_then(|()| stream.set_write_timeout(timeout))
+            .map_err(|error| {
+                ProviderAccountError::Runtime(format!(
+                    "configure forwarded account lease timeout: {error}"
+                ))
+            })?;
+        let bytes = serde_json::to_vec(&BrokerRequest {
+            secret: self.handle.secret.clone(),
+            operation,
+        })
+        .map_err(|error| ProviderAccountError::Runtime(error.to_string()))?;
+        stream
+            .write_all(&bytes)
+            .map_err(|error| ProviderAccountError::Runtime(error.to_string()))?;
+        stream
+            .write_all(b"\n")
+            .map_err(|error| ProviderAccountError::Runtime(error.to_string()))?;
+        let mut response = Vec::new();
+        stream
+            .read_to_end(&mut response)
+            .map_err(|error| ProviderAccountError::Runtime(error.to_string()))?;
+        let response = serde_json::from_slice::<BrokerResponse>(&response)
+            .map_err(|error| ProviderAccountError::Runtime(error.to_string()))?;
+        match response {
+            BrokerResponse::Error(error) => Err(ProviderAccountError::Runtime(error)),
+            response => Ok(response),
+        }
+    }
+
+    pub(crate) fn describe(&self) -> Result<AccountLease, ProviderAccountError> {
+        match self.request(BrokerOperation::Describe)? {
+            BrokerResponse::Lease(lease) => Ok(lease),
+            _ => Err(ProviderAccountError::Runtime(
+                "account lease broker returned the wrong response".to_string(),
+            )),
+        }
+    }
+
+    pub(crate) fn resolve(
+        &self,
+        provider: Provider,
+        provider_session_id: Option<String>,
+    ) -> Result<LeaseResolution, ProviderAccountError> {
+        match self.request(BrokerOperation::Resolve {
+            provider,
+            provider_session_id,
+        })? {
+            BrokerResponse::Resolution(resolution) => Ok(resolution),
+            _ => Err(ProviderAccountError::Runtime(
+                "account lease broker returned the wrong response".to_string(),
+            )),
+        }
+    }
+
+    pub(crate) fn pin_session(
+        &self,
+        provider: Provider,
+        provider_session_id: &str,
+        account_id: &ProviderAccountId,
+    ) -> Result<(), ProviderAccountError> {
+        match self.request(BrokerOperation::PinSession {
+            provider,
+            provider_session_id: provider_session_id.to_string(),
+            account_id: account_id.clone(),
+        })? {
+            BrokerResponse::Ok => Ok(()),
+            _ => Err(ProviderAccountError::Runtime(
+                "account lease broker returned the wrong response".to_string(),
+            )),
+        }
+    }
+
+    pub(crate) fn record_health(
+        &self,
+        provider: Provider,
+        account_id: &ProviderAccountId,
+        signal: &RateLimitSignal,
+    ) -> Result<(), ProviderAccountError> {
+        match self.request(BrokerOperation::RecordHealth {
+            provider,
+            account_id: account_id.clone(),
+            signal: signal.clone(),
+        })? {
+            BrokerResponse::Ok => Ok(()),
+            _ => Err(ProviderAccountError::Runtime(
+                "account lease broker returned the wrong response".to_string(),
+            )),
+        }
+    }
+}
+
+pub(crate) fn account_lease_active() -> bool {
+    std::env::var_os(ACCOUNT_LEASE_ENV).is_some_and(|value| !value.is_empty())
+}
+
+/// Confirm that this process inherited a valid lease and can reach its broker.
+/// `lf ssh` runs this before the target command so an incompatible remote `lf`
+/// or a failed socket forward cannot fall through to ambient remote accounts.
+pub fn probe_forwarded_authority() -> Result<(), ProviderAccountError> {
+    let client = AccountLeaseClient::from_env()?.ok_or_else(|| {
+        ProviderAccountError::Runtime("forwarded account lease is unavailable".to_string())
+    })?;
+    client.describe()?;
+    Ok(())
+}
+
+pub fn validate_account_selection(
+    selection: &AccountSelection,
+) -> Result<(), ProviderAccountError> {
+    if !account_lease_active() || selection.is_default() {
+        return Ok(());
+    }
+    Err(ProviderAccountError::Runtime(
+        "account authority was fixed by an outer `lf` invocation; a nested `lf` cannot set \
+         --account/--only-account"
+            .to_string(),
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::fs;
+    use std::os::unix::ffi::OsStringExt;
+    use std::path::PathBuf;
+    use std::sync::Arc;
+
+    use super::{
+        account_lease_active, grants_for_selection, prepare_root_lease, probe_forwarded_authority,
+        resolve_selectors, validate_account_selection, AccountLease, AccountLeaseBroker,
+        AccountLeaseClient, AccountLeaseHandle, AccountSelection, PreparedAccountLease,
+        ProviderAccountSelector, ProviderGrant, ResolvedSelector, ACCOUNT_LEASE_ENV,
+    };
+    use crate::profile::{ProviderRoute, RouteScope};
+    use crate::provider_account::{new_account, parse_account_id, RateLimitSignal};
+    use crate::provider_auth::Provider;
+    use crate::store::{open_store, ProviderAccount, ProviderAccountId, StorageConfig};
+    use tempfile::tempdir;
+    fn id(value: &str) -> ProviderAccountId {
+        parse_account_id(value).unwrap()
+    }
+    fn account(provider: Provider, account_id: &str, login: &str) -> ProviderAccount {
+        let mut account = new_account(
+            provider,
+            id(account_id),
+            PathBuf::from(format!("/accounts/{provider}/{account_id}")),
+            Some(crate::profile::EmailAddress::parse(login).unwrap()),
+        );
+        account.updated_at = 1;
+        account
+    }
+    fn selection_from(flag: &str) -> AccountSelection {
+        AccountSelection::from_flags(&[flag.to_string()], &[]).unwrap()
+    }
+    fn resolved(
+        catalog: &[ProviderAccount],
+        selection: &AccountSelection,
+    ) -> Vec<ResolvedSelector> {
+        resolve_selectors(catalog, selection.selectors()).unwrap()
+    }
+    fn grant(grants: &[ProviderGrant], provider: Provider) -> &ProviderGrant {
+        grants
+            .iter()
+            .find(|grant| grant.provider == provider)
+            .unwrap()
+    }
+    struct RestoreEnv(&'static str, Option<std::ffi::OsString>);
+    impl RestoreEnv {
+        fn capture(name: &'static str) -> Self {
+            Self(name, std::env::var_os(name))
+        }
+    }
+    impl Drop for RestoreEnv {
+        fn drop(&mut self) {
+            match &self.1 {
+                Some(value) => std::env::set_var(self.0, value),
+                None => std::env::remove_var(self.0),
+            }
+        }
+    }
+    #[test]
+    fn preference_orders_selected_first_and_keeps_provider_fallbacks() {
+        let catalog = vec![
+            account(Provider::Claude, "personal", "personal@example.com"),
+            account(Provider::Claude, "work", "work@example.com"),
+            account(Provider::Codex, "primary", "primary@example.com"),
+            account(Provider::Codex, "work", "work@example.com"),
+        ];
+        let selection = selection_from("work");
+        let grants = grants_for_selection(
+            HashMap::from([
+                (Provider::Claude, vec![id("personal")]),
+                (Provider::Codex, vec![id("primary")]),
+            ]),
+            &resolved(&catalog, &selection),
+            &selection,
+        );
+        assert_eq!(
+            grant(&grants, Provider::Claude).accounts,
+            vec![id("work"), id("personal")]
+        );
+        assert_eq!(
+            grant(&grants, Provider::Codex).accounts,
+            vec![id("work"), id("primary")]
+        );
+    }
+    #[test]
+    fn provider_qualified_selectors_target_one_provider() {
+        let catalog = vec![
+            account(Provider::Claude, "shared", "claude@example.com"),
+            account(Provider::Codex, "shared", "codex@example.com"),
+        ];
+        let selection = AccountSelection::from_flags(&["codex=shared".to_string()], &[]).unwrap();
+        let grants = grants_for_selection(
+            HashMap::from([(Provider::Claude, vec![id("shared")])]),
+            &resolved(&catalog, &selection),
+            &selection,
+        );
+        assert_eq!(grants.len(), 2);
+        assert_eq!(grant(&grants, Provider::Codex).preferred, 1);
+        assert_eq!(grant(&grants, Provider::Claude).preferred, 0);
+    }
+    #[test]
+    fn restriction_exposes_only_selected_providers() {
+        let catalog = vec![
+            account(Provider::Claude, "personal", "personal@example.com"),
+            account(Provider::Codex, "reserve", "reserve@example.com"),
+        ];
+        let selection = AccountSelection::from_flags(&[], &["codex=reserve".to_string()]).unwrap();
+        let grants =
+            grants_for_selection(HashMap::new(), &resolved(&catalog, &selection), &selection);
+        assert_eq!(grants.len(), 1);
+        assert_eq!(grants[0].provider, Provider::Codex);
+        assert_eq!(grants[0].accounts, vec![id("reserve")]);
+    }
+    #[test]
+    fn ambiguous_and_duplicate_selectors_fail_before_launch() {
+        let catalog = vec![
+            account(Provider::Codex, "engineering-one", "one@example.com"),
+            account(Provider::Codex, "engineering-two", "two@example.com"),
+        ];
+        let ambiguous = resolve_selectors(
+            &catalog,
+            &[ProviderAccountSelector::parse("codex=engineering").unwrap()],
+        )
+        .unwrap_err();
+        assert!(ambiguous.to_string().contains("matches several accounts"));
+        let duplicate = resolve_selectors(
+            &catalog,
+            &[
+                ProviderAccountSelector::parse("codex=engineering-one").unwrap(),
+                ProviderAccountSelector::parse("codex=engineering-one").unwrap(),
+            ],
+        )
+        .unwrap_err();
+        assert!(duplicate
+            .to_string()
+            .contains("duplicates codex/engineering-one"));
+    }
+    #[test]
+    fn nested_account_flags_are_rejected() {
+        let _lock = crate::journal::test_env_lock();
+        let _restore = RestoreEnv::capture(ACCOUNT_LEASE_ENV);
+        let selection = selection_from("codex=reserve");
+        std::env::set_var(ACCOUNT_LEASE_ENV, "forwarded");
+        let error = validate_account_selection(&selection).unwrap_err();
+        assert!(error.to_string().contains("fixed by an outer `lf`"));
+        validate_account_selection(&AccountSelection::default()).unwrap();
+        std::env::remove_var(ACCOUNT_LEASE_ENV);
+        validate_account_selection(&selection).unwrap();
+        std::env::set_var(ACCOUNT_LEASE_ENV, std::ffi::OsString::from_vec(vec![0xff]));
+        assert!(account_lease_active());
+        assert!(AccountLeaseClient::from_env().is_err());
+    }
+    #[allow(clippy::await_holding_lock)]
+    #[tokio::test]
+    async fn root_preparation_keeps_a_healthy_fallback_when_a_preference_has_no_credential() {
+        let _lock = crate::journal::test_env_lock();
+        let temp = tempdir().unwrap();
+        let _home = RestoreEnv::capture("LF_HOME");
+        let _database = RestoreEnv::capture("LF_DB_PATH");
+        let _lease = RestoreEnv::capture(ACCOUNT_LEASE_ENV);
+        std::env::set_var("LF_HOME", temp.path());
+        std::env::remove_var("LF_DB_PATH");
+        std::env::remove_var(ACCOUNT_LEASE_ENV);
+
+        let store = Arc::new(
+            open_store(&StorageConfig::sqlite(temp.path().join("loopflow.db")))
+                .await
+                .unwrap(),
+        );
+        let mut preferred = account(Provider::Claude, "preferred", "preferred@example.com");
+        preferred.home = None;
+        let mut fallback = account(Provider::Claude, "fallback", "fallback@example.com");
+        fallback.home = Some(temp.path().join("claude-fallback"));
+        fs::create_dir_all(fallback.home.as_ref().unwrap()).unwrap();
+        fs::write(
+            fallback.home.as_ref().unwrap().join(".credentials.json"),
+            r#"{"claudeAiOauth":{"accessToken":"fallback-secret","expiresAt":4102444800000}}"#,
+        )
+        .unwrap();
+        store.upsert_provider_account(&preferred).await.unwrap();
+        store.upsert_provider_account(&fallback).await.unwrap();
+        store
+            .set_provider_route(&ProviderRoute {
+                scope: RouteScope::Default,
+                provider: Provider::Claude,
+                accounts: vec![fallback.account_id.clone()],
+                created_at: 1,
+                updated_at: 1,
+            })
+            .await
+            .unwrap();
+
+        let selection =
+            AccountSelection::from_flags(&["claude=preferred".to_string()], &[]).unwrap();
+        let prepared = prepare_root_lease(&selection)
+            .await
+            .unwrap()
+            .expect("the fallback route should produce a lease");
+        let grant = prepared.lease.grant(Provider::Claude).unwrap();
+        assert_eq!(
+            grant.accounts,
+            vec![preferred.account_id.clone(), fallback.account_id.clone()]
+        );
+        assert_eq!(grant.preferred, 1);
+        assert!(!prepared
+            .credentials
+            .contains_key(&(Provider::Claude, preferred.account_id)));
+        assert_eq!(
+            prepared
+                .credentials
+                .get(&(Provider::Claude, fallback.account_id.clone()))
+                .map(String::as_str),
+            Some("fallback-secret")
+        );
+
+        let broker = AccountLeaseBroker::start(prepared).unwrap();
+        let client = AccountLeaseClient {
+            handle: broker.local_handle(),
+        };
+        assert_eq!(
+            client.resolve(Provider::Claude, None).unwrap().account_id,
+            fallback.account_id
+        );
+    }
+    /// Exercise the fixed grant across inheritance, fallback, resume, and cleanup.
+    #[allow(clippy::await_holding_lock)]
+    #[tokio::test]
+    async fn broker_serves_a_fixed_grant_and_fails_closed_on_drop() {
+        let temp = tempdir().unwrap();
+        let store = Arc::new(
+            open_store(&StorageConfig::sqlite(temp.path().join("lease.db")))
+                .await
+                .unwrap(),
+        );
+        let grants = vec![
+            ProviderGrant {
+                provider: Provider::Claude,
+                accounts: vec![id("personal"), id("work")],
+                preferred: 0,
+            },
+            ProviderGrant {
+                provider: Provider::Codex,
+                accounts: vec![id("reserve"), id("primary")],
+                preferred: 1,
+            },
+        ];
+        let mut credentials = HashMap::new();
+        for grant in &grants {
+            for account_id in &grant.accounts {
+                let mut account = new_account(
+                    grant.provider,
+                    account_id.clone(),
+                    temp.path()
+                        .join(grant.provider.as_str())
+                        .join(account_id.as_str()),
+                    None,
+                );
+                if grant.provider == Provider::Codex && account_id == &id("reserve") {
+                    account.cooldown_until =
+                        Some(time::OffsetDateTime::now_utc().unix_timestamp() + 3600);
+                }
+                store.upsert_provider_account(&account).await.unwrap();
+                credentials.insert(
+                    (grant.provider, account_id.clone()),
+                    format!("{}-{account_id}-secret", grant.provider),
+                );
+            }
+        }
+        let lease = AccountLease { grants };
+        let expected_lease = serde_json::to_vec(&lease).unwrap();
+        let restricted_credentials = credentials.clone();
+        let prepared = PreparedAccountLease {
+            lease,
+            credentials,
+            store: Arc::clone(&store),
+            restricted: false,
+        };
+        let broker = AccountLeaseBroker::start(prepared).unwrap();
+        assert!(!format!("{broker:?}").contains(&broker.secret));
+        let mut inherited = broker.local_handle();
+        let mut client = AccountLeaseClient {
+            handle: inherited.clone(),
+        };
+        for _ in 0..3 {
+            inherited = AccountLeaseHandle::decode(&inherited.encode().unwrap()).unwrap();
+            client = AccountLeaseClient {
+                handle: inherited.clone(),
+            };
+            assert_eq!(
+                serde_json::to_vec(&client.describe().unwrap()).unwrap(),
+                expected_lease
+            );
+        }
+        // A wrong secret is rejected: the lease is a capability, not the socket.
+        let forged = AccountLeaseClient {
+            handle: AccountLeaseHandle {
+                socket: broker.local_socket().to_path_buf(),
+                secret: "not-the-secret".to_string(),
+            },
+        };
+        assert!(!format!("{forged:?}").contains("not-the-secret"));
+        assert!(forged
+            .describe()
+            .unwrap_err()
+            .to_string()
+            .contains("missing or expired"));
+        // A resumed fallback account does not consume the preferred attempt.
+        store
+            .pin_provider_session_route(Provider::Codex, "fallback-session", &id("primary"))
+            .await
+            .unwrap();
+        let fallback_resume = client
+            .resolve(Provider::Codex, Some("fallback-session".to_string()))
+            .unwrap();
+        assert_eq!(fallback_resume.account_id, id("primary"));
+        assert!(fallback_resume.resume_requested_session);
+        // Preferred `reserve` still gets its one attempt despite the cooldown.
+        let codex = client.resolve(Provider::Codex, None).unwrap();
+        assert_eq!(codex.account_id, id("reserve"));
+        // A sibling resolution avoids the spent, rate-limited preferred.
+        let sibling = client.resolve(Provider::Codex, None).unwrap();
+        assert_eq!(sibling.account_id, id("primary"));
+        // Resume stays on the account the store recorded for the session.
+        store
+            .pin_provider_session_route(Provider::Codex, "existing-session", &id("reserve"))
+            .await
+            .unwrap();
+        let resumed = client
+            .resolve(Provider::Codex, Some("existing-session".to_string()))
+            .unwrap();
+        assert_eq!(resumed.account_id, id("reserve"));
+        assert!(resumed.resume_requested_session);
+        // A remote-store account outside the grant stays unavailable.
+        let remote_only = new_account(
+            Provider::Codex,
+            id("remote-only"),
+            temp.path().join("codex").join("remote-only"),
+            None,
+        );
+        store.upsert_provider_account(&remote_only).await.unwrap();
+        store
+            .pin_provider_session_route(Provider::Codex, "outside-session", &id("remote-only"))
+            .await
+            .unwrap();
+        let outside = client
+            .resolve(Provider::Codex, Some("outside-session".to_string()))
+            .unwrap();
+        assert_eq!(outside.account_id, id("primary"));
+        assert!(!outside.resume_requested_session);
+        let restricted = AccountLeaseBroker::start(PreparedAccountLease {
+            lease: AccountLease {
+                grants: vec![ProviderGrant {
+                    provider: Provider::Codex,
+                    accounts: vec![id("reserve"), id("primary")],
+                    preferred: 2,
+                }],
+            },
+            credentials: restricted_credentials,
+            store: Arc::clone(&store),
+            restricted: true,
+        })
+        .unwrap();
+        let restricted_client = AccountLeaseClient {
+            handle: restricted.local_handle(),
+        };
+        assert_eq!(
+            restricted_client
+                .resolve(Provider::Codex, None)
+                .unwrap()
+                .account_id,
+            id("reserve")
+        );
+        restricted_client
+            .record_health(
+                Provider::Codex,
+                &id("reserve"),
+                &RateLimitSignal {
+                    utilization_percent: Some(100),
+                    resets_at: None,
+                    limited: true,
+                    reason: "test".to_string(),
+                    windows: Vec::new(),
+                },
+            )
+            .unwrap();
+        assert_eq!(
+            restricted_client
+                .resolve(Provider::Codex, None)
+                .unwrap()
+                .account_id,
+            id("primary")
+        );
+        let _lock = crate::journal::test_env_lock();
+        let _restore = RestoreEnv::capture(ACCOUNT_LEASE_ENV);
+        std::env::set_var(ACCOUNT_LEASE_ENV, broker.local_handle().encode().unwrap());
+        let route = crate::provider_account::resolve_provider_account(Provider::Claude, None)
+            .await
+            .unwrap()
+            .expect("forwarded grant should resolve a route");
+        let mut command = std::process::Command::new("claude");
+        command.env("CODEX_ACCESS_TOKEN", "ambient-secret");
+        route.apply(&mut command);
+        assert!(command.get_envs().any(|(name, value)| {
+            name == "CLAUDE_CODE_OAUTH_TOKEN"
+                && value.is_some_and(|value| {
+                    let value = value.to_string_lossy();
+                    value.starts_with("claude-") && value.ends_with("-secret")
+                })
+        }));
+        assert!(command
+            .get_envs()
+            .any(|(name, value)| name == "CODEX_ACCESS_TOKEN" && value.is_none()));
+        probe_forwarded_authority().unwrap();
+        std::env::set_var(ACCOUNT_LEASE_ENV, "malformed");
+        assert!(probe_forwarded_authority().is_err());
+        std::env::remove_var(ACCOUNT_LEASE_ENV);
+        assert!(probe_forwarded_authority().is_err());
+        let socket = broker.local_socket().to_path_buf();
+        drop(broker);
+        assert!(!socket.exists());
+        assert!(client
+            .describe()
+            .unwrap_err()
+            .to_string()
+            .contains("unavailable or expired"));
+    }
+}

--- a/rust/loopflow/src/store/mod.rs
+++ b/rust/loopflow/src/store/mod.rs
@@ -668,6 +668,18 @@ impl Store {
         .await
     }
 
+    pub async fn provider_session_account(
+        &self,
+        provider: Provider,
+        provider_session_id: &str,
+    ) -> StoreResult<Option<ProviderAccountId>> {
+        let provider_session_id = provider_session_id.to_string();
+        run_sqlite(&self.sqlite, move |store| {
+            store.provider_session_account(provider, &provider_session_id)
+        })
+        .await
+    }
+
     pub async fn select_provider_account(
         &self,
         provider: Provider,
@@ -863,7 +875,7 @@ pub struct ProviderAccountSelection {
 
 /// One observed subscription rate-limit window: how much of the plan's
 /// `session`/`weekly`/`weekly:<model>` window an account has consumed.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct AccountLimitWindow {
     pub window: String,
     pub used_percent: u8,

--- a/rust/loopflow/src/store/sqlite.rs
+++ b/rust/loopflow/src/store/sqlite.rs
@@ -1006,6 +1006,25 @@ impl SqliteStore {
         Ok(())
     }
 
+    pub fn provider_session_account(
+        &self,
+        provider: Provider,
+        provider_session_id: &str,
+    ) -> StoreResult<Option<ProviderAccountId>> {
+        let conn = self.conn.lock().expect("store mutex poisoned");
+        conn.query_row(
+            "SELECT account_id FROM provider_session_accounts
+             WHERE provider = ?1 AND provider_session_id = ?2",
+            params![provider.as_str(), provider_session_id],
+            |row| row.get::<_, String>(0),
+        )
+        .optional()?
+        .as_deref()
+        .map(ProviderAccountId::parse)
+        .transpose()
+        .map_err(StoreError::InvalidData)
+    }
+
     pub fn select_provider_account(
         &self,
         provider: Provider,

--- a/website/main.py
+++ b/website/main.py
@@ -183,6 +183,7 @@ DOCS_NAV = [
     # Reference
     ("lf", "lf"),
     ("Config", "config"),
+    ("Security", "security"),
     ("Troubleshooting", "troubleshooting"),
 ]
 
@@ -197,6 +198,7 @@ DOC_DESCRIPTIONS = {
     "architecture": "No server: the store, the journal, Homes, lf ssh, lfd",
     "lf": "Every command, PR/planning/release operations, the builtin catalog",
     "config": "Config files, context assembly, models, accounts and profiles",
+    "security": "Execution boundaries, permissions, credentials, and account authority",
     "troubleshooting": "Exact failure → cause → fix",
 }
 

--- a/website/tests/e2e/test_docs.py
+++ b/website/tests/e2e/test_docs.py
@@ -10,6 +10,7 @@ NAV_SLUGS = [
     "architecture",
     "lf",
     "config",
+    "security",
     "troubleshooting",
 ]
 
@@ -41,6 +42,21 @@ def test_docs_sidebar_navigation(page: Page, base_url: str):
     page.goto(f"{base_url}/docs")
     page.locator(".docs-nav").locator("a", has_text="Config").click()
     assert "/docs/config" in page.url
+
+
+def test_docs_security_page_states_forwarded_authority_guarantees(
+    page: Page, base_url: str
+):
+    page.goto(f"{base_url}/docs/security")
+    content = page.locator(".docs-content")
+    assert content.is_visible()
+    text = content.inner_text()
+    assert "--only-account" in text
+    assert "Only the first is general containment" in text
+    assert "workspace-write" in text
+    assert "fail closed" in text
+    assert "Doppler master credential never" in text
+    assert "second SSH hop" in text
 
 
 def test_docs_nonexistent_redirects(page: Page, base_url: str):

--- a/website/tests/test_accessibility.py
+++ b/website/tests/test_accessibility.py
@@ -14,6 +14,7 @@ PAGES_TO_TEST = [
     "/docs",
     "/docs/agent-api",
     "/docs/config",
+    "/docs/security",
     "/download",
 ]
 


### PR DESCRIPTION
## Usage

```bash
# Prefer accounts for one run; children inherit the same grant
lf --account claude=personal --account codex=reserve implement

# Restrict the process tree to exactly the selected accounts
lf --only-account codex=reserve review

# Forward the selected route to a remote host over a foreground broker
lf --account claude=personal ssh mini -- lf task pursue
```

## Summary

Replaces the `--account`/`LF_ACCOUNT` env-passing model with a lease broker that resolves managed Claude and Codex accounts once at the outer invocation and hands the process tree a fixed, opaque grant. `--account` prefers each matching account before its provider's normal route; `--only-account` removes every unselected account so a provider without a match is simply unavailable. The two flags are repeatable, accept `claude=`/`codex=` forms, and cannot be combined. Nested `lf` processes inherit the grant through the handle and cannot widen, narrow, or reorder it.

Over SSH, accounts resolve on the origin machine and the remote receives only a short-lived lease handle; a reverse-forwarded owner-only Unix socket reaches a broker owned by the foreground `lf ssh` process. No managed credential files land on the remote host. Broker failure, missing credentials, and expired handles fail closed; detached forms (`tmux`, `nohup`, `--detach`, second SSH hops) are rejected. Under a forwarded lease, remote account/route edits and subscription polling are disabled, while `lf usage` still reports local process token spend.

## Changes

- New `provider_account/lease.rs` holds the broker, `AccountSelection`, and forwarded-authority probe; `provider_account.rs` shrinks accordingly
- Local commands with a selection get an in-process broker; SSH and remote-Home routing build and forward theirs in the transport path
- `home::route` threads the account selection so remote-Home commands carry the grant
- New `docs/security.md` covering execution boundaries, action policy, identity/lease forwarding, and stored/transmitted data; linked from the README
- `docs/config.md` and `docs/lf.md` updated for managed accounts, access profiles, routes, and the `--account`/`--only-account` semantics
- Website e2e/docs and accessibility tests updated for the new security page