### PR TITLE
auth: route provider launches through explicit authority

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -17,7 +17,7 @@ Configure loopflow via CLI flags, global config (`~/.lf/config.yaml`), or repo c
 | Direction (judgment/intent) | `--direction NAME` | `direction: NAME` |
 | Chrome automation | `--chrome` | `chrome: true` |
 | Yolo mode (skip permissions) | — | `yolo: true` |
-| Interactive launch surface | `--tui` / `--ide` | `session.launch: tui` |
+| Claude/Codex/OpenCode launch surface | `--tui` / `--ide` | `session.launch: tui` |
 
 ## Context Assembly
 
@@ -319,9 +319,10 @@ session:
   launch: tui          # tui | ide
 ```
 
-`tui` opens the vendor CLI/TUI in the current terminal. `ide` opens the Codex or
-Claude app by URL scheme and falls back to `tui` if no app handles the link.
-OpenCode is terminal-only. The per-run flags `--tui` / `--ide` override this default.
+`tui` opens Claude, Codex, or OpenCode in the current terminal. `ide` opens the
+Codex or Claude app by URL scheme and falls back to `tui` if no app handles the
+link. OpenCode is terminal-only. The per-run flags `--tui` / `--ide` override
+this default.
 
 ### Summaries
 
@@ -343,6 +344,8 @@ Connect providers once, then route each repository through managed accounts:
 ```bash
 lf auth status                   # GitHub / Claude / Codex / OpenCode Zen / Linear
 lf auth github                   # connect a provider in your browser
+lf auth opencode                 # connect OpenCode Zen in your browser
+lf auth configure opencode       # store OPENCODE_API_KEY from the environment
 lf auth connect claude primary@example.com --chrome-profile primary@example.com
 lf auth accounts claude          # cached account state; no network request
 lf auth accounts --verify        # compare cached state with every provider now
@@ -361,6 +364,19 @@ record the ordered logins a provider may use. A provider child stays pinned to
 its selected login for its lifetime. Shared logins are tried once and share one
 cooldown. Profiles, bindings, and repo routes live in the local database —
 Loopflow sends no account topology to a central service.
+
+Managed Claude and Codex launches use the repository route, then the default
+route. Without either route, every automatic managed login is eligible.
+Missing, disabled, cooling, and limited logins are skipped. With no managed
+login, the provider CLI uses its ambient default credentials.
+
+An active usage window at 95% or above demotes that login behind accounts below
+the threshold. Declared route order decides ties.
+
+OpenCode Zen uses one provider credential rather than the managed subscription
+account route. Its stored credential applies to local headless and terminal
+OpenCode launches and foreground SSH; subscription polling and the 95% demotion
+threshold do not apply.
 
 `auth connect <provider> <email-prefix> --chrome-profile` opens the selected
 Chrome directory and binds the verified login. Codex

--- a/docs/lf.md
+++ b/docs/lf.md
@@ -189,7 +189,7 @@ level stays there. Put `--` before literal arguments that look like flags.
 
 | Flag | Description |
 |------|-------------|
-| `--tui` / `--ide` | Hand off to an interactive vendor session (terminal or vendor app); overrides `session.launch` |
+| `--tui` / `--ide` | Hand off Claude, Codex, or OpenCode to the terminal, or Claude/Codex to their app; overrides `session.launch` |
 
 ## Browser Automation
 
@@ -211,7 +211,7 @@ lf ship -w feature-branch
 | `--docs PATH[,PATH...]` | Prefetch docs into context—files, globs, or dirs (default: none) |
 | `-w, --wave NAME` | Wave name for wave/ scoping |
 | `-m, --model MODEL` | Model to use |
-| `--tui` / `--ide` | Hand off to an interactive vendor session (terminal or vendor app); overrides `session.launch` |
+| `--tui` / `--ide` | Hand off Claude, Codex, or OpenCode to the terminal, or Claude/Codex to their app; overrides `session.launch` |
 
 Flows are defined in `.lf/flows/`. See [Configuration](config.md).
 
@@ -463,9 +463,15 @@ a missing credential continues through the healthy fallback route.
 selected provider accounts. Both flags are repeatable and accept
 `claude=<selector>` or `codex=<selector>`. They cannot be combined.
 
-Use the flags for interactive vendor sessions too (`--tui`): logging into a
-managed login with a bare `codex login` creates a second session and evicts
-the managed one ("needs re-login"); entering through lf shares one session.
+Use the flags for Claude and Codex terminal sessions too (`--tui`): logging
+into a managed login with a bare `codex login` creates a second session and
+evicts the managed one ("needs re-login"); entering through lf shares one
+session.
+
+Without an account flag, managed Claude and Codex launches use the repository
+route, then the default route. If neither exists, all automatic managed logins
+are eligible and Loopflow skips known cooling or limited accounts. If no
+managed login exists, the provider CLI uses its ambient default credentials.
 
 `lf usage` leads with each managed account's subscription state — provider-
 reported plan, session and weekly windows as percent *used*, reset times —
@@ -592,7 +598,7 @@ mechanical git/PR operations. Tier skills add scoped delegation. Use
 lf debug -c    # include current clipboard text in the prompt
 ```
 
-### Launch an interactive vendor session
+### Launch Claude, Codex, or OpenCode interactively
 
 ```bash
 lf design                 # interactive skill → uses session.launch (default: tui)
@@ -600,8 +606,9 @@ lf gate --tui             # force a terminal handoff for a normally-headless ski
 lf : "fix the bug" --ide -m codex   # force the Codex app instead
 ```
 
-`--tui` and `--ide` override the repo default. Set `session.launch: ide` in
-`.lf/config.yaml` to make the vendor app the default for interactive skills.
+`--tui` opens Claude, Codex, or OpenCode in the terminal. `--ide` opens Claude
+or Codex in its app. Both override the repo default. Set `session.launch: ide`
+in `.lf/config.yaml` to make the app the default for interactive skills.
 
 ### External skills
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -135,6 +135,10 @@ it forwards the extracted Claude or Codex access token in the remote process
 environment. Configure a managed route or pass `--only-account` when provider
 authority must stay behind the broker.
 
+OpenCode Zen is not a managed subscription account. Foreground SSH forwards
+its locally resolved API key in the remote process environment; commands using
+`--remote-native` forward none.
+
 Nested `lf` processes inherit the same fixed grant through the handle. They
 cannot widen, narrow, or reorder it; nested `--account` and `--only-account`
 flags fail. A resumed provider session stays on its recorded account when that

--- a/rust/loopflow/src/engine/agent.rs
+++ b/rust/loopflow/src/engine/agent.rs
@@ -1293,12 +1293,9 @@ fn _launch_agent_once(
         cmd.env("LOOPFLOW_DIRECTIVE_FILE", relay_path);
     }
 
-    // Never forward API keys to agent subprocesses. Claude Code, Codex, etc.
-    // should use their own auth (subscription/OAuth). A stray ANTHROPIC_API_KEY
-    // in the shell causes Claude Code to silently bill the API instead.
-    cmd.env_remove("ANTHROPIC_API_KEY");
-    cmd.env_remove("OPENAI_API_KEY");
-    cmd.env_remove("GEMINI_API_KEY");
+    // Ambient API keys are filtered by executable. Explicitly stored provider
+    // credentials are then restored only for the executable that owns them.
+    crate::provider_auth::apply_provider_env_to_command(program, &mut cmd);
     crate::harness::configure_vendor_std_env(&mut cmd)
         .map_err(|error| CoreError::ExecutionFailed(error.to_string()))?;
 

--- a/rust/loopflow/src/lf/commands/auth.rs
+++ b/rust/loopflow/src/lf/commands/auth.rs
@@ -155,12 +155,8 @@ fn forwarded_accounts(raw_provider: Option<&str>) -> Result<()> {
             if position < grant.preferred {
                 labels.push("preferred");
             }
-            println!(
-                "{:<12} {} {}",
-                grant.provider,
-                account_id,
-                labels.join(" · ")
-            );
+            let account = client.login_email(grant.provider, account_id)?;
+            println!("{:<12} {} {}", grant.provider, account, labels.join(" · "));
         }
     }
     Ok(())

--- a/rust/loopflow/src/lf/commands/profile.rs
+++ b/rust/loopflow/src/lf/commands/profile.rs
@@ -13,7 +13,7 @@ use crate::provider_account::{
 };
 use crate::provider_auth::Provider;
 use crate::repository::RepoId;
-use crate::store::{ProviderAccount, ProviderAccountId, SharedStore};
+use crate::store::{ProviderAccount, SharedStore};
 
 pub fn run(cmd: &ProfileCommand, _repo_root: &Path) -> Result<()> {
     if crate::provider_account::lease::account_lease_active() {
@@ -82,7 +82,8 @@ fn show_forwarded_routes() -> Result<()> {
             } else {
                 ""
             };
-            println!("  {}. {}{preferred}", position + 1, account_id);
+            let account = client.login_email(grant.provider, account_id)?;
+            println!("  {}. {}{preferred}", position + 1, account);
         }
     }
     Ok(())
@@ -187,18 +188,18 @@ async fn set_route(
     let provider = parse_managed_provider(raw_provider)?;
     let mut accounts = Vec::new();
     for raw_account in raw_accounts {
-        accounts.push(
-            find_provider_account(store, provider, raw_account)
-                .await?
-                .account_id,
-        );
+        accounts.push(find_provider_account(store, provider, raw_account).await?);
     }
+    let account_ids = accounts
+        .iter()
+        .map(|account| account.account_id.clone())
+        .collect();
     let now = now_unix();
     store
         .set_provider_route(&ProviderRoute {
             scope: scope.clone(),
             provider,
-            accounts: accounts.clone(),
+            accounts: account_ids,
             created_at: now,
             updated_at: now,
         })
@@ -211,7 +212,7 @@ async fn set_route(
         "{label} {provider}: {}",
         accounts
             .iter()
-            .map(ProviderAccountId::as_str)
+            .map(account_login)
             .collect::<Vec<_>>()
             .join(" -> ")
     );

--- a/rust/loopflow/src/lf/commands/ssh.rs
+++ b/rust/loopflow/src/lf/commands/ssh.rs
@@ -34,7 +34,9 @@ use crate::pm::PmProviderKind;
 use crate::provider_account::lease::{
     self, AccountLeaseBroker, AccountLeaseHandle, AccountSelection, PreparedAccountLease,
 };
-use crate::provider_auth::{extract_claude_token, extract_codex_access_token};
+use crate::provider_auth::{
+    extract_claude_token, extract_codex_access_token, extract_opencode_zen_token,
+};
 
 pub const EXPECTED_HOME_ID_ENV: &str = "LF_EXPECTED_HOME_ID";
 
@@ -47,6 +49,7 @@ pub const DEFAULT_REPO: &str = "src/loopflow";
 struct Credentials {
     gh_token: Option<String>,
     provider_authority: ProviderAuthority,
+    opencode_token: Option<String>,
     pm_token: Option<String>,
     /// PM provider the token belongs to (e.g. `linear`).
     pm_provider: Option<String>,
@@ -100,6 +103,7 @@ impl std::fmt::Debug for Credentials {
             .debug_struct("Credentials")
             .field("gh_token", &self.gh_token.is_some())
             .field("provider_authority", &provider_authority)
+            .field("opencode_token", &self.opencode_token.is_some())
             .field("pm_token", &self.pm_token.is_some())
             .field("pm_provider", &self.pm_provider)
             .field(
@@ -410,6 +414,7 @@ async fn resolve_credentials(
     Ok(Credentials {
         gh_token: resolve_gh_token(),
         provider_authority,
+        opencode_token: _resolve_opencode_token(&home).await,
         pm_token: resolve_pm_token().await,
         pm_provider: Some(PmProviderKind::Linear.as_str().to_string()),
         secrets,
@@ -459,12 +464,19 @@ fn resolve_doppler_secret(name: &str) -> anyhow::Result<String> {
 /// PM/Linear access token from the local store credential store. Absent when no
 /// store exists or no Linear credential is stored.
 async fn resolve_pm_token() -> Option<String> {
+    _resolve_stored_provider_token(PmProviderKind::Linear.as_str()).await
+}
+
+async fn _resolve_opencode_token(home: &std::path::Path) -> Option<String> {
+    _resolve_stored_provider_token("opencodezen")
+        .await
+        .or_else(|| extract_opencode_zen_token(home).map(|token| token.access_token))
+}
+
+async fn _resolve_stored_provider_token(provider: &str) -> Option<String> {
     let cfg = crate::store::storage_config_from_env().ok()?;
     let store = crate::store::open_store(&cfg).await.ok()?;
-    let token = store
-        .get_provider_token(PmProviderKind::Linear.as_str())
-        .await
-        .ok()??;
+    let token = store.get_provider_token(provider).await.ok()??;
     Some(token.access_token)
         .map(|value| value.trim().to_string())
         .filter(|value| !value.is_empty())
@@ -545,6 +557,9 @@ fn build_preamble(
         if let Some(token) = nonempty(codex_token) {
             lines.push(format!("export CODEX_ACCESS_TOKEN={}", sh_quote(token)));
         }
+    }
+    if let Some(token) = nonempty(&credentials.opencode_token) {
+        lines.push(format!("export OPENCODE_API_KEY={}", sh_quote(token)));
     }
     if let Some(lease_handle) = lease_handle {
         match lease_handle.encode() {
@@ -802,6 +817,7 @@ mod tests {
         Credentials {
             gh_token: Some("gh-secret".to_string()),
             provider_authority: ProviderAuthority::default(),
+            opencode_token: Some("opencode-secret".to_string()),
             pm_token: Some("linear-secret".to_string()),
             pm_provider: Some("linear".to_string()),
             secrets: vec![("STRIPE_KEY".to_string(), "sk-live-123".to_string())],
@@ -869,6 +885,7 @@ mod tests {
         );
 
         assert!(preamble.contains("export GH_TOKEN='gh-secret'"));
+        assert!(preamble.contains("export OPENCODE_API_KEY='opencode-secret'"));
         assert!(!preamble.contains("export CLAUDE_CODE_OAUTH_TOKEN="));
         assert!(!preamble.contains("export CODEX_ACCESS_TOKEN="));
         assert!(preamble.contains(&format!("export {}=", lease::ACCOUNT_LEASE_ENV)));
@@ -952,6 +969,7 @@ mod tests {
             "GH_TOKEN",
             "CLAUDE_CODE_OAUTH_TOKEN",
             "CODEX_ACCESS_TOKEN",
+            "OPENCODE_API_KEY",
             "LF_FORWARDED_PM_TOKEN",
             lease::ACCOUNT_LEASE_ENV,
         ] {
@@ -982,6 +1000,7 @@ mod tests {
 
         assert!(!debug.contains("gh-secret"));
         assert!(!debug.contains("linear-secret"));
+        assert!(!debug.contains("opencode-secret"));
         assert!(!debug.contains("sk-live-123"));
         assert!(debug.contains("STRIPE_KEY"));
     }

--- a/rust/loopflow/src/lf/commands/util.rs
+++ b/rust/loopflow/src/lf/commands/util.rs
@@ -4,6 +4,7 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use crate::engine::{check_cli_available, codex_permission_args, workspace_add_dirs, LaunchTarget};
+use crate::provider_auth::Provider;
 
 pub fn find_repo_root() -> Result<PathBuf> {
     crate::engine::repo::find_repo_root()
@@ -166,14 +167,35 @@ fn spawn_session_command(command: &SessionCommand) -> Result<()> {
         ));
     }
 
-    let status = Command::new(&command.program)
+    let provider = match command.program.as_str() {
+        "claude" => Some(Provider::Claude),
+        "codex" => Some(Provider::Codex),
+        _ => None,
+    };
+    let account_route = provider
+        .map(|provider| crate::provider_account::resolve_provider_account_blocking(provider, None))
+        .transpose()
+        .map_err(|error| anyhow!("failed to select provider account: {error}"))?
+        .flatten();
+
+    let mut process = Command::new(&command.program);
+    if provider == Some(Provider::Codex)
+        && account_route
+            .as_ref()
+            .is_some_and(crate::provider_account::ProviderAccountRoute::uses_native_home)
+    {
+        process.args(["-c", "cli_auth_credentials_store=\"file\""]);
+    }
+    process
         .args(&command.args)
         .current_dir(&command.cwd)
-        .env_remove("LOOPFLOW_DIRECTIVE_FILE")
-        .env_remove("ANTHROPIC_API_KEY")
-        .env_remove("OPENAI_API_KEY")
-        .env_remove("GEMINI_API_KEY")
-        .status()?;
+        .env_remove("LOOPFLOW_DIRECTIVE_FILE");
+    crate::provider_auth::apply_provider_env_to_command(&command.program, &mut process);
+    if let Some(route) = &account_route {
+        tracing::info!(provider = %command.program, "selected managed provider account");
+        route.apply(&mut process);
+    }
+    let status = process.status()?;
 
     if status.success() {
         Ok(())
@@ -210,6 +232,36 @@ fn percent_encode(value: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::profile::EmailAddress;
+    use crate::provider_account::new_account;
+    use crate::store::{
+        open_store, CredentialType, ProviderAccountId, ProviderToken, StorageConfig,
+    };
+    use std::ffi::OsString;
+
+    struct EnvRestore(Vec<(&'static str, Option<OsString>)>);
+
+    impl EnvRestore {
+        fn capture(names: &[&'static str]) -> Self {
+            Self(
+                names
+                    .iter()
+                    .map(|name| (*name, std::env::var_os(name)))
+                    .collect(),
+            )
+        }
+    }
+
+    impl Drop for EnvRestore {
+        fn drop(&mut self) {
+            for (name, value) in &self.0 {
+                match value {
+                    Some(value) => std::env::set_var(name, value),
+                    None => std::env::remove_var(name),
+                }
+            }
+        }
+    }
 
     fn path() -> PathBuf {
         PathBuf::from("/tmp/loop flow")
@@ -368,6 +420,139 @@ mod tests {
             main.canonicalize().unwrap()
         );
         assert!(launch.command.args.ends_with(&args(&["--", "fix it"])));
+    }
+
+    #[allow(clippy::await_holding_lock)]
+    #[tokio::test]
+    async fn session_launch_tui_claude_uses_a_healthy_managed_login() {
+        let _lock = crate::journal::test_env_lock();
+        let temp = tempfile::tempdir().unwrap();
+        let _restore = EnvRestore::capture(&[
+            "LF_HOME",
+            "LF_DB_PATH",
+            "LF_ACCOUNT_LEASE",
+            "LF_TEST_SESSION_ENV",
+            "CLAUDE_CONFIG_DIR",
+            "PATH",
+        ]);
+        std::env::set_var("LF_HOME", temp.path());
+        std::env::remove_var("LF_DB_PATH");
+        std::env::remove_var("LF_ACCOUNT_LEASE");
+        std::env::set_var("CLAUDE_CONFIG_DIR", "ambient");
+
+        let bin = temp.path().join("bin");
+        std::fs::create_dir(&bin).unwrap();
+        let claude = bin.join("claude");
+        std::fs::write(
+            &claude,
+            "#!/bin/sh\nprintf '%s' \"$CLAUDE_CONFIG_DIR\" > \"$LF_TEST_SESSION_ENV\"\n",
+        )
+        .unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+
+            let mut permissions = std::fs::metadata(&claude).unwrap().permissions();
+            permissions.set_mode(0o755);
+            std::fs::set_permissions(&claude, permissions).unwrap();
+        }
+        let path = std::env::var_os("PATH").unwrap_or_default();
+        std::env::set_var(
+            "PATH",
+            std::env::join_paths(std::iter::once(bin).chain(std::env::split_paths(&path))).unwrap(),
+        );
+        let capture = temp.path().join("session-env");
+        std::env::set_var("LF_TEST_SESSION_ENV", &capture);
+
+        let store = open_store(&StorageConfig::sqlite(temp.path().join("loopflow.db")))
+            .await
+            .unwrap();
+        let account_home = temp.path().join("accounts/claude/jackstah");
+        let account = new_account(
+            Provider::Claude,
+            ProviderAccountId::parse("jackstah").unwrap(),
+            account_home.clone(),
+            Some(EmailAddress::parse("jackstah@gmail.com").unwrap()),
+        );
+        store.upsert_provider_account(&account).await.unwrap();
+
+        launch_session(LaunchTarget::Tui, "claude", None, temp.path(), "review it").unwrap();
+
+        assert_eq!(
+            std::fs::read_to_string(capture).unwrap(),
+            account_home.to_string_lossy()
+        );
+    }
+
+    #[allow(clippy::await_holding_lock)]
+    #[tokio::test]
+    async fn session_launch_tui_opencode_uses_the_stored_zen_credential() {
+        let _lock = crate::journal::test_env_lock();
+        let temp = tempfile::tempdir().unwrap();
+        let _restore = EnvRestore::capture(&[
+            "LF_HOME",
+            "LF_DB_PATH",
+            "LF_ACCOUNT_LEASE",
+            "LF_TEST_SESSION_ENV",
+            "OPENCODE_API_KEY",
+            "PATH",
+        ]);
+        std::env::set_var("LF_HOME", temp.path());
+        std::env::remove_var("LF_DB_PATH");
+        std::env::remove_var("LF_ACCOUNT_LEASE");
+        std::env::set_var("OPENCODE_API_KEY", "ambient-key");
+
+        let bin = temp.path().join("bin");
+        std::fs::create_dir(&bin).unwrap();
+        let opencode = bin.join("opencode");
+        std::fs::write(
+            &opencode,
+            "#!/bin/sh\nprintf '%s' \"$OPENCODE_API_KEY\" > \"$LF_TEST_SESSION_ENV\"\n",
+        )
+        .unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+
+            let mut permissions = std::fs::metadata(&opencode).unwrap().permissions();
+            permissions.set_mode(0o755);
+            std::fs::set_permissions(&opencode, permissions).unwrap();
+        }
+        let path = std::env::var_os("PATH").unwrap_or_default();
+        std::env::set_var(
+            "PATH",
+            std::env::join_paths(std::iter::once(bin).chain(std::env::split_paths(&path))).unwrap(),
+        );
+        let capture = temp.path().join("session-env");
+        std::env::set_var("LF_TEST_SESSION_ENV", &capture);
+
+        let store = open_store(&StorageConfig::sqlite(temp.path().join("loopflow.db")))
+            .await
+            .unwrap();
+        store
+            .upsert_provider_token(&ProviderToken {
+                provider: Provider::OpenCodeZen.as_str().to_string(),
+                access_token: "stored-key".to_string(),
+                refresh_token: None,
+                oauth_client_id: None,
+                expires_at: None,
+                login: Some("zen@example.com".to_string()),
+                updated_at: time::OffsetDateTime::now_utc().unix_timestamp(),
+                credential_type: CredentialType::ApiKey,
+            })
+            .await
+            .unwrap();
+
+        launch_session(
+            LaunchTarget::Tui,
+            "opencode",
+            None,
+            temp.path(),
+            "review it",
+        )
+        .unwrap();
+
+        assert_eq!(std::fs::read_to_string(capture).unwrap(), "stored-key");
     }
 
     #[test]

--- a/rust/loopflow/src/lf/mod.rs
+++ b/rust/loopflow/src/lf/mod.rs
@@ -83,11 +83,11 @@ pub struct Cli {
     #[arg(short = 'b', long = "batch", short_alias = 'B')]
     pub batch: bool,
 
-    /// Hand off to an interactive vendor session in the terminal (overrides session.launch)
+    /// Hand off Claude, Codex, or OpenCode to the terminal (overrides session.launch)
     #[arg(long, conflicts_with = "ide")]
     pub tui: bool,
 
-    /// Hand off to an interactive vendor session in the vendor app (overrides session.launch)
+    /// Hand off Claude or Codex to the vendor app (overrides session.launch)
     #[arg(long)]
     pub ide: bool,
 

--- a/rust/loopflow/src/provider_account.rs
+++ b/rust/loopflow/src/provider_account.rs
@@ -23,7 +23,7 @@ use crate::store::{CredentialState, RoutingState};
 
 const DEFAULT_COOLDOWN_SECS: i64 = 15 * 60;
 const RESET_GRACE_SECS: i64 = 5;
-const STRAINED_UTILIZATION_PERCENT: u8 = 75;
+const STRAINED_UTILIZATION_PERCENT: u8 = 95;
 const PROVIDER_CREDENTIAL_ENV_VARS: [&str; 6] = [
     "CLAUDE_CODE_OAUTH_TOKEN",
     "ANTHROPIC_API_KEY",
@@ -110,7 +110,7 @@ pub enum ProviderAccountError {
         provider: Provider,
         accounts: String,
     },
-    #[error("configured {provider} route has no eligible account: {accounts}")]
+    #[error("no eligible managed {provider} account: {accounts}")]
     NoEligibleAccount {
         provider: Provider,
         accounts: String,
@@ -684,13 +684,22 @@ pub(crate) async fn provider_route_account_ids(
         }
         None => None,
     };
-    Ok(match route {
-        Some(route) => Some(route.accounts),
-        None => store
-            .provider_route(&RouteScope::Default, provider)
-            .await?
-            .map(|route| route.accounts),
-    })
+    if let Some(route) = route {
+        return Ok(Some(route.accounts));
+    }
+    if let Some(route) = store.provider_route(&RouteScope::Default, provider).await? {
+        return Ok(Some(route.accounts));
+    }
+
+    let today = time::OffsetDateTime::now_utc().date();
+    let accounts = store
+        .list_provider_accounts(Some(provider.as_str()))
+        .await?
+        .into_iter()
+        .filter(|account| account.eligible_for_automatic_routing(today))
+        .map(|account| account.account_id)
+        .collect::<Vec<_>>();
+    Ok((!accounts.is_empty()).then_some(accounts))
 }
 
 pub(crate) fn resolve_provider_account_blocking(
@@ -1294,7 +1303,7 @@ mod account_first_tests {
                 &second.account_id,
                 &[crate::store::AccountLimitWindow {
                     window: "weekly".to_string(),
-                    used_percent: 80,
+                    used_percent: 95,
                     resets_at: Some(now_unix() + 3600),
                     plan: None,
                 }],
@@ -1343,7 +1352,7 @@ mod account_first_tests {
             .upsert_provider_account_limits(
                 Provider::Codex.as_str(),
                 &first.account_id,
-                &[window(80, Some(now_unix() + 3600))],
+                &[window(95, Some(now_unix() + 3600))],
                 "poll",
             )
             .await
@@ -1373,9 +1382,9 @@ mod account_first_tests {
 
         // Under the bar, already reset, or never resetting: declared order stands.
         for window in [
-            window(STRAINED_UTILIZATION_PERCENT - 1, Some(now_unix() + 3600)),
-            window(80, Some(now_unix() - 1)),
-            window(80, None),
+            window(94, Some(now_unix() + 3600)),
+            window(95, Some(now_unix() - 1)),
+            window(95, None),
         ] {
             store
                 .upsert_provider_account_limits(
@@ -1442,7 +1451,43 @@ mod account_first_tests {
                 .await
                 .unwrap_err()
                 .to_string(),
-            "configured claude route has no eligible account: 'missing@example.com' credential is missing"
+            "no eligible managed claude account: 'missing@example.com' credential is missing"
         );
+    }
+
+    #[allow(clippy::await_holding_lock)]
+    #[tokio::test]
+    async fn accounts_form_an_implicit_route_when_no_route_is_configured() {
+        let _lock = crate::journal::test_env_lock();
+        let temp = tempdir().unwrap();
+        let _restore = EnvRestore::capture(&["LF_HOME", lease::ACCOUNT_LEASE_ENV]);
+        std::env::set_var("LF_HOME", temp.path());
+        std::env::remove_var(lease::ACCOUNT_LEASE_ENV);
+        let store = Arc::new(
+            open_store(&StorageConfig::sqlite(temp.path().join("loopflow.db")))
+                .await
+                .unwrap(),
+        );
+        let limited = account(Provider::Claude, "a-limited", temp.path());
+        let healthy = account(Provider::Claude, "z-healthy", temp.path());
+        store.upsert_provider_account(&limited).await.unwrap();
+        store.upsert_provider_account(&healthy).await.unwrap();
+        store
+            .record_provider_account_health(
+                Provider::Claude.as_str(),
+                &limited.account_id,
+                Some(100),
+                Some(now_unix() + 300),
+                Some("subscription usage limit"),
+            )
+            .await
+            .unwrap();
+
+        let route = resolve_provider_account(Provider::Claude, None)
+            .await
+            .unwrap()
+            .expect("a healthy managed account should be selected");
+
+        assert_eq!(route.account_id(), &healthy.account_id);
     }
 }

--- a/rust/loopflow/src/provider_account/lease.rs
+++ b/rust/loopflow/src/provider_account/lease.rs
@@ -81,7 +81,7 @@ impl ProviderAccountSelector {
         let account = account.trim();
         if account.is_empty() {
             return Err(ProviderAccountError::Runtime(format!(
-                "{provider}= requires an account id or login email"
+                "{provider}= requires a login email or prefix"
             )));
         }
         Ok(Self {
@@ -1052,6 +1052,27 @@ impl AccountLeaseClient {
         }
     }
 
+    pub(crate) fn login_email(
+        &self,
+        provider: Provider,
+        account_id: &ProviderAccountId,
+    ) -> Result<String, ProviderAccountError> {
+        let facts = self.account_facts(provider, account_id)?;
+        let account = facts.account.ok_or_else(|| {
+            ProviderAccountError::Runtime(format!(
+                "forwarded {provider} account has no catalog entry"
+            ))
+        })?;
+        account
+            .login_email
+            .map(|login| login.to_string())
+            .ok_or_else(|| {
+                ProviderAccountError::Runtime(format!(
+                    "forwarded {provider} account has no login email"
+                ))
+            })
+    }
+
     pub(crate) fn pin_session(
         &self,
         provider: Provider,
@@ -1401,7 +1422,10 @@ mod tests {
                     temp.path()
                         .join(grant.provider.as_str())
                         .join(account_id.as_str()),
-                    None,
+                    Some(
+                        crate::profile::EmailAddress::parse(&format!("{account_id}@example.com"))
+                            .unwrap(),
+                    ),
                 );
                 if grant.provider == Provider::Codex && account_id == &id("reserve") {
                     account.cooldown_until =
@@ -1473,6 +1497,12 @@ mod tests {
                 .account_facts(Provider::Claude, &id("personal"))
                 .unwrap()
                 .credential_available
+        );
+        assert_eq!(
+            client
+                .login_email(Provider::Claude, &id("personal"))
+                .unwrap(),
+            "personal@example.com"
         );
         let facts = client
             .account_facts(Provider::Codex, &id("reserve"))

--- a/rust/loopflow/src/provider_account/recovery.rs
+++ b/rust/loopflow/src/provider_account/recovery.rs
@@ -931,7 +931,7 @@ mod tests {
         let candidate = project_route_candidate(
             route("claude", Some("work")),
             Some(&account),
-            &[limit("work", 80, Some(NOW + 60))],
+            &[limit("work", 95, Some(NOW + 60))],
             evidence(),
             NOW,
             today(),

--- a/rust/loopflow/src/provider_auth/mod.rs
+++ b/rust/loopflow/src/provider_auth/mod.rs
@@ -2837,7 +2837,7 @@ fn opencode_auth_path(home_dir: &Path) -> PathBuf {
     home_dir.join(".local/share/opencode/auth.json")
 }
 
-fn extract_opencode_zen_token(home_dir: &Path) -> Option<ProviderToken> {
+pub(crate) fn extract_opencode_zen_token(home_dir: &Path) -> Option<ProviderToken> {
     let (access_token, login, expires_at) = if let Some(key) = read_nonempty_env("OPENCODE_API_KEY")
     {
         (key, None, None)
@@ -3588,7 +3588,10 @@ pub fn env_var_for_token(token: &ProviderToken) -> Option<(String, String)> {
 pub async fn provider_env_vars(store: &crate::store::Store) -> Vec<(String, String)> {
     let tokens = match store.list_provider_tokens().await {
         Ok(tokens) => tokens,
-        Err(_) => return Vec::new(),
+        Err(error) => {
+            warn!(%error, "stored provider credentials are unavailable");
+            return Vec::new();
+        }
     };
     let mut vars = Vec::new();
     for token in tokens {
@@ -3597,6 +3600,65 @@ pub async fn provider_env_vars(store: &crate::store::Store) -> Vec<(String, Stri
         }
     }
     vars
+}
+
+/// Apply stored provider credentials that are valid for this executable.
+///
+/// Agent launch is synchronous, while the credential store is async. Keep the
+/// runtime on a short-lived worker so callers remain safe inside Tokio too.
+pub(crate) fn apply_provider_env_to_command(program: &str, command: &mut std::process::Command) {
+    for env_name in api_key_env_names() {
+        if !api_key_env_allowed_for_program(program, env_name) {
+            command.env_remove(env_name);
+        }
+    }
+
+    let program = program.to_string();
+    let worker = match std::thread::Builder::new()
+        .name("lf-provider-env".to_string())
+        .spawn(move || {
+            let runtime = match tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+            {
+                Ok(runtime) => runtime,
+                Err(error) => {
+                    warn!(%error, "could not start stored provider credential lookup");
+                    return Vec::new();
+                }
+            };
+            runtime.block_on(async {
+                let store = match crate::store::open_registry_for_authority().await {
+                    Ok(store) => store,
+                    Err(crate::store::RegistryUnavailable::MissingFile { .. }) => {
+                        return Vec::new();
+                    }
+                    Err(error) => {
+                        warn!(?error, "stored provider credential registry is unavailable");
+                        return Vec::new();
+                    }
+                };
+                provider_env_vars(&store).await
+            })
+        }) {
+        Ok(worker) => worker,
+        Err(error) => {
+            warn!(%error, "could not start stored provider credential lookup");
+            return;
+        }
+    };
+    let env_vars = match worker.join() {
+        Ok(env_vars) => env_vars,
+        Err(_) => {
+            warn!("stored provider credential lookup panicked");
+            return;
+        }
+    };
+    for (name, value) in env_vars {
+        if provider_env_allowed_for_program(&program, &name) {
+            command.env(name, value);
+        }
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Usage

lf auth status
lf auth configure opencode
lf design --tui -m claude
lf : "review this" --tui -m opencode

## Summary

Carry provider authority consistently through terminal and SSH launch surfaces. Managed Claude and Codex sessions now honor repository/default account routing and account health, OpenCode Zen uses its stored provider credential, and remote/native boundaries remove credentials they should not forward.

## Changes

- Select healthy managed Claude/Codex accounts for headless and interactive launches, falling back to ambient credentials only when no managed route exists.
- Apply stored OpenCode Zen credentials to local TUI and foreground SSH launches.
- Strip provider API keys from executables and remote-native paths that do not own them.
- Document route order, 95% usage demotion, launch-surface support, and the OpenCode provider-token model.