### PR TITLE
run: recover across exact provider routes

### DIFF
--- a/rust/loopflow/src/engine/agent.rs
+++ b/rust/loopflow/src/engine/agent.rs
@@ -1054,7 +1054,7 @@ fn _classify_agent_failure(harness: &str, result: &LaunchResult) -> Option<Agent
             resets_at: signal.resets_at,
         });
     }
-    _find_provider_error(result, _classify_transient_text)
+    _find_provider_error(result, classify_retryable_agent_failure)
 }
 
 fn _find_provider_error<T>(result: &LaunchResult, classify: fn(&str) -> Option<T>) -> Option<T> {
@@ -1113,7 +1113,7 @@ fn _classify_provider_error_value<T>(
     }
 }
 
-fn _classify_transient_text(text: &str) -> Option<AgentFailure> {
+pub(crate) fn classify_retryable_agent_failure(text: &str) -> Option<AgentFailure> {
     let text = text.to_ascii_lowercase();
     if text.contains("at capacity") || text.contains("capacity temporarily unavailable") {
         Some(AgentFailure::Capacity)

--- a/rust/loopflow/src/harness/claude.rs
+++ b/rust/loopflow/src/harness/claude.rs
@@ -14,8 +14,9 @@ use crate::engine::agent::{build_claude_session_turn_args, AgentConfig};
 use crate::harness::claude_mapping::ReaderState;
 use crate::harness::common::{spawn_stderr_logger, TurnInProgressGuard};
 use crate::harness::{claude_mapping, Harness, HarnessError, RawProviderEvent};
-use crate::provider_account::{resolve_provider_account, ProviderAccountRoute};
+use crate::provider_account::{resolve_provider_account_exact, ProviderAccountRoute};
 use crate::provider_auth::Provider;
+use crate::store::ProviderAccountId;
 
 pub struct ClaudeHarness {
     events: mpsc::UnboundedSender<ConversationEvent>,
@@ -26,6 +27,7 @@ pub struct ClaudeHarness {
     /// subsequent turns resume it via `--resume`.
     provider_session_id: Arc<Mutex<Option<String>>>,
     account_route: Option<ProviderAccountRoute>,
+    requested_account_id: Option<ProviderAccountId>,
     turn_in_progress: Arc<AtomicBool>,
     child: Option<Child>,
     reader_task: Option<JoinHandle<()>>,
@@ -49,6 +51,7 @@ impl ClaudeHarness {
             should_seed_task_prompt: true,
             provider_session_id: Arc::new(Mutex::new(None)),
             account_route: None,
+            requested_account_id: None,
             turn_in_progress: Arc::new(AtomicBool::new(false)),
             child: None,
             reader_task: None,
@@ -98,8 +101,12 @@ impl Harness for ClaudeHarness {
             .lock()
             .expect("claude provider session id lock poisoned")
             .clone();
-        let account_route =
-            resolve_provider_account(Provider::Claude, requested_session.as_deref()).await?;
+        let account_route = resolve_provider_account_exact(
+            Provider::Claude,
+            requested_session.as_deref(),
+            self.requested_account_id.as_ref(),
+        )
+        .await?;
         if account_route
             .as_ref()
             .is_some_and(|route| !route.resume_requested_session())
@@ -350,6 +357,16 @@ impl Harness for ClaudeHarness {
             .provider_session_id
             .lock()
             .expect("claude provider session id lock poisoned") = provider_session_id;
+    }
+
+    fn set_provider_account_id(&mut self, account_id: Option<ProviderAccountId>) {
+        self.requested_account_id = account_id;
+    }
+
+    fn provider_account_id(&self) -> Option<ProviderAccountId> {
+        self.account_route
+            .as_ref()
+            .map(|route| route.account_id().clone())
     }
 }
 

--- a/rust/loopflow/src/harness/codex.rs
+++ b/rust/loopflow/src/harness/codex.rs
@@ -36,8 +36,9 @@ use crate::harness::lf_tag::LfTagParser;
 use crate::harness::{
     codex_mapping, ApprovalPolicy, Harness, HarnessError, RawProviderEvent, SendCurrentOutcome,
 };
-use crate::provider_account::{resolve_provider_account, ProviderAccountRoute};
+use crate::provider_account::{resolve_provider_account_exact, ProviderAccountRoute};
 use crate::provider_auth::Provider;
+use crate::store::ProviderAccountId;
 
 /// SIGKILL an entire process group. Killing only the direct child orphans
 /// the real app-server when `codex` on PATH is an npm shim that spawns it as
@@ -526,6 +527,7 @@ pub struct CodexHarness {
     provider_session_id: Arc<Mutex<Option<String>>>,
     resume_provider_session_id: Option<String>,
     account_route: Option<ProviderAccountRoute>,
+    requested_account_id: Option<ProviderAccountId>,
     /// Live turn id (from turn/started, cleared at turn/completed); steer and
     /// interrupt address the turn with it.
     current_turn_id: Arc<Mutex<Option<String>>>,
@@ -571,6 +573,7 @@ impl CodexHarness {
             provider_session_id: Arc::new(Mutex::new(None)),
             resume_provider_session_id: None,
             account_route: None,
+            requested_account_id: None,
             current_turn_id: Arc::new(Mutex::new(None)),
             initialize_request_id: Arc::new(AtomicI64::new(0)),
             thread_start_request_id: Arc::new(AtomicI64::new(0)),
@@ -708,8 +711,12 @@ impl Harness for CodexHarness {
         self.launch = Some(config.clone());
         self.should_seed_prompt = true;
         let requested_session = self.resume_provider_session_id.clone();
-        let account_route =
-            resolve_provider_account(Provider::Codex, requested_session.as_deref()).await?;
+        let account_route = resolve_provider_account_exact(
+            Provider::Codex,
+            requested_session.as_deref(),
+            self.requested_account_id.as_ref(),
+        )
+        .await?;
         self.resume_provider_session_id = match &account_route {
             Some(route) if route.resume_requested_session() => requested_session,
             Some(_) => None,
@@ -876,6 +883,16 @@ impl Harness for CodexHarness {
 
     fn set_provider_session_id(&mut self, provider_session_id: Option<String>) {
         self.resume_provider_session_id = provider_session_id;
+    }
+
+    fn set_provider_account_id(&mut self, account_id: Option<ProviderAccountId>) {
+        self.requested_account_id = account_id;
+    }
+
+    fn provider_account_id(&self) -> Option<ProviderAccountId> {
+        self.account_route
+            .as_ref()
+            .map(|route| route.account_id().clone())
     }
 }
 

--- a/rust/loopflow/src/harness/mod.rs
+++ b/rust/loopflow/src/harness/mod.rs
@@ -311,6 +311,13 @@ pub trait Harness: Send + Sync {
     /// Seed a previously persisted vendor session id so the next turn resumes
     /// it. Drivers that take resume state at `start` instead ignore this.
     fn set_provider_session_id(&mut self, _provider_session_id: Option<String>) {}
+    /// Pin this Launch to the exact managed account already recorded in its
+    /// durable route. Accountless providers keep the default no-op.
+    fn set_provider_account_id(&mut self, _account_id: Option<crate::store::ProviderAccountId>) {}
+    /// The managed account selected before the first provider Turn begins.
+    fn provider_account_id(&self) -> Option<crate::store::ProviderAccountId> {
+        None
+    }
 }
 
 /// Constructor fn: `(harness_kind, approval, event_tx) -> harness`.

--- a/rust/loopflow/src/ops/project.rs
+++ b/rust/loopflow/src/ops/project.rs
@@ -382,6 +382,7 @@ pub(crate) async fn launch_project_process(
             cwd: Path::new(wave.repo()).to_path_buf(),
             tmux_name,
             agent: session.agent.clone(),
+            account_id: None,
             resume_token: session.provider_session_id.clone(),
         },
     )

--- a/rust/loopflow/src/ops/run.rs
+++ b/rust/loopflow/src/ops/run.rs
@@ -16,6 +16,7 @@ pub(crate) struct RunLaunch {
     pub cwd: PathBuf,
     pub tmux_name: String,
     pub agent: String,
+    pub account_id: Option<crate::store::ProviderAccountId>,
     pub resume_token: Option<String>,
 }
 
@@ -35,7 +36,10 @@ pub(crate) async fn launch_in_run(
                 route: LaunchRoute {
                     provider,
                     model,
-                    account_id: None,
+                    account_id: request
+                        .account_id
+                        .as_ref()
+                        .map(|account_id| account_id.as_str().to_string()),
                 },
                 containment: Containment::Tmux {
                     name: tmux_name.clone(),

--- a/rust/loopflow/src/ops/task.rs
+++ b/rust/loopflow/src/ops/task.rs
@@ -1878,6 +1878,7 @@ async fn launch_task_process(
             cwd: session.worktree.clone(),
             tmux_name,
             agent: session.agent.clone(),
+            account_id: None,
             resume_token: session.provider_session_id.clone(),
         },
     )

--- a/rust/loopflow/src/project/runner.rs
+++ b/rust/loopflow/src/project/runner.rs
@@ -20,6 +20,10 @@ use crate::harness::{
     ApprovalPolicy, Harness, RecoveryDecision, SendCurrentOutcome,
 };
 use crate::project::{ChildEventPayload, Project, ProjectEventKind, ProjectId};
+use crate::provider_account::recovery::{
+    capability_key, plan_run_route_recovery, settle_route_recovery, stop_launch_for_recovery,
+    ExactRoute, RecoveryChoice, RecoverySettlement, RecoveryStopOutcome,
+};
 use crate::store::SharedStore;
 use crate::wave::playhead::{
     BodyProvenance, Playhead, PlayheadEvent, QueuedInvocation, StepKind, StepOutcome,
@@ -54,6 +58,7 @@ async fn spawn_failover(
     session: &Project,
     lease: &RunLease,
     wave: &Wave,
+    route: &ExactRoute,
 ) -> Result<()> {
     let tmux_name = format!(
         "lf-project-{}-{}",
@@ -68,7 +73,8 @@ async fn spawn_failover(
             wave_id: session.wave_id.clone(),
             cwd: Path::new(wave.repo()).to_path_buf(),
             tmux_name,
-            agent: session.agent.clone(),
+            agent: route.agent.agent(),
+            account_id: route.account_id.clone(),
             resume_token: session.provider_session_id.clone(),
         },
     )
@@ -116,7 +122,7 @@ async fn run_project_inner(
     else {
         unreachable!("LaunchLive returns a Launch receipt")
     };
-    let run_control = crate::trace::ControlLaunch {
+    let mut run_control = crate::trace::ControlLaunch {
         run_id: run.id,
         home_id: run.home_id,
         account_id: launch.route.account_id.clone(),
@@ -156,13 +162,28 @@ async fn run_project_inner(
     let (event_tx, mut event_rx) = mpsc::unbounded_channel();
     let mut harness = default_create_harness(&harness_name, ApprovalPolicy::AutoApprove, event_tx)?;
     harness.set_provider_session_id(session.provider_session_id.clone());
+    let requested_account = launch
+        .route
+        .account_id
+        .as_deref()
+        .map(crate::store::ProviderAccountId::parse)
+        .transpose()
+        .map_err(|reason| anyhow!("invalid Launch account route: {reason}"))?;
+    harness.set_provider_account_id(requested_account);
     store.validate_run_lease(lease).await?;
     harness.start(&prepared.turn.config).await?;
     session.provider = harness_name;
     session.provider_session_id = harness.provider_session_id();
-    store
-        .observe_launch_provider(lease, &launch.id, session.provider_session_id.clone())
+    let launch = store
+        .observe_launch_provider(
+            lease,
+            &launch.id,
+            harness.provider_account_id(),
+            session.provider_session_id.clone(),
+        )
         .await?;
+    run_control.account_id = launch.route.account_id.clone();
+    run_control.resume_token = launch.resume_token.clone();
     if let Err(error) = store.update_project_for_run(&session, lease).await {
         let _ = harness.stop().await;
         return Err(error.into());
@@ -912,10 +933,8 @@ async fn finish_failed(
     anyhow::bail!(error.to_string())
 }
 
-/// Handle a body failure with disconnect-class recovery: classify the failure,
-/// and if it's a disconnect/hollow-body with a configured backup agent, hand
-/// the next generation to the backup instead of leaving the body failed for
-/// the supervisor to respawn the same flaky provider.
+/// Recover a retryable body failure through the Run's next exact route after
+/// PRD-38 permits replacement and the current containment stops positively.
 async fn handle_body_failure(
     store: &SharedStore,
     session: &mut Project,
@@ -924,7 +943,7 @@ async fn handle_body_failure(
     wave: &Wave,
     reason: &str,
     turn_had_durable_side_effect: bool,
-) -> Result<Option<RunLease>> {
+) -> Result<Option<(RunLease, ExactRoute)>> {
     let wave_config = read_wave_config(Path::new(wave.repo()), wave.name());
     let backup_agent = wave_config.as_ref().and_then(|c| c.backup_agent.as_deref());
     let decision = classify_disconnect_recovery(
@@ -934,59 +953,84 @@ async fn handle_body_failure(
         backup_agent,
     );
 
-    match decision {
-        RecoveryDecision::HandoffToBackup { agent, provider } => {
-            let _ = harness.stop().await;
-            store
-                .append_project_event_for_run(
-                    &session.id,
-                    lease,
-                    &ProjectEventKind::Failed {
-                        error: reason.to_string(),
-                        resumable: true,
-                    },
-                )
-                .await?;
-            store.update_project_for_run(session, lease).await?;
-            let launch = store.current_launch(lease).await?.ok_or_else(|| {
-                anyhow!("Project Run {} has no Launch to hand back", lease.run_id)
-            })?;
-            store
-                .advance_run(
-                    lease,
-                    crate::durable::RunAdvance::LaunchEnded {
-                        launch_id: launch.id,
-                        outcome: crate::durable::BoundaryState::Failed,
-                    },
-                )
-                .await?;
-            let handoff = ChildBodyHandoff {
-                from_agent: session.agent.clone(),
-                to_agent: agent.clone(),
-                from_provider: session.provider.clone(),
-                to_provider: provider.clone(),
-                reason: format!(
-                    "disconnect-class failure; handing off from {} to {agent}",
-                    session.agent
-                ),
-            };
-            if session.provider != provider {
-                session.provider_session_id = None;
+    let route_recovery_permitted = matches!(
+        decision,
+        RecoveryDecision::HandoffToBackup { .. } | RecoveryDecision::AllowRetry
+    ) || (matches!(decision, RecoveryDecision::Normal)
+        && !turn_had_durable_side_effect
+        && crate::engine::agent::classify_retryable_agent_failure(reason).is_some());
+
+    if route_recovery_permitted {
+        let launch = store
+            .current_launch(lease)
+            .await?
+            .ok_or_else(|| anyhow!("Project Run {} has no Launch to hand back", lease.run_id))?;
+        let current_route = ExactRoute::try_from(&launch.route)?;
+        let stopped = match stop_launch_for_recovery(store, lease, harness).await? {
+            RecoveryStopOutcome::Stopped(stopped) => stopped,
+            RecoveryStopOutcome::Fenced { error, stop } => {
+                tracing::error!(project = %session.id, containment = ?stop.containment, %error, "Project recovery left the Run fenced");
+                return Ok(None);
             }
-            session.agent = agent;
-            session.provider = provider;
-            store.update_project_for_run(session, lease).await?;
-            store
-                .append_project_event_for_run(
-                    &session.id,
-                    lease,
-                    &ProjectEventKind::BodyHandedOff { handoff },
-                )
-                .await?;
-            let rotated = store.rotate_run_lease(lease).await?;
-            store.update_project_for_run(session, &rotated).await?;
-            Ok(Some(rotated))
-        }
+        };
+        let choice = plan_run_route_recovery(store, lease, backup_agent).await?;
+        let failure = match &choice {
+            RecoveryChoice::Launch(_) => reason.to_string(),
+            RecoveryChoice::AwaitCapability { reasons } => format!(
+                "{reason}; waiting on provider route capability: {}",
+                capability_key(reasons)
+            ),
+        };
+        store
+            .append_project_event_for_run(
+                &session.id,
+                lease,
+                &ProjectEventKind::Failed {
+                    error: failure,
+                    resumable: true,
+                },
+            )
+            .await?;
+        store.update_project_for_run(session, lease).await?;
+        return match settle_route_recovery(store, lease, stopped, choice).await? {
+            RecoverySettlement::Launch {
+                lease: rotated,
+                route,
+            } => {
+                let agent = route.agent.agent();
+                let provider = route.agent.provider.clone();
+                let handoff = ChildBodyHandoff {
+                    from_agent: session.agent.clone(),
+                    to_agent: agent.clone(),
+                    from_provider: session.provider.clone(),
+                    to_provider: provider.clone(),
+                    reason: format!("route recovery after {reason}"),
+                };
+                if current_route.agent.provider != route.agent.provider
+                    || current_route.account_id != route.account_id
+                {
+                    session.provider_session_id = None;
+                }
+                session.agent = agent;
+                session.provider = provider;
+                store.update_project_for_run(session, &rotated).await?;
+                store
+                    .append_project_event_for_run(
+                        &session.id,
+                        &rotated,
+                        &ProjectEventKind::BodyHandedOff { handoff },
+                    )
+                    .await?;
+                Ok(Some((rotated, route)))
+            }
+            RecoverySettlement::AwaitCapability { wait } => {
+                tracing::info!(project = %session.id, wait = %wait.id, "Project waiting for a provider route capability");
+                Ok(None)
+            }
+        };
+    }
+
+    match decision {
         RecoveryDecision::Stop => {
             let non_convergence = format!(
                 "{reason}; not replay-safe (durable side effects this turn) and no backup agent configured"
@@ -995,9 +1039,14 @@ async fn handle_body_failure(
                 .await
                 .map(|_| None)
         }
-        _ => finish_failed(store, session, lease, harness, reason, None)
-            .await
-            .map(|_| None),
+        RecoveryDecision::Normal | RecoveryDecision::AllowRetry => {
+            finish_failed(store, session, lease, harness, reason, None)
+                .await
+                .map(|_| None)
+        }
+        RecoveryDecision::HandoffToBackup { .. } => unreachable!(
+            "backup handoff is consumed by route recovery before ordinary failure handling"
+        ),
     }
 }
 
@@ -1010,7 +1059,7 @@ async fn fail_and_maybe_relaunch(
     reason: &str,
     turn_had_durable_side_effect: bool,
 ) -> Result<()> {
-    let Some(rotated) = handle_body_failure(
+    let Some((rotated, route)) = handle_body_failure(
         store,
         session,
         lease,
@@ -1023,7 +1072,7 @@ async fn fail_and_maybe_relaunch(
     else {
         return Ok(());
     };
-    spawn_failover(store, session, &rotated, wave).await
+    spawn_failover(store, session, &rotated, wave, &route).await
 }
 
 async fn finish_abandoned(

--- a/rust/loopflow/src/provider_account.rs
+++ b/rust/loopflow/src/provider_account.rs
@@ -470,12 +470,27 @@ pub(crate) async fn resolve_provider_account(
     provider: Provider,
     provider_session_id: Option<&str>,
 ) -> Result<Option<ProviderAccountRoute>, ProviderAccountError> {
+    resolve_provider_account_exact(provider, provider_session_id, None).await
+}
+
+pub(crate) async fn resolve_provider_account_exact(
+    provider: Provider,
+    provider_session_id: Option<&str>,
+    exact_account_id: Option<&ProviderAccountId>,
+) -> Result<Option<ProviderAccountRoute>, ProviderAccountError> {
     ensure_supported(provider)?;
     // A forwarded or locally-brokered account lease is the single source of
     // account authority when active. Descendants never re-resolve a selection;
     // they resolve one credential from the broker.
     if let Some(client) = lease::AccountLeaseClient::from_env()? {
-        let resolution = client.resolve(provider, provider_session_id.map(str::to_string))?;
+        let resolution = match exact_account_id {
+            Some(account_id) => client.resolve_exact(
+                provider,
+                account_id,
+                provider_session_id.map(str::to_string),
+            )?,
+            None => client.resolve(provider, provider_session_id.map(str::to_string))?,
+        };
         return Ok(Some(ProviderAccountRoute {
             provider,
             account_id: resolution.account_id.clone(),
@@ -501,6 +516,15 @@ pub(crate) async fn resolve_provider_account(
     if candidates.is_empty() {
         return Ok(None);
     }
+    let candidates = match exact_account_id {
+        Some(account_id) if candidates.contains(account_id) => vec![account_id.clone()],
+        Some(account_id) => {
+            return Err(ProviderAccountError::Runtime(format!(
+                "{provider}/{account_id} is outside the configured account route"
+            )))
+        }
+        None => candidates,
+    };
     let selection = store
         .select_provider_account(provider, &candidates, provider_session_id)
         .await?;
@@ -611,13 +635,13 @@ pub(crate) fn match_account<'a>(
     }
 }
 
-fn current_repo_id() -> Result<Option<RepoId>, ProviderAccountError> {
+pub(crate) fn current_repo_id() -> Result<Option<RepoId>, ProviderAccountError> {
     let current = std::env::current_dir()
         .map_err(|error| ProviderAccountError::Runtime(error.to_string()))?;
     Ok(RepoId::discover(&current).ok())
 }
 
-async fn provider_route_account_ids(
+pub(crate) async fn provider_route_account_ids(
     store: &SharedStore,
     repo_id: Option<&RepoId>,
     provider: Provider,

--- a/rust/loopflow/src/provider_account/lease.rs
+++ b/rust/loopflow/src/provider_account/lease.rs
@@ -23,7 +23,7 @@ use crate::provider_account::{
     account_login, match_account, AccountMatch, ProviderAccountError, RateLimitSignal,
 };
 use crate::provider_auth::Provider;
-use crate::store::{ProviderAccount, ProviderAccountId, SharedStore};
+use crate::store::{AccountLimitRow, ProviderAccount, ProviderAccountId, SharedStore};
 
 /// The encoded [`AccountLeaseHandle`] carried across process boundaries.
 pub const ACCOUNT_LEASE_ENV: &str = "LF_ACCOUNT_LEASE";
@@ -43,7 +43,7 @@ pub(crate) struct AccountLease {
 }
 
 impl AccountLease {
-    fn grant(&self, provider: Provider) -> Option<&ProviderGrant> {
+    pub(crate) fn grant(&self, provider: Provider) -> Option<&ProviderGrant> {
         self.grants.iter().find(|grant| grant.provider == provider)
     }
 }
@@ -417,6 +417,15 @@ enum BrokerOperation {
         provider: Provider,
         provider_session_id: Option<String>,
     },
+    ResolveExact {
+        provider: Provider,
+        account_id: ProviderAccountId,
+        provider_session_id: Option<String>,
+    },
+    AccountFacts {
+        provider: Provider,
+        account_id: ProviderAccountId,
+    },
     PinSession {
         provider: Provider,
         provider_session_id: String,
@@ -434,6 +443,13 @@ pub(crate) struct LeaseResolution {
     pub(crate) account_id: ProviderAccountId,
     access_token: String,
     pub(crate) resume_requested_session: bool,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub(crate) struct LeaseAccountFacts {
+    pub(crate) account: Option<ProviderAccount>,
+    pub(crate) limits: Vec<AccountLimitRow>,
+    pub(crate) credential_available: bool,
 }
 
 impl std::fmt::Debug for LeaseResolution {
@@ -457,6 +473,7 @@ impl LeaseResolution {
 enum BrokerResponse {
     Lease(AccountLease),
     Resolution(LeaseResolution),
+    AccountFacts(Box<LeaseAccountFacts>),
     Ok,
     Error(String),
 }
@@ -592,6 +609,40 @@ impl BrokerState {
         })
     }
 
+    async fn resolve_exact(
+        &mut self,
+        provider: Provider,
+        account_id: &ProviderAccountId,
+        provider_session_id: Option<&str>,
+    ) -> Result<LeaseResolution, ProviderAccountError> {
+        self.grant_contains(provider, account_id)?;
+        let access_token = self
+            .prepared
+            .credentials
+            .get(&(provider, account_id.clone()))
+            .cloned()
+            .ok_or_else(|| ProviderAccountError::NoAuthenticatedAccount {
+                provider,
+                accounts: format!("'{account_id}'"),
+            })?;
+        let resume_requested_session = match provider_session_id {
+            Some(session_id) => self
+                .prepared
+                .store
+                .provider_session_account(provider, session_id)
+                .await?
+                .is_some_and(|pinned| pinned == *account_id),
+            None => false,
+        };
+        self.spent_preferences
+            .insert((provider, account_id.clone()));
+        Ok(LeaseResolution {
+            account_id: account_id.clone(),
+            access_token,
+            resume_requested_session,
+        })
+    }
+
     fn grant_contains(
         &self,
         provider: Provider,
@@ -629,6 +680,43 @@ impl BrokerState {
                 self.resolve(provider, provider_session_id.as_deref())
                     .await?,
             )),
+            BrokerOperation::ResolveExact {
+                provider,
+                account_id,
+                provider_session_id,
+            } => Ok(BrokerResponse::Resolution(
+                self.resolve_exact(provider, &account_id, provider_session_id.as_deref())
+                    .await?,
+            )),
+            BrokerOperation::AccountFacts {
+                provider,
+                account_id,
+            } => {
+                self.grant_contains(provider, &account_id)?;
+                let account = self
+                    .prepared
+                    .store
+                    .list_provider_accounts(Some(provider.as_str()))
+                    .await?
+                    .into_iter()
+                    .find(|account| account.account_id == account_id);
+                let limits = self
+                    .prepared
+                    .store
+                    .provider_account_limits(Some(provider.as_str()))
+                    .await?
+                    .into_iter()
+                    .filter(|limit| limit.account_id == account_id)
+                    .collect();
+                Ok(BrokerResponse::AccountFacts(Box::new(LeaseAccountFacts {
+                    account,
+                    limits,
+                    credential_available: self
+                        .prepared
+                        .credentials
+                        .contains_key(&(provider, account_id)),
+                })))
+            }
             BrokerOperation::PinSession {
                 provider,
                 provider_session_id,
@@ -899,6 +987,40 @@ impl AccountLeaseClient {
             provider_session_id,
         })? {
             BrokerResponse::Resolution(resolution) => Ok(resolution),
+            _ => Err(ProviderAccountError::Runtime(
+                "account lease broker returned the wrong response".to_string(),
+            )),
+        }
+    }
+
+    pub(crate) fn resolve_exact(
+        &self,
+        provider: Provider,
+        account_id: &ProviderAccountId,
+        provider_session_id: Option<String>,
+    ) -> Result<LeaseResolution, ProviderAccountError> {
+        match self.request(BrokerOperation::ResolveExact {
+            provider,
+            account_id: account_id.clone(),
+            provider_session_id,
+        })? {
+            BrokerResponse::Resolution(resolution) => Ok(resolution),
+            _ => Err(ProviderAccountError::Runtime(
+                "account lease broker returned the wrong response".to_string(),
+            )),
+        }
+    }
+
+    pub(crate) fn account_facts(
+        &self,
+        provider: Provider,
+        account_id: &ProviderAccountId,
+    ) -> Result<LeaseAccountFacts, ProviderAccountError> {
+        match self.request(BrokerOperation::AccountFacts {
+            provider,
+            account_id: account_id.clone(),
+        })? {
+            BrokerResponse::AccountFacts(facts) => Ok(*facts),
             _ => Err(ProviderAccountError::Runtime(
                 "account lease broker returned the wrong response".to_string(),
             )),
@@ -1303,6 +1425,25 @@ mod tests {
         // A sibling resolution avoids the spent, rate-limited preferred.
         let sibling = client.resolve(Provider::Codex, None).unwrap();
         assert_eq!(sibling.account_id, id("primary"));
+        assert!(
+            client
+                .account_facts(Provider::Claude, &id("personal"))
+                .unwrap()
+                .credential_available
+        );
+        let facts = client
+            .account_facts(Provider::Codex, &id("reserve"))
+            .unwrap();
+        assert!(facts
+            .account
+            .is_some_and(|account| account.cooldown_until.is_some()));
+        let exact = client
+            .resolve_exact(Provider::Claude, &id("work"), None)
+            .unwrap();
+        assert_eq!(exact.account_id, id("work"));
+        assert!(client
+            .resolve_exact(Provider::Claude, &id("outside"), None)
+            .is_err());
         // Resume stays on the account the store recorded for the session.
         store
             .pin_provider_session_route(Provider::Codex, "existing-session", &id("reserve"))

--- a/rust/loopflow/src/provider_account/recovery.rs
+++ b/rust/loopflow/src/provider_account/recovery.rs
@@ -4,10 +4,17 @@ use std::collections::HashSet;
 
 use thiserror::Error;
 
-use crate::durable::{LaunchId, LaunchRoute};
+use crate::durable::{
+    AdvanceReceipt, BoundaryState, CapabilityRef, ContainmentObservation, LaunchId, LaunchRoute,
+    RunAdvance, RunLease, StopCause, StopReceipt, Wait, WaitOn,
+};
 use crate::engine::config::parse_agent;
+use crate::harness::Harness;
+use crate::provider_account::lease::{AccountLease, AccountLeaseClient};
+use crate::provider_auth::{AuthStatus, Provider, ProviderAuthService};
 use crate::store::{
     AccountLimitRow, CredentialState, ProviderAccount, ProviderAccountId, RoutingState,
+    SharedStore, StoreError,
 };
 
 /// The canonical provider and model selected for one agent Launch.
@@ -28,6 +35,13 @@ impl AgentRoute {
             return Err(ExactRouteError::EmptyProvider);
         }
         Ok(Self { provider, model })
+    }
+
+    pub fn agent(&self) -> String {
+        match &self.model {
+            Some(model) => format!("{}:{model}", self.provider),
+            None => self.provider.clone(),
+        }
     }
 }
 
@@ -275,11 +289,372 @@ pub fn derive_chain_exclusions(
     Ok(routes)
 }
 
+#[derive(Debug, Error)]
+pub(crate) enum RunRouteRecoveryError {
+    #[error(transparent)]
+    Store(#[from] StoreError),
+    #[error(transparent)]
+    Account(#[from] crate::provider_account::ProviderAccountError),
+    #[error(transparent)]
+    ExactRoute(#[from] ExactRouteError),
+    #[error(transparent)]
+    History(#[from] RecoveryHistoryError),
+    #[error("Run {0} has no Launch history to recover")]
+    MissingLaunch(crate::durable::RunId),
+}
+
+/// The PRD-38 replacement seam consumed one route choice without taking over
+/// containment or effect judgment from its caller.
+#[derive(Debug)]
+pub(crate) enum RecoverySettlement {
+    Launch { lease: RunLease, route: ExactRoute },
+    AwaitCapability { wait: Wait },
+}
+
+#[derive(Debug)]
+pub(crate) enum RecoveryStopOutcome {
+    Stopped(StoppedLaunch),
+    Fenced {
+        error: String,
+        stop: Box<StopReceipt>,
+    },
+}
+
+/// Proof that the current executor positively stopped its provider containment.
+/// Only [`stop_launch_for_recovery`] can mint it.
+#[derive(Debug)]
+pub(crate) struct StoppedLaunch {
+    launch_id: LaunchId,
+}
+
+/// Read the fixed account grant and this Run's durable Launch chain, then apply
+/// the pure same-provider-before-backup policy.
+pub(crate) async fn plan_run_route_recovery(
+    store: &SharedStore,
+    lease: &RunLease,
+    backup_agent: Option<&str>,
+) -> Result<RecoveryChoice, RunRouteRecoveryError> {
+    let launches = store.launches_for_run(&lease.run_id).await?;
+    let first = launches
+        .first()
+        .ok_or_else(|| RunRouteRecoveryError::MissingLaunch(lease.run_id.clone()))?;
+    let current = launches
+        .last()
+        .expect("non-empty Launch history has a current Launch");
+    let primary_agent = ExactRoute::try_from(&first.route)?.agent;
+    let fixed_client = AccountLeaseClient::from_env()?;
+    let fixed_lease = fixed_client
+        .as_ref()
+        .map(AccountLeaseClient::describe)
+        .transpose()?;
+
+    let mut candidates = route_candidates(
+        store,
+        &primary_agent,
+        fixed_client.as_ref(),
+        fixed_lease.as_ref(),
+    )
+    .await?;
+    if let Some(backup) = backup_agent
+        .map(str::trim)
+        .filter(|agent| !agent.is_empty())
+    {
+        let backup = AgentRoute::parse(backup)?;
+        if backup != primary_agent {
+            candidates.extend(
+                route_candidates(store, &backup, fixed_client.as_ref(), fixed_lease.as_ref())
+                    .await?,
+            );
+        }
+    }
+    let mut seen = HashSet::new();
+    candidates.retain(|candidate| seen.insert(candidate.route.clone()));
+
+    // A Run ends when it succeeds or enters a Wait, so every ordered Launch in
+    // this still-active Run belongs to the current consecutive recovery chain.
+    let history = launches
+        .iter()
+        .enumerate()
+        .map(|(index, launch)| {
+            Ok(RecoveryHistoryEntry {
+                launch_id: launch.id.clone(),
+                route: ExactRoute::try_from(&launch.route)?,
+                recovery_predecessor: index
+                    .checked_sub(1)
+                    .map(|previous| launches[previous].id.clone()),
+            })
+        })
+        .collect::<Result<Vec<_>, ExactRouteError>>()?;
+    let excluded = derive_chain_exclusions(&history, &current.id)?;
+    Ok(plan_route_recovery(&candidates, &excluded))
+}
+
+async fn route_candidates(
+    store: &SharedStore,
+    agent: &AgentRoute,
+    fixed_client: Option<&AccountLeaseClient>,
+    fixed_lease: Option<&AccountLease>,
+) -> Result<Vec<RouteCandidate>, RunRouteRecoveryError> {
+    let Some(provider) = managed_provider(agent) else {
+        return Ok(vec![
+            accountless_candidate(store, agent, fixed_lease.is_none()).await,
+        ]);
+    };
+    let (account_ids, preferred) = match fixed_lease {
+        Some(lease) => match lease.grant(provider) {
+            Some(grant) => (grant.accounts.clone(), grant.preferred),
+            None => {
+                return Ok(vec![project_route_candidate(
+                    ExactRoute {
+                        agent: agent.clone(),
+                        account_id: None,
+                    },
+                    None,
+                    &[],
+                    RouteEvidence {
+                        within_grant: false,
+                        explicitly_selected: false,
+                        credential_resolves: false,
+                    },
+                    time::OffsetDateTime::now_utc().unix_timestamp(),
+                    time::OffsetDateTime::now_utc().date(),
+                )])
+            }
+        },
+        None => {
+            let repo_id = super::current_repo_id()?;
+            match super::provider_route_account_ids(store, repo_id.as_ref(), provider).await? {
+                Some(accounts) if !accounts.is_empty() => (accounts, 0),
+                _ => {
+                    return Ok(vec![accountless_candidate(store, agent, true).await]);
+                }
+            }
+        }
+    };
+
+    let local_facts = match fixed_client {
+        Some(_) => None,
+        None => Some((
+            store
+                .list_provider_accounts(Some(provider.as_str()))
+                .await?,
+            store
+                .provider_account_limits(Some(provider.as_str()))
+                .await?,
+        )),
+    };
+    let now = time::OffsetDateTime::now_utc();
+    let mut candidates = Vec::with_capacity(account_ids.len());
+    for (index, account_id) in account_ids.iter().enumerate() {
+        let (account, limits, credential_resolves) = match fixed_client {
+            Some(client) => {
+                let facts = client.account_facts(provider, account_id)?;
+                (facts.account, facts.limits, facts.credential_available)
+            }
+            None => {
+                let (accounts, limits) = local_facts
+                    .as_ref()
+                    .expect("local account facts exist without a forwarded lease");
+                let account = accounts
+                    .iter()
+                    .find(|account| account.account_id == *account_id)
+                    .cloned();
+                let credential_resolves = account.as_ref().is_some_and(|account| {
+                    account.home.as_deref().is_some_and(std::path::Path::exists)
+                });
+                (account, limits.clone(), credential_resolves)
+            }
+        };
+        candidates.push(project_route_candidate(
+            ExactRoute {
+                agent: agent.clone(),
+                account_id: Some(account_id.clone()),
+            },
+            account.as_ref(),
+            &limits,
+            RouteEvidence {
+                within_grant: true,
+                explicitly_selected: index < preferred,
+                credential_resolves,
+            },
+            now.unix_timestamp(),
+            now.date(),
+        ));
+    }
+    let preferred = preferred.min(candidates.len());
+    candidates[preferred..].sort_by_key(|candidate| candidate.strained);
+    Ok(candidates)
+}
+
+async fn accountless_candidate(
+    store: &SharedStore,
+    agent: &AgentRoute,
+    within_grant: bool,
+) -> RouteCandidate {
+    let credential_resolves = match auth_provider(agent) {
+        Some(provider) => ProviderAuthService::new(store.clone())
+            .status(provider)
+            .await
+            .is_ok_and(|snapshot| matches!(snapshot.status, AuthStatus::Active { .. })),
+        None => false,
+    };
+    let now = time::OffsetDateTime::now_utc();
+    project_route_candidate(
+        ExactRoute {
+            agent: agent.clone(),
+            account_id: None,
+        },
+        None,
+        &[],
+        RouteEvidence {
+            within_grant,
+            explicitly_selected: false,
+            credential_resolves,
+        },
+        now.unix_timestamp(),
+        now.date(),
+    )
+}
+
+fn managed_provider(agent: &AgentRoute) -> Option<Provider> {
+    match agent.provider.as_str() {
+        "claude" => Some(Provider::Claude),
+        "codex" => Some(Provider::Codex),
+        _ => None,
+    }
+}
+
+fn auth_provider(agent: &AgentRoute) -> Option<Provider> {
+    match agent.provider.as_str() {
+        "claude" => Some(Provider::Claude),
+        "codex" => Some(Provider::Codex),
+        "opencode" | "opencodezen" => Some(Provider::OpenCodeZen),
+        _ => None,
+    }
+}
+
+/// End the failed Launch, then either rotate the same Run lease for the chosen
+/// successor or record a typed capability Wait. The caller has already proved
+/// containment/effect safety and stopped the provider process.
+pub(crate) async fn settle_route_recovery(
+    store: &SharedStore,
+    lease: &RunLease,
+    stopped: StoppedLaunch,
+    choice: RecoveryChoice,
+) -> Result<RecoverySettlement, RunRouteRecoveryError> {
+    store
+        .advance_run(
+            lease,
+            RunAdvance::LaunchEnded {
+                launch_id: stopped.launch_id,
+                outcome: BoundaryState::Failed,
+            },
+        )
+        .await?;
+    match choice {
+        RecoveryChoice::Launch(route) => Ok(RecoverySettlement::Launch {
+            lease: store.rotate_run_lease(lease).await?,
+            route,
+        }),
+        RecoveryChoice::AwaitCapability { reasons } => {
+            let receipt = store
+                .advance_run(
+                    lease,
+                    RunAdvance::Wait {
+                        on: WaitOn::Capability {
+                            capability: CapabilityRef {
+                                kind: "provider_route".to_string(),
+                                key: capability_key(&reasons),
+                            },
+                        },
+                    },
+                )
+                .await?;
+            let AdvanceReceipt::Wait(wait) = receipt else {
+                unreachable!("RunAdvance::Wait returns a Wait receipt")
+            };
+            Ok(RecoverySettlement::AwaitCapability { wait })
+        }
+    }
+}
+
+/// Stop the provider subtree before consuming a route choice. Failure leaves
+/// the old Launch and Run fenced as unprovable; no stopped token exists, so a
+/// caller cannot rotate the lease or start a successor through this seam.
+pub(crate) async fn stop_launch_for_recovery(
+    store: &SharedStore,
+    lease: &RunLease,
+    harness: &mut dyn Harness,
+) -> Result<RecoveryStopOutcome, RunRouteRecoveryError> {
+    let launch = store
+        .current_launch(lease)
+        .await?
+        .ok_or_else(|| RunRouteRecoveryError::MissingLaunch(lease.run_id.clone()))?;
+    match harness.stop().await {
+        Ok(()) => Ok(RecoveryStopOutcome::Stopped(StoppedLaunch {
+            launch_id: launch.id,
+        })),
+        Err(error) => {
+            let error = format!("provider containment stop failed: {error}");
+            let stop = store
+                .stop_run(
+                    lease,
+                    StopCause::Failed {
+                        reason: error.clone(),
+                    },
+                    ContainmentObservation::Unprovable,
+                )
+                .await?;
+            Ok(RecoveryStopOutcome::Fenced {
+                error,
+                stop: Box::new(stop),
+            })
+        }
+    }
+}
+
+pub(crate) fn capability_key(reasons: &[(ExactRoute, RouteUnavailable)]) -> String {
+    if reasons.is_empty() {
+        return "recovery_chain_exhausted".to_string();
+    }
+    reasons
+        .iter()
+        .map(|(route, reason)| {
+            let account = route
+                .account_id
+                .as_ref()
+                .map(ProviderAccountId::as_str)
+                .unwrap_or("ambient");
+            let reason = match reason {
+                RouteUnavailable::Credential => "credential".to_string(),
+                RouteUnavailable::Capacity { resets_at } => resets_at
+                    .map(|reset| format!("capacity_until_{reset}"))
+                    .unwrap_or_else(|| "capacity".to_string()),
+                RouteUnavailable::Policy => "policy".to_string(),
+            };
+            format!("{}/{account}:{reason}", route.agent.agent())
+        })
+        .collect::<Vec<_>>()
+        .join(",")
+}
+
 #[cfg(test)]
 mod tests {
+    use std::path::PathBuf;
+    use std::sync::Arc;
+
+    use async_trait::async_trait;
     use time::{Date, Month};
 
     use super::*;
+    use crate::durable::{
+        AdvanceReceipt, Containment, Launch, LaunchState, RunState, RunTrigger, WorkRef, WorkStatus,
+    };
+    use crate::engine::agent::AgentConfig;
+    use crate::harness::Harness;
+    use crate::id::WaveId;
+    use crate::store::{open_store, StorageConfig};
+    use crate::wave::Wave;
 
     const NOW: i64 = 1_000;
 
@@ -340,6 +715,99 @@ mod tests {
             readiness,
             strained: false,
         }
+    }
+
+    #[derive(Debug)]
+    struct StopHarness {
+        fails: bool,
+    }
+
+    #[async_trait]
+    impl Harness for StopHarness {
+        async fn start(&mut self, _config: &AgentConfig) -> anyhow::Result<()> {
+            Ok(())
+        }
+
+        async fn send_input(&mut self, _content: &str) -> anyhow::Result<()> {
+            Ok(())
+        }
+
+        async fn interrupt(&mut self) -> anyhow::Result<()> {
+            Ok(())
+        }
+
+        async fn stop(&mut self) -> anyhow::Result<()> {
+            if self.fails {
+                anyhow::bail!("native descendants remain live");
+            }
+            Ok(())
+        }
+
+        fn provider_session_id(&self) -> Option<String> {
+            None
+        }
+    }
+
+    async fn wave_work() -> (SharedStore, WorkRef) {
+        let directory = tempfile::tempdir().unwrap().keep();
+        let store = Arc::new(
+            open_store(&StorageConfig::sqlite(directory.join("registry.db")))
+                .await
+                .unwrap(),
+        );
+        let wave = Wave::new(
+            WaveId::new(),
+            "route-recovery".to_string(),
+            directory.display().to_string(),
+        );
+        store.create_wave(&wave).await.unwrap();
+        let work = WorkRef::Wave(wave.id().clone());
+        (store, work)
+    }
+
+    async fn start_launch(
+        store: &SharedStore,
+        work: &WorkRef,
+        route: &ExactRoute,
+    ) -> (RunLease, Launch) {
+        let (_run, lease) = store.reserve_run(work, RunTrigger::User).await.unwrap();
+        let launch = append_launch(store, &lease, route).await;
+        (lease, launch)
+    }
+
+    async fn append_launch(store: &SharedStore, lease: &RunLease, route: &ExactRoute) -> Launch {
+        let receipt = store
+            .advance_run(
+                lease,
+                RunAdvance::LaunchStarting {
+                    route: LaunchRoute::from(route),
+                    containment: Containment::Tmux {
+                        name: format!("lf-route-recovery-{}", route.agent.provider),
+                    },
+                    cwd: PathBuf::from("/tmp/route-recovery"),
+                    surface: "headless".to_string(),
+                    opaque: false,
+                    resume_token: None,
+                },
+            )
+            .await
+            .unwrap();
+        let AdvanceReceipt::Launch(launch) = receipt else {
+            panic!("expected Launch receipt")
+        };
+        let receipt = store
+            .advance_run(
+                lease,
+                RunAdvance::LaunchLive {
+                    launch_id: launch.id,
+                },
+            )
+            .await
+            .unwrap();
+        let AdvanceReceipt::Launch(launch) = receipt else {
+            panic!("expected live Launch receipt")
+        };
+        launch
     }
 
     #[test]
@@ -614,6 +1082,174 @@ mod tests {
         assert_eq!(
             derive_chain_exclusions(&history, &second_id).unwrap(),
             vec![first, second]
+        );
+    }
+
+    #[tokio::test]
+    async fn failed_containment_stop_cannot_create_a_successor_launch() {
+        let (store, work) = wave_work().await;
+        let first_route = route("claude", Some("work"));
+        let (lease, first) = start_launch(&store, &work, &first_route).await;
+        let mut harness = StopHarness { fails: true };
+
+        let stopped = stop_launch_for_recovery(&store, &lease, &mut harness)
+            .await
+            .unwrap();
+
+        let RecoveryStopOutcome::Fenced { stop, .. } = stopped else {
+            panic!("failed stop must fence the Run")
+        };
+        assert_eq!(stop.containment, ContainmentObservation::Unprovable);
+        assert_eq!(stop.run.state, RunState::Stopping);
+        assert_eq!(
+            store.launches_for_run(&lease.run_id).await.unwrap().len(),
+            1
+        );
+        assert_eq!(
+            store
+                .current_launch_for_run(&lease.run_id)
+                .await
+                .unwrap()
+                .unwrap()
+                .state,
+            LaunchState::Stopping
+        );
+        assert_eq!(
+            store.current_run(&work).await.unwrap().unwrap().state,
+            RunState::Stopping
+        );
+        assert!(store.rotate_run_lease(&lease).await.is_err());
+        assert!(store
+            .advance_run(
+                &lease,
+                RunAdvance::LaunchEnded {
+                    launch_id: first.id,
+                    outcome: BoundaryState::Failed,
+                },
+            )
+            .await
+            .is_err());
+    }
+
+    #[tokio::test]
+    async fn recovery_settlement_keeps_account_and_provider_fallback_in_one_run() {
+        let (store, work) = wave_work().await;
+        let work_route = route("claude", Some("work"));
+        let personal_route = route("claude", Some("personal"));
+        let backup_route = route("codex", Some("backup"));
+        let (first_lease, first) = start_launch(&store, &work, &work_route).await;
+        let run_id = first_lease.run_id.clone();
+        let mut harness = StopHarness { fails: false };
+        let RecoveryStopOutcome::Stopped(stopped) =
+            stop_launch_for_recovery(&store, &first_lease, &mut harness)
+                .await
+                .unwrap()
+        else {
+            panic!("successful stop must mint settlement proof")
+        };
+        let RecoverySettlement::Launch {
+            lease: second_lease,
+            route: second_route,
+        } = settle_route_recovery(
+            &store,
+            &first_lease,
+            stopped,
+            RecoveryChoice::Launch(personal_route.clone()),
+        )
+        .await
+        .unwrap()
+        else {
+            panic!("expected same-provider successor")
+        };
+        assert_eq!(second_route, personal_route);
+        assert_eq!(second_lease.run_id, run_id);
+        assert!(store.validate_run_lease(&first_lease).await.is_err());
+        let second = append_launch(&store, &second_lease, &second_route).await;
+
+        let RecoveryStopOutcome::Stopped(stopped) =
+            stop_launch_for_recovery(&store, &second_lease, &mut harness)
+                .await
+                .unwrap()
+        else {
+            panic!("successful second stop must mint settlement proof")
+        };
+        let RecoverySettlement::Launch {
+            lease: third_lease,
+            route: third_route,
+        } = settle_route_recovery(
+            &store,
+            &second_lease,
+            stopped,
+            RecoveryChoice::Launch(backup_route.clone()),
+        )
+        .await
+        .unwrap()
+        else {
+            panic!("expected backup-provider successor")
+        };
+        assert_eq!(third_route, backup_route);
+        assert_eq!(third_lease.run_id, run_id);
+        assert!(store.validate_run_lease(&second_lease).await.is_err());
+        let third = append_launch(&store, &third_lease, &third_route).await;
+
+        let launches = store.launches_for_run(&run_id).await.unwrap();
+        assert_eq!(launches.len(), 3);
+        assert_eq!(launches[0].id, first.id);
+        assert_eq!(launches[0].state, LaunchState::Ended);
+        assert_eq!(launches[0].route, LaunchRoute::from(&work_route));
+        assert_eq!(launches[1].id, second.id);
+        assert_eq!(launches[1].state, LaunchState::Ended);
+        assert_eq!(launches[1].route, LaunchRoute::from(&personal_route));
+        assert_eq!(launches[2].id, third.id);
+        assert_eq!(launches[2].state, LaunchState::Live);
+        assert_eq!(launches[2].route, LaunchRoute::from(&backup_route));
+    }
+
+    #[tokio::test]
+    async fn exhausted_routes_record_a_typed_capability_wait() {
+        let (store, work) = wave_work().await;
+        let first_route = route("claude", Some("work"));
+        let backup_route = route("codex", Some("backup"));
+        let (lease, _) = start_launch(&store, &work, &first_route).await;
+        let mut harness = StopHarness { fails: false };
+        let RecoveryStopOutcome::Stopped(stopped) =
+            stop_launch_for_recovery(&store, &lease, &mut harness)
+                .await
+                .unwrap()
+        else {
+            panic!("successful stop must mint settlement proof")
+        };
+
+        let RecoverySettlement::AwaitCapability { wait } = settle_route_recovery(
+            &store,
+            &lease,
+            stopped,
+            RecoveryChoice::AwaitCapability {
+                reasons: vec![
+                    (first_route, RouteUnavailable::Credential),
+                    (backup_route, RouteUnavailable::Policy),
+                ],
+            },
+        )
+        .await
+        .unwrap() else {
+            panic!("expected typed capability Wait")
+        };
+
+        let WaitOn::Capability { capability } = &wait.on else {
+            panic!("expected capability Wait")
+        };
+        assert_eq!(capability.kind, "provider_route");
+        assert_eq!(capability.key, "claude/work:credential,codex/backup:policy");
+        let WorkStatus::Waiting { wait: stored_wait } = store.work_status(&work).await.unwrap()
+        else {
+            panic!("expected Work to expose the capability Wait")
+        };
+        assert_eq!(stored_wait.id, wait.id);
+        assert_eq!(stored_wait.on, wait.on);
+        assert_eq!(
+            store.launches_for_run(&lease.run_id).await.unwrap().len(),
+            1
         );
     }
 

--- a/rust/loopflow/src/store/durable.rs
+++ b/rust/loopflow/src/store/durable.rs
@@ -199,6 +199,14 @@ impl Store {
         .await
     }
 
+    pub(crate) async fn launches_for_run(
+        &self,
+        run_id: &crate::durable::RunId,
+    ) -> StoreResult<Vec<crate::durable::Launch>> {
+        let run_id = run_id.clone();
+        run_sqlite(&self.sqlite, move |store| store.launches_for_run(&run_id)).await
+    }
+
     /// Reconcile an observed Run after its writer has disappeared.
     ///
     /// The exact Run and Launch ids fence the observation against a concurrent
@@ -229,12 +237,18 @@ impl Store {
         &self,
         lease: &RunLease,
         launch_id: &LaunchId,
+        account_id: Option<crate::store::ProviderAccountId>,
         resume_token: Option<String>,
     ) -> StoreResult<crate::durable::Launch> {
         let lease = lease.clone();
         let launch_id = launch_id.clone();
         run_sqlite(&self.sqlite, move |store| {
-            store.observe_launch_provider(&lease, &launch_id, resume_token.as_deref())
+            store.observe_launch_provider(
+                &lease,
+                &launch_id,
+                account_id.as_ref(),
+                resume_token.as_deref(),
+            )
         })
         .await
     }

--- a/rust/loopflow/src/store/mod.rs
+++ b/rust/loopflow/src/store/mod.rs
@@ -834,7 +834,7 @@ impl std::fmt::Display for ProviderAccountId {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct ProviderAccount {
     pub provider: String,
     pub account_id: ProviderAccountId,
@@ -937,7 +937,7 @@ pub struct AccountLimitWindow {
 }
 
 /// A stored window observation for one managed account.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct AccountLimitRow {
     pub provider: String,
     pub account_id: ProviderAccountId,

--- a/rust/loopflow/src/store/sqlite/durable.rs
+++ b/rust/loopflow/src/store/sqlite/durable.rs
@@ -676,6 +676,23 @@ impl SqliteStore {
         control_launch_for_run_in(&conn, run_id)
     }
 
+    pub(crate) fn launches_for_run(&self, run_id: &RunId) -> StoreResult<Vec<Launch>> {
+        let conn = self.conn.lock().expect("store mutex poisoned");
+        let mut statement = conn.prepare(
+            "SELECT id FROM agent_launches
+             WHERE product_run_id=?1 ORDER BY started_at, rowid",
+        )?;
+        let ids = statement
+            .query_map([run_id.as_str()], |row| row.get::<_, String>(0))?
+            .collect::<Result<Vec<_>, _>>()?;
+        ids.into_iter()
+            .map(|id| {
+                let id = LaunchId::parse(&id).map_err(invalid_durable)?;
+                control_launch_in(&conn, &id)
+            })
+            .collect()
+    }
+
     pub(crate) fn recover_run(
         &self,
         run_id: &RunId,
@@ -792,6 +809,7 @@ impl SqliteStore {
         &self,
         lease: &RunLease,
         launch_id: &LaunchId,
+        account_id: Option<&crate::store::ProviderAccountId>,
         resume_token: Option<&str>,
     ) -> StoreResult<Launch> {
         let mut conn = self.conn.lock().expect("store mutex poisoned");
@@ -805,10 +823,17 @@ impl SqliteStore {
         }
         if tx.execute(
             "UPDATE agent_launches
-             SET resume_token=COALESCE(?3, resume_token),
-                 provider_session_id=COALESCE(?3, provider_session_id)
-             WHERE id=?1 AND product_run_id=?2 AND launch_state IN ('starting','live')",
-            params![launch_id.as_str(), lease.run_id.as_str(), resume_token],
+             SET account_id=COALESCE(account_id, ?3),
+                 resume_token=COALESCE(?4, resume_token),
+                 provider_session_id=COALESCE(?4, provider_session_id)
+             WHERE id=?1 AND product_run_id=?2 AND launch_state IN ('starting','live')
+               AND (?3 IS NULL OR account_id IS NULL OR account_id=?3)",
+            params![
+                launch_id.as_str(),
+                lease.run_id.as_str(),
+                account_id.map(crate::store::ProviderAccountId::as_str),
+                resume_token,
+            ],
         )? == 0
         {
             return Err(StoreError::NotFound);
@@ -3357,7 +3382,7 @@ mod observe_launch_provider_tests {
         let launch_id = live_launch_id(&store, &path);
 
         let launch = store
-            .observe_launch_provider(&lease, &launch_id, Some("thread_abc"))
+            .observe_launch_provider(&lease, &launch_id, None, Some("thread_abc"))
             .expect("record the observed provider");
 
         assert_eq!(launch.resume_token.as_deref(), Some("thread_abc"));
@@ -3381,13 +3406,32 @@ mod observe_launch_provider_tests {
         let launch_id = live_launch_id(&store, &path);
 
         store
-            .observe_launch_provider(&lease, &launch_id, Some("thread_abc"))
+            .observe_launch_provider(&lease, &launch_id, None, Some("thread_abc"))
             .unwrap();
         let launch = store
-            .observe_launch_provider(&lease, &launch_id, None)
+            .observe_launch_provider(&lease, &launch_id, None, None)
             .unwrap();
 
         assert_eq!(launch.resume_token.as_deref(), Some("thread_abc"));
+    }
+
+    #[test]
+    fn a_launch_records_one_exact_account_route_and_rejects_route_drift() {
+        let (dir, store, work) = store_with_wave();
+        let path = dir.path().join("loopflow.db");
+        let (lease, _) = start_launch(&store, &work);
+        let launch_id = live_launch_id(&store, &path);
+        let work_account = crate::store::ProviderAccountId::parse("work").unwrap();
+        let personal_account = crate::store::ProviderAccountId::parse("personal").unwrap();
+
+        let launch = store
+            .observe_launch_provider(&lease, &launch_id, Some(&work_account), None)
+            .unwrap();
+
+        assert_eq!(launch.route.account_id.as_deref(), Some("work"));
+        assert!(store
+            .observe_launch_provider(&lease, &launch_id, Some(&personal_account), None)
+            .is_err());
     }
 
     /// Fail closed: once the Run is stopped it is no longer a writer, so it
@@ -3408,7 +3452,7 @@ mod observe_launch_provider_tests {
             .expect("stop the Run with proven containment absence");
 
         let error = store
-            .observe_launch_provider(&lease, &launch_id, Some("thread_zzz"))
+            .observe_launch_provider(&lease, &launch_id, None, Some("thread_zzz"))
             .expect_err("a stopped Run must not remain a writer");
 
         assert!(

--- a/rust/loopflow/src/task/runner.rs
+++ b/rust/loopflow/src/task/runner.rs
@@ -20,6 +20,10 @@ use crate::harness::{
     classify_disconnect_recovery, drain_turn_failure_reason, ApprovalPolicy, Harness,
     RecoveryDecision,
 };
+use crate::provider_account::recovery::{
+    capability_key, plan_run_route_recovery, settle_route_recovery, stop_launch_for_recovery,
+    ExactRoute, RecoveryChoice, RecoverySettlement, RecoveryStopOutcome,
+};
 use crate::store::SharedStore;
 use crate::task::{
     CiCheck, Observation, PrPhase, Task, TaskEventKind, TaskGateProposal, TaskId,
@@ -66,7 +70,12 @@ async fn owning_wave(store: &SharedStore, session: &Task) -> Result<Wave> {
         .ok_or_else(|| anyhow!("owning Wave {} is not registered", session.wave_id))
 }
 
-async fn spawn_failover(store: &SharedStore, session: &Task, lease: &RunLease) -> Result<()> {
+async fn spawn_failover(
+    store: &SharedStore,
+    session: &Task,
+    lease: &RunLease,
+    route: &ExactRoute,
+) -> Result<()> {
     let tmux_name = format!(
         "lf-task-{}-{}",
         &session.id.as_str()[3..11],
@@ -80,7 +89,8 @@ async fn spawn_failover(store: &SharedStore, session: &Task, lease: &RunLease) -
             wave_id: session.wave_id.clone(),
             cwd: session.worktree.clone(),
             tmux_name,
-            agent: session.agent.clone(),
+            agent: route.agent.agent(),
+            account_id: route.account_id.clone(),
             resume_token: session.provider_session_id.clone(),
         },
     )
@@ -128,7 +138,7 @@ async fn run_task_with(
     else {
         unreachable!("LaunchLive returns a Launch receipt")
     };
-    let run_control = crate::trace::ControlLaunch {
+    let mut run_control = crate::trace::ControlLaunch {
         run_id: run.id,
         home_id: run.home_id,
         account_id: launch.route.account_id.clone(),
@@ -157,13 +167,28 @@ async fn run_task_with(
     let (event_tx, mut event_rx) = mpsc::unbounded_channel();
     let mut harness = create_harness(&harness_name, ApprovalPolicy::AutoApprove, event_tx)?;
     harness.set_provider_session_id(session.provider_session_id.clone());
+    let requested_account = launch
+        .route
+        .account_id
+        .as_deref()
+        .map(crate::store::ProviderAccountId::parse)
+        .transpose()
+        .map_err(|reason| anyhow!("invalid Launch account route: {reason}"))?;
+    harness.set_provider_account_id(requested_account);
     store.validate_run_lease(lease).await?;
     harness.start(&prepared.turn.config).await?;
     session.provider = harness_name;
     session.provider_session_id = harness.provider_session_id();
-    store
-        .observe_launch_provider(lease, &launch.id, session.provider_session_id.clone())
+    let launch = store
+        .observe_launch_provider(
+            lease,
+            &launch.id,
+            harness.provider_account_id(),
+            session.provider_session_id.clone(),
+        )
         .await?;
+    run_control.account_id = launch.route.account_id.clone();
+    run_control.resume_token = launch.resume_token.clone();
     if let Err(error) = store.update_task_for_run(&session, lease).await {
         let _ = harness.stop().await;
         return Err(error.into());
@@ -1405,10 +1430,8 @@ async fn finish_infra_blocked(
     Ok(())
 }
 
-/// Handle a body failure with disconnect-class recovery: classify the failure,
-/// and if it's a disconnect/hollow-body with a configured backup agent, hand
-/// the next generation to the backup instead of leaving the body failed for
-/// the supervisor to respawn the same flaky provider.
+/// Recover a retryable body failure through the Run's next exact route after
+/// PRD-38 permits replacement and the current containment stops positively.
 #[allow(clippy::too_many_arguments)] // capture is a terminal-path output, not a knob
 async fn handle_body_failure(
     store: &SharedStore,
@@ -1419,7 +1442,7 @@ async fn handle_body_failure(
     reason: &str,
     turn_had_durable_side_effect: bool,
     capture: Option<&crate::trace::CaptureHandle>,
-) -> Result<Option<RunLease>> {
+) -> Result<Option<(RunLease, ExactRoute)>> {
     finish_capture(capture, "failed");
     let wave_config = read_wave_config(Path::new(wave.repo()), wave.name());
     let backup_agent = wave_config.as_ref().and_then(|c| c.backup_agent.as_deref());
@@ -1430,60 +1453,84 @@ async fn handle_body_failure(
         backup_agent,
     );
 
-    match decision {
-        RecoveryDecision::HandoffToBackup { agent, provider } => {
-            let _ = harness.stop().await;
-            store
-                .append_task_event_for_run(
-                    &session.id,
-                    lease,
-                    &TaskEventKind::Failed {
-                        error: reason.to_string(),
-                        resumable: true,
-                    },
-                )
-                .await?;
-            store.update_task_for_run(session, lease).await?;
-            let launch = store
-                .current_launch(lease)
-                .await?
-                .ok_or_else(|| anyhow!("Task Run {} has no Launch to hand back", lease.run_id))?;
-            store
-                .advance_run(
-                    lease,
-                    crate::durable::RunAdvance::LaunchEnded {
-                        launch_id: launch.id,
-                        outcome: crate::durable::BoundaryState::Failed,
-                    },
-                )
-                .await?;
-            let handoff = ChildBodyHandoff {
-                from_agent: session.agent.clone(),
-                to_agent: agent.clone(),
-                from_provider: session.provider.clone(),
-                to_provider: provider.clone(),
-                reason: format!(
-                    "disconnect-class failure; handing off from {} to {agent}",
-                    session.agent
-                ),
-            };
-            if session.provider != provider {
-                session.provider_session_id = None;
+    let route_recovery_permitted = matches!(
+        decision,
+        RecoveryDecision::HandoffToBackup { .. } | RecoveryDecision::AllowRetry
+    ) || (matches!(decision, RecoveryDecision::Normal)
+        && !turn_had_durable_side_effect
+        && crate::engine::agent::classify_retryable_agent_failure(reason).is_some());
+
+    if route_recovery_permitted {
+        let launch = store
+            .current_launch(lease)
+            .await?
+            .ok_or_else(|| anyhow!("Task Run {} has no Launch to hand back", lease.run_id))?;
+        let current_route = ExactRoute::try_from(&launch.route)?;
+        let stopped = match stop_launch_for_recovery(store, lease, harness).await? {
+            RecoveryStopOutcome::Stopped(stopped) => stopped,
+            RecoveryStopOutcome::Fenced { error, stop } => {
+                tracing::error!(task = %session.id, containment = ?stop.containment, %error, "Task recovery left the Run fenced");
+                return Ok(None);
             }
-            session.agent = agent;
-            session.provider = provider;
-            store.update_task_for_run(session, lease).await?;
-            store
-                .append_task_event_for_run(
-                    &session.id,
-                    lease,
-                    &TaskEventKind::BodyHandedOff { handoff },
-                )
-                .await?;
-            let rotated = store.rotate_run_lease(lease).await?;
-            store.update_task_for_run(session, &rotated).await?;
-            Ok(Some(rotated))
-        }
+        };
+        let choice = plan_run_route_recovery(store, lease, backup_agent).await?;
+        let failure = match &choice {
+            RecoveryChoice::Launch(_) => reason.to_string(),
+            RecoveryChoice::AwaitCapability { reasons } => format!(
+                "{reason}; waiting on provider route capability: {}",
+                capability_key(reasons)
+            ),
+        };
+        store
+            .append_task_event_for_run(
+                &session.id,
+                lease,
+                &TaskEventKind::Failed {
+                    error: failure,
+                    resumable: true,
+                },
+            )
+            .await?;
+        store.update_task_for_run(session, lease).await?;
+        return match settle_route_recovery(store, lease, stopped, choice).await? {
+            RecoverySettlement::Launch {
+                lease: rotated,
+                route,
+            } => {
+                let agent = route.agent.agent();
+                let provider = route.agent.provider.clone();
+                let handoff = ChildBodyHandoff {
+                    from_agent: session.agent.clone(),
+                    to_agent: agent.clone(),
+                    from_provider: session.provider.clone(),
+                    to_provider: provider.clone(),
+                    reason: format!("route recovery after {reason}"),
+                };
+                if current_route.agent.provider != route.agent.provider
+                    || current_route.account_id != route.account_id
+                {
+                    session.provider_session_id = None;
+                }
+                session.agent = agent;
+                session.provider = provider;
+                store.update_task_for_run(session, &rotated).await?;
+                store
+                    .append_task_event_for_run(
+                        &session.id,
+                        &rotated,
+                        &TaskEventKind::BodyHandedOff { handoff },
+                    )
+                    .await?;
+                Ok(Some((rotated, route)))
+            }
+            RecoverySettlement::AwaitCapability { wait } => {
+                tracing::info!(task = %session.id, wait = %wait.id, "Task waiting for a provider route capability");
+                Ok(None)
+            }
+        };
+    }
+
+    match decision {
         RecoveryDecision::Stop => {
             let non_convergence = format!(
                 "{reason}; not replay-safe (durable side effects this turn) and no backup agent configured"
@@ -1510,6 +1557,9 @@ async fn handle_body_failure(
                 .await
                 .map(|_| None)
         }
+        RecoveryDecision::HandoffToBackup { .. } => unreachable!(
+            "backup handoff is consumed by route recovery before ordinary failure handling"
+        ),
     }
 }
 
@@ -1524,7 +1574,7 @@ async fn fail_and_maybe_relaunch(
     turn_had_durable_side_effect: bool,
     capture: Option<&crate::trace::CaptureHandle>,
 ) -> Result<()> {
-    let Some(rotated) = handle_body_failure(
+    let Some((rotated, route)) = handle_body_failure(
         store,
         session,
         lease,
@@ -1538,7 +1588,7 @@ async fn fail_and_maybe_relaunch(
     else {
         return Ok(());
     };
-    spawn_failover(store, session, &rotated).await
+    spawn_failover(store, session, &rotated, &route).await
 }
 
 async fn finish_abandoned(


### PR DESCRIPTION
## Try it

```bash
cargo test -p loopflow provider_account::recovery
cargo test -p loopflow broker_serves_a_fixed_grant_and_fails_closed_on_drop
```

## Summary

Retryable Task and Project failures now recover within the same durable Run by selecting the next exact provider, model, and account route. When replay safety permits replacement, recovery exhausts eligible accounts on the primary provider before using the configured backup agent, avoiding repeated launches against the same failed route.

## Changes

- Pin Claude and Codex harnesses to the account recorded on each Launch and reject route drift
- Evaluate credentials, capacity, cooldowns, routing policy, grants, and account strain when selecting recovery routes
- Exclude routes already attempted in the current recovery chain while preserving one auditable Run history
- Stop provider containment before replacing a Launch; fence the Run when containment cannot be proven stopped
- Clear incompatible provider sessions when the account or provider changes
- Record a typed `provider_route` capability wait when every permitted route is unavailable