### PR TITLE
architecture: map the feedback-control cutover

### DIFF
--- a/scratch/architecture.md
+++ b/scratch/architecture.md
@@ -1,0 +1,153 @@
+# Architecture review and feedback-control slice
+
+## Intent
+
+> "We should start with the architectural design in order to gain broader
+> context ... However we are not taking on the scope of fully focusing all the
+> architecture today. We ultimately want to get to carving out the right slice
+> that addresses the issues that I just discussed."
+
+Use a top-down architecture review to recover the current truth, update
+`docs/architecture.md`, and select one coherent implementation slice around
+Wave/Project/Task feedback. Do not attempt the entire remaining architecture
+cutover in this work.
+
+The target user experience has natural stopping points where either a human or
+an LLM can enter the same feedback workflow before or after code is written.
+CLI-first operation, a closed desktop app, and a missing parent process must not
+strand durable work.
+
+## Evidence so far
+
+The branch has landed most of the durable control vocabulary:
+
+```text
+Work -> Epoch -> Run -> Launch -> optional Turn
+            \-> Basis <- Steer / selected evidence
+            \-> Wait
+```
+
+- Review rows, review dispositions, handoffs, and `ChildCommand` are gone.
+- Review is derived from interactive flow position, Launch attention, and its
+  route to either User or parent Work.
+- One opaque Run lease authorizes child control.
+- Project and Wave code contain child-Review control lanes.
+- Project and Task execution still runs through legacy Session/body ownership,
+  process generations, statuses, leases, and duplicated runners.
+
+`docs/architecture.md` currently contradicts itself: its opening says parent
+loops do not prioritize child attention, while its implementation frontier says
+Project and Wave drain child Review before background work. It also references
+`scratch/implementation-plan.md`, which is not present. The architecture page
+must distinguish current behavior, remaining bridge, and future target using
+the code as evidence.
+
+## Questions the design must answer
+
+1. What exact durable fact means "feedback is wanted now"?
+2. Is a Project a continuously resident server, or stable Work that may have no
+   process and is woken from durable attention?
+3. Who advances a Task when its Review is routed to a Project but no Project
+   executor is alive?
+4. Which feedback operations are genuinely distinct from `steer`, `interrupt`,
+   `close_review`, and ordinary Run wake/stop?
+5. What command/API surface should humans and headless controllers share?
+6. Which guarantees survive without the desktop app, Wave server, Project
+   process, provider continuation, or a clean canonical checkout?
+
+## Feedback routing decision
+
+Unattended feedback routes to immediate parent Work:
+
+```text
+Task Review -> Project Work
+Project Review -> Wave Work
+Wave/subwave Review -> its parent Wave when one exists
+```
+
+Human-attended feedback routes to the authenticated User. Automated review does
+not impersonate User. After the control model is stable, prompt/context quality
+must be evaluated independently: the parent needs enough durable child output,
+Work truth, flow intent, workspace/PR/CI evidence, and the exact question to
+make a good judgment.
+
+## Feedback concept inventory
+
+The live system currently expresses related ideas in several overlapping
+forms:
+
+| Representation | What it currently means | Disposition candidate |
+| --- | --- | --- |
+| `Skill.interactive` | both provider launch mode and a conversational flow step | split the two meanings |
+| `InteractionPolicy::{Require, Defer}` | actually selects User vs parent reviewer | replace with an explicit reviewer/route |
+| `TaskPhasePlan.interaction_policy` | persists reviewer choice across legacy Session launches | delete with Session; put reviewer on durable flow position |
+| `FlowAction::{WaitInteractive, DeferInteractive}` | duplicates the same route choice in flow execution | collapse to one Review/checkpoint action |
+| `FlowPosition.interactive` | says the current step is a feedback interval | replace boolean with optional typed reviewer/route |
+| Launch `attention_kind/work` | copies the Review route onto provider lifetime | remove route ownership from Launch |
+| Launch `attention_at` | says the reviewer currently owes a response | retain the distinction, but key it by durable Basis/Turn rather than only a timestamp |
+| `Review` | derived conversational interval | keep as a projection, not stored aggregate |
+| `ChildReview` | parent-facing Review plus rendered child evidence | collapse into the same Review projection/context renderer |
+| `ReviewGateState` | obsolete Requested/Active/Approved/ChangesRequested disposition model | delete; production only constructs Active |
+| `TaskAction::Review` | present a GitHub PR or resolve a completion gate | separate PR presentation from flow feedback |
+| `AfterMerge::Review` | keep Task open after merge | rename as Task continuation intent, not Review disposition |
+| Swift `TaskAttention*` / `NowGroup` | scheduling/UI projection across all kinds of work | retain as a projection; do not make it feedback truth |
+| `ChildBodyHandoff*` | legacy Session/body process transition | delete with Session controller |
+
+The likely normalized ownership is:
+
+```rust
+enum Reviewer {
+    User,
+    Parent,
+}
+
+struct FlowPosition {
+    // existing flow coordinates
+    reviewer: Option<Reviewer>,
+    pending_feedback: Option<Basis>,
+}
+
+struct Review { // derived projection
+    work: WorkRef,
+    position: FlowPosition,
+    launch: Option<LaunchId>,
+}
+```
+
+The exact pending-feedback key remains open. It should identify the durable
+boundary/request that awaits a response and supply ordering/idempotency; a bare
+timestamp is weak identity. The important ownership rule is already visible:
+the feedback stop belongs to Work/flow, while Launch is only its current
+transport and presentation surface.
+
+## Current failure seam
+
+A Task Review routed to its Project is stored against stable Work/Run facts,
+but waking the parent crosses back into the legacy Session controller:
+
+```text
+Task Run routes Review -> Project Work attention
+Task event -> observation_outbox -> resolve ProjectSession successor
+                              -> launch ProjectSession body (best effort)
+                              -> warning only when wake fails
+```
+
+This half-migration is not a safe foundation for a feedback-only patch. The
+Project can have durable attention without a corresponding shared-runtime wake,
+and the warning path intentionally leaves it queued. Completing the Work/Run
+execution migration is therefore a likely prerequisite to the feedback/API
+slice, not unrelated architecture work.
+
+The candidate boundary is now:
+
+1. finish shared Work/Run reservation, wake, execution, stop, settlement, and
+   recovery for Wave, Project, and Task;
+2. delete Session/body execution authority and ProjectSession-chain routing;
+3. express human and headless feedback as the same durable Review/Steer/close
+   protocol over that runtime;
+4. collapse `lf task`, `lf project`, and generic `lf work` commands around the
+   resulting concepts.
+
+This remains narrower than finishing every open architecture question: Home
+migration, provider usage normalization, opaque-TUI handback, historical Epoch
+diagnostics, and unrelated UI work are outside unless they block the cutover.

--- a/scratch/open-work.md
+++ b/scratch/open-work.md
@@ -1,0 +1,47 @@
+# Open Work — 2026-07-17
+
+## Review recovery pass
+
+| Task | Current evidence | Action |
+| --- | --- | --- |
+| INT-5 | Recovered successor is live under Claude with all interaction policies deferred | Let the body continue |
+| INT-6 | Recovered successor is live under Codex with all interaction policies deferred | Let the body continue |
+| INT-4 | Fresh Claude body is live on the fourth PR record with all interaction policies deferred | Let the body continue |
+| PRD-20 | Design review returned changes: preserve one shipping judgment and SHA-pinned settlement, remove active-Session authority; Claude recovery body is live | Redesign against Run/Review, rebase, and repair PR #1052 CI |
+| ENG-115 | Design approved; exact-frontier repair body relaunched under Claude with all interaction policies deferred | Finish implementation and carry Run naming through the launch boundary |
+| PRD-38 | Session-deletion body remains live; its legacy completed Kickoff review is being consumed under a temporary Require policy | Finish implementation, then restore Kickoff to Defer before Gate |
+| INT-9 | Live successor body | Leave running |
+| INT-10 | Live successor body | Leave running |
+| RUL-5 | Live successor with Project-routed review | Leave to parent lane unless it stalls |
+| GAM-4 | Completed | No action |
+| RUL-1 | PR #119 merged; obsolete User-routed Session abandoned; worktree removed | No restart |
+| INT-1 | PR #113 merged; obsolete User-routed Session abandoned; worktree removed | No restart |
+
+Settled in this pass: PRD-6, PRD-9, and PRD-12 are terminal after their merged
+work was verified. PRD-6 required reconstructing a clean detached worktree from
+its recorded merge commit because completion currently refuses when a merged
+worktree has already been removed.
+
+## Safety boundary
+
+Do not batch-rewrite review ownership at an occupied waitpoint. The legacy
+store keys the waitpoint to policy and reviewer, so a Require-to-Defer rewrite
+before the completed exercise advances causes `interaction review waitpoint
+already belongs to a different exercise`. Preserve the review, let its current
+runner consume completion, then persist the headless policy from an inactive
+boundary.
+
+## Architecture bugs surfaced
+
+- `task complete` can bypass an outstanding Project review even when status
+  reports completion unavailable. PRD-12 demonstrated the split between the
+  derived legal-action model and the mutation guard.
+- `task complete` requires the historical worktree to exist even after every PR
+  merged and the checkout was safely removed. Completion should fence on the
+  recorded merged evidence, not filesystem resurrection.
+- Converting a completed User waitpoint to Defer before its runner advances
+  collides with the old review identity. Headless conversion needs an atomic
+  carry rule rather than a temporary direct policy rewrite.
+- `task interrupt` can persist a replacement while the resident body remains
+  active, but `task run --headless` requires no active body. There is no public
+  non-terminal stop/park operation for this conversion boundary.


### PR DESCRIPTION
## Usage

```bash
git diff main...HEAD -- scratch/architecture.md scratch/open-work.md
```

## Summary

Documents the current feedback-control architecture and narrows the next implementation slice around durable Wave, Project, and Task review routing. The review identifies the legacy Session controller as the critical migration seam and preserves operational evidence from the open-work recovery pass.

## Changes

- Inventory overlapping feedback, review, routing, and attention concepts
- Define parent Work as the route for unattended feedback
- Propose Work/flow ownership for durable feedback stops instead of Launch ownership
- Identify shared Work/Run execution as a prerequisite to a reliable feedback API
- Record active work recovery decisions, safety constraints, and architecture bugs discovered during the review
- Keep Home migration, usage normalization, historical diagnostics, and unrelated UI work outside this slice