### PR TITLE
pm: fix Linear PR-attachment argument and make a wrong mutation argument fail CI

### DIFF
--- a/rust/loopflow/src/ops/pm.rs
+++ b/rust/loopflow/src/ops/pm.rs
@@ -517,15 +517,9 @@ impl PmClient {
         }
     }
 
-    async fn link_attachment(
-        &self,
-        issue_id: &str,
-        url: &str,
-        title: &str,
-        subtitle: &str,
-    ) -> PmResult<String> {
+    async fn link_attachment(&self, issue_id: &str, url: &str, title: &str) -> PmResult<String> {
         match self {
-            Self::Linear(client) => client.link_attachment(issue_id, url, title, subtitle).await,
+            Self::Linear(client) => client.link_attachment(issue_id, url, title).await,
         }
     }
 
@@ -1494,12 +1488,7 @@ async fn link_pr_with_client(
             }
         }
         None => match client
-            .link_attachment(
-                &request.issue_id,
-                &request.url,
-                &request.title,
-                &request.subtitle,
-            )
+            .link_attachment(&request.issue_id, &request.url, &request.title)
             .await
         {
             Ok(id) => ids.attachment_id = Some(id),
@@ -2684,7 +2673,7 @@ mod tests {
     };
     use crate::wave::Wave;
     use axum::http::StatusCode;
-    use serde_json::json;
+    use serde_json::{json, Value};
     use std::path::PathBuf;
     use time::OffsetDateTime;
 
@@ -4046,9 +4035,17 @@ mod tests {
         assert!(outcome.error.is_none());
 
         let requests = requests.lock().await;
-        assert!(requests
+        let link = requests
             .iter()
-            .any(|req| req.body.contains("attachmentLinkURL")));
+            .find(|req| req.body.contains("attachmentLinkURL"))
+            .expect("create sends attachmentLinkURL");
+        // The create path must never send an argument Linear rejects: the
+        // `subtitle` on attachmentLinkURL is the 400 that shipped in #1010.
+        let link_body: Value = serde_json::from_str(&link.body).expect("link body is json");
+        assert!(
+            link_body["variables"].get("subtitle").is_none(),
+            "attachmentLinkURL must not send a subtitle variable"
+        );
         assert!(requests
             .iter()
             .any(|req| req.body.contains("commentCreate")));

--- a/rust/loopflow/src/pm/linear.rs
+++ b/rust/loopflow/src/pm/linear.rs
@@ -254,8 +254,13 @@ const UPDATE_COMMENT_MUTATION: &str = r#"mutation UpdateComment($id: String!, $b
   }
 }"#;
 
-const LINK_ATTACHMENT_MUTATION: &str = r#"mutation LinkAttachment($issueId: String!, $url: String!, $title: String!, $subtitle: String!) {
-  attachmentLinkURL(issueId: $issueId, url: $url, title: $title, subtitle: $subtitle) {
+// `attachmentLinkURL` links a URL and dedupes on it — re-linking the same PR
+// returns the existing attachment rather than duplicating. It accepts `issueId`,
+// `url`, and `title`, but not `subtitle` (that lives on `attachmentUpdate`'s
+// input). PR state is carried in the managed comment body and filled onto the
+// attachment as a subtitle by the later `attachmentUpdate`.
+const LINK_ATTACHMENT_MUTATION: &str = r#"mutation LinkAttachment($issueId: String!, $url: String!, $title: String!) {
+  attachmentLinkURL(issueId: $issueId, url: $url, title: $title) {
     attachment {
       id
     }
@@ -876,7 +881,6 @@ impl LinearClient {
         issue_id: &str,
         url: &str,
         title: &str,
-        subtitle: &str,
     ) -> PmResult<String> {
         let response: AttachmentLinkData = self
             .graphql(
@@ -885,7 +889,6 @@ impl LinearClient {
                     "issueId": issue_id,
                     "url": url,
                     "title": title,
-                    "subtitle": subtitle,
                 }),
             )
             .await?;
@@ -1455,6 +1458,22 @@ mod tests {
         assert!(CREATE_COMMENT_MUTATION.contains("$issueId: String!"));
     }
 
+    /// A wrong argument on a Linear mutation must fail here, not ship a 400 on
+    /// every publish (#1010, where `subtitle` on `attachmentLinkURL` shipped green
+    /// because the mock echoed success). `subtitle` is legal on `attachmentUpdate`
+    /// but not on `attachmentLinkURL`, so pin each mutation directly.
+    #[test]
+    fn attachment_link_omits_subtitle_and_update_keeps_it() {
+        assert!(
+            !LINK_ATTACHMENT_MUTATION.contains("subtitle"),
+            "attachmentLinkURL rejects subtitle; it must not appear in the create mutation"
+        );
+        assert!(
+            UPDATE_ATTACHMENT_MUTATION.contains("subtitle: $subtitle"),
+            "attachmentUpdate carries PR state as its input subtitle"
+        );
+    }
+
     #[test]
     fn workflow_state_filters_use_linear_team_id() {
         assert!(CREATE_ITEM_MUTATION.contains("$teamId: String!"));
@@ -1984,7 +2003,7 @@ mod tests {
         let client = LinearClient::with_base_url("linear-secret".to_string(), None, base_url);
 
         let attachment_id = client
-            .link_attachment("issue-1", "https://example/pr/7", "GitHub PR #7", "Open")
+            .link_attachment("issue-1", "https://example/pr/7", "GitHub PR #7")
             .await
             .expect("link attachment succeeds");
         assert_eq!(attachment_id, "att-1");
@@ -2007,6 +2026,13 @@ mod tests {
             .contains("attachmentLinkURL"));
         assert_eq!(link["variables"]["issueId"], json!("issue-1"));
         assert_eq!(link["variables"]["url"], json!("https://example/pr/7"));
+        // The create path must not send an argument Linear rejects.
+        // `attachmentLinkURL` has no `subtitle`; sending one is the 400 that
+        // shipped in #1010. PR state rides the managed comment body instead.
+        assert!(
+            link["variables"].get("subtitle").is_none(),
+            "attachmentLinkURL must not send a subtitle variable"
+        );
 
         let update: Value =
             serde_json::from_str(&requests[1].body).expect("attachment update body is json");


### PR DESCRIPTION
attachmentLinkURL rejects subtitle (400 on every published PR since #1010). Remove it from the create mutation/variable/call chain; attachmentUpdate keeps subtitle (its input accepts it) and the managed comment body already embeds PR state. The bug shipped green because the test mocked success; now the invariants are pinned directly — the create mutation excludes subtitle, the update mutation retains it, and the serialized create request carries no subtitle variable. Closes ENG-79.