### PR TITLE
store: repair legacy task gate proposal json

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -260,10 +260,8 @@ jobs:
 
             src="$tmpdir/lf"
             dst="$install_dir/lf"
-            tmp="$install_dir/.lf.tmp.$$"
-            cp "$src" "$tmp"
-            chmod +x "$tmp"
-            mv -f "$tmp" "$dst"
+            chmod +x "$src"
+            "$src" install promote --cli-target "$dst"
 
             echo "Installed to $install_dir/lf"
 

--- a/python/tests/test_canonicalize_migrations.py
+++ b/python/tests/test_canonicalize_migrations.py
@@ -204,6 +204,22 @@ def test_test_materialization_has_explicit_disposable_authority(repo: Path) -> N
     assert (repo / MIGRATIONS / "0.12.0.001_release.sql").exists()
 
 
+def test_test_materialization_models_the_next_patch_after_a_release(repo: Path) -> None:
+    (repo / "Cargo.toml").write_text(
+        '[workspace]\n\n[workspace.package]\nversion = "0.12.2"\nedition = "2021"\n'
+    )
+    draft(repo, "first_patch")
+    assert run(repo, "0.12.2").returncode == 0
+    draft(repo, "next_patch")
+
+    result = run(repo, "0.12.2", "--materialize-for-tests")
+
+    assert result.returncode == 0, result.stderr
+    assert "0.12.2 -> 0.12.3" in result.stdout
+    assert (repo / MIGRATIONS / "0.12.3.001_release.sql").exists()
+    assert 'version = "0.12.3"' in (repo / "Cargo.toml").read_text()
+
+
 def test_re_running_the_same_release_is_deterministic(tmp_path: Path) -> None:
     def build(name: str) -> Path:
         repo = tmp_path / name

--- a/python/tests/test_release_automation.py
+++ b/python/tests/test_release_automation.py
@@ -230,6 +230,21 @@ def test_release_dmg_workflow_bounds_build_and_upload():
     )
 
 
+def test_release_installer_uses_the_promotion_boundary_to_activate_the_binary():
+    release = yaml.load(
+        (ROOT / ".github/workflows/release.yml").read_text(),
+        Loader=yaml.BaseLoader,
+    )
+    installer = next(
+        step["run"]
+        for step in release["jobs"]["release"]["steps"]
+        if step.get("name") == "Generate shell installer"
+    )
+
+    assert '"$src" install promote --cli-target "$dst"' in installer
+    assert 'mv -f "$tmp" "$dst"' not in installer
+
+
 def test_loopflow_ui_gate_keeps_mac_test_runners_signed():
     ci = (ROOT / ".github/workflows/ci.yml").read_text()
     test_script = (ROOT / "scripts/test.py").read_text()

--- a/python/tests/test_shell_installer.py
+++ b/python/tests/test_shell_installer.py
@@ -47,7 +47,13 @@ def _write_stubs(stub_dir: Path) -> None:
         "#!/bin/sh\n"
         'dir=""; prev=""\n'
         'for a in "$@"; do [ "$prev" = "-C" ] && dir="$a"; prev="$a"; done\n'
-        '[ -n "$dir" ] && echo x > "$dir/lf"\n'
+        'if [ -n "$dir" ]; then\n'
+        '  cat > "$dir/lf" <<\'LF\'\n'
+        "#!/bin/sh\n"
+        "printf '%s\\n' \"$*\" >> \"$LFTEST_PROMOTE_LOG\"\n"
+        "exit 0\n"
+        "LF\n"
+        "fi\n"
         "exit 0\n"
     )
     for f in (curl, tar):
@@ -79,6 +85,7 @@ def env(tmp_path: Path) -> dict[str, str]:
         "PATH": f"{stub_dir}:{os.environ['PATH']}",
         "LF_INSTALL_DIR": str(tmp_path / "dest"),
         "LFTEST_LOG": str(tmp_path / "curl.log"),
+        "LFTEST_PROMOTE_LOG": str(tmp_path / "promote.log"),
     }
 
 
@@ -118,6 +125,16 @@ def test_equals_version_builds_versioned_url(
     result = _run(installer, ["--version=0.9.9"], env)
     assert result.returncode == 0, result.stderr
     assert "download/v0.9.9/" in (tmp_path / "curl.log").read_text()
+
+
+def test_downloaded_candidate_owns_activation(
+    installer: Path, env: dict[str, str], tmp_path: Path
+) -> None:
+    result = _run(installer, [], env)
+    assert result.returncode == 0, result.stderr
+    assert (tmp_path / "promote.log").read_text().strip() == (
+        f"install promote --cli-target {tmp_path / 'dest/lf'}"
+    )
 
 
 def test_missing_version_value_fails_clearly(installer: Path, env: dict[str, str]) -> None:

--- a/rust/loopflow/src/store/MIGRATIONS.md
+++ b/rust/loopflow/src/store/MIGRATIONS.md
@@ -46,13 +46,22 @@ that is merely behind main — adding only drafts — stays green.
 Rust CI materializes the draft set in its disposable checkout before running the
 test suite. This exercises the same deterministic schema and generated registry
 the release cut would produce without publishing either one. The checkout is
-discarded after the job; source builds and the shared store still see only
-canonical migrations from a merged release.
+discarded after the job; if the active version already has a canonical batch,
+the materializer advances the disposable package to the next patch namespace.
+Source builds and the shared store still see only canonical migrations from a
+merged release.
 
 The runner temporarily disables foreign-key actions around the transaction so a
 SQLite table rebuild cannot cascade-delete child history. It runs
 `PRAGMA foreign_key_check` before commit and restores enforcement afterward; a
 migration that leaves a dangling reference rolls back as one unit.
+
+Persisted JSON is schema too. Changing a required field, enum variant, or wire
+shape in a DTO stored by the database requires an ordinal-free repair draft and
+a typed upgrade test seeded with the previous shape. Before commit, the runner
+deserializes every registered persisted JSON column into its current Rust type
+and reports all incompatible rows together; any failure rolls back the complete
+migration transaction.
 
 Before advancing an existing on-disk database, the runner takes a SQLite backup
 inside the same exclusive transaction and publishes it atomically beside the

--- a/rust/loopflow/src/store/migrations.rs
+++ b/rust/loopflow/src/store/migrations.rs
@@ -651,41 +651,72 @@ fn apply_sqlite_transaction(
 }
 
 pub(crate) fn validate_persisted_json(conn: &rusqlite::Connection) -> StoreResult<()> {
-    validate_json_column::<crate::task::PmWritebackState>(
+    let mut failures = validate_json_column::<crate::task::PmWritebackState>(
         conn,
         "tasks",
         "id",
         "pm_writeback_json",
     )?;
-    validate_json_column::<crate::task::TaskGateProposal>(
+    failures.extend(validate_json_column::<crate::task::TaskGateProposal>(
         conn,
         "tasks",
         "id",
         "gate_proposal_json",
-    )?;
-    validate_json_column::<crate::task::CiObservation>(conn, "task_prs", "id", "ci_observation")?;
-    validate_json_column::<crate::task::GithubObservation>(
+    )?);
+    failures.extend(validate_json_column::<crate::task::CiObservation>(
+        conn,
+        "task_prs",
+        "id",
+        "ci_observation",
+    )?);
+    failures.extend(validate_json_column::<crate::task::GithubObservation>(
         conn,
         "task_prs",
         "id",
         "github_observation",
-    )?;
-    validate_json_column::<crate::task::TaskEventKind>(conn, "task_events", "id", "kind_json")?;
-    validate_json_column::<crate::project::ProjectEventKind>(
+    )?);
+    failures.extend(validate_json_column::<crate::task::TaskEventKind>(
+        conn,
+        "task_events",
+        "id",
+        "kind_json",
+    )?);
+    failures.extend(validate_json_column::<crate::project::ProjectEventKind>(
         conn,
         "project_events",
         "id",
         "kind_json",
-    )?;
-    validate_json_column::<crate::project::ChildEventPayload>(
+    )?);
+    failures.extend(validate_json_column::<crate::project::ChildEventPayload>(
         conn,
         "observation_outbox",
         "id",
         "payload_json",
-    )?;
-    validate_json_column::<Vec<String>>(conn, "ci_incidents", "identity", "failure_set_json")?;
-    validate_json_column::<crate::durable::RunTrigger>(conn, "runs", "id", "trigger_json")?;
-    validate_json_column::<crate::durable::WaitOn>(conn, "waits", "id", "on_json")
+    )?);
+    failures.extend(validate_json_column::<Vec<String>>(
+        conn,
+        "ci_incidents",
+        "identity",
+        "failure_set_json",
+    )?);
+    failures.extend(validate_json_column::<crate::durable::RunTrigger>(
+        conn,
+        "runs",
+        "id",
+        "trigger_json",
+    )?);
+    failures.extend(validate_json_column::<crate::durable::WaitOn>(
+        conn, "waits", "id", "on_json",
+    )?);
+
+    if failures.is_empty() {
+        Ok(())
+    } else {
+        Err(StoreError::InvalidData(format!(
+            "semantic migration check failed:\n  - {}",
+            failures.join("\n  - ")
+        )))
+    }
 }
 
 fn validate_json_column<T: DeserializeOwned>(
@@ -693,22 +724,21 @@ fn validate_json_column<T: DeserializeOwned>(
     table: &str,
     key: &str,
     column: &str,
-) -> StoreResult<()> {
+) -> StoreResult<Vec<String>> {
     let sql =
         format!("SELECT CAST({key} AS TEXT), {column} FROM {table} WHERE {column} IS NOT NULL");
     let mut statement = conn.prepare(&sql)?;
     let rows = statement.query_map([], |row| {
         Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
     })?;
+    let mut failures = Vec::new();
     for row in rows {
         let (row_key, json) = row?;
-        serde_json::from_str::<T>(&json).map_err(|error| {
-            StoreError::InvalidData(format!(
-                "semantic migration check failed for {table}.{column} row {row_key}: {error}"
-            ))
-        })?;
+        if let Err(error) = serde_json::from_str::<T>(&json) {
+            failures.push(format!("{table}.{column} row {row_key}: {error}"));
+        }
     }
-    Ok(())
+    Ok(failures)
 }
 
 pub(crate) fn apply_sqlite_with_backup(
@@ -1526,9 +1556,10 @@ mod tests {
     };
 
     const REOPEN_REPAIR_NAME: &str = "retire_obsolete_pm_reopen_writebacks";
+    const GATE_PROPOSAL_REPAIR_NAME: &str = "repair_legacy_task_gate_proposals";
 
-    fn _reopen_repair_is_canonical() -> bool {
-        let marker = format!("-- draft: {REOPEN_REPAIR_NAME}");
+    fn _draft_is_canonical(name: &str) -> bool {
+        let marker = format!("-- draft: {name}");
         MIGRATIONS
             .iter()
             .any(|migration| migration.sql.lines().any(|line| line == marker.as_str()))
@@ -1581,10 +1612,10 @@ mod tests {
         }
     }
 
-    fn _reopen_repair_sql() -> String {
+    fn _repair_sql(name: &str) -> String {
         let drafts =
             std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src/store/migrations/drafts");
-        let prefix = format!("{REOPEN_REPAIR_NAME}__");
+        let prefix = format!("{name}__");
         let repair = fs::read_dir(&drafts)
             .unwrap()
             .map(|entry| entry.unwrap().path())
@@ -1593,7 +1624,7 @@ mod tests {
                     .and_then(|name| name.to_str())
                     .is_some_and(|name| name.starts_with(&prefix) && name.ends_with(".sql"))
             })
-            .expect("reopen repair is canonical or present as an ordinal-free draft");
+            .expect("repair is canonical or present as an ordinal-free draft");
         fs::read_to_string(repair).unwrap()
     }
 
@@ -2708,7 +2739,7 @@ mod tests {
     }
 
     #[test]
-    fn pending_reopen_writeback_upgrades_to_a_typed_stable_task() {
+    fn legacy_persisted_json_upgrades_to_typed_stable_tasks() {
         let directory = tempfile::tempdir().unwrap();
         let path = directory.path().join("loopflow.db");
         let conn = rusqlite::Connection::open(&path).unwrap();
@@ -2735,7 +2766,7 @@ mod tests {
             [],
         )
         .unwrap();
-        conn.execute(
+        conn.execute_batch(
             "INSERT INTO task_sessions (
                 id, issue_id, issue_identifier, issue_title, issue_description,
                 project_id, project_slug, project_name, project_prompt_context, wave_id,
@@ -2743,7 +2774,16 @@ mod tests {
                 agent, provider, created_at, updated_at,
                 pm_snapshot_synced_at, pm_writeback_json, project_session_id,
                 current_directive_version, incorporated_directive_version
-             ) VALUES (
+             ) VALUES
+             (
+                'ts_completed', 'issue-completed', 'INF-DONE', 'Finish it', '',
+                'project-reopen', 'runtime', 'Runtime', 'Definition',
+                '00000000-0000-0000-0000-000000000001',
+                'completed', 'done', 10, '/repo.inf-done',
+                'jack/inf-done', 'base-sha', 'codex', 'codex', 10, 20,
+                9, '{\"state\":\"current\"}', 'ps_reopen', 1, 1
+             ),
+             (
                 'ts_reopen', 'issue-reopen', 'INF-REOPEN', 'Resume it', '',
                 'project-reopen', 'runtime', 'Runtime', 'Definition',
                 '00000000-0000-0000-0000-000000000001',
@@ -2751,12 +2791,61 @@ mod tests {
                 'jack/inf-reopen', 'base-sha', 'codex', 'codex', 10, 20,
                 9, '{\"state\":\"pending\",\"operation\":\"reopen_task\",\"error\":\"offline\"}',
                 'ps_reopen', 1, 1
-             )",
-            [],
+             ),
+             (
+                'ts_blocked', 'issue-blocked', 'INF-BLOCKED', 'Unblock it', '',
+                'project-reopen', 'runtime', 'Runtime', 'Definition',
+                '00000000-0000-0000-0000-000000000001',
+                'blocked', 'dependency', 10, '/repo.inf-blocked',
+                'jack/inf-blocked', 'base-sha', 'codex', 'codex', 10, 20,
+                9, '{\"state\":\"current\"}', 'ps_reopen', 1, 1
+             ),
+             (
+                'ts_failed', 'issue-failed', 'INF-FAILED', 'Recover it', '',
+                'project-reopen', 'runtime', 'Runtime', 'Definition',
+                '00000000-0000-0000-0000-000000000001',
+                'failed', 'provider error', 10, '/repo.inf-failed',
+                'jack/inf-failed', 'base-sha', 'codex', 'codex', 10, 20,
+                9, '{\"state\":\"current\"}', 'ps_reopen', 1, 1
+             ),
+             (
+                'ts_abandoned', 'issue-abandoned', 'INF-ABANDONED', 'Retire it', '',
+                'project-reopen', 'runtime', 'Runtime', 'Definition',
+                '00000000-0000-0000-0000-000000000001',
+                'abandoned', 'superseded', 10, '/repo.inf-abandoned',
+                'jack/inf-abandoned', 'base-sha', 'codex', 'codex', 10, 20,
+                9, '{\"state\":\"current\"}', 'ps_reopen', 1, 1
+             ),
+             (
+                'ts_current', 'issue-current', 'INF-CURRENT', 'Keep it', '',
+                'project-reopen', 'runtime', 'Runtime', 'Definition',
+                '00000000-0000-0000-0000-000000000001',
+                'waiting', 'review', 10, '/repo.inf-current',
+                'jack/inf-current', 'base-sha', 'codex', 'codex', 10, 20,
+                9, '{\"state\":\"current\"}', 'ps_reopen', 1, 1
+             );",
         )
         .unwrap();
 
         conn.pragma_update(None, "foreign_keys", "OFF").unwrap();
+        apply_set(&conn, prefix_before("interaction_reviews")).unwrap();
+        conn.execute_batch(
+            "UPDATE task_sessions
+             SET gate_proposal_json = CASE id
+                 WHEN 'ts_completed' THEN '{\"status\":\"completed\",\"reason\":\"all done\"}'
+                 WHEN 'ts_reopen' THEN '{\"status\":\"waiting\",\"reason\":\"needs another pass\"}'
+                 WHEN 'ts_blocked' THEN '{\"status\":\"blocked\",\"reason\":\"dependency\"}'
+                 WHEN 'ts_failed' THEN '{\"status\":\"failed\",\"reason\":\"provider error\"}'
+                 WHEN 'ts_abandoned' THEN '{\"status\":\"abandoned\",\"reason\":\"superseded\"}'
+                 WHEN 'ts_current' THEN '{\"done\":false,\"reason\":\"current\",\"future\":\"preserved\"}'
+             END
+             WHERE id IN (
+                 'ts_completed', 'ts_reopen', 'ts_blocked', 'ts_failed', 'ts_abandoned',
+                 'ts_current'
+             );",
+        )
+        .unwrap();
+
         apply_set(&conn, MIGRATIONS).unwrap();
         let stale: String = conn
             .query_row(
@@ -2765,10 +2854,34 @@ mod tests {
                 |row| row.get(0),
             )
             .unwrap();
-        if !_reopen_repair_is_canonical() {
+        if !_draft_is_canonical(REOPEN_REPAIR_NAME) {
             assert!(stale.contains("reopen_task"));
-            conn.execute_batch(&_reopen_repair_sql()).unwrap();
+            conn.execute_batch(&_repair_sql(REOPEN_REPAIR_NAME))
+                .unwrap();
         }
+        if !_draft_is_canonical(GATE_PROPOSAL_REPAIR_NAME) {
+            conn.execute_batch(&_repair_sql(GATE_PROPOSAL_REPAIR_NAME))
+                .unwrap();
+        }
+        assert_eq!(
+            conn.query_row(
+                "SELECT gate_proposal_json FROM tasks WHERE external_issue_id='issue-current'",
+                [],
+                |row| row.get::<_, String>(0),
+            )
+            .unwrap(),
+            "{\"done\":false,\"reason\":\"current\",\"future\":\"preserved\"}"
+        );
+        assert_eq!(
+            conn.query_row(
+                "SELECT COUNT(*) FROM tasks
+                 WHERE json_type(gate_proposal_json, '$.status') IS NOT NULL",
+                [],
+                |row| row.get::<_, i64>(0),
+            )
+            .unwrap(),
+            0
+        );
         validate_foreign_keys(&conn).unwrap();
         validate_persisted_json(&conn).unwrap();
         conn.pragma_update(None, "foreign_keys", "ON").unwrap();
@@ -2780,10 +2893,18 @@ mod tests {
                  WHERE external_issue_id='issue-reopen'",
                 [],
             )?;
+            conn.execute(
+                "UPDATE tasks
+                 SET gate_proposal_json='{\"reason\":\"missing done\"}'
+                 WHERE external_issue_id='issue-completed'",
+                [],
+            )?;
             Ok(())
         })
         .unwrap_err();
-        assert!(error.to_string().contains("tasks.pm_writeback_json"));
+        let message = error.to_string();
+        assert!(message.contains("tasks.pm_writeback_json"));
+        assert!(message.contains("tasks.gate_proposal_json"));
         assert_eq!(
             conn.query_row(
                 "SELECT pm_writeback_json FROM tasks WHERE external_issue_id='issue-reopen'",
@@ -2798,11 +2919,21 @@ mod tests {
         let store = crate::store::sqlite::SqliteStore::new(&path).unwrap();
         store.health_check().unwrap();
         let tasks = store.list_tasks(None).unwrap();
-        assert_eq!(tasks.len(), 1);
+        assert_eq!(tasks.len(), 6);
+        let reopen = tasks
+            .iter()
+            .find(|task| task.launch.issue.identifier == "INF-REOPEN")
+            .unwrap();
         assert!(matches!(
-            tasks[0].pm_writeback,
+            reopen.pm_writeback,
             crate::task::PmWritebackState::Current
         ));
+        let mut decisions = tasks
+            .iter()
+            .map(|task| task.gate_proposal.as_ref().unwrap().done)
+            .collect::<Vec<_>>();
+        decisions.sort_unstable();
+        assert_eq!(decisions, vec![false, false, false, false, false, true]);
     }
 
     #[test]

--- a/rust/loopflow/src/store/migrations/drafts/repair_legacy_task_gate_proposals__c6528abe5b7b5709187fea308a40b67f.sql
+++ b/rust/loopflow/src/store/migrations/drafts/repair_legacy_task_gate_proposals__c6528abe5b7b5709187fea308a40b67f.sql
@@ -1,0 +1,27 @@
+-- name: repair_legacy_task_gate_proposals
+-- id: c6528abe5b7b5709187fea308a40b67f
+-- depends_on: 
+
+-- TaskGateProposal replaced the Session-era terminal status with a boolean.
+UPDATE tasks
+SET gate_proposal_json = json_remove(
+    json_set(
+        gate_proposal_json,
+        '$.done',
+        json(
+            CASE json_extract(gate_proposal_json, '$.status')
+                WHEN 'completed' THEN 'true'
+                WHEN 'waiting' THEN 'false'
+                WHEN 'blocked' THEN 'false'
+                WHEN 'failed' THEN 'false'
+                WHEN 'abandoned' THEN 'false'
+            END
+        )
+    ),
+    '$.status'
+)
+WHERE gate_proposal_json IS NOT NULL
+  AND json_type(gate_proposal_json, '$.done') IS NULL
+  AND json_extract(gate_proposal_json, '$.status') IN (
+    'completed', 'waiting', 'blocked', 'failed', 'abandoned'
+);

--- a/scripts/canonicalize_migrations.py
+++ b/scripts/canonicalize_migrations.py
@@ -29,9 +29,11 @@ identically. The draft id is authoring-time identity only; it never appears in
 canonical output. An empty draft set is a no-op.
 
 Writing requires explicit release-cut authority. CI may materialize the same tree
-in its disposable checkout with `--materialize-for-tests`; all other invocations
-are previews. Stdlib only, so the release path needs no Python environment — only
-an interpreter.
+in its disposable checkout with `--materialize-for-tests`; when the active
+package version has already published a batch, that authority models the next
+patch and bumps the disposable Cargo workspace version with it. All other
+invocations are previews. Stdlib only, so the release path needs no Python
+environment — only an interpreter.
 """
 
 from __future__ import annotations
@@ -46,6 +48,7 @@ REPO_ROOT = Path(__file__).parent.parent
 MIGRATIONS_DIR = REPO_ROOT / "rust/loopflow/src/store/migrations"
 DRAFTS_DIR = MIGRATIONS_DIR / "drafts"
 MIGRATIONS_RS = REPO_ROOT / "rust/loopflow/src/store/migrations.rs"
+PACKAGE_MANIFEST = REPO_ROOT / "Cargo.toml"
 MIGRATION_NAME = re.compile(r"^(\d+)\.(\d+)\.(?:(\d+)\.)?(\d{3})_([a-z0-9_]+)\.sql$")
 # `<name>__<id>.sql`; the readable name never contains `__`, so the last `__`
 # separates it from the immutable 128-bit token (32 hex chars).
@@ -235,6 +238,35 @@ def _new_registry_text(entries: str) -> str:
     return source[:end] + entries + source[end:]
 
 
+def _test_package_manifest(current: str, next_version: str) -> str:
+    if not PACKAGE_MANIFEST.is_file():
+        _fail(f"test materialization cannot find {PACKAGE_MANIFEST.name}")
+    lines = PACKAGE_MANIFEST.read_text().splitlines(keepends=True)
+    in_workspace_package = False
+    for index, line in enumerate(lines):
+        stripped = line.strip()
+        if stripped == "[workspace.package]":
+            in_workspace_package = True
+            continue
+        if stripped.startswith("["):
+            in_workspace_package = False
+        if not in_workspace_package:
+            continue
+        body = line.rstrip("\r\n")
+        newline = line[len(body) :]
+        match = re.match(r'^(\s*version\s*=\s*")([^"]+)(".*)$', body)
+        if match is None:
+            continue
+        if match.group(2) != current:
+            _fail(
+                f"{PACKAGE_MANIFEST.name} workspace version {match.group(2)!r} "
+                f"does not match requested test version {current!r}"
+            )
+        lines[index] = f"{match.group(1)}{next_version}{match.group(3)}{newline}"
+        return "".join(lines)
+    _fail(f"{PACKAGE_MANIFEST.name} has no [workspace.package] version")
+
+
 def _atomic_write(path: Path, data: str) -> None:
     """Replace `path` atomically via a temp file in the same directory + os.replace."""
     handle = tempfile.NamedTemporaryFile(
@@ -255,7 +287,13 @@ def _atomic_write(path: Path, data: str) -> None:
         raise
 
 
-def _install(canonical: Path, sql: str, drafts: list[Draft], registry_text: str) -> None:
+def _install(
+    canonical: Path,
+    sql: str,
+    drafts: list[Draft],
+    registry_text: str,
+    package_manifest_text: str | None,
+) -> None:
     """Write the planned batch atomically: on any failure, restore byte-for-byte.
 
     Order matters for rollback: create canonical files, replace the registry, then
@@ -263,8 +301,10 @@ def _install(canonical: Path, sql: str, drafts: list[Draft], registry_text: str)
     deleted drafts, the original registry, and removing created files.
     """
     original_registry = MIGRATIONS_RS.read_bytes()
+    original_manifest = PACKAGE_MANIFEST.read_bytes() if package_manifest_text else None
     deleted: list[tuple[Path, bytes]] = []
     registry_written = False
+    manifest_written = False
     canonical_written = False
     try:
         if canonical.exists():
@@ -273,6 +313,9 @@ def _install(canonical: Path, sql: str, drafts: list[Draft], registry_text: str)
         canonical_written = True
         _atomic_write(MIGRATIONS_RS, registry_text)
         registry_written = True
+        if package_manifest_text is not None:
+            _atomic_write(PACKAGE_MANIFEST, package_manifest_text)
+            manifest_written = True
         for draft in drafts:
             path = DRAFTS_DIR / draft.filename
             data = path.read_bytes()
@@ -281,6 +324,9 @@ def _install(canonical: Path, sql: str, drafts: list[Draft], registry_text: str)
     except BaseException as error:
         for path, data in deleted:
             path.write_bytes(data)
+        if manifest_written:
+            assert original_manifest is not None
+            PACKAGE_MANIFEST.write_bytes(original_manifest)
         if registry_written:
             MIGRATIONS_RS.write_bytes(original_registry)
         if canonical_written:
@@ -342,11 +388,21 @@ def main() -> None:
         namespace = tuple(int(match.group(index)) for index in range(1, 4))
         if namespace == (major, minor, patch):
             release_files.append(path.name)
+    package_manifest_text = None
     if release_files:
-        _fail(
-            f"release {major}.{minor}.{patch} already has canonical migration(s): "
-            f"{', '.join(sorted(release_files))}"
-        )
+        if write_mode != "--materialize-for-tests":
+            _fail(
+                f"release {major}.{minor}.{patch} already has canonical migration(s): "
+                f"{', '.join(sorted(release_files))}"
+            )
+        current = f"{major}.{minor}.{patch}"
+        patch += 1
+        next_version = f"{major}.{minor}.{patch}"
+        next_file = MIGRATIONS_DIR / f"{next_version}.001_release.sql"
+        if next_file.exists():
+            _fail(f"test release {next_version} already has canonical migration {next_file.name}")
+        package_manifest_text = _test_package_manifest(current, next_version)
+        print(f"test materialization advances the disposable package {current} -> {next_version}")
 
     canonical = MIGRATIONS_DIR / f"{major}.{minor}.{patch}.001_release.sql"
     print(f"canonicalizing {len(ordered)} draft(s) into {major}.{minor}.{patch}.001_release:")
@@ -357,7 +413,7 @@ def main() -> None:
         return
 
     registry_text = _new_registry_text(_entry(major, minor, patch))
-    _install(canonical, _batch_sql(ordered), ordered, registry_text)
+    _install(canonical, _batch_sql(ordered), ordered, registry_text, package_manifest_text)
     print(
         f"wrote 1 canonical migration from {len(ordered)} draft(s); "
         "run scripts/check_migrations.py to verify"


### PR DESCRIPTION
## Usage

```bash
cargo test -p loopflow legacy_persisted_json_upgrades_to_typed_stable_tasks
uv run pytest python/tests/test_canonicalize_migrations.py python/tests/test_release_automation.py python/tests/test_shell_installer.py
```

## Summary

Repairs legacy task gate proposal JSON before it reaches the current typed store boundary. Migration validation now reports every incompatible persisted JSON row and rolls back the transaction as a unit, making DTO shape changes explicit and recoverable.

## Changes

- Convert legacy gate proposal `status` values to the current `done` boolean while preserving unrelated JSON fields
- Exercise old writeback and gate proposal shapes through a typed upgrade test
- Aggregate semantic validation failures across all registered persisted JSON columns
- Materialize post-release drafts in CI under the next disposable patch namespace
- Delegate shell installer activation to the downloaded binary's `install promote` command