### PR TITLE
migrations: validate persisted state before promotion

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Materialize draft migrations for tests
         run: |
           VERSION=$(uv run python -c 'import tomllib; print(tomllib.load(open("Cargo.toml", "rb"))["workspace"]["package"]["version"])')
-          uv run python scripts/canonicalize_migrations.py "$VERSION"
+          uv run python scripts/canonicalize_migrations.py "$VERSION" --materialize-for-tests
       - uses: Swatinem/rust-cache@v2
         with:
           key: test

--- a/python/tests/test_canonicalize_migrations.py
+++ b/python/tests/test_canonicalize_migrations.py
@@ -70,8 +70,12 @@ def draft_names(repo: Path) -> set[str]:
 
 
 def run(repo: Path, *args: str) -> subprocess.CompletedProcess:
+    arguments = list(args)
+    authorities = {"--check", "--dry-run", "--release-cut", "--materialize-for-tests"}
+    if not authorities.intersection(arguments):
+        arguments.append("--release-cut")
     return subprocess.run(
-        [sys.executable, "scripts/canonicalize_migrations.py", *args],
+        [sys.executable, "scripts/canonicalize_migrations.py", *arguments],
         cwd=repo,
         capture_output=True,
         text=True,
@@ -169,6 +173,33 @@ def test_check_mode_writes_nothing(repo: Path) -> None:
     assert "0.11.002_add_wave_colour" in result.stdout
     assert (repo / MIGRATIONS_RS).read_text() == before
     assert draft_names(repo) == {"add_wave_colour"}
+
+
+def test_plain_invocation_cannot_create_canonical_migrations(repo: Path) -> None:
+    draft(repo, "add_wave_colour")
+    before = (repo / MIGRATIONS_RS).read_text()
+
+    result = subprocess.run(
+        [sys.executable, "scripts/canonicalize_migrations.py", "0.11.30"],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 2
+    assert "outside the release cut" in result.stderr
+    assert (repo / MIGRATIONS_RS).read_text() == before
+    assert canonical_files(repo) == ["0.11.001_initial.sql"]
+    assert draft_names(repo) == {"add_wave_colour"}
+
+
+def test_test_materialization_has_explicit_disposable_authority(repo: Path) -> None:
+    draft(repo, "add_wave_colour")
+
+    result = run(repo, "0.12.0", "--materialize-for-tests")
+
+    assert result.returncode == 0, result.stderr
+    assert (repo / MIGRATIONS / "0.12.001_add_wave_colour.sql").exists()
 
 
 def test_re_running_the_same_release_is_deterministic(tmp_path: Path) -> None:

--- a/python/tests/test_check_migrations.py
+++ b/python/tests/test_check_migrations.py
@@ -177,6 +177,19 @@ def test_a_migration_ahead_of_the_package_version_fails(repo: Path):
     assert "namespaced ahead" in result.stderr
 
 
+def test_a_new_canonical_migration_behind_the_active_namespace_fails(repo: Path):
+    (repo / "Cargo.toml").write_text('[workspace.package]\nversion = "0.11.0"\n')
+    (repo / "pyproject.toml").write_text('[project]\nversion = "0.11.0"\n')
+    (repo / MIGRATIONS / "0.10.002_too_old.sql").write_text("SELECT 1;\n")
+    _register(repo, (0, 10, 1, "initial"), (0, 10, 2, "too_old"))
+
+    result = check(repo)
+
+    assert result.returncode == 1
+    assert "namespaced behind the active package namespace 0.11" in result.stderr
+    assert "ordinal-free draft" in result.stderr
+
+
 def test_a_malformed_migration_name_fails(repo: Path):
     (repo / MIGRATIONS / "002_oops.sql").write_text("SELECT 1;\n")
 

--- a/python/tests/test_release_automation.py
+++ b/python/tests/test_release_automation.py
@@ -258,6 +258,7 @@ def test_rust_ci_materializes_drafts_before_running_tests():
 
     assert materialize < test
     assert "scripts/canonicalize_migrations.py" in command
+    assert "--materialize-for-tests" in command
     assert '["workspace"]["package"]["version"]' in command
 
 

--- a/rust/loopflow/build.rs
+++ b/rust/loopflow/build.rs
@@ -87,6 +87,8 @@ fn main() {
 }
 
 fn emit_build_provenance(manifest_dir: &Path) {
+    let package_version =
+        env::var("CARGO_PKG_VERSION").expect("CARGO_PKG_VERSION not set by Cargo");
     let git_root = manifest_dir
         .ancestors()
         .find(|ancestor| ancestor.join(".git").exists());
@@ -120,7 +122,7 @@ fn emit_build_provenance(manifest_dir: &Path) {
             "LOOPFLOW_MIGRATION_AUTHORITY must be `published` or `validation_only`, got `{migration_authority}`"
         );
     }
-    let mut source_revision = git_root
+    let source_revision = git_root
         .and_then(|root| {
             Command::new("git")
                 .args(["rev-parse", "HEAD"])
@@ -140,6 +142,28 @@ fn emit_build_provenance(manifest_dir: &Path) {
             .output()
             .is_ok_and(|output| output.status.success() && !output.stdout.is_empty())
     });
+    let version_tag = format!("v{package_version}");
+    let is_tagged_release = !dirty
+        && git_root.is_some_and(|root| {
+            Command::new("git")
+                .args(["tag", "--points-at", "HEAD", "--list", &version_tag])
+                .current_dir(root)
+                .output()
+                .is_ok_and(|output| {
+                    output.status.success()
+                        && String::from_utf8_lossy(&output.stdout)
+                            .lines()
+                            .any(|tag| tag == version_tag)
+                })
+        });
+    let build_version = if is_tagged_release || source_revision == "unknown" {
+        package_version
+    } else {
+        let short_revision = source_revision.get(..9).unwrap_or(&source_revision);
+        let dirty_suffix = if dirty { ".dirty" } else { "" };
+        format!("{package_version}+{short_revision}{dirty_suffix}")
+    };
+    let mut source_revision = source_revision;
     if dirty {
         source_revision.push_str("-dirty");
     }
@@ -147,10 +171,15 @@ fn emit_build_provenance(manifest_dir: &Path) {
     println!("cargo:rustc-env=LOOPFLOW_BUILD_SOURCE_ROOT={}", source_root);
     println!("cargo:rustc-env=LOOPFLOW_MIGRATION_AUTHORITY={migration_authority}");
     println!("cargo:rustc-env=LOOPFLOW_BUILD_SOURCE_REVISION={source_revision}");
+    println!("cargo:rustc-env=LOOPFLOW_BUILD_VERSION={build_version}");
     println!("cargo:rerun-if-env-changed=LOOPFLOW_BUILD_PROVENANCE");
     println!("cargo:rerun-if-env-changed=LOOPFLOW_MIGRATION_AUTHORITY");
+    println!(
+        "cargo:rerun-if-changed={}",
+        manifest_dir.join("src").display()
+    );
     if let Some(root) = git_root {
-        for git_path in ["HEAD", "refs/heads"] {
+        for git_path in ["HEAD", "refs/heads", "refs/tags", "packed-refs"] {
             if let Ok(output) = Command::new("git")
                 .args(["rev-parse", "--git-path", git_path])
                 .current_dir(root)
@@ -158,7 +187,13 @@ fn emit_build_provenance(manifest_dir: &Path) {
             {
                 if output.status.success() {
                     let path = String::from_utf8_lossy(&output.stdout);
-                    println!("cargo:rerun-if-changed={}", path.trim());
+                    let path = Path::new(path.trim());
+                    let path = if path.is_absolute() {
+                        path.to_path_buf()
+                    } else {
+                        root.join(path)
+                    };
+                    println!("cargo:rerun-if-changed={}", path.display());
                 }
             }
         }

--- a/rust/loopflow/src/build_info.rs
+++ b/rust/loopflow/src/build_info.rs
@@ -147,6 +147,8 @@ pub fn source_revision() -> &'static str {
     env!("LOOPFLOW_BUILD_SOURCE_REVISION")
 }
 
+pub const BUILD_VERSION: &str = env!("LOOPFLOW_BUILD_VERSION");
+
 pub fn migration_authority() -> MigrationAuthority {
     match env!("LOOPFLOW_MIGRATION_AUTHORITY") {
         "published" => MigrationAuthority::Published,
@@ -187,8 +189,9 @@ mod tests {
     use std::process::Command;
 
     use super::{
-        classify_revision, migration_authority, parse_provenance, provenance, source_identity_for,
-        source_revision, source_root, BuildFreshness, BuildProvenance, MigrationAuthority,
+        classify_revision, migration_authority, parse_provenance, provenance, short_revision,
+        source_identity_for, source_revision, source_root, BuildFreshness, BuildProvenance,
+        MigrationAuthority, BUILD_VERSION,
     };
 
     /// A throwaway `A -> B -> C` repo keeps classifier tests offline.
@@ -338,5 +341,13 @@ mod tests {
             MigrationAuthority::Published | MigrationAuthority::ValidationOnly
         ));
         assert!(!source_revision().is_empty());
+        let package_version = env!("CARGO_PKG_VERSION");
+        assert!(
+            BUILD_VERSION == package_version
+                || BUILD_VERSION.starts_with(&format!("{package_version}+"))
+        );
+        if source_revision() != "unknown" && BUILD_VERSION != package_version {
+            assert!(BUILD_VERSION.contains(short_revision(source_revision())));
+        }
     }
 }

--- a/rust/loopflow/src/durable.rs
+++ b/rust/loopflow/src/durable.rs
@@ -190,6 +190,7 @@ impl RunState {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum RunTrigger {
+    Migration,
     Input {
         basis: Basis,
     },

--- a/rust/loopflow/src/lf/commands/install.rs
+++ b/rust/loopflow/src/lf/commands/install.rs
@@ -39,6 +39,7 @@ pub struct CandidateIdentity {
     pub source_identity: String,
     pub authority: MigrationAuthority,
     pub package_version: String,
+    pub build_version: Option<String>,
     pub latest_known_migration: String,
 }
 
@@ -49,8 +50,15 @@ impl CandidateIdentity {
             source_identity: build_info::source_identity(),
             authority: build_info::migration_authority(),
             package_version: env!("CARGO_PKG_VERSION").to_string(),
+            build_version: Some(build_info::BUILD_VERSION.to_string()),
             latest_known_migration: migrations::latest_known_version(),
         }
+    }
+
+    fn display_version(&self) -> &str {
+        self.build_version
+            .as_deref()
+            .unwrap_or(&self.package_version)
     }
 }
 
@@ -336,7 +344,7 @@ fn render_human(preview: &PromotionPreview) {
     let candidate = &preview.candidate;
     println!(
         "Promotion preflight (candidate {}, {})",
-        build_info::short_revision(&candidate.source_revision),
+        candidate.display_version(),
         serde_authority(candidate.authority),
     );
     println!("  shared store   {}", preview.database_path);
@@ -1117,7 +1125,12 @@ pub fn promote(
         },
     )?;
 
-    println!("promoted: {} -> {}", cli_target.display(), dest.display());
+    println!(
+        "promoted {}: {} -> {}",
+        preview.candidate.display_version(),
+        cli_target.display(),
+        dest.display()
+    );
     match rollback {
         Some(prior) => render_retained_prior(&prior, cli_target),
         None => println!("no prior binary retained (target did not exist)"),
@@ -1189,6 +1202,31 @@ mod promote_tests {
         fs::create_dir_all(&helpers).unwrap();
         write_preflight_binary(&helpers.join("lf"), candidate, verdict);
         fs::write(root.join("new-app"), b"new").unwrap();
+    }
+
+    #[test]
+    fn promotion_identity_carries_the_displayed_build_version() {
+        let identity = CandidateIdentity::current();
+
+        assert_eq!(
+            identity.build_version.as_deref(),
+            Some(crate::build_info::BUILD_VERSION)
+        );
+    }
+
+    #[test]
+    fn retained_pre_build_identity_binaries_still_parse_for_rollback() {
+        let identity: CandidateIdentity = serde_json::from_value(serde_json::json!({
+            "source_revision": "0123456789abcdef",
+            "source_identity": "release",
+            "authority": "published",
+            "package_version": "0.12.1",
+            "latest_known_migration": "0.11.035_drop_child_commands"
+        }))
+        .unwrap();
+
+        assert_eq!(identity.build_version, None);
+        assert_eq!(identity.display_version(), "0.12.1");
     }
 
     #[test]

--- a/rust/loopflow/src/lf/mod.rs
+++ b/rust/loopflow/src/lf/mod.rs
@@ -9,7 +9,7 @@ pub mod output;
 #[derive(Parser, Debug, Default)]
 #[command(name = "lf")]
 #[command(about = "Open Loopflow or run its CLI")]
-#[command(version)]
+#[command(version = crate::build_info::BUILD_VERSION)]
 pub struct Cli {
     #[command(subcommand)]
     pub command: Option<Commands>,
@@ -1754,6 +1754,16 @@ pub enum WtCommand {
 mod tests {
     use super::*;
     use clap::CommandFactory;
+
+    #[test]
+    fn version_output_uses_the_embedded_build_identity() {
+        let error = Cli::try_parse_from(["lf", "--version"]).expect_err("version exits");
+        assert_eq!(error.kind(), clap::error::ErrorKind::DisplayVersion);
+        assert_eq!(
+            error.to_string(),
+            format!("lf {}\n", crate::build_info::BUILD_VERSION)
+        );
+    }
 
     #[test]
     fn ci_report_accepts_machine_wide_filters() {

--- a/rust/loopflow/src/ops/release.rs
+++ b/rust/loopflow/src/ops/release.rs
@@ -258,6 +258,7 @@ fn canonicalize_migrations(repo: &Path, version: &str) -> OpsResult<()> {
     let output = Command::new("python3")
         .arg(&script)
         .arg(version)
+        .arg("--release-cut")
         .current_dir(repo)
         .output()
         .map_err(|err| {

--- a/rust/loopflow/src/store/MIGRATIONS.md
+++ b/rust/loopflow/src/store/MIGRATIONS.md
@@ -22,7 +22,7 @@ migration), not by a serial number.
 ## The release cut assigns canonical ids
 
 The release PR is the single publication boundary that turns drafts into canonical
-migrations. `lf release run` invokes `scripts/canonicalize_migrations.py` inside the
+migrations. `lf release run` invokes the canonicalizer with `--release-cut` inside the
 release worktree, **after the version bump and before the commit**, so the generated
 files are part of the release PR and run under real Rust CI before the queue merges
 and tags. It freezes the draft set, rejects missing or cyclic dependencies (and two
@@ -34,8 +34,10 @@ plans the whole tail in memory, then installs it atomically — writing
 `<major>.<minor>.<ordinal>_<name>.sql`, appending the `Migration` entry, and deleting
 the draft — and on any failure restores the tree byte-for-byte. Same drafts and
 version always produce the same ids and diff, so an aborted release regenerates
-identically. The manual script is a `--check` preview only; the release run is the
-authority that installs.
+identically. The manual script is a `--check` preview only; creating canonical files
+requires `--release-cut`. Rust CI uses the separate `--materialize-for-tests`
+authority in its disposable checkout. The release run is the authority that
+publishes.
 
 Only the merged release commit is canonical migration authority. Between releases,
 ordinary merges add drafts, so main's canonical set does not move and a branch
@@ -72,7 +74,8 @@ the last release tag and fails the build if one moved.
 - The directory and the `MIGRATIONS` registry name the same migrations, with the
   same ids and names. A file nobody registered never runs; a registry entry whose
   id, name, and file disagree is a lie about what a database applied.
-- The registry is in id order, and no id is namespaced ahead of the package version.
+- The registry is in id order. No id is namespaced ahead of the package version,
+  and no new canonical migration is introduced behind the active package namespace.
 - Every canonical migration already on `origin/main` has the same ordinal, name, and
   bytes.
 - Nothing that shipped in the last release tag has changed.

--- a/rust/loopflow/src/store/migrations.rs
+++ b/rust/loopflow/src/store/migrations.rs
@@ -9,6 +9,7 @@ use std::time::Duration;
 use crate::store::{StoreError, StoreResult};
 use fs2::FileExt;
 use rusqlite::OptionalExtension;
+use serde::de::DeserializeOwned;
 use sha2::{Digest, Sha256};
 
 // -- Identity -----------------------------------------------------------------
@@ -556,7 +557,8 @@ fn apply_sqlite_transaction(
         Ok(()) => {
             let result = before_migration(conn)
                 .and_then(|()| apply_set(conn, MIGRATIONS))
-                .and_then(|()| validate_foreign_keys(conn));
+                .and_then(|()| validate_foreign_keys(conn))
+                .and_then(|()| validate_persisted_json(conn));
             match result {
                 Ok(()) => conn.execute_batch("COMMIT").map_err(StoreError::from),
                 Err(error) => {
@@ -577,6 +579,67 @@ fn apply_sqlite_transaction(
         Err(error) => Err(error),
         Ok(()) => restore_result,
     }
+}
+
+pub(crate) fn validate_persisted_json(conn: &rusqlite::Connection) -> StoreResult<()> {
+    validate_json_column::<crate::task::PmWritebackState>(
+        conn,
+        "tasks",
+        "id",
+        "pm_writeback_json",
+    )?;
+    validate_json_column::<crate::task::TaskGateProposal>(
+        conn,
+        "tasks",
+        "id",
+        "gate_proposal_json",
+    )?;
+    validate_json_column::<crate::task::CiObservation>(conn, "task_prs", "id", "ci_observation")?;
+    validate_json_column::<crate::task::GithubObservation>(
+        conn,
+        "task_prs",
+        "id",
+        "github_observation",
+    )?;
+    validate_json_column::<crate::task::TaskEventKind>(conn, "task_events", "id", "kind_json")?;
+    validate_json_column::<crate::project::ProjectEventKind>(
+        conn,
+        "project_events",
+        "id",
+        "kind_json",
+    )?;
+    validate_json_column::<crate::project::ChildEventPayload>(
+        conn,
+        "observation_outbox",
+        "id",
+        "payload_json",
+    )?;
+    validate_json_column::<Vec<String>>(conn, "ci_incidents", "identity", "failure_set_json")?;
+    validate_json_column::<crate::durable::RunTrigger>(conn, "runs", "id", "trigger_json")?;
+    validate_json_column::<crate::durable::WaitOn>(conn, "waits", "id", "on_json")
+}
+
+fn validate_json_column<T: DeserializeOwned>(
+    conn: &rusqlite::Connection,
+    table: &str,
+    key: &str,
+    column: &str,
+) -> StoreResult<()> {
+    let sql =
+        format!("SELECT CAST({key} AS TEXT), {column} FROM {table} WHERE {column} IS NOT NULL");
+    let mut statement = conn.prepare(&sql)?;
+    let rows = statement.query_map([], |row| {
+        Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+    })?;
+    for row in rows {
+        let (row_key, json) = row?;
+        serde_json::from_str::<T>(&json).map_err(|error| {
+            StoreError::InvalidData(format!(
+                "semantic migration check failed for {table}.{column} row {row_key}: {error}"
+            ))
+        })?;
+    }
+    Ok(())
 }
 
 pub(crate) fn apply_sqlite_with_backup(
@@ -1379,6 +1442,7 @@ fn incompatible() -> StoreError {
 
 #[cfg(test)]
 mod tests {
+    use std::fs;
     use std::sync::mpsc::sync_channel;
     use std::time::Duration;
 
@@ -1388,9 +1452,11 @@ mod tests {
         active_namespace, applied_versions, apply_set, apply_sqlite, apply_sqlite_transaction,
         apply_sqlite_with_backup, backup_before_migration, latest_applied_version_sqlite,
         latest_known_version, latest_version_sqlite, pending_migrations, product_schema,
-        validate_foreign_keys, validate_set, validate_sqlite, Migration, MigrationId,
-        DIVERGENT_MIGRATIONS, MIGRATIONS,
+        validate_foreign_keys, validate_persisted_json, validate_set, validate_sqlite, Migration,
+        MigrationId, DIVERGENT_MIGRATIONS, MIGRATIONS,
     };
+
+    const REOPEN_REPAIR_NAME: &str = "retire_obsolete_pm_reopen_writebacks";
 
     /// Stand-ins for the releases that have not happened yet: one more migration
     /// in the baseline's minor, and the first of the next minor.
@@ -1435,6 +1501,28 @@ mod tests {
             )
             .unwrap();
         }
+    }
+
+    fn _reopen_repair_sql() -> String {
+        if let Some(migration) = MIGRATIONS
+            .iter()
+            .find(|migration| migration.name == REOPEN_REPAIR_NAME)
+        {
+            return migration.sql.to_string();
+        }
+        let drafts =
+            std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src/store/migrations/drafts");
+        let prefix = format!("{REOPEN_REPAIR_NAME}__");
+        let repair = fs::read_dir(&drafts)
+            .unwrap()
+            .map(|entry| entry.unwrap().path())
+            .find(|path| {
+                path.file_name()
+                    .and_then(|name| name.to_str())
+                    .is_some_and(|name| name.starts_with(&prefix) && name.ends_with(".sql"))
+            })
+            .expect("reopen repair is canonical or present as an ordinal-free draft");
+        fs::read_to_string(repair).unwrap()
     }
 
     fn apply_permuted_history(conn: &rusqlite::Connection) {
@@ -2540,6 +2628,108 @@ mod tests {
             )
             .unwrap();
         assert_eq!(events, 0);
+    }
+
+    #[test]
+    fn pending_reopen_writeback_upgrades_to_a_typed_stable_task() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("loopflow.db");
+        let conn = rusqlite::Connection::open(&path).unwrap();
+        conn.execute_batch("PRAGMA foreign_keys = ON").unwrap();
+        apply_set(&conn, &MIGRATIONS[..2]).unwrap();
+        conn.execute(
+            "INSERT INTO waves (id, name, repo, created_at)
+             VALUES ('00000000-0000-0000-0000-000000000001', 'runtime', '/repo', 1)",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO project_sessions (
+                id, project_id, project_slug, project_name, project_prompt_context,
+                wave_id, pm_snapshot_synced_at, status, status_reason, status_at,
+                iteration, observation_cursor, agent, provider,
+                created_at, updated_at,
+                current_directive_version, incorporated_directive_version
+             ) VALUES (
+                'ps_reopen', 'project-reopen', 'runtime', 'Runtime', 'Definition',
+                '00000000-0000-0000-0000-000000000001', 9, 'running', 'active', 10, 1, 0, 'codex', 'codex',
+                10, 20, 1, 1
+             )",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO task_sessions (
+                id, issue_id, issue_identifier, issue_title, issue_description,
+                project_id, project_slug, project_name, project_prompt_context, wave_id,
+                status, status_reason, status_at, worktree, branch, base_commit,
+                agent, provider, created_at, updated_at,
+                pm_snapshot_synced_at, pm_writeback_json, project_session_id,
+                current_directive_version, incorporated_directive_version
+             ) VALUES (
+                'ts_reopen', 'issue-reopen', 'INF-REOPEN', 'Resume it', '',
+                'project-reopen', 'runtime', 'Runtime', 'Definition',
+                '00000000-0000-0000-0000-000000000001',
+                'waiting', 'writeback failed', 10, '/repo.inf-reopen',
+                'jack/inf-reopen', 'base-sha', 'codex', 'codex', 10, 20,
+                9, '{\"state\":\"pending\",\"operation\":\"reopen_task\",\"error\":\"offline\"}',
+                'ps_reopen', 1, 1
+             )",
+            [],
+        )
+        .unwrap();
+
+        conn.pragma_update(None, "foreign_keys", "OFF").unwrap();
+        apply_set(&conn, MIGRATIONS).unwrap();
+        let stale: String = conn
+            .query_row(
+                "SELECT pm_writeback_json FROM tasks WHERE external_issue_id='issue-reopen'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        if !MIGRATIONS
+            .iter()
+            .any(|migration| migration.name == REOPEN_REPAIR_NAME)
+        {
+            assert!(stale.contains("reopen_task"));
+        }
+
+        conn.execute_batch(&_reopen_repair_sql()).unwrap();
+        validate_foreign_keys(&conn).unwrap();
+        validate_persisted_json(&conn).unwrap();
+        conn.pragma_update(None, "foreign_keys", "ON").unwrap();
+
+        let error = apply_sqlite_transaction(&conn, |conn| {
+            conn.execute(
+                "UPDATE tasks
+                 SET pm_writeback_json='{\"state\":\"pending\",\"operation\":\"invented\",\"error\":\"offline\"}'
+                 WHERE external_issue_id='issue-reopen'",
+                [],
+            )?;
+            Ok(())
+        })
+        .unwrap_err();
+        assert!(error.to_string().contains("tasks.pm_writeback_json"));
+        assert_eq!(
+            conn.query_row(
+                "SELECT pm_writeback_json FROM tasks WHERE external_issue_id='issue-reopen'",
+                [],
+                |row| row.get::<_, String>(0),
+            )
+            .unwrap(),
+            "{\"state\":\"current\"}"
+        );
+        drop(conn);
+
+        let store = crate::store::sqlite::SqliteStore::new(&path).unwrap();
+        store.health_check().unwrap();
+        let tasks = store.list_tasks(None).unwrap();
+        assert_eq!(tasks.len(), 1);
+        assert!(matches!(
+            tasks[0].pm_writeback,
+            crate::task::PmWritebackState::Current
+        ));
     }
 
     #[test]

--- a/rust/loopflow/src/store/migrations/drafts/retire_obsolete_pm_reopen_writebacks__3152c8349e624cc5ab4ab08c9b50c268.sql
+++ b/rust/loopflow/src/store/migrations/drafts/retire_obsolete_pm_reopen_writebacks__3152c8349e624cc5ab4ab08c9b50c268.sql
@@ -1,0 +1,8 @@
+-- name: retire_obsolete_pm_reopen_writebacks
+-- id: 3152c8349e624cc5ab4ab08c9b50c268
+-- depends_on: delete_sessions
+-- Stable Tasks no longer retry the Session-era Linear reopen operation.
+UPDATE tasks
+SET pm_writeback_json = '{"state":"current"}'
+WHERE json_extract(pm_writeback_json, '$.state') = 'pending'
+  AND json_extract(pm_writeback_json, '$.operation') = 'reopen_task';

--- a/rust/loopflow/src/store/sqlite.rs
+++ b/rust/loopflow/src/store/sqlite.rs
@@ -541,7 +541,7 @@ impl SqliteStore {
     pub fn health_check(&self) -> StoreResult<()> {
         let conn = self.conn.lock().expect("store mutex poisoned");
         conn.query_row("SELECT 1", [], |_| Ok(()))?;
-        Ok(())
+        super::migrations::validate_persisted_json(&conn)
     }
 
     pub fn schema_version(&self) -> StoreResult<String> {

--- a/scripts/canonicalize_migrations.py
+++ b/scripts/canonicalize_migrations.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 """Freeze the draft migration set into a canonical, ordered, ordinal-assigned tail.
 
-    uv run python scripts/canonicalize_migrations.py 0.11.30           # patch cut
-    uv run python scripts/canonicalize_migrations.py 0.12.0 --check    # plan only
+    uv run python scripts/canonicalize_migrations.py 0.12.2 --release-cut
+    uv run python scripts/canonicalize_migrations.py 0.12.2 --check
 
 The release cut is the single publication boundary that turns drafts into
 canonical migrations. `lf release run` invokes this inside its release worktree,
@@ -29,7 +29,10 @@ produce the same ids, files, and diff, so an aborted release regenerates
 identically. The draft id is authoring-time identity only; it never appears in
 canonical output. An empty draft set is a no-op.
 
-Stdlib only, so the release path needs no Python environment — only an interpreter.
+Writing requires explicit release-cut authority. CI may materialize the same tree
+in its disposable checkout with `--materialize-for-tests`; all other invocations
+are previews. Stdlib only, so the release path needs no Python environment — only
+an interpreter.
 """
 
 from __future__ import annotations
@@ -282,14 +285,34 @@ def _install(plan: list[tuple[int, int, int, Draft]], registry_text: str) -> Non
 
 def main() -> None:
     check = False
+    write_mode: str | None = None
     positional: list[str] = []
     for argument in sys.argv[1:]:
         if argument in ("--check", "--dry-run"):
             check = True
+        elif argument in ("--release-cut", "--materialize-for-tests"):
+            if write_mode is not None:
+                print("choose one canonical migration write authority", file=sys.stderr)
+                raise SystemExit(2)
+            write_mode = argument
         else:
             positional.append(argument)
     if len(positional) != 1:
-        print("usage: canonicalize_migrations.py <version> [--check]", file=sys.stderr)
+        print(
+            "usage: canonicalize_migrations.py <version> "
+            "[--check|--release-cut|--materialize-for-tests]",
+            file=sys.stderr,
+        )
+        raise SystemExit(2)
+    if check and write_mode is not None:
+        print("--check cannot be combined with a write authority", file=sys.stderr)
+        raise SystemExit(2)
+    if not check and write_mode is None:
+        print(
+            "refusing to create canonical migrations outside the release cut; "
+            "use --check to preview",
+            file=sys.stderr,
+        )
         raise SystemExit(2)
     version = VERSION.match(positional[0])
     if not version:

--- a/scripts/check_migrations.py
+++ b/scripts/check_migrations.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
 """Verify the migration set before it can be released.
 
-Fails when a migration is malformed, namespaced ahead of the package version,
+Fails when a migration is malformed, newly canonicalized behind the active package
+namespace, namespaced ahead of the package version,
 collides with another id, is not registered in Rust (or is registered under a
 different id or name), diverges from current main, or — the rule that matters —
 when a migration that already shipped has been edited, renamed, or deleted.
@@ -232,6 +233,32 @@ def _check_current_main(local: dict[tuple[int, int, int], str]) -> None:
             _fail(f"{local_name} differs from origin/main and is already durable history")
 
 
+def _check_new_canonical_namespaces(
+    local: dict[tuple[int, int, int], str],
+    active: tuple[int, int],
+    tag: str | None,
+) -> None:
+    """Only historical canonical files may remain behind the active namespace."""
+    canonical = _migrations_at_ref("origin/main")
+    if not canonical:
+        canonical = _migrations_at_ref("main")
+    known = set(canonical)
+    if tag is not None:
+        for name in _shipped_migrations(tag):
+            match = MIGRATION_NAME.match(name)
+            if match:
+                major, minor, ordinal, _ = match.groups()
+                known.add((int(major), int(minor), int(ordinal)))
+
+    for key, name in sorted(local.items()):
+        if key[:2] < active and key not in known:
+            _fail(
+                f"new canonical migration {name} is namespaced behind the active package "
+                f"namespace {active[0]}.{active[1]}; author an ordinal-free draft and let "
+                "the release cut assign its namespace"
+            )
+
+
 def _draft_cycle(drafts: dict[str, list[str]]) -> list[str] | None:
     """A dependency cycle among drafts as a node path, or None. Ordinals are
     assigned at the release cut by a topological sort, so a cycle has no order
@@ -328,6 +355,7 @@ def _fail(message: str) -> None:
 
 def main() -> None:
     active = _package_version()
+    tag = _last_release_tag()
 
     if not MIGRATIONS_DIR.is_dir():
         _fail(f"{MIGRATIONS_DIR.relative_to(REPO_ROOT)} is missing")
@@ -360,6 +388,7 @@ def main() -> None:
 
     _check_registry(ids)
     _check_current_main(ids)
+    _check_new_canonical_namespaces(ids, active, tag)
 
     released_names = {
         match.group(4) for name in ids.values() if (match := MIGRATION_NAME.match(name))
@@ -372,7 +401,6 @@ def main() -> None:
     for key in sorted(ids):
         print(f"  {ids[key]}")
 
-    tag = _last_release_tag()
     if tag is None:
         print("no release tag yet — skipping the immutability check")
         return


### PR DESCRIPTION
## Usage

```bash
cargo run -p loopflow -- --version
uv run python scripts/canonicalize_migrations.py 0.12.1 --check
cargo test -p loopflow pending_reopen_writeback_upgrades_to_a_typed_stable_task
```

## Summary

This PR makes migration publication and binary promotion fail closed. It repairs obsolete Session-era reopen writebacks, verifies persisted JSON against current Rust types before committing migrations and during health checks, and exposes the exact candidate build so operators can identify what is being promoted.

## Changes

- Add a draft migration that retires stale `reopen_task` writebacks from Stable Tasks
- Roll back migrations when typed persisted JSON cannot be deserialized
- Require explicit `--release-cut` authority to publish canonical migrations, with separate disposable authority for CI
- Reject newly canonicalized migrations placed behind the active package namespace
- Embed commit and dirty-state metadata in development build versions while preserving clean release-tag versions
- Show the embedded build version in `lf --version` and promotion output, with compatibility for older retained binary metadata