### PR TITLE
release: reconcile moved version tags from origin

### DIFF
--- a/rust/loopflow/src/ops/release.rs
+++ b/rust/loopflow/src/ops/release.rs
@@ -1515,16 +1515,20 @@ fn latest_tag(repo: &Path, target: &ReleaseTarget) -> OpsResult<String> {
 }
 
 fn latest_tag_optional(repo: &Path, target: &ReleaseTarget) -> OpsResult<Option<String>> {
-    // Fetch tags from origin so we see tags created in worktrees or other clones.
-    let fetch = run_output(repo, "git", &["fetch", "origin", "--tags", "--quiet"])?;
+    // Release tags on origin are authoritative. Long-lived release hosts may
+    // retain an old object for a tag that was repaired remotely; force-update
+    // this target's remote version tags while preserving local-only tags from
+    // an interrupted push.
+    let pattern = tag_glob(target);
+    let refspec = format!("+refs/tags/{pattern}:refs/tags/{pattern}");
+    let fetch = run_output(repo, "git", &["fetch", "origin", "--quiet", &refspec])?;
     if !fetch.status.success() {
         return Err(OpsError::CommandFailed {
-            command: "git fetch origin --tags --quiet".to_string(),
+            command: format!("git fetch origin --quiet {refspec}"),
             stderr: String::from_utf8_lossy(&fetch.stderr).to_string(),
         });
     }
 
-    let pattern = tag_glob(target);
     let tags = run_stdout(
         repo,
         "git",

--- a/rust/loopflow/tests/release_tests.rs
+++ b/rust/loopflow/tests/release_tests.rs
@@ -259,6 +259,30 @@ fn release_check_uses_direct_commits_as_release_truth() {
 }
 
 #[test]
+fn release_check_reconciles_version_tags_to_origin() {
+    let gh_script = write_gh_script("[]");
+    let _env = EnvGuard::new(&[("gh", gh_script.as_str())]);
+    let repo = TestRepo::new();
+    git(&repo, &["tag", "v0.9.0"]);
+    git(&repo, &["push", "origin", "v0.9.0"]);
+    let stale_sha = git_output(&repo, &["rev-parse", "v0.9.0"]);
+
+    fs::write(repo.path().join("repair.txt"), "remote release truth\n").unwrap();
+    git(&repo, &["add", "repair.txt"]);
+    git(&repo, &["commit", "-m", "Repair release tag"]);
+    let remote_sha = git_output(&repo, &["rev-parse", "HEAD"]);
+    git(&repo, &["push", "origin", "HEAD:refs/heads/tag-repair"]);
+    git_output_bare(
+        &repo,
+        &["update-ref", "refs/tags/v0.9.0", &remote_sha, &stale_sha],
+    );
+    let changes = release_check(repo.path(), None).expect("check should reconcile tags");
+
+    assert!(changes.commits.is_empty());
+    assert_eq!(git_output(&repo, &["rev-parse", "v0.9.0"]), remote_sha);
+}
+
+#[test]
 fn release_check_reads_evidence_without_running_repository_hooks() {
     let gh_script = write_gh_script("[]");
     let _env = EnvGuard::new(&[("gh", gh_script.as_str())]);


### PR DESCRIPTION
## Summary\n\nTreats matching version tags on origin as authoritative when a long-lived release host retains an older local object. Force-updates only the target's remote version tags while preserving local-only tags from interrupted pushes.\n\n## Proof\n\n- 
running 24 tests
test bump_version_invalid_format ... ok
test bump_version_minor ... ok
test bump_version_patch ... ok
test bump_version_major ... ok
test release_bump_updates_cargo_toml ... ok
test release_check_reconciles_version_tags_to_origin ... ok
test release_tag_fails_if_remote_tag_points_to_different_commit ... ok
test release_check_returns_empty_without_tag ... ok
test release_tag_is_idempotent_when_remote_tag_matches_head ... ok
test release_check_uses_direct_commits_as_release_truth ... ok
test release_keeps_existing_header ... ok
test release_check_reads_evidence_without_running_repository_hooks ... ok
test release_notes_context_fuses_decisions_with_exact_commits ... ok
test release_run_keeps_a_failed_tag_red_until_a_fix_merges ... ok
test release_run_is_a_green_noop_without_merged_changes ... ok
test release_run_refuses_to_skip_an_incomplete_tag ... ok
test release_run_resumes_an_existing_explicit_tag ... ok
test release_status_reports_latest_tag_and_release ... ok
test release_status_does_not_count_a_draft_as_complete ... ok
test release_status_scopes_to_named_target ... ok
test release_notes_falls_back_when_agent_cli_is_missing ... ok
test release_generates_notes_and_writes_file ... ok
test release_check_returns_merged_prs ... ok
test release_with_bump_keyword ... ok

test result: ok. 24 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 7.17s\n- \n- Reproduced against the maintained checkout's historical moved tags