### PR TITLE
migrations: scope canonical batches to package releases

### DIFF
--- a/python/tests/test_canonicalize_migrations.py
+++ b/python/tests/test_canonicalize_migrations.py
@@ -1,4 +1,4 @@
-"""The release cut: drafts become a canonical, ordered, ordinal-assigned tail."""
+"""The release cut: drafts become one ordered, release-scoped batch."""
 
 import subprocess
 import sys
@@ -17,6 +17,7 @@ REGISTRY = """const MIGRATIONS: &[Migration] = &[
         id: MigrationId {
             major: 0,
             minor: 11,
+            patch: None,
             ordinal: 1,
         },
         name: "initial",
@@ -94,24 +95,24 @@ def test_empty_draft_set_is_a_noop(repo: Path) -> None:
     assert (repo / MIGRATIONS_RS).read_text() == before
 
 
-def test_two_independent_drafts_get_a_contiguous_tail_ordered_by_name(repo: Path) -> None:
+def test_two_independent_drafts_become_one_release_batch_ordered_by_name(repo: Path) -> None:
     draft(repo, "add_wave_colour")
     draft(repo, "add_task_priority")
 
     result = run(repo, "0.11.30")
 
     assert result.returncode == 0, result.stderr
-    # Contiguous after the last released ordinal (001), ordered by name.
     assert canonical_files(repo) == [
         "0.11.001_initial.sql",
-        "0.11.002_add_task_priority.sql",
-        "0.11.003_add_wave_colour.sql",
+        "0.11.30.001_release.sql",
     ]
     # Drafts are consumed, leaving none behind.
     assert list((repo / DRAFTS).glob("*.sql")) == []
     registry = (repo / MIGRATIONS_RS).read_text()
-    assert 'name: "add_task_priority"' in registry
-    assert 'name: "add_wave_colour"' in registry
+    assert "patch: Some(30)" in registry
+    assert 'name: "release"' in registry
+    batch = (repo / MIGRATIONS / "0.11.30.001_release.sql").read_text()
+    assert batch.index("-- draft: add_task_priority") < batch.index("-- draft: add_wave_colour")
     assert registry.rstrip().endswith("];")
 
 
@@ -125,9 +126,10 @@ def test_a_dependency_orders_before_its_dependent_against_name_order(repo: Path)
     assert result.returncode == 0, result.stderr
     assert canonical_files(repo) == [
         "0.11.001_initial.sql",
-        "0.11.002_z_setup.sql",
-        "0.11.003_a_backfill.sql",
+        "0.11.30.001_release.sql",
     ]
+    batch = (repo / MIGRATIONS / "0.11.30.001_release.sql").read_text()
+    assert batch.index("-- draft: z_setup") < batch.index("-- draft: a_backfill")
 
 
 def test_the_canonical_file_carries_the_body_without_the_header(repo: Path) -> None:
@@ -135,18 +137,18 @@ def test_the_canonical_file_carries_the_body_without_the_header(repo: Path) -> N
 
     run(repo, "0.11.30")
 
-    written = (repo / MIGRATIONS / "0.11.002_add_wave_colour.sql").read_text()
-    assert written == "ALTER TABLE waves ADD COLUMN colour TEXT;\n"
+    written = (repo / MIGRATIONS / "0.11.30.001_release.sql").read_text()
+    assert written == ("-- draft: add_wave_colour\nALTER TABLE waves ADD COLUMN colour TEXT;\n")
     assert "-- name:" not in written
 
 
-def test_a_minor_bump_starts_a_fresh_ordinal_sequence(repo: Path) -> None:
+def test_a_minor_release_uses_its_full_package_version(repo: Path) -> None:
     draft(repo, "add_wave_colour")
 
     result = run(repo, "0.12.0")
 
     assert result.returncode == 0, result.stderr
-    assert (repo / MIGRATIONS / "0.12.001_add_wave_colour.sql").exists()
+    assert (repo / MIGRATIONS / "0.12.0.001_release.sql").exists()
 
 
 def test_a_cycle_fails_before_writing_anything(repo: Path) -> None:
@@ -170,7 +172,7 @@ def test_check_mode_writes_nothing(repo: Path) -> None:
     result = run(repo, "0.11.30", "--check")
 
     assert result.returncode == 0, result.stderr
-    assert "0.11.002_add_wave_colour" in result.stdout
+    assert "0.11.30.001_release" in result.stdout
     assert (repo / MIGRATIONS_RS).read_text() == before
     assert draft_names(repo) == {"add_wave_colour"}
 
@@ -199,7 +201,7 @@ def test_test_materialization_has_explicit_disposable_authority(repo: Path) -> N
     result = run(repo, "0.12.0", "--materialize-for-tests")
 
     assert result.returncode == 0, result.stderr
-    assert (repo / MIGRATIONS / "0.12.001_add_wave_colour.sql").exists()
+    assert (repo / MIGRATIONS / "0.12.0.001_release.sql").exists()
 
 
 def test_re_running_the_same_release_is_deterministic(tmp_path: Path) -> None:
@@ -223,13 +225,25 @@ def test_re_running_the_same_release_is_deterministic(tmp_path: Path) -> None:
     assert (first / MIGRATIONS_RS).read_text() == (second / MIGRATIONS_RS).read_text()
 
 
+def test_a_release_cannot_publish_a_second_batch(repo: Path) -> None:
+    draft(repo, "add_wave_colour")
+    assert run(repo, "0.11.30").returncode == 0
+    draft(repo, "add_task_priority")
+
+    result = run(repo, "0.11.30")
+
+    assert result.returncode == 1
+    assert "already has canonical migration" in result.stderr
+    assert draft_names(repo) == {"add_task_priority"}
+
+
 def test_an_abandoned_release_leaves_drafts_regenerable(repo: Path) -> None:
     draft(repo, "add_wave_colour")
     # A failed release never merged its ids; --check proves the plan without
     # publishing, and a later real run regenerates the same id.
-    assert "0.11.002_add_wave_colour" in run(repo, "0.11.30", "--check").stdout
+    assert "0.11.30.001_release" in run(repo, "0.11.30", "--check").stdout
     run(repo, "0.11.30")
-    assert (repo / MIGRATIONS / "0.11.002_add_wave_colour.sql").exists()
+    assert (repo / MIGRATIONS / "0.11.30.001_release.sql").exists()
 
 
 def test_a_dependency_on_a_released_migration_canonicalizes_after_it(repo: Path) -> None:
@@ -240,7 +254,18 @@ def test_a_dependency_on_a_released_migration_canonicalizes_after_it(repo: Path)
     result = run(repo, "0.11.30")
 
     assert result.returncode == 0, result.stderr
-    assert (repo / MIGRATIONS / "0.11.002_add_wave_colour.sql").exists()
+    assert (repo / MIGRATIONS / "0.11.30.001_release.sql").exists()
+
+
+def test_a_dependency_can_name_a_draft_from_an_earlier_release_batch(repo: Path) -> None:
+    draft(repo, "add_wave_colour")
+    assert run(repo, "0.11.30").returncode == 0
+    draft(repo, "backfill_colour", depends_on="add_wave_colour")
+
+    result = run(repo, "0.11.31")
+
+    assert result.returncode == 0, result.stderr
+    assert (repo / MIGRATIONS / "0.11.31.001_release.sql").exists()
 
 
 def test_a_dependency_on_an_unknown_name_fails(repo: Path) -> None:
@@ -252,6 +277,16 @@ def test_a_dependency_on_an_unknown_name_fails(repo: Path) -> None:
     assert result.returncode == 1
     assert "neither a draft" in result.stderr
     assert (repo / MIGRATIONS_RS).read_text() == before
+    assert draft_names(repo) == {"add_wave_colour"}
+
+
+def test_a_draft_cannot_forge_release_provenance(repo: Path) -> None:
+    draft(repo, "add_wave_colour", body="-- draft: invented\nSELECT 1;\n")
+
+    result = run(repo, "0.11.30")
+
+    assert result.returncode == 1
+    assert "reserved `-- draft:`" in result.stderr
     assert draft_names(repo) == {"add_wave_colour"}
 
 

--- a/python/tests/test_check_migrations.py
+++ b/python/tests/test_check_migrations.py
@@ -20,24 +20,34 @@ def _git(repo: Path, *args: str) -> None:
     subprocess.run(["git", *args], cwd=repo, check=True, capture_output=True)
 
 
-def _registry(*entries: tuple[int, int, int, str]) -> str:
+def _registry(*entries: tuple) -> str:
     """A MIGRATIONS registry in Rust, shaped as migrations.rs writes it."""
-    body = "".join(
-        f"""Migration {{
+    rendered = []
+    for entry in entries:
+        if len(entry) == 4:
+            major, minor, ordinal, name = entry
+            patch = None
+            filename = f"{major}.{minor}.{ordinal:03d}_{name}.sql"
+        else:
+            major, minor, patch, ordinal, name = entry
+            filename = f"{major}.{minor}.{patch}.{ordinal:03d}_{name}.sql"
+        patch_value = "None" if patch is None else f"Some({patch})"
+        rendered.append(
+            f"""Migration {{
     id: MigrationId {{
         major: {major},
         minor: {minor},
+        patch: {patch_value},
         ordinal: {ordinal},
     }},
     name: "{name}",
-    sql: include_str!("migrations/{major}.{minor}.{ordinal:03d}_{name}.sql"),
+    sql: include_str!("migrations/{filename}"),
 }}, """
-        for major, minor, ordinal, name in entries
-    )
-    return f"const MIGRATIONS: &[Migration] = &[{body}];\n"
+        )
+    return f"const MIGRATIONS: &[Migration] = &[{''.join(rendered)}];\n"
 
 
-def _register(repo: Path, *entries: tuple[int, int, int, str]) -> None:
+def _register(repo: Path, *entries: tuple) -> None:
     (repo / MIGRATIONS_RS).write_text(_registry(*entries))
 
 
@@ -76,9 +86,11 @@ def test_a_shipped_migration_left_alone_passes(repo: Path):
     assert "unchanged since v0.10.1" in result.stdout
 
 
-def test_appending_a_migration_to_the_active_namespace_passes(repo: Path):
-    (repo / MIGRATIONS / "0.10.002_add_note.sql").write_text("ALTER TABLE waves ADD note TEXT;\n")
-    _register(repo, (0, 10, 1, "initial"), (0, 10, 2, "add_note"))
+def test_a_batch_matching_the_active_package_release_passes(repo: Path):
+    (repo / MIGRATIONS / "0.10.1.001_release.sql").write_text(
+        "-- draft: add_note\nALTER TABLE waves ADD note TEXT;\n"
+    )
+    _register(repo, (0, 10, 1, "initial"), (0, 10, 1, 1, "release"))
 
     result = check(repo)
     assert result.returncode == 0, result.stderr
@@ -86,7 +98,9 @@ def test_appending_a_migration_to_the_active_namespace_passes(repo: Path):
 
 def test_a_migration_file_nobody_registered_fails(repo: Path):
     """An unregistered migration never runs — shipping one is shipping a no-op."""
-    (repo / MIGRATIONS / "0.10.002_add_note.sql").write_text("ALTER TABLE waves ADD note TEXT;\n")
+    (repo / MIGRATIONS / "0.10.1.001_release.sql").write_text(
+        "-- draft: add_note\nALTER TABLE waves ADD note TEXT;\n"
+    )
 
     result = check(repo)
     assert result.returncode == 1
@@ -170,7 +184,7 @@ def test_moving_the_migration_directory_does_not_void_the_check(repo: Path):
 
 
 def test_a_migration_ahead_of_the_package_version_fails(repo: Path):
-    (repo / MIGRATIONS / "0.11.001_too_new.sql").write_text("SELECT 1;\n")
+    (repo / MIGRATIONS / "0.11.0.001_release.sql").write_text("-- draft: too_new\nSELECT 1;\n")
 
     result = check(repo)
     assert result.returncode == 1
@@ -180,14 +194,56 @@ def test_a_migration_ahead_of_the_package_version_fails(repo: Path):
 def test_a_new_canonical_migration_behind_the_active_namespace_fails(repo: Path):
     (repo / "Cargo.toml").write_text('[workspace.package]\nversion = "0.11.0"\n')
     (repo / "pyproject.toml").write_text('[project]\nversion = "0.11.0"\n')
-    (repo / MIGRATIONS / "0.10.002_too_old.sql").write_text("SELECT 1;\n")
-    _register(repo, (0, 10, 1, "initial"), (0, 10, 2, "too_old"))
+    (repo / MIGRATIONS / "0.10.1.001_release.sql").write_text("-- draft: too_old\nSELECT 1;\n")
+    _register(repo, (0, 10, 1, "initial"), (0, 10, 1, 1, "release"))
 
     result = check(repo)
 
     assert result.returncode == 1
-    assert "namespaced behind the active package namespace 0.11" in result.stderr
+    assert "namespaced behind the active package namespace 0.11.0" in result.stderr
     assert "ordinal-free draft" in result.stderr
+
+
+def test_a_batch_from_an_older_patch_release_fails(repo: Path):
+    (repo / "Cargo.toml").write_text('[workspace.package]\nversion = "0.10.2"\n')
+    (repo / "pyproject.toml").write_text('[project]\nversion = "0.10.2"\n')
+    (repo / MIGRATIONS / "0.10.1.001_release.sql").write_text("-- draft: too_old\nSELECT 1;\n")
+    _register(repo, (0, 10, 1, "initial"), (0, 10, 1, 1, "release"))
+
+    result = check(repo)
+
+    assert result.returncode == 1
+    assert "active package namespace 0.10.2" in result.stderr
+
+
+def test_a_new_legacy_three_part_migration_fails(repo: Path):
+    (repo / MIGRATIONS / "0.10.002_add_note.sql").write_text("SELECT 1;\n")
+    _register(repo, (0, 10, 1, "initial"), (0, 10, 2, "add_note"))
+
+    result = check(repo)
+
+    assert result.returncode == 1
+    assert "legacy three-part format" in result.stderr
+
+
+def test_a_release_cannot_publish_more_than_its_single_batch(repo: Path):
+    (repo / MIGRATIONS / "0.10.1.002_release.sql").write_text("-- draft: add_note\nSELECT 1;\n")
+    _register(repo, (0, 10, 1, "initial"), (0, 10, 1, 2, "release"))
+
+    result = check(repo)
+
+    assert result.returncode == 1
+    assert "single `<version>.001_release.sql`" in result.stderr
+
+
+def test_a_release_batch_requires_draft_provenance(repo: Path):
+    (repo / MIGRATIONS / "0.10.1.001_release.sql").write_text("SELECT 1;\n")
+    _register(repo, (0, 10, 1, "initial"), (0, 10, 1, 1, "release"))
+
+    result = check(repo)
+
+    assert result.returncode == 1
+    assert "carries no `-- draft:` provenance" in result.stderr
 
 
 def test_a_malformed_migration_name_fails(repo: Path):
@@ -296,6 +352,15 @@ def test_a_draft_dependency_cycle_fails(repo: Path):
     result = check(repo)
     assert result.returncode == 1
     assert "cycle" in result.stderr
+
+
+def test_a_draft_cannot_forge_release_provenance(repo: Path):
+    _draft(repo, "add_wave_colour", body="-- draft: invented\nSELECT 1;\n")
+
+    result = check(repo)
+
+    assert result.returncode == 1
+    assert "reserved `-- draft:`" in result.stderr
 
 
 def test_a_draft_colliding_with_a_released_name_fails(repo: Path):

--- a/python/tests/test_new_migration.py
+++ b/python/tests/test_new_migration.py
@@ -18,6 +18,7 @@ REGISTRY = """const MIGRATIONS: &[Migration] = &[
         id: MigrationId {
             major: 0,
             minor: 11,
+            patch: None,
             ordinal: 1,
         },
         name: "initial",
@@ -145,6 +146,16 @@ def test_depends_on_records_a_draft_dependency(repo: Path) -> None:
 
 def test_depends_on_accepts_a_released_migration(repo: Path) -> None:
     result = run(repo, "backfill_colour", "--depends-on", "initial")
+    assert result.returncode == 0, result.stderr
+
+
+def test_depends_on_accepts_a_draft_published_inside_a_release_batch(repo: Path) -> None:
+    (repo / MIGRATIONS / "0.11.2.001_release.sql").write_text(
+        "-- draft: add_wave_colour\nSELECT 1;\n"
+    )
+
+    result = run(repo, "backfill_colour", "--depends-on", "add_wave_colour")
+
     assert result.returncode == 0, result.stderr
 
 

--- a/rust/loopflow/src/ops/release.rs
+++ b/rust/loopflow/src/ops/release.rs
@@ -1781,11 +1781,10 @@ mod tests {
     /// call site makes the drafts never freeze and the asserts below fail. A
     /// direct helper call cannot catch that regression.
     ///
-    /// The bare temp worktree has no manifests (so the version bump is a no-op)
-    /// and no repo/wave/store context (so the release-notes stage fails fast,
-    /// with no network). Canonicalization runs before that stage, so the tree is
-    /// already frozen by the time `prepare_release_in_worktree` returns its
-    /// (expected) error — which we ignore and assert on the tree instead.
+    /// The bare temp worktree has no manifests (so the version bump is a no-op).
+    /// A deliberate release-note archive collision then stops the workflow before
+    /// it launches an agent. Canonicalization runs first, so the tree is already
+    /// frozen by the time `prepare_release_in_worktree` returns that expected error.
     #[test]
     fn the_release_run_canonicalizes_drafts_into_the_committed_tree() {
         let script =
@@ -1811,7 +1810,7 @@ mod tests {
             &registry_rs,
             "const MIGRATIONS: &[Migration] = &[\n    Migration {\n        \
              id: MigrationId {\n            major: 0,\n            minor: 11,\n            \
-             ordinal: 1,\n        },\n        name: \"initial\",\n        \
+             patch: None,\n            ordinal: 1,\n        },\n        name: \"initial\",\n        \
              sql: include_str!(\"migrations/0.11.001_initial.sql\"),\n    },\n];\n",
         )
         .unwrap();
@@ -1822,9 +1821,15 @@ mod tests {
              ALTER TABLE waves ADD COLUMN colour TEXT;\n",
         )
         .unwrap();
+        let unreleased = root.join("release/unreleased");
+        let release_archive = root.join("release/v0.11.4");
+        fs::create_dir_all(&unreleased).unwrap();
+        fs::create_dir_all(&release_archive).unwrap();
+        fs::write(unreleased.join("collision.md"), "unreleased\n").unwrap();
+        fs::write(release_archive.join("collision.md"), "archived\n").unwrap();
 
         // A target with no manifests: the version bump is a no-op, canonicalize
-        // runs, then the notes stage fails fast in this contextless worktree.
+        // runs, then the deliberate archive collision stops the notes stage.
         let target = ReleaseTarget {
             name: "default".to_string(),
             area: Vec::new(),
@@ -1832,7 +1837,7 @@ mod tests {
             manifests: Vec::new(),
             workflow: None,
         };
-        let _ = prepare_release_in_worktree(
+        let result = prepare_release_in_worktree(
             root,
             "0.11.4",
             "v0.11.3",
@@ -1840,19 +1845,21 @@ mod tests {
             &target,
             &crate::ops::progress::NullProgress,
         );
+        assert!(
+            result.is_err(),
+            "release-note collision should stop release"
+        );
 
         // The draft is now a canonical, registered migration.
-        let canonical = migrations.join("0.11.002_add_wave_colour.sql");
+        let canonical = migrations.join("0.11.4.001_release.sql");
         assert!(canonical.is_file(), "canonical migration not written");
         assert_eq!(
             fs::read_to_string(&canonical).unwrap(),
-            "ALTER TABLE waves ADD COLUMN colour TEXT;\n"
+            "-- draft: add_wave_colour\nALTER TABLE waves ADD COLUMN colour TEXT;\n"
         );
         let registry = fs::read_to_string(&registry_rs).unwrap();
-        assert!(
-            registry.contains("name: \"add_wave_colour\""),
-            "not registered"
-        );
+        assert!(registry.contains("patch: Some(4)"), "patch not registered");
+        assert!(registry.contains("name: \"release\""), "not registered");
         // The draft is consumed.
         let remaining: Vec<_> = fs::read_dir(&drafts)
             .unwrap()

--- a/rust/loopflow/src/store/MIGRATIONS.md
+++ b/rust/loopflow/src/store/MIGRATIONS.md
@@ -26,18 +26,18 @@ migrations. `lf release run` invokes the canonicalizer with `--release-cut` insi
 release worktree, **after the version bump and before the commit**, so the generated
 files are part of the release PR and run under real Rust CI before the queue merges
 and tags. It freezes the draft set, rejects missing or cyclic dependencies (and two
-drafts sharing a readable name in one cut), topologically orders it (edges first,
-ties broken by name — never merge time, PR number, or wall clock), and assigns the
-next contiguous ordinals in the namespace of the version being cut (a patch continues
-the current `<major>.<minor>`; a minor bump starts a fresh sequence at ordinal 1). It
-plans the whole tail in memory, then installs it atomically — writing
-`<major>.<minor>.<ordinal>_<name>.sql`, appending the `Migration` entry, and deleting
-the draft — and on any failure restores the tree byte-for-byte. Same drafts and
-version always produce the same ids and diff, so an aborted release regenerates
-identically. The manual script is a `--check` preview only; creating canonical files
-requires `--release-cut`. Rust CI uses the separate `--materialize-for-tests`
-authority in its disposable checkout. The release run is the authority that
-publishes.
+drafts sharing a readable name in one cut), and topologically orders it (edges
+first, ties broken by name — never merge time, PR number, or wall clock). It then
+concatenates the ordered bodies into the release's one
+`<major>.<minor>.<patch>.001_release.sql` batch. `-- draft: <name>` markers retain
+the authoring identities for dependencies and incident review. The cut appends one
+`Migration` entry and deletes all consumed drafts atomically; on any failure it
+restores the tree byte-for-byte. The same drafts and version always produce the
+same id and diff, so an aborted release regenerates identically. A second batch for
+the same package version is rejected. The manual script is a `--check` preview
+only; creating canonical files requires `--release-cut`. Rust CI uses the separate
+`--materialize-for-tests` authority in its disposable checkout. The release run is
+the authority that publishes.
 
 Only the merged release commit is canonical migration authority. Between releases,
 ordinary merges add drafts, so main's canonical set does not move and a branch
@@ -74,8 +74,9 @@ the last release tag and fails the build if one moved.
 - The directory and the `MIGRATIONS` registry name the same migrations, with the
   same ids and names. A file nobody registered never runs; a registry entry whose
   id, name, and file disagree is a lie about what a database applied.
-- The registry is in id order. No id is namespaced ahead of the package version,
-  and no new canonical migration is introduced behind the active package namespace.
+- The registry is in id order. New canonical ids match the full package version,
+  use ordinal `001`, and name the single batch `release`. Known historical
+  three-part ids remain valid; no new one can be introduced.
 - Every canonical migration already on `origin/main` has the same ordinal, name, and
   bytes.
 - Nothing that shipped in the last release tag has changed.
@@ -90,26 +91,26 @@ before anything is cut. Same script, both paths.
 
 ## Identity
 
-```
-0.10.001_initial.sql
- │  │  │   └── name — part of the identity, so a rename is a break
- │  │  └────── ordinal, three digits, restarting in each namespace
- └──┴───────── namespace: package major.minor when authored
+```text
+0.12.2.001_release.sql
+ │  │ │  │   └── canonical batch name
+ │  │ │  └────── ordinal; one batch means every release uses 001
+ └──┴─┴───────── package major.minor.patch that published the batch
 ```
 
-- Patch releases append into the current namespace; after a minor bump,
-  subsequent migrations start a new one.
-  `0.11.001` and `0.12.001` are distinct migrations.
-- Order is the numeric tuple `(major, minor, ordinal)`, never a string sort —
-  `0.9.001` precedes `0.10.001`, which lexical order would invert.
+- Historical `0.10.001_initial.sql` / `0.11.037_*.sql` ids remain immutable
+  three-part ids. New canonical migrations always use the four-part format.
+- Order is numeric: `(major, minor, patch, ordinal)`, with legacy ids before
+  release-scoped ids in the same major/minor line. A binary skipped from `1.1.0`
+  to `1.2.0` applies every missing patch and minor batch in that order.
 - The file stem *is* the `schema_migrations.version` string. `MigrationId` in
   `migrations.rs` is the only thing that formats or parses it.
 - The ledger records the SQL checksum, parent-history fingerprint, build
   provenance, source checkout and revision, and package version. Old canonical
   rows receive checksums when the provenance migration first runs; their writer
   is intentionally left unknown rather than attributed to the upgrading build.
-- The active namespace comes from the workspace `Cargo.toml` version, so a
-  migration authored ahead of the version is a release error, not a choice.
+- The active namespace is the full workspace `Cargo.toml` version, so a batch
+  authored for an earlier or later package release is an error, not a choice.
 
 ## What a database can be told
 

--- a/rust/loopflow/src/store/migrations.rs
+++ b/rust/loopflow/src/store/migrations.rs
@@ -14,16 +14,17 @@ use sha2::{Digest, Sha256};
 
 // -- Identity -----------------------------------------------------------------
 
-/// A migration's release-scoped identity: `{major}.{minor}.{ordinal:03}`.
+/// A migration's identity: legacy `{major}.{minor}.{ordinal:03}` or release-scoped
+/// `{major}.{minor}.{patch}.{ordinal:03}`.
 ///
-/// The namespace is the package major.minor when the migration is authored;
-/// patch releases append into the same namespace. Ordering is the numeric tuple,
-/// never a string sort — `0.9.001` precedes `0.10.001`, which lexical order
-/// would invert.
+/// New migrations carry the full package version of their release cut. Historical
+/// three-part ids remain immutable and sort before release-scoped ids in the same
+/// major/minor line. Ordering is numeric, never a string sort.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub struct MigrationId {
     pub major: u32,
     pub minor: u32,
+    pub patch: Option<u32>,
     pub ordinal: u32,
 }
 
@@ -33,23 +34,39 @@ impl MigrationId {
     /// ledger row from the pre-namespace era is told apart from a future release.
     fn parse_version(version: &str) -> Option<Self> {
         let (id, _name) = version.split_once('_')?;
-        let mut parts = id.split('.');
-        let mut number = || parts.next()?.parse().ok();
-        let (major, minor, ordinal) = (number()?, number()?, number()?);
-        if parts.next().is_some() {
-            return None;
+        let numbers = id
+            .split('.')
+            .map(str::parse)
+            .collect::<Result<Vec<u32>, _>>()
+            .ok()?;
+        match numbers.as_slice() {
+            [major, minor, ordinal] => Some(MigrationId {
+                major: *major,
+                minor: *minor,
+                patch: None,
+                ordinal: *ordinal,
+            }),
+            [major, minor, patch, ordinal] => Some(MigrationId {
+                major: *major,
+                minor: *minor,
+                patch: Some(*patch),
+                ordinal: *ordinal,
+            }),
+            _ => None,
         }
-        Some(MigrationId {
-            major,
-            minor,
-            ordinal,
-        })
     }
 }
 
 impl fmt::Display for MigrationId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}.{}.{:03}", self.major, self.minor, self.ordinal)
+        match self.patch {
+            Some(patch) => write!(
+                f,
+                "{}.{}.{}.{:03}",
+                self.major, self.minor, patch, self.ordinal
+            ),
+            None => write!(f, "{}.{}.{:03}", self.major, self.minor, self.ordinal),
+        }
     }
 }
 
@@ -69,14 +86,14 @@ impl Migration {
     }
 }
 
-/// Every migration, in id order. A new one is appended here and to the
-/// directory; `scripts/new_migration.py` picks the next free ordinal in the
-/// active namespace.
+/// Every canonical migration, in id order. Release cuts append one generated
+/// batch after topologically ordering the ordinal-free drafts.
 const MIGRATIONS: &[Migration] = &[
     Migration {
         id: MigrationId {
             major: 0,
             minor: 10,
+            patch: None,
             ordinal: 1,
         },
         name: "initial",
@@ -86,6 +103,7 @@ const MIGRATIONS: &[Migration] = &[
         id: MigrationId {
             major: 0,
             minor: 10,
+            patch: None,
             ordinal: 2,
         },
         name: "session_execution_context",
@@ -95,6 +113,7 @@ const MIGRATIONS: &[Migration] = &[
         id: MigrationId {
             major: 0,
             minor: 11,
+            patch: None,
             ordinal: 1,
         },
         name: "task_prs",
@@ -104,6 +123,7 @@ const MIGRATIONS: &[Migration] = &[
         id: MigrationId {
             major: 0,
             minor: 11,
+            patch: None,
             ordinal: 2,
         },
         name: "project_session_successors",
@@ -113,6 +133,7 @@ const MIGRATIONS: &[Migration] = &[
         id: MigrationId {
             major: 0,
             minor: 11,
+            patch: None,
             ordinal: 3,
         },
         name: "child_body_lease",
@@ -122,6 +143,7 @@ const MIGRATIONS: &[Migration] = &[
         id: MigrationId {
             major: 0,
             minor: 11,
+            patch: None,
             ordinal: 4,
         },
         name: "task_pr_ci_state",
@@ -131,6 +153,7 @@ const MIGRATIONS: &[Migration] = &[
         id: MigrationId {
             major: 0,
             minor: 11,
+            patch: None,
             ordinal: 5,
         },
         name: "provider_accounts",
@@ -140,6 +163,7 @@ const MIGRATIONS: &[Migration] = &[
         id: MigrationId {
             major: 0,
             minor: 11,
+            patch: None,
             ordinal: 6,
         },
         name: "context_launch_work",
@@ -149,6 +173,7 @@ const MIGRATIONS: &[Migration] = &[
         id: MigrationId {
             major: 0,
             minor: 11,
+            patch: None,
             ordinal: 7,
         },
         name: "task_pr_parent",
@@ -158,6 +183,7 @@ const MIGRATIONS: &[Migration] = &[
         id: MigrationId {
             major: 0,
             minor: 11,
+            patch: None,
             ordinal: 8,
         },
         name: "interactive_handoffs",
@@ -167,6 +193,7 @@ const MIGRATIONS: &[Migration] = &[
         id: MigrationId {
             major: 0,
             minor: 11,
+            patch: None,
             ordinal: 9,
         },
         name: "context_pressure",
@@ -176,6 +203,7 @@ const MIGRATIONS: &[Migration] = &[
         id: MigrationId {
             major: 0,
             minor: 11,
+            patch: None,
             ordinal: 10,
         },
         name: "context_input_normalization",
@@ -185,6 +213,7 @@ const MIGRATIONS: &[Migration] = &[
         id: MigrationId {
             major: 0,
             minor: 11,
+            patch: None,
             ordinal: 11,
         },
         name: "profiles",
@@ -194,6 +223,7 @@ const MIGRATIONS: &[Migration] = &[
         id: MigrationId {
             major: 0,
             minor: 11,
+            patch: None,
             ordinal: 12,
         },
         name: "provider_account_lifecycle",
@@ -203,6 +233,7 @@ const MIGRATIONS: &[Migration] = &[
         id: MigrationId {
             major: 0,
             minor: 11,
+            patch: None,
             ordinal: 13,
         },
         name: "task_review_state",
@@ -212,6 +243,7 @@ const MIGRATIONS: &[Migration] = &[
         id: MigrationId {
             major: 0,
             minor: 11,
+            patch: None,
             ordinal: 14,
         },
         name: "task_lifecycle",
@@ -221,6 +253,7 @@ const MIGRATIONS: &[Migration] = &[
         id: MigrationId {
             major: 0,
             minor: 11,
+            patch: None,
             ordinal: 15,
         },
         name: "interaction_reviews",
@@ -230,6 +263,7 @@ const MIGRATIONS: &[Migration] = &[
         id: MigrationId {
             major: 0,
             minor: 11,
+            patch: None,
             ordinal: 16,
         },
         name: "task_linear_observations",
@@ -239,6 +273,7 @@ const MIGRATIONS: &[Migration] = &[
         id: MigrationId {
             major: 0,
             minor: 11,
+            patch: None,
             ordinal: 17,
         },
         name: "migration_provenance",
@@ -248,6 +283,7 @@ const MIGRATIONS: &[Migration] = &[
         id: MigrationId {
             major: 0,
             minor: 11,
+            patch: None,
             ordinal: 18,
         },
         name: "session_body_provenance",
@@ -257,6 +293,7 @@ const MIGRATIONS: &[Migration] = &[
         id: MigrationId {
             major: 0,
             minor: 11,
+            patch: None,
             ordinal: 19,
         },
         name: "task_pr_github_observation",
@@ -266,6 +303,7 @@ const MIGRATIONS: &[Migration] = &[
         id: MigrationId {
             major: 0,
             minor: 11,
+            patch: None,
             ordinal: 20,
         },
         name: "task_pr_linear_linkage",
@@ -275,6 +313,7 @@ const MIGRATIONS: &[Migration] = &[
         id: MigrationId {
             major: 0,
             minor: 11,
+            patch: None,
             ordinal: 21,
         },
         name: "provider_deliveries",
@@ -284,6 +323,7 @@ const MIGRATIONS: &[Migration] = &[
         id: MigrationId {
             major: 0,
             minor: 11,
+            patch: None,
             ordinal: 22,
         },
         name: "task_session_successors",
@@ -293,6 +333,7 @@ const MIGRATIONS: &[Migration] = &[
         id: MigrationId {
             major: 0,
             minor: 11,
+            patch: None,
             ordinal: 23,
         },
         name: "capture_pruned_state",
@@ -302,6 +343,7 @@ const MIGRATIONS: &[Migration] = &[
         id: MigrationId {
             major: 0,
             minor: 11,
+            patch: None,
             ordinal: 24,
         },
         name: "ci_incidents",
@@ -311,6 +353,7 @@ const MIGRATIONS: &[Migration] = &[
         id: MigrationId {
             major: 0,
             minor: 11,
+            patch: None,
             ordinal: 25,
         },
         name: "usage_deltas",
@@ -320,6 +363,7 @@ const MIGRATIONS: &[Migration] = &[
         id: MigrationId {
             major: 0,
             minor: 11,
+            patch: None,
             ordinal: 26,
         },
         name: "lineage_boundary",
@@ -329,6 +373,7 @@ const MIGRATIONS: &[Migration] = &[
         id: MigrationId {
             major: 0,
             minor: 11,
+            patch: None,
             ordinal: 27,
         },
         name: "accounts_first",
@@ -338,6 +383,7 @@ const MIGRATIONS: &[Migration] = &[
         id: MigrationId {
             major: 0,
             minor: 11,
+            patch: None,
             ordinal: 29,
         },
         name: "ci_incident_repaired_head",
@@ -347,6 +393,7 @@ const MIGRATIONS: &[Migration] = &[
         id: MigrationId {
             major: 0,
             minor: 11,
+            patch: None,
             ordinal: 30,
         },
         name: "one_spend_grain",
@@ -356,6 +403,7 @@ const MIGRATIONS: &[Migration] = &[
         id: MigrationId {
             major: 0,
             minor: 11,
+            patch: None,
             ordinal: 31,
         },
         name: "durable_input_spine",
@@ -365,6 +413,7 @@ const MIGRATIONS: &[Migration] = &[
         id: MigrationId {
             major: 0,
             minor: 11,
+            patch: None,
             ordinal: 32,
         },
         name: "run_launch_attention",
@@ -374,6 +423,7 @@ const MIGRATIONS: &[Migration] = &[
         id: MigrationId {
             major: 0,
             minor: 11,
+            patch: None,
             ordinal: 33,
         },
         name: "launch_attention_only",
@@ -383,6 +433,7 @@ const MIGRATIONS: &[Migration] = &[
         id: MigrationId {
             major: 0,
             minor: 11,
+            patch: None,
             ordinal: 34,
         },
         name: "typed_ci_runs",
@@ -392,6 +443,7 @@ const MIGRATIONS: &[Migration] = &[
         id: MigrationId {
             major: 0,
             minor: 11,
+            patch: None,
             ordinal: 35,
         },
         name: "drop_child_commands",
@@ -401,6 +453,7 @@ const MIGRATIONS: &[Migration] = &[
         id: MigrationId {
             major: 0,
             minor: 11,
+            patch: None,
             ordinal: 36,
         },
         name: "delete_sessions",
@@ -410,6 +463,7 @@ const MIGRATIONS: &[Migration] = &[
         id: MigrationId {
             major: 0,
             minor: 11,
+            patch: None,
             ordinal: 37,
         },
         name: "capture_terminal_states",
@@ -426,6 +480,7 @@ const DIVERGENT_MIGRATIONS: &[Migration] = &[
         id: MigrationId {
             major: 0,
             minor: 11,
+            patch: None,
             ordinal: 8,
         },
         name: "context_pressure",
@@ -435,6 +490,7 @@ const DIVERGENT_MIGRATIONS: &[Migration] = &[
         id: MigrationId {
             major: 0,
             minor: 11,
+            patch: None,
             ordinal: 9,
         },
         name: "context_input_normalization",
@@ -444,6 +500,7 @@ const DIVERGENT_MIGRATIONS: &[Migration] = &[
         id: MigrationId {
             major: 0,
             minor: 11,
+            patch: None,
             ordinal: 10,
         },
         name: "profiles",
@@ -453,6 +510,7 @@ const DIVERGENT_MIGRATIONS: &[Migration] = &[
         id: MigrationId {
             major: 0,
             minor: 11,
+            patch: None,
             ordinal: 11,
         },
         name: "provider_account_lifecycle",
@@ -476,20 +534,21 @@ const LEGACY_BASELINE_VERSION: &str = "001_initial";
 const RECREATE_MESSAGE: &str =
     "incompatible Loopflow database; delete loopflow.db and rerun the command";
 
-/// The major.minor a migration authored today belongs to, from the single version
+/// The package version a migration release cut belongs to, from the single
 /// source of truth (the workspace `Cargo.toml`, via Cargo).
 ///
 /// # Panics
 ///
 /// Panics if the package version is not `major.minor.patch`, which Cargo rejects
 /// long before this runs.
-pub fn active_namespace() -> (u32, u32) {
+pub fn active_namespace() -> (u32, u32, u32) {
     let version = env!("CARGO_PKG_VERSION");
     let mut parts = version.split('.');
     let major = parts.next().and_then(|part| part.parse().ok());
     let minor = parts.next().and_then(|part| part.parse().ok());
-    match (major, minor) {
-        (Some(major), Some(minor)) => (major, minor),
+    let patch = parts.next().and_then(|part| part.parse().ok());
+    match (major, minor, patch, parts.next()) {
+        (Some(major), Some(minor), Some(patch), None) => (major, minor, patch),
         _ => panic!("package version {version} is not major.minor.patch"),
     }
 }
@@ -1458,12 +1517,20 @@ mod tests {
 
     const REOPEN_REPAIR_NAME: &str = "retire_obsolete_pm_reopen_writebacks";
 
+    fn _reopen_repair_is_canonical() -> bool {
+        let marker = format!("-- draft: {REOPEN_REPAIR_NAME}");
+        MIGRATIONS
+            .iter()
+            .any(|migration| migration.sql.lines().any(|line| line == marker.as_str()))
+    }
+
     /// Stand-ins for the releases that have not happened yet: one more migration
     /// in the baseline's minor, and the first of the next minor.
     const SECOND_IN_SAME_MINOR: Migration = Migration {
         id: MigrationId {
             major: 0,
             minor: 10,
+            patch: None,
             ordinal: 2,
         },
         name: "add_note",
@@ -1473,6 +1540,7 @@ mod tests {
         id: MigrationId {
             major: 0,
             minor: 11,
+            patch: None,
             ordinal: 1,
         },
         name: "add_colour",
@@ -1504,12 +1572,6 @@ mod tests {
     }
 
     fn _reopen_repair_sql() -> String {
-        if let Some(migration) = MIGRATIONS
-            .iter()
-            .find(|migration| migration.name == REOPEN_REPAIR_NAME)
-        {
-            return migration.sql.to_string();
-        }
         let drafts =
             std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src/store/migrations/drafts");
         let prefix = format!("{REOPEN_REPAIR_NAME}__");
@@ -1617,8 +1679,13 @@ mod tests {
 
         let active = active_namespace();
         for migration in MIGRATIONS {
+            let namespace = (
+                migration.id.major,
+                migration.id.minor,
+                migration.id.patch.unwrap_or(0),
+            );
             assert!(
-                (migration.id.major, migration.id.minor) <= active,
+                namespace <= active,
                 "{} is namespaced ahead of the package version",
                 migration.version()
             );
@@ -2688,14 +2755,10 @@ mod tests {
                 |row| row.get(0),
             )
             .unwrap();
-        if !MIGRATIONS
-            .iter()
-            .any(|migration| migration.name == REOPEN_REPAIR_NAME)
-        {
+        if !_reopen_repair_is_canonical() {
             assert!(stale.contains("reopen_task"));
+            conn.execute_batch(&_reopen_repair_sql()).unwrap();
         }
-
-        conn.execute_batch(&_reopen_repair_sql()).unwrap();
         validate_foreign_keys(&conn).unwrap();
         validate_persisted_json(&conn).unwrap();
         conn.pragma_update(None, "foreign_keys", "ON").unwrap();
@@ -3126,25 +3189,89 @@ mod tests {
         let id = |major, minor, ordinal| MigrationId {
             major,
             minor,
+            patch: None,
             ordinal,
         };
         assert!(id(0, 9, 1) < id(0, 10, 1));
         assert!(id(0, 10, 2) < id(0, 11, 1));
         assert_eq!(id(0, 10, 1).to_string(), "0.10.001");
+
+        let release = MigrationId {
+            major: 0,
+            minor: 12,
+            patch: Some(2),
+            ordinal: 1,
+        };
+        assert!(id(0, 12, 37) < release);
+        assert_eq!(release.to_string(), "0.12.2.001");
     }
 
     #[test]
-    fn only_release_scoped_versions_parse() {
+    fn a_skipped_patch_is_part_of_the_pending_release_suffix() {
+        let releases = [
+            Migration {
+                id: MigrationId {
+                    major: 1,
+                    minor: 1,
+                    patch: Some(0),
+                    ordinal: 1,
+                },
+                name: "release",
+                sql: "SELECT 1;",
+            },
+            Migration {
+                id: MigrationId {
+                    major: 1,
+                    minor: 1,
+                    patch: Some(1),
+                    ordinal: 1,
+                },
+                name: "release",
+                sql: "SELECT 2;",
+            },
+            Migration {
+                id: MigrationId {
+                    major: 1,
+                    minor: 2,
+                    patch: Some(0),
+                    ordinal: 1,
+                },
+                name: "release",
+                sql: "SELECT 3;",
+            },
+        ];
+        let applied = [releases[0].version()];
+
+        let pending = pending_migrations(&applied, &releases).unwrap();
+
+        assert_eq!(
+            pending.iter().map(Migration::version).collect::<Vec<_>>(),
+            ["1.1.1.001_release", "1.2.0.001_release"]
+        );
+    }
+
+    #[test]
+    fn legacy_and_release_scoped_versions_parse() {
         assert_eq!(
             MigrationId::parse_version("0.10.001_initial"),
             Some(MigrationId {
                 major: 0,
                 minor: 10,
+                patch: None,
                 ordinal: 1,
             })
         );
         assert_eq!(MigrationId::parse_version("001_initial"), None);
-        assert_eq!(MigrationId::parse_version("0.10.1.2_initial"), None);
+        assert_eq!(
+            MigrationId::parse_version("0.12.2.001_release"),
+            Some(MigrationId {
+                major: 0,
+                minor: 12,
+                patch: Some(2),
+                ordinal: 1,
+            })
+        );
+        assert_eq!(MigrationId::parse_version("0.10.1.2.3_initial"), None);
         assert_eq!(MigrationId::parse_version("0.10.001"), None);
     }
 }

--- a/rust/loopflow/src/store/migrations/drafts/README.md
+++ b/rust/loopflow/src/store/migrations/drafts/README.md
@@ -5,7 +5,7 @@ a stable snake_case name, an immutable authoring id (a 128-bit token, 32 hex cha
 and no ordinal, living at
 `<name>__<id>.sql`. The file itself is the draft's registration — there is nothing to
 paste into `migrations.rs`. The release cut (`lf release run`) orders the accumulated
-drafts and assigns canonical `<major>.<minor>.<ordinal>` ids. Because two branches
+drafts and publishes one canonical `<major>.<minor>.<patch>.001_release` batch. Because two branches
 authoring the same name mint different 128-bit ids, they never collide or share an
 edit. See
 `../MIGRATIONS.md`. This directory is empty between releases.

--- a/scripts/canonicalize_migrations.py
+++ b/scripts/canonicalize_migrations.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Freeze the draft migration set into a canonical, ordered, ordinal-assigned tail.
+"""Freeze the draft migration set into one release-scoped canonical batch.
 
     uv run python scripts/canonicalize_migrations.py 0.12.2 --release-cut
     uv run python scripts/canonicalize_migrations.py 0.12.2 --check
@@ -14,13 +14,12 @@ the release PR and run under real Rust CI before the queue merges and tags. It:
      readable name in the same cut;
   3. topologically orders the set (dependency edges, ties broken by name), a
      total order that does not depend on merge timing, PR number, or wall clock;
-  4. assigns the next contiguous ordinals in the namespace of the version being
-     cut — a patch continues the current `<major>.<minor>`, a minor/major bump
-     starts a fresh sequence at ordinal 1;
-  5. installs the tail *atomically*: it plans everything in memory first, then
-     writes the canonical `<major>.<minor>.<ordinal>_<name>.sql` files, replaces
-     the MIGRATIONS registry, and deletes the drafts — and on any failure restores
-     the tree byte-for-byte.
+  4. concatenates the ordered SQL into the release's single canonical
+     `<major>.<minor>.<patch>.001_release.sql` batch, retaining `-- draft:`
+     provenance markers;
+  5. installs the batch *atomically*: it plans everything in memory first, then
+     writes the canonical file, replaces the MIGRATIONS registry, and deletes
+     the drafts — and on any failure restores the tree byte-for-byte.
 
 A dependency may name another draft in the cut or an already-released migration
 (a released upstream is an ancestor of the whole cut, so it imposes no in-cut
@@ -47,7 +46,7 @@ REPO_ROOT = Path(__file__).parent.parent
 MIGRATIONS_DIR = REPO_ROOT / "rust/loopflow/src/store/migrations"
 DRAFTS_DIR = MIGRATIONS_DIR / "drafts"
 MIGRATIONS_RS = REPO_ROOT / "rust/loopflow/src/store/migrations.rs"
-MIGRATION_NAME = re.compile(r"^(\d+)\.(\d+)\.(\d{3})_([a-z0-9_]+)\.sql$")
+MIGRATION_NAME = re.compile(r"^(\d+)\.(\d+)\.(?:(\d+)\.)?(\d{3})_([a-z0-9_]+)\.sql$")
 # `<name>__<id>.sql`; the readable name never contains `__`, so the last `__`
 # separates it from the immutable 128-bit token (32 hex chars).
 DRAFT_FILE = re.compile(r"^([a-z][a-z0-9_]*)__([0-9a-f]{32})\.sql$")
@@ -58,6 +57,7 @@ DRAFT_HEADER_NAME = re.compile(r"^--[ \t]*name:[ \t]*([a-z][a-z0-9_]*)[ \t]*$", 
 DRAFT_HEADER_ID = re.compile(r"^--[ \t]*id:[ \t]*(.*)$", re.MULTILINE)
 DRAFT_HEADER_DEPENDS = re.compile(r"^--[ \t]*depends_on:[ \t]*(.*)$", re.MULTILINE)
 HEADER_LINE = re.compile(r"^--[ \t]*(name|id|depends_on):")
+DRAFT_MARKER = re.compile(r"^--[ \t]*draft:[ \t]*([a-z][a-z0-9_]*)[ \t]*$", re.MULTILINE)
 VERSION = re.compile(r"^v?(\d+)\.(\d+)\.(\d+)$")
 
 
@@ -75,27 +75,20 @@ def _fail(message: str) -> None:
     raise SystemExit(1)
 
 
-def _released() -> dict[tuple[int, int], list[int]]:
-    """Ordinals already released, grouped by `(major, minor)` namespace."""
-    namespaces: dict[tuple[int, int], list[int]] = {}
-    if not MIGRATIONS_DIR.is_dir():
-        return namespaces
-    for path in MIGRATIONS_DIR.iterdir():
-        match = MIGRATION_NAME.match(path.name)
-        if match:
-            major, minor, ordinal, _ = match.groups()
-            namespaces.setdefault((int(major), int(minor)), []).append(int(ordinal))
-    return namespaces
-
-
 def _released_names() -> set[str]:
+    """Draft identities already published, including names inside release batches."""
     if not MIGRATIONS_DIR.is_dir():
         return set()
-    return {
-        match.group(4)
-        for path in MIGRATIONS_DIR.iterdir()
-        if (match := MIGRATION_NAME.match(path.name))
-    }
+    names = set()
+    for path in MIGRATIONS_DIR.iterdir():
+        match = MIGRATION_NAME.match(path.name)
+        if not match:
+            continue
+        if match.group(3) is None:
+            names.add(match.group(5))
+        else:
+            names.update(DRAFT_MARKER.findall(path.read_text()))
+    return names
 
 
 def _draft_body(text: str) -> str:
@@ -114,9 +107,14 @@ def _read_drafts() -> list[Draft]:
             continue
         match = DRAFT_FILE.match(path.name)
         if not match:
-            _fail(f"draft {path.name} is not `<snake_case_name>__<id>.sql` — run scripts/new_migration.py")
+            _fail(
+                f"draft {path.name} is not `<snake_case_name>__<id>.sql` "
+                "— run scripts/new_migration.py"
+            )
         name, file_id = match.group(1), match.group(2)
         text = path.read_text()
+        if DRAFT_MARKER.search(text):
+            _fail(f"draft {path.name} uses reserved `-- draft:` release provenance")
         header = DRAFT_HEADER_NAME.search(text)
         if not header:
             _fail(f"draft {path.name} has no `-- name:` header")
@@ -199,18 +197,30 @@ def _order(drafts: list[Draft]) -> list[Draft]:
     return [by_name[name] for name in order]
 
 
-def _entry(major: int, minor: int, ordinal: int, name: str) -> str:
+def _entry(major: int, minor: int, patch: int) -> str:
     return (
         f"    Migration {{\n"
         f"        id: MigrationId {{\n"
         f"            major: {major},\n"
         f"            minor: {minor},\n"
-        f"            ordinal: {ordinal},\n"
+        f"            patch: Some({patch}),\n"
+        f"            ordinal: 1,\n"
         f"        }},\n"
-        f'        name: "{name}",\n'
-        f'        sql: include_str!("migrations/{major}.{minor}.{ordinal:03d}_{name}.sql"),\n'
+        f'        name: "release",\n'
+        f'        sql: include_str!("migrations/{major}.{minor}.{patch}.001_release.sql"),\n'
         f"    }},\n"
     )
+
+
+def _batch_sql(drafts: list[Draft]) -> str:
+    blocks = []
+    for draft in drafts:
+        body = draft.sql.rstrip("\n")
+        block = f"-- draft: {draft.name}"
+        if body:
+            block += f"\n{body}"
+        blocks.append(block)
+    return "\n\n".join(blocks) + "\n"
 
 
 def _new_registry_text(entries: str) -> str:
@@ -245,27 +255,25 @@ def _atomic_write(path: Path, data: str) -> None:
         raise
 
 
-def _install(plan: list[tuple[int, int, int, Draft]], registry_text: str) -> None:
-    """Write the planned tail atomically: on any failure, restore byte-for-byte.
+def _install(canonical: Path, sql: str, drafts: list[Draft], registry_text: str) -> None:
+    """Write the planned batch atomically: on any failure, restore byte-for-byte.
 
     Order matters for rollback: create canonical files, replace the registry, then
     delete drafts last. A failure at any step undoes what came before — restoring
     deleted drafts, the original registry, and removing created files.
     """
     original_registry = MIGRATIONS_RS.read_bytes()
-    created: list[Path] = []
     deleted: list[tuple[Path, bytes]] = []
     registry_written = False
+    canonical_written = False
     try:
-        for major, minor, ordinal, draft in plan:
-            canonical = MIGRATIONS_DIR / f"{major}.{minor}.{ordinal:03d}_{draft.name}.sql"
-            if canonical.exists():
-                raise RuntimeError(f"{canonical.name} already exists")
-            canonical.write_text(draft.sql)
-            created.append(canonical)
+        if canonical.exists():
+            raise RuntimeError(f"{canonical.name} already exists")
+        canonical.write_text(sql)
+        canonical_written = True
         _atomic_write(MIGRATIONS_RS, registry_text)
         registry_written = True
-        for _major, _minor, _ordinal, draft in plan:
+        for draft in drafts:
             path = DRAFTS_DIR / draft.filename
             data = path.read_bytes()
             path.unlink()
@@ -275,9 +283,9 @@ def _install(plan: list[tuple[int, int, int, Draft]], registry_text: str) -> Non
             path.write_bytes(data)
         if registry_written:
             MIGRATIONS_RS.write_bytes(original_registry)
-        for path in created:
+        if canonical_written:
             try:
-                path.unlink()
+                canonical.unlink()
             except FileNotFoundError:
                 pass
         _fail(f"install failed; tree restored byte-for-byte ({error})")
@@ -318,7 +326,7 @@ def main() -> None:
     if not version:
         print(f"version {positional[0]!r} is not major.minor.patch", file=sys.stderr)
         raise SystemExit(2)
-    major, minor = int(version.group(1)), int(version.group(2))
+    major, minor, patch = (int(version.group(index)) for index in range(1, 4))
 
     drafts = _read_drafts()
     if not drafts:
@@ -326,27 +334,34 @@ def main() -> None:
         return
 
     ordered = _order(drafts)
-    released = _released()
-    next_ordinal = max(released.get((major, minor), []), default=0) + 1
+    release_files = []
+    for path in MIGRATIONS_DIR.iterdir():
+        match = MIGRATION_NAME.match(path.name)
+        if not match or match.group(3) is None:
+            continue
+        namespace = tuple(int(match.group(index)) for index in range(1, 4))
+        if namespace == (major, minor, patch):
+            release_files.append(path.name)
+    if release_files:
+        _fail(
+            f"release {major}.{minor}.{patch} already has canonical migration(s): "
+            f"{', '.join(sorted(release_files))}"
+        )
 
-    plan = []
-    for offset, draft in enumerate(ordered):
-        ordinal = next_ordinal + offset
-        plan.append((major, minor, ordinal, draft))
-
-    print(f"canonicalizing {len(plan)} draft(s) into {major}.{minor}:")
-    for major_, minor_, ordinal, draft in plan:
+    canonical = MIGRATIONS_DIR / f"{major}.{minor}.{patch}.001_release.sql"
+    print(f"canonicalizing {len(ordered)} draft(s) into {major}.{minor}.{patch}.001_release:")
+    for draft in ordered:
         depends = ", ".join(draft.depends_on) if draft.depends_on else "(none)"
-        print(f"  {major_}.{minor_}.{ordinal:03d}_{draft.name}  <- draft {draft.name} [{depends}]")
+        print(f"  draft {draft.name} [{depends}]")
     if check:
         return
 
-    entries = "".join(
-        _entry(major_, minor_, ordinal, draft.name) for major_, minor_, ordinal, draft in plan
+    registry_text = _new_registry_text(_entry(major, minor, patch))
+    _install(canonical, _batch_sql(ordered), ordered, registry_text)
+    print(
+        f"wrote 1 canonical migration from {len(ordered)} draft(s); "
+        "run scripts/check_migrations.py to verify"
     )
-    registry_text = _new_registry_text(entries)
-    _install(plan, registry_text)
-    print(f"wrote {len(plan)} canonical migration(s); run scripts/check_migrations.py to verify")
 
 
 if __name__ == "__main__":

--- a/scripts/check_migrations.py
+++ b/scripts/check_migrations.py
@@ -28,7 +28,7 @@ REPO_ROOT = Path(__file__).parent.parent
 MIGRATIONS_DIR = REPO_ROOT / "rust/loopflow/src/store/migrations"
 DRAFTS_DIR = MIGRATIONS_DIR / "drafts"
 MIGRATIONS_RS = REPO_ROOT / "rust/loopflow/src/store/migrations.rs"
-MIGRATION_NAME = re.compile(r"^(\d+)\.(\d+)\.(\d{3})_([a-z0-9_]+)\.sql$")
+MIGRATION_NAME = re.compile(r"^(\d+)\.(\d+)\.(?:(\d+)\.)?(\d{3})_([a-z0-9_]+)\.sql$")
 # A draft file is `<name>__<id>.sql`; the readable name never contains `__`, and
 # the id is an immutable 128-bit token (32 hex chars).
 DRAFT_FILE = re.compile(r"^([a-z][a-z0-9_]*)__([0-9a-f]{32})\.sql$")
@@ -36,7 +36,9 @@ DRAFT_FILE = re.compile(r"^([a-z][a-z0-9_]*)__([0-9a-f]{32})\.sql$")
 # value would swallow the newline and capture the next SQL line.
 DRAFT_HEADER_NAME = re.compile(r"^--[ \t]*name:[ \t]*([a-z][a-z0-9_]*)[ \t]*$", re.MULTILINE)
 DRAFT_HEADER_DEPENDS = re.compile(r"^--[ \t]*depends_on:[ \t]*(.*)$", re.MULTILINE)
+DRAFT_MARKER = re.compile(r"^--[ \t]*draft:[ \t]*([a-z][a-z0-9_]*)[ \t]*$", re.MULTILINE)
 VERSION_LINE = re.compile(r'^version = "([^"]+)"', re.MULTILINE)
+MigrationKey = tuple[int, int, int, int]
 
 # One `Migration { .. }` entry of the MIGRATIONS registry in migrations.rs.
 REGISTRY_ENTRY = re.compile(
@@ -44,6 +46,7 @@ REGISTRY_ENTRY = re.compile(
         id:\s*MigrationId\s*\{\s*
             major:\s*(?P<major>\d+),\s*
             minor:\s*(?P<minor>\d+),\s*
+            patch:\s*(?P<patch>None|Some\((?P<patch_number>\d+)\)),\s*
             ordinal:\s*(?P<ordinal>\d+),?\s*
         \},\s*
         name:\s*"(?P<name>[a-z0-9_]+)",\s*
@@ -53,8 +56,8 @@ REGISTRY_ENTRY = re.compile(
 )
 
 
-def _package_version() -> tuple[int, int]:
-    """The active major.minor, from the one version both manifests must agree on."""
+def _package_version() -> tuple[int, int, int]:
+    """The active package version, from the one version both manifests agree on."""
     versions = {}
     for manifest in ("Cargo.toml", "pyproject.toml"):
         match = VERSION_LINE.search((REPO_ROOT / manifest).read_text())
@@ -69,10 +72,27 @@ def _package_version() -> tuple[int, int]:
     parts = version.split(".")
     if len(parts) != 3 or not all(part.isdigit() for part in parts):
         _fail(f"version {version!r} is not major.minor.patch")
-    return int(parts[0]), int(parts[1])
+    return int(parts[0]), int(parts[1]), int(parts[2])
 
 
-def _registry() -> list[tuple[tuple[int, int, int], str, str]]:
+def _migration(match: re.Match[str]) -> tuple[MigrationKey, str]:
+    major, minor, patch, ordinal, name = match.groups()
+    patch_number = -1 if patch is None else int(patch)
+    return (int(major), int(minor), patch_number, int(ordinal)), name
+
+
+def _identity(key: MigrationKey) -> str:
+    major, minor, patch, ordinal = key
+    if patch < 0:
+        return f"{major}.{minor}.{ordinal:03d}"
+    return f"{major}.{minor}.{patch}.{ordinal:03d}"
+
+
+def _filename(key: MigrationKey, name: str) -> str:
+    return f"{_identity(key)}_{name}.sql"
+
+
+def _registry() -> list[tuple[MigrationKey, str, str]]:
     """The MIGRATIONS registry in Rust, as `(id, name, file)` in declaration order.
 
     Read from the source rather than from a build, so the release gate needs no
@@ -92,19 +112,20 @@ def _registry() -> list[tuple[tuple[int, int, int], str, str]]:
         key = (
             int(match.group("major")),
             int(match.group("minor")),
+            -1 if match.group("patch") == "None" else int(match.group("patch_number")),
             int(match.group("ordinal")),
         )
         entries.append((key, match.group("name"), match.group("file")))
     return entries
 
 
-def _check_registry(files: dict[tuple[int, int, int], str]) -> None:
+def _check_registry(files: dict[MigrationKey, str]) -> None:
     """The registry and the directory must name the same migrations, identically."""
     entries = _registry()
 
-    registered: dict[tuple[int, int, int], str] = {}
+    registered: dict[MigrationKey, str] = {}
     for key, name, file in entries:
-        expected = f"{key[0]}.{key[1]}.{key[2]:03d}_{name}.sql"
+        expected = _filename(key, name)
         if file != expected:
             _fail(
                 f"registry entry {expected} includes {file} "
@@ -113,10 +134,7 @@ def _check_registry(files: dict[tuple[int, int, int], str]) -> None:
         if not (MIGRATIONS_DIR / file).is_file():
             _fail(f"registry entry {file} has no file in {MIGRATIONS_DIR.name}/")
         if key in registered:
-            _fail(
-                f"registry entry {file} collides with {registered[key]} "
-                f"at {key[0]}.{key[1]}.{key[2]:03d}"
-            )
+            _fail(f"registry entry {file} collides with {registered[key]} at {_identity(key)}")
         registered[key] = file
 
     for key, name in sorted(files.items()):
@@ -171,7 +189,7 @@ def _shipped_migrations(tag: str) -> dict[str, bytes]:
     return shipped
 
 
-def _migrations_at_ref(ref: str) -> dict[tuple[int, int, int], tuple[str, bytes]]:
+def _migrations_at_ref(ref: str) -> dict[MigrationKey, tuple[str, bytes]]:
     exists = subprocess.run(
         ["git", "rev-parse", "--verify", "--quiet", ref],
         cwd=REPO_ROOT,
@@ -200,18 +218,18 @@ def _migrations_at_ref(ref: str) -> dict[tuple[int, int, int], tuple[str, bytes]
         match = MIGRATION_NAME.match(name)
         if not match:
             continue
-        major, minor, ordinal, _ = match.groups()
+        key, _name = _migration(match)
         content = subprocess.run(
             ["git", "show", f"{ref}:{relative}"],
             cwd=REPO_ROOT,
             capture_output=True,
             check=True,
         ).stdout
-        migrations[(int(major), int(minor), int(ordinal))] = (name, content)
+        migrations[key] = (name, content)
     return migrations
 
 
-def _check_current_main(local: dict[tuple[int, int, int], str]) -> None:
+def _check_current_main(local: dict[MigrationKey, str]) -> None:
     """Main is already durable history even before its next release tag."""
     canonical = _migrations_at_ref("origin/main")
     if not canonical:
@@ -224,9 +242,9 @@ def _check_current_main(local: dict[tuple[int, int, int], str]) -> None:
         if local_name is None:
             _fail(f"{canonical_name} exists on origin/main but is missing from this branch")
         if local_name != canonical_name:
-            identity = f"{key[0]}.{key[1]}.{key[2]:03d}"
             _fail(
-                f"{local_name} collides with {canonical_name} on origin/main at {identity}; "
+                f"{local_name} collides with {canonical_name} on origin/main at "
+                f"{_identity(key)}; "
                 "rebase and allocate a new migration"
             )
         if (MIGRATIONS_DIR / local_name).read_bytes() != canonical_content:
@@ -234,11 +252,11 @@ def _check_current_main(local: dict[tuple[int, int, int], str]) -> None:
 
 
 def _check_new_canonical_namespaces(
-    local: dict[tuple[int, int, int], str],
-    active: tuple[int, int],
+    local: dict[MigrationKey, str],
+    active: tuple[int, int, int],
     tag: str | None,
 ) -> None:
-    """Only historical canonical files may remain behind the active namespace."""
+    """Only known history may use legacy ids or precede the active release."""
     canonical = _migrations_at_ref("origin/main")
     if not canonical:
         canonical = _migrations_at_ref("main")
@@ -247,15 +265,23 @@ def _check_new_canonical_namespaces(
         for name in _shipped_migrations(tag):
             match = MIGRATION_NAME.match(name)
             if match:
-                major, minor, ordinal, _ = match.groups()
-                known.add((int(major), int(minor), int(ordinal)))
+                key, _name = _migration(match)
+                known.add(key)
 
     for key, name in sorted(local.items()):
-        if key[:2] < active and key not in known:
+        if key in known:
+            continue
+        if key[2] < 0:
+            _fail(
+                f"new canonical migration {name} uses the legacy three-part format; "
+                "author an ordinal-free draft and let the release cut assign its full "
+                "package version"
+            )
+        if key[:3] < active:
             _fail(
                 f"new canonical migration {name} is namespaced behind the active package "
-                f"namespace {active[0]}.{active[1]}; author an ordinal-free draft and let "
-                "the release cut assign its namespace"
+                f"namespace {active[0]}.{active[1]}.{active[2]}; author an "
+                "ordinal-free draft and let the release cut assign its namespace"
             )
 
 
@@ -308,6 +334,8 @@ def _check_drafts(released_names: set[str]) -> None:
             )
         name = match.group(1)
         text = path.read_text()
+        if DRAFT_MARKER.search(text):
+            _fail(f"draft {path.name} uses reserved `-- draft:` release provenance")
         header = DRAFT_HEADER_NAME.search(text)
         if not header:
             _fail(f"draft {path.name} has no `-- name:` header")
@@ -316,10 +344,7 @@ def _check_drafts(released_names: set[str]) -> None:
         if name in released_names:
             _fail(f"draft {name} collides with a released migration of the same name")
         if name in drafts:
-            _fail(
-                f"two drafts share the readable name {name!r} — rename one "
-                "before releasing"
-            )
+            _fail(f"two drafts share the readable name {name!r} — rename one before releasing")
         depends = DRAFT_HEADER_DEPENDS.search(text)
         dependencies: list[str] = []
         if depends:
@@ -360,7 +385,7 @@ def main() -> None:
     if not MIGRATIONS_DIR.is_dir():
         _fail(f"{MIGRATIONS_DIR.relative_to(REPO_ROOT)} is missing")
 
-    ids: dict[tuple[int, int, int], str] = {}
+    ids: dict[MigrationKey, str] = {}
     for path in sorted(MIGRATIONS_DIR.iterdir()):
         if path.is_dir():
             # `drafts/` holds unordered draft migrations, checked separately.
@@ -368,19 +393,30 @@ def main() -> None:
         match = MIGRATION_NAME.match(path.name)
         if not match:
             _fail(
-                f"{path.name} is not `<major>.<minor>.<ordinal:03>_<name>.sql` "
+                f"{path.name} is not a legacy `<major>.<minor>.<ordinal:03>_<name>.sql` "
+                "or release `<major>.<minor>.<patch>.<ordinal:03>_<name>.sql` "
                 "— run scripts/new_migration.py"
             )
-        major, minor, ordinal, _ = match.groups()
-        key = (int(major), int(minor), int(ordinal))
+        key, name = _migration(match)
 
         if key in ids:
             _fail(f"{path.name} collides with {ids[key]}")
-        if key[:2] > active:
+        if key[2] < 0 and key[:2] > active[:2]:
             _fail(
                 f"{path.name} is namespaced ahead of the package version "
-                f"{active[0]}.{active[1]}"
+                f"{active[0]}.{active[1]}.{active[2]}"
             )
+        if key[2] >= 0:
+            if key[:3] > active:
+                _fail(
+                    f"{path.name} is namespaced ahead of the package version "
+                    f"{active[0]}.{active[1]}.{active[2]}"
+                )
+            if key[3] != 1 or name != "release":
+                _fail(
+                    f"{path.name} is not the single `<version>.001_release.sql` "
+                    "canonical batch for its package release"
+                )
         ids[key] = path.name
 
     if not ids:
@@ -390,9 +426,21 @@ def main() -> None:
     _check_current_main(ids)
     _check_new_canonical_namespaces(ids, active, tag)
 
-    released_names = {
-        match.group(4) for name in ids.values() if (match := MIGRATION_NAME.match(name))
-    }
+    released_names = set()
+    for key, filename in ids.items():
+        match = MIGRATION_NAME.match(filename)
+        if match is None:
+            continue
+        if key[2] < 0:
+            released_names.add(match.group(5))
+            continue
+        markers = DRAFT_MARKER.findall((MIGRATIONS_DIR / filename).read_text())
+        if not markers:
+            _fail(f"{filename} carries no `-- draft:` provenance markers")
+        for marker in markers:
+            if marker in released_names:
+                _fail(f"released draft identity {marker!r} appears more than once")
+            released_names.add(marker)
     _check_drafts(released_names)
 
     # Deterministic order across namespaces is the numeric tuple, never the string:
@@ -414,10 +462,7 @@ def main() -> None:
                 "— a released migration is never renamed or deleted"
             )
         if current.read_bytes() != content:
-            _fail(
-                f"{name} shipped in {tag} and has been edited "
-                "— add a forward migration instead"
-            )
+            _fail(f"{name} shipped in {tag} and has been edited — add a forward migration instead")
 
     if not shipped:
         # True exactly once: the store's migrations postdate the last tag, so no

--- a/scripts/new_migration.py
+++ b/scripts/new_migration.py
@@ -12,7 +12,7 @@ collision-resistant — two branches would need on the order of 2**64 same-name
 drafts before a birthday collision, so distinct files are a guarantee, not a
 hope. A draft has no ordinal: the release cut
 (`lf release run`) is the single boundary that orders the accumulated drafts and
-assigns canonical `<major>.<minor>.<ordinal>` ids.
+publishes one canonical `<major>.<minor>.<patch>.001_release` batch.
 
 Because two branches authoring the same readable name mint different ids, they
 write different files and never collide or share an edit — and this script edits
@@ -37,7 +37,8 @@ REPO_ROOT = Path(__file__).parent.parent
 MIGRATIONS_DIR = REPO_ROOT / "rust/loopflow/src/store/migrations"
 DRAFTS_DIR = MIGRATIONS_DIR / "drafts"
 NAME = re.compile(r"^[a-z][a-z0-9_]*$")
-MIGRATION_NAME = re.compile(r"^(\d+)\.(\d+)\.(\d{3})_([a-z0-9_]+)\.sql$")
+MIGRATION_NAME = re.compile(r"^(\d+)\.(\d+)\.(?:(\d+)\.)?(\d{3})_([a-z0-9_]+)\.sql$")
+DRAFT_MARKER = re.compile(r"^--[ \t]*draft:[ \t]*([a-z][a-z0-9_]*)[ \t]*$", re.MULTILINE)
 # A draft file is `<name>__<id>.sql`; the name never contains `__`, so the last
 # `__` separates the readable name from the immutable 128-bit token (32 hex chars).
 DRAFT_ID = re.compile(r"^[0-9a-f]{32}$")
@@ -47,20 +48,23 @@ DRAFT_FILE = re.compile(r"^([a-z][a-z0-9_]*)__([0-9a-f]{32})\.sql$")
 def _released_names() -> set[str]:
     if not MIGRATIONS_DIR.is_dir():
         return set()
-    return {
-        match.group(4)
-        for path in MIGRATIONS_DIR.iterdir()
-        if (match := MIGRATION_NAME.match(path.name))
-    }
+    names = set()
+    for path in MIGRATIONS_DIR.iterdir():
+        match = MIGRATION_NAME.match(path.name)
+        if not match:
+            continue
+        if match.group(3) is None:
+            names.add(match.group(5))
+        else:
+            names.update(DRAFT_MARKER.findall(path.read_text()))
+    return names
 
 
 def _draft_names() -> set[str]:
     if not DRAFTS_DIR.is_dir():
         return set()
     return {
-        match.group(1)
-        for path in DRAFTS_DIR.iterdir()
-        if (match := DRAFT_FILE.match(path.name))
+        match.group(1) for path in DRAFTS_DIR.iterdir() if (match := DRAFT_FILE.match(path.name))
     }
 
 


### PR DESCRIPTION
## Usage

```bash
uv run python scripts/new_migration.py add_wave_colour
uv run python scripts/canonicalize_migrations.py 0.12.2 --check
uv run python scripts/check_migrations.py
```

## Summary

Release cuts now combine dependency-ordered migration drafts into one canonical `<major>.<minor>.<patch>.001_release.sql` batch tied to the exact package version. This makes migration ownership match the release that introduced it while preserving compatibility with historical three-part migration IDs.

## Changes

- Concatenate each release’s drafts into one atomic batch, retaining `-- draft: <name>` provenance markers
- Extend migration identity, parsing, and ordering to include an optional patch version so skipped patch releases remain pending
- Preserve draft names for dependencies across release batches
- Reject second batches for the same release, new legacy-format migrations, missing provenance, and forged provenance markers
- Update release integration coverage, migration checks, authoring tools, and documentation for the release-scoped format