### PR TITLE
runtime: add live call-tree monitoring and safe pruning

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,9 @@ lf ls                  # every durable Wave and its Home/runtime evidence
 lf roadmap             # every open Task across every wave, bucketed by need
 lf status designer     # one wave's live Project → Task hierarchy
 lf trace <exec-id>     # what one agent did — and exactly what it was told
+lf ps                  # rank live call trees by cumulative completed output
+lf top                 # refresh call-tree rates, age, idle time, and health
+lf prune --dry-run     # inspect dead receipts and registered orphan providers
 lf usage               # subscription state and spend, per account and repo
 ```
 

--- a/docs/conducting.md
+++ b/docs/conducting.md
@@ -3,8 +3,8 @@
 Running one agent is a conversation. Running many is conducting: knowing what
 is playing, what is stuck, what needs you, what it cost — and redirecting a
 performer without stopping the piece. Loopflow answers all of that from the
-local ledger. Its read surfaces take `--json`; `lf top` is the human-oriented
-exception because it renders a live terminal graph.
+local ledger. Use `lf ps --json` for a machine-readable activity frame and
+`lf top` for the continuously refreshed terminal view.
 
 ## See everything
 
@@ -38,15 +38,21 @@ wave, project, task, repo, flow, skill, provider, model, or outcome.
 ## Health and spend
 
 ```bash
-lf top             # output-token throughput last hour + running processes
+lf ps              # one call-tree snapshot ranked by completed output
+lf top             # continuously refresh rates, age, idle time, and health
+lf prune --dry-run # inspect safely removable process state
 lf usage           # subscription state per account, spend by repo/provider
 lf tokens          # lines and tokens per directory; --days walks history
 lf ci --since 7d   # how failed CI was detected, repaired, and landed
 lf doctor          # audit the ledger: continuity, attribution, lineage
 ```
 
-`lf top` is the first move when work feels slow — machine-health evidence
-before guessing. `lf ci` reads the local ledger, not GitHub: it reports how
+`lf top` is the first move when work feels slow — live machine-health evidence.
+Use `lf ps --json` when another tool or agent needs one stable, parseable frame.
+Both contain only OS-live process trees; completed calls disappear. Run
+`lf prune --dry-run` before cleanup. Plain `lf prune` removes stale Exec
+receipts and registered orphan OpenCode groups, never unclaimed provider PIDs.
+`lf ci` reads the local ledger, not GitHub: it reports how
 much of CI repair happened without a human.
 
 ## Steer

--- a/docs/lf.md
+++ b/docs/lf.md
@@ -402,7 +402,13 @@ lf usage --refresh              # poll every account's provider now
 lf usage --json --days 30       # one additive row per measured provider Turn
 lf ci --since 7d                # CI repair attempts, latency, and outcomes
 lf ci --since 7d --json         # complete machine-wide incident receipt
-lf top                          # persisted last-hour Turn throughput + live processes
+lf ps                            # one live call-tree snapshot, ranked by completed output
+lf ps --sort rate-5m             # rank siblings by five-minute completion throughput
+lf ps --json                     # versioned flat nodes with stable parent ids
+lf top                           # refresh the same snapshot every two seconds on a TTY
+lf top --json                    # emit once; redirected output also emits once without ANSI
+lf prune --dry-run               # list stale receipts and registered orphan process groups
+lf prune                         # remove those receipts and reap those process groups
 lf doctor                       # audit continuity, identity, lineage, coverage, receipts
 lf doctor --json                # machine-readable audit
 ```
@@ -410,6 +416,20 @@ lf doctor --json                # machine-readable audit
 `lf ls` reads the Wave registry. `lf status` focuses one Wave's operational
 truth. `lf roadmap` overlays the current Linear-backed plan without creating a
 second runtime model.
+
+`lf ps` and `lf top` show OS-live processes only. Exact PID/start-time receipts
+attach `lf` processes to call records; exact ancestry attaches provider
+processes. Completed calls and launches disappear. A live provider's completed
+Turns supply cumulative tokens, while five- and thirty-minute rates divide
+tokens completed inside each exact window. Exec rows fold their live descendants
+once. Missing measurements stay explicit and elapsed time never implies death.
+
+Both commands open the live Home ledger and ownership registry read-only. This
+also applies under `scripts/dev-lf`: source builds can inspect real activity
+without gaining migration or write authority over the installed database.
+`lf prune` is the separate write boundary. It removes dead Exec receipts and
+reaps only OpenCode process groups whose registered owner is absent. It never
+kills unclaimed provider PIDs; inspect exact targets with `--dry-run` first.
 
 ```bash
 lf -m codex --account manabot-eng@ : "fix the tests"   # prefer this login, then route

--- a/rust/loopflow/src/bin/lf.rs
+++ b/rust/loopflow/src/bin/lf.rs
@@ -1381,7 +1381,15 @@ fn main() -> anyhow::Result<()> {
                 repo.as_deref(),
                 *json,
             ),
-            Some(Commands::Top) => loopflow::lf::commands::top::run(),
+            Some(Commands::Ps { json, sort }) => {
+                loopflow::lf::commands::top::run_ps(*json, *sort)
+            }
+            Some(Commands::Top { json, sort }) => {
+                loopflow::lf::commands::top::run_top(*json, *sort)
+            }
+            Some(Commands::Prune { dry_run, json }) => {
+                loopflow::lf::commands::top::run_prune(*json, *dry_run)
+            }
             Some(Commands::Context {
                 days,
                 started_after,

--- a/rust/loopflow/src/engine/builtins/LOOPFLOW.md
+++ b/rust/loopflow/src/engine/builtins/LOOPFLOW.md
@@ -98,10 +98,20 @@ Task with `--stack-on <parent-task>`. Do not rotate the parent Task onto a secon
 simultaneously open PR; its multi-PR history remains serial. The child binds to
 the parent's active PR at launch and never follows later serial PRs implicitly.
 
-When work feels slow or stuck, run `lf top` before guessing. It shows provider-
-reported output-token throughput for the last hour and the currently running
-`lf` and provider processes; use it as machine-health evidence, not as a
-lifecycle control.
+When work feels slow or stuck, run `lf top` before guessing. It continuously
+ranks OS-live Loopflow call trees by five-minute completed-output throughput and
+shows cumulative tokens, age, idle time, health, and provider PIDs. Completed
+calls and launches disappear. Use it as machine-health evidence, not as a
+lifecycle control. Use `lf ps --json` for one stable, parseable frame;
+redirected `lf top` also emits once without ANSI. Both commands read the live
+Home's ledger and ownership registry without migrating or writing them,
+including when invoked through `scripts/dev-lf`.
+
+Rates count provider-reported output only when a Turn ends; they are completion
+throughput, not decoding speed. Time alone never means dead. `lf prune
+--dry-run` lists the separate cleanup boundary; plain `lf prune` removes dead
+Exec receipts and reaps registered orphan OpenCode process groups. Never kill
+an `unclaimed` provider PID from `lf ps`: ownership is not proven.
 
 ## Inspect
 

--- a/rust/loopflow/src/harness/opencode_runtime.rs
+++ b/rust/loopflow/src/harness/opencode_runtime.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::time::{Duration, Instant};
@@ -19,9 +20,13 @@ pub struct OpenCodeReapReport {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-struct OpenCodeServerEntry {
-    opencode_pid: u32,
-    owner_loopflow_pid: u32,
+pub(crate) struct OpenCodeServerEntry {
+    pub opencode_pid: u32,
+    pub owner_loopflow_pid: u32,
+}
+
+pub(crate) fn registered_opencode_servers_at(lf_home: &Path) -> Result<Vec<OpenCodeServerEntry>> {
+    read_registry_entries(&lf_home.join(OPENCODE_REGISTRY_FILE))
 }
 
 pub(crate) fn register_opencode_server(opencode_pid: u32) -> Result<()> {
@@ -35,6 +40,21 @@ pub(crate) fn unregister_opencode_server(opencode_pid: u32) -> Result<()> {
 pub fn reap_orphaned_opencode_servers() -> OpenCodeReapReport {
     reap_orphaned_opencode_servers_at_path(
         &registry_path(),
+        |_| true,
+        pid_is_alive,
+        classify_leader,
+        process_group_alive,
+        terminate_process_group,
+    )
+}
+
+pub(crate) fn reap_selected_orphaned_opencode_servers_at(
+    lf_home: &Path,
+    process_groups: &HashSet<u32>,
+) -> OpenCodeReapReport {
+    reap_orphaned_opencode_servers_at_path(
+        &lf_home.join(OPENCODE_REGISTRY_FILE),
+        |pid| process_groups.contains(&pid),
         pid_is_alive,
         classify_leader,
         process_group_alive,
@@ -86,6 +106,7 @@ enum LeaderState {
 
 fn reap_orphaned_opencode_servers_at_path(
     path: &Path,
+    eligible: impl Fn(u32) -> bool,
     owner_pid_alive: impl Fn(u32) -> bool,
     leader: impl Fn(u32) -> LeaderState,
     group_alive: impl Fn(u32) -> bool,
@@ -103,6 +124,10 @@ fn reap_orphaned_opencode_servers_at_path(
 
     let mut retained = Vec::with_capacity(entries.len());
     for entry in entries {
+        if !eligible(entry.opencode_pid) {
+            retained.push(entry);
+            continue;
+        }
         if owner_pid_alive(entry.owner_loopflow_pid) {
             retained.push(entry);
             continue;
@@ -370,6 +395,7 @@ mod tests {
 
         let report = reap_orphaned_opencode_servers_at_path(
             &path,
+            |_| true,
             |pid| owner_alive.contains(&pid),
             |pid| {
                 if opencode_pids.contains(&pid) {
@@ -412,6 +438,7 @@ mod tests {
 
         let report = reap_orphaned_opencode_servers_at_path(
             &path,
+            |_| true,
             |_| false,
             |_| LeaderState::Dead,
             |pgid| alive_groups.contains(&pgid),
@@ -443,6 +470,7 @@ mod tests {
         let killed = Mutex::new(Vec::new());
         let report = reap_orphaned_opencode_servers_at_path(
             &path,
+            |_| true,
             |_| false,
             |_| LeaderState::Dead,
             |_| false,
@@ -469,6 +497,7 @@ mod tests {
         let killed = Mutex::new(Vec::new());
         let report = reap_orphaned_opencode_servers_at_path(
             &path,
+            |_| true,
             |_| false,
             |_| LeaderState::Other,
             |_| true,
@@ -494,6 +523,7 @@ mod tests {
 
         let report = reap_orphaned_opencode_servers_at_path(
             &path,
+            |_| true,
             |_| false,
             |_| LeaderState::Opencode,
             |_| true,
@@ -514,6 +544,28 @@ mod tests {
     }
 
     #[test]
+    fn selected_reap_preserves_unlisted_orphans() {
+        let tmp = tempdir().expect("tempdir");
+        let path = registry_path(tmp.path());
+        write_registry_entries(&path, &[entry(60, 2), entry(61, 2)]).expect("write registry");
+
+        let report = reap_orphaned_opencode_servers_at_path(
+            &path,
+            |pid| pid == 60,
+            |_| false,
+            |_| LeaderState::Opencode,
+            |_| true,
+            |_| true,
+        );
+
+        assert_eq!(report.reaped, 1);
+        assert_eq!(
+            read_registry_entries(&path).expect("read entries"),
+            vec![entry(61, 2)]
+        );
+    }
+
+    #[test]
     fn reap_is_idempotent() {
         let tmp = tempdir().expect("tempdir");
         let path = registry_path(tmp.path());
@@ -521,6 +573,7 @@ mod tests {
 
         let first = reap_orphaned_opencode_servers_at_path(
             &path,
+            |_| true,
             |_| false,
             |pid| {
                 if pid == 20 {
@@ -542,6 +595,7 @@ mod tests {
 
         let second = reap_orphaned_opencode_servers_at_path(
             &path,
+            |_| true,
             |_| false,
             |pid| {
                 if pid == 20 {

--- a/rust/loopflow/src/journal/mod.rs
+++ b/rust/loopflow/src/journal/mod.rs
@@ -19,6 +19,7 @@ use crate::store::RunEventRow;
 
 const JOURNAL_ROOT: &str = ".lf/journal/runs";
 const JOURNAL_EXCLUDE_ENTRY: &str = ".lf/journal/";
+const EXEC_PROCESS_ROOT: &str = "runtime/exec-processes";
 pub const LF_TRACE_ID_ENV: &str = "LF_TRACE_ID";
 pub const LF_PROCESS_ID_ENV: &str = "LF_PROCESS_ID";
 
@@ -128,6 +129,16 @@ struct RunContext {
     /// True when this process minted the run id (vs inheriting LF_TRACE_ID);
     /// the export is removed again when the run ends.
     minted_run_id: bool,
+}
+
+/// Exact, process-local ownership evidence for a live Loopflow Exec.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub(crate) struct ExecProcessReceipt {
+    pub schema_version: u32,
+    pub trace_id: String,
+    pub exec_id: String,
+    pub pid: u32,
+    pub started_at: i64,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
@@ -268,6 +279,7 @@ fn try_emit(
             LfEventType::Completed | LfEventType::Errored | LfEventType::Escalated
         )
     {
+        remove_exec_process_receipt();
         if context.minted_run_id {
             std::env::remove_var(LF_TRACE_ID_ENV);
         }
@@ -526,6 +538,11 @@ fn ensure_run_context(
         minted_run_id,
     };
     set_context(context.clone());
+    if let Err(error) = write_exec_process_receipt(&context) {
+        debug!(error = %error, exec_id = %context.process_id, "live Exec receipt unavailable");
+    } else {
+        crate::engine::agent::register_interrupt_cleanup(remove_exec_process_receipt);
+    }
 
     if let Some(wave_name) = wave_name {
         if fields.wave_name.as_deref() != Some(wave_name.as_str()) {
@@ -674,6 +691,85 @@ fn clear_context() {
     RUN_CONTEXT.with(|cell| {
         *cell.borrow_mut() = None;
     });
+}
+
+pub(crate) fn read_exec_process_receipts_at(
+    lf_home: &Path,
+) -> Result<Vec<ExecProcessReceipt>, std::io::Error> {
+    let root = lf_home.join(EXEC_PROCESS_ROOT);
+    let entries = match fs::read_dir(root) {
+        Ok(entries) => entries,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(error) => return Err(error),
+    };
+    let mut receipts = Vec::new();
+    for entry in entries {
+        let entry = entry?;
+        if !entry.file_type()?.is_file() {
+            continue;
+        }
+        let path = entry.path();
+        if path.extension().and_then(|value| value.to_str()) != Some("json")
+            || path
+                .file_stem()
+                .and_then(|value| value.to_str())
+                .and_then(|value| value.parse::<u32>().ok())
+                .is_none()
+        {
+            continue;
+        }
+        let Ok(content) = fs::read(path) else {
+            continue;
+        };
+        let Ok(receipt) = serde_json::from_slice::<ExecProcessReceipt>(&content) else {
+            continue;
+        };
+        if receipt.schema_version == 1 {
+            receipts.push(receipt);
+        }
+    }
+    Ok(receipts)
+}
+
+pub(crate) fn remove_exec_process_receipt_at(
+    lf_home: &Path,
+    pid: u32,
+) -> Result<bool, std::io::Error> {
+    let path = lf_home.join(EXEC_PROCESS_ROOT).join(format!("{pid}.json"));
+    match fs::remove_file(path) {
+        Ok(()) => Ok(true),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(false),
+        Err(error) => Err(error),
+    }
+}
+
+fn write_exec_process_receipt(context: &RunContext) -> Result<(), std::io::Error> {
+    let root = crate::store::lf_home_dir().join(EXEC_PROCESS_ROOT);
+    fs::create_dir_all(&root)?;
+    let pid = std::process::id();
+    let receipt = ExecProcessReceipt {
+        schema_version: 1,
+        trace_id: context.run_id.to_string(),
+        exec_id: context.process_id.to_string(),
+        pid,
+        started_at: OffsetDateTime::now_utc().unix_timestamp(),
+    };
+    let bytes = serde_json::to_vec(&receipt).map_err(std::io::Error::other)?;
+    let path = root.join(format!("{pid}.json"));
+    let temporary = root.join(format!(".{pid}.json.tmp"));
+    fs::write(&temporary, bytes)?;
+    fs::rename(temporary, path)
+}
+
+fn remove_exec_process_receipt() {
+    let path = crate::store::lf_home_dir()
+        .join(EXEC_PROCESS_ROOT)
+        .join(format!("{}.json", std::process::id()));
+    if let Err(error) = fs::remove_file(path) {
+        if error.kind() != std::io::ErrorKind::NotFound {
+            debug!(error = %error, "failed to remove live Exec receipt");
+        }
+    }
 }
 
 fn ensure_journal_ignored(repo_root: &Path) -> Result<(), std::io::Error> {
@@ -1367,6 +1463,39 @@ mod tests {
         );
 
         assert!(is_clean(&worktree).expect("worktree should stay clean"));
+    }
+
+    #[test]
+    fn run_lifecycle_publishes_and_removes_exact_process_ownership() {
+        let guard = journal_test_guard();
+        let repo = TestRepo::new();
+        let worktree = repo.create_named_worktree("runtime");
+        let command = vec!["lf".to_string(), "build".to_string()];
+
+        emit(
+            &worktree,
+            LfNode::Run,
+            LfEventType::Started,
+            started_fields(&command, &worktree, "runtime"),
+        );
+        let receipts =
+            super::read_exec_process_receipts_at(guard.home()).expect("read live receipt");
+        assert_eq!(receipts.len(), 1);
+        assert_eq!(receipts[0].pid, std::process::id());
+        assert_eq!(
+            receipts[0].exec_id,
+            std::env::var(super::LF_PROCESS_ID_ENV).expect("current Exec id")
+        );
+
+        emit(
+            &worktree,
+            LfNode::Run,
+            LfEventType::Completed,
+            LfEventFields::default(),
+        );
+        assert!(super::read_exec_process_receipts_at(guard.home())
+            .expect("read terminal receipt state")
+            .is_empty());
     }
 
     #[test]

--- a/rust/loopflow/src/lf/commands/top.rs
+++ b/rust/loopflow/src/lf/commands/top.rs
@@ -1,29 +1,191 @@
-//! `lf top` — one-hour provider throughput and live Loopflow activity.
+//! Loopflow activity snapshots: `lf ps` once, `lf top` continuously on a TTY.
 
 use std::collections::{HashMap, HashSet};
+use std::fs::File;
+use std::io::{IsTerminal, Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::thread;
+use std::time::{Duration, Instant};
 
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, Context, Result};
+use clap::ValueEnum;
+use serde::{Deserialize, Serialize};
+use time::format_description::well_known::Rfc3339;
+use time::OffsetDateTime;
 
+use crate::harness::opencode_runtime::{
+    reap_selected_orphaned_opencode_servers_at, registered_opencode_servers_at, OpenCodeServerEntry,
+};
+use crate::journal::{
+    read_exec_process_receipts_at, remove_exec_process_receipt_at, ExecProcessReceipt,
+};
 use crate::lf::output::{format_int, truncate};
-use crate::store::{sqlite::SqliteStore, TurnSpendRow};
+use crate::store::{sqlite::SqliteStore, RunEventRow};
+use crate::trace::{AgentInvocationRow, AgentTurnRow};
 
-const WINDOW_MINUTES: usize = 60;
-const BUCKET_SECONDS: i64 = 60;
-const GRAPH_HEIGHT: usize = 8;
-const PROCESS_COMMAND_WIDTH: usize = 88;
+const SCHEMA_VERSION: u32 = 1;
+const FAST_WINDOW_SECONDS: i64 = 300;
+const SLOW_WINDOW_SECONDS: i64 = 1_800;
+const STALLED_AFTER_SECONDS: i64 = 1_800;
+const REFRESH_INTERVAL: Duration = Duration::from_secs(2);
+const PROCESS_START_TOLERANCE_SECONDS: i64 = 3;
+const COMMAND_WIDTH: usize = 82;
 
-#[derive(Debug, PartialEq)]
-struct RunningProcess {
-    pid: u32,
-    elapsed: String,
-    kind: ProcessKind,
-    command: String,
-    workspace: Option<String>,
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, ValueEnum)]
+#[non_exhaustive]
+pub enum ActivitySort {
+    #[default]
+    Tokens,
+    #[value(name = "rate-5m")]
+    Rate5m,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum ActivityNodeKind {
+    Exec,
+    ProviderLaunch,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum ActivityState {
+    Working,
+    Waiting,
+    Stalled,
+}
+
+impl ActivityState {
+    fn label(self) -> &'static str {
+        match self {
+            Self::Working => "working",
+            Self::Waiting => "waiting",
+            Self::Stalled => "stalled",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct OutputActivity {
+    pub measured_output_tokens: u64,
+    pub output_tokens_fast: u64,
+    pub output_tokens_slow: u64,
+    pub output_tokens_per_second_fast: f64,
+    pub output_tokens_per_second_slow: f64,
+    pub measured_turns: u64,
+    pub unmeasured_turns: u64,
+}
+
+impl OutputActivity {
+    fn add(&mut self, other: &Self) {
+        self.measured_output_tokens = self
+            .measured_output_tokens
+            .saturating_add(other.measured_output_tokens);
+        self.output_tokens_fast = self
+            .output_tokens_fast
+            .saturating_add(other.output_tokens_fast);
+        self.output_tokens_slow = self
+            .output_tokens_slow
+            .saturating_add(other.output_tokens_slow);
+        self.measured_turns = self.measured_turns.saturating_add(other.measured_turns);
+        self.unmeasured_turns = self.unmeasured_turns.saturating_add(other.unmeasured_turns);
+        self.finish_rates();
+    }
+
+    fn finish_rates(&mut self) {
+        self.output_tokens_per_second_fast =
+            self.output_tokens_fast as f64 / FAST_WINDOW_SECONDS as f64;
+        self.output_tokens_per_second_slow =
+            self.output_tokens_slow as f64 / SLOW_WINDOW_SECONDS as f64;
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ActivityNode {
+    pub id: String,
+    pub parent_id: Option<String>,
+    pub kind: ActivityNodeKind,
+    pub label: String,
+    pub pid: Option<u32>,
+    pub started_at: i64,
+    pub last_progress_at: Option<i64>,
+    pub state: ActivityState,
+    pub direct: OutputActivity,
+    pub cumulative: OutputActivity,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum ProviderClaim {
+    Orphaned,
+    Unclaimed,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ProviderProcess {
+    pub pid: u32,
+    pub ppid: u32,
+    pub process_group: u32,
+    pub started_at: i64,
+    pub kernel_state: String,
+    pub provider: String,
+    pub command: String,
+    pub claim: ProviderClaim,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ActivitySnapshot {
+    pub schema_version: u32,
+    pub observed_at: i64,
+    pub fast_window_seconds: i64,
+    pub slow_window_seconds: i64,
+    pub aggregate: OutputActivity,
+    pub nodes: Vec<ActivityNode>,
+    pub provider_processes: Vec<ProviderProcess>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ProcessPruneReport {
+    pub schema_version: u32,
+    pub observed_at: i64,
+    pub dry_run: bool,
+    pub stale_exec_receipt_pids: Vec<u32>,
+    pub removed_exec_receipts: u32,
+    pub orphaned_opencode_process_groups: Vec<u32>,
+    pub reaped_opencode_process_groups: u32,
+    pub errors: u32,
+}
+
+#[derive(Debug, Clone)]
+struct ActivityData {
+    events: Vec<RunEventRow>,
+    launches: Vec<AgentInvocationRow>,
+    turns: Vec<AgentTurnRow>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct OsProcess {
+    pid: u32,
+    ppid: u32,
+    process_group: u32,
+    started_at: i64,
+    kernel_state: String,
+    command: String,
+    kind: Option<ProcessKind>,
+}
+
+#[derive(Debug, Clone)]
+struct ProcessSnapshot {
+    processes: Vec<OsProcess>,
+    receipts: Vec<ExecProcessReceipt>,
+    opencode_servers: Vec<OpenCodeServerEntry>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum ProcessKind {
     Lf,
     Codex,
@@ -42,25 +204,139 @@ impl ProcessKind {
             Self::OpenCode => "opencode",
         }
     }
+
+    fn is_provider(self) -> bool {
+        !matches!(self, Self::Lf)
+    }
 }
 
-pub fn run() -> Result<()> {
-    let now = time::OffsetDateTime::now_utc().unix_timestamp();
-    let ledger_path = crate::store::database_path_from_env()?;
-    let spend = read_turn_spend(&ledger_path, now - (WINDOW_MINUTES as i64 * BUCKET_SECONDS))?;
-    let mut buckets = [0_u64; WINDOW_MINUTES];
-    add_ledger_tokens(&mut buckets, &spend, now);
-    let processes = running_loopflow_processes()?;
+#[derive(Debug, Clone)]
+struct ExecRecord {
+    trace_id: String,
+    id: String,
+    parent_id: Option<String>,
+    label: String,
+    started_at: i64,
+}
 
-    print!("{}", render_dashboard(&buckets, &processes));
-    Ok(())
+#[derive(Debug, Clone, Copy)]
+enum ReceiptEvidence {
+    Present(u32),
+    Absent,
+    Missing,
+}
+
+pub fn run_ps(json: bool, sort: ActivitySort) -> Result<()> {
+    let snapshot = load_snapshot()?;
+    print_snapshot(&snapshot, json, sort)
+}
+
+pub fn run_top(json: bool, sort: ActivitySort) -> Result<()> {
+    let interactive = !json && std::io::stdout().is_terminal();
+    if !interactive {
+        return run_ps(json, sort);
+    }
+
+    let mut stdout = std::io::stdout().lock();
+    loop {
+        let frame_started = Instant::now();
+        let snapshot = load_snapshot()?;
+        write!(stdout, "\x1b[H\x1b[J{}", render_snapshot(&snapshot, sort))?;
+        stdout.flush()?;
+        thread::sleep(REFRESH_INTERVAL.saturating_sub(frame_started.elapsed()));
+    }
+}
+
+pub fn run_prune(json: bool, dry_run: bool) -> Result<()> {
+    let now = OffsetDateTime::now_utc().unix_timestamp();
+    let lf_home = crate::store::observability_home_dir();
+    let processes = observe_processes(now, &lf_home)?;
+    let (stale_exec_receipt_pids, orphaned_opencode_process_groups) =
+        resolve_prune_targets(&processes);
+    let mut report = ProcessPruneReport {
+        schema_version: SCHEMA_VERSION,
+        observed_at: now,
+        dry_run,
+        stale_exec_receipt_pids,
+        removed_exec_receipts: 0,
+        orphaned_opencode_process_groups,
+        reaped_opencode_process_groups: 0,
+        errors: 0,
+    };
+    if !dry_run {
+        for pid in &report.stale_exec_receipt_pids {
+            match remove_exec_process_receipt_at(&lf_home, *pid) {
+                Ok(true) => report.removed_exec_receipts += 1,
+                Ok(false) => {}
+                Err(error) => {
+                    tracing::warn!(pid, error = %error, "failed to prune stale Exec receipt");
+                    report.errors += 1;
+                }
+            }
+        }
+        let selected = report
+            .orphaned_opencode_process_groups
+            .iter()
+            .copied()
+            .collect::<HashSet<_>>();
+        let opencode = reap_selected_orphaned_opencode_servers_at(&lf_home, &selected);
+        report.reaped_opencode_process_groups = opencode.reaped;
+        report.errors = report.errors.saturating_add(opencode.errors);
+    }
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&report)?);
+    } else {
+        print!("{}", render_prune_report(&report));
+    }
+    if report.errors == 0 {
+        Ok(())
+    } else {
+        Err(anyhow!(
+            "process prune completed with {} errors",
+            report.errors
+        ))
+    }
+}
+
+fn resolve_prune_targets(processes: &ProcessSnapshot) -> (Vec<u32>, Vec<u32>) {
+    let process_by_pid = processes
+        .processes
+        .iter()
+        .map(|process| (process.pid, process))
+        .collect::<HashMap<_, _>>();
+    let mut stale_exec_receipt_pids = processes
+        .receipts
+        .iter()
+        .filter(|receipt| !receipt_matches_live_lf(receipt, &process_by_pid))
+        .map(|receipt| receipt.pid)
+        .collect::<Vec<_>>();
+    stale_exec_receipt_pids.sort_unstable();
+    stale_exec_receipt_pids.dedup();
+
+    let mut orphaned_opencode_process_groups = processes
+        .opencode_servers
+        .iter()
+        .filter(|entry| !process_by_pid.contains_key(&entry.owner_loopflow_pid))
+        .filter(|entry| {
+            process_by_pid
+                .get(&entry.opencode_pid)
+                .is_some_and(|process| process.kind == Some(ProcessKind::OpenCode))
+                || processes.processes.iter().any(|process| {
+                    process.process_group == entry.opencode_pid && process.pid != entry.opencode_pid
+                })
+        })
+        .map(|entry| entry.opencode_pid)
+        .collect::<Vec<_>>();
+    orphaned_opencode_process_groups.sort_unstable();
+    orphaned_opencode_process_groups.dedup();
+    (stale_exec_receipt_pids, orphaned_opencode_process_groups)
 }
 
 /// Best-effort snapshot of directories currently owned by a live process.
 ///
-/// Worktree cleanup uses this as a second ownership signal alongside durable
-/// Tasks. An empty set is returned when `lsof` is unavailable so the
-/// daemon can still rely on its registry on minimal hosts.
+/// Worktree cleanup uses this independent ownership signal. It intentionally
+/// remains broader than the exact receipts used by the activity view.
 pub fn running_workspace_paths() -> HashSet<PathBuf> {
     let output = Command::new("lsof").args(["-d", "cwd", "-Fn"]).output();
     let Ok(output) = output else {
@@ -77,137 +353,97 @@ pub fn running_workspace_paths() -> HashSet<PathBuf> {
         .collect()
 }
 
-fn read_turn_spend(path: &Path, since: i64) -> Result<Vec<TurnSpendRow>> {
-    SqliteStore::open_run_ledger_read_only(path)
-        .and_then(|store| store.turn_spend_since(since))
-        .map_err(|error| anyhow!("failed to read Turn ledger {}: {error}", path.display()))
+fn load_snapshot() -> Result<ActivitySnapshot> {
+    let now = OffsetDateTime::now_utc().unix_timestamp();
+    let lf_home = crate::store::observability_home_dir();
+    let path = crate::store::observability_database_path()?;
+    let data = read_activity_data(&path)?;
+    let processes = observe_processes(now, &lf_home)?;
+    collect_activity(data, processes, now)
 }
 
-fn add_ledger_tokens(buckets: &mut [u64; WINDOW_MINUTES], spend: &[TurnSpendRow], now: i64) {
-    for turn in spend {
-        let Some(index) = bucket_index(turn.at, now) else {
-            continue;
-        };
-        let output = turn.output_tokens.unwrap_or(0).max(0) as u64;
-        buckets[index] = buckets[index].saturating_add(output);
+fn read_activity_data(path: &Path) -> Result<ActivityData> {
+    if !path.exists() {
+        return Ok(ActivityData {
+            events: Vec::new(),
+            launches: Vec::new(),
+            turns: Vec::new(),
+        });
     }
-}
-
-fn bucket_index(timestamp: i64, now: i64) -> Option<usize> {
-    let start = now - WINDOW_MINUTES as i64 * BUCKET_SECONDS + 1;
-    (start..=now)
-        .contains(&timestamp)
-        .then_some(((timestamp - start) / BUCKET_SECONDS) as usize)
-}
-
-fn render_dashboard(buckets: &[u64; WINDOW_MINUTES], processes: &[RunningProcess]) -> String {
-    let mut output = String::new();
-    output.push_str("LOOPFLOW THROUGHPUT · LAST 60 MINUTES\n");
-    output.push_str("persisted provider Turn output tokens/s · one-minute activity buckets\n\n");
-    output.push_str(&render_graph(buckets));
-    output.push('\n');
-    output.push_str(&render_processes(processes));
-    output
-}
-
-fn render_graph(buckets: &[u64; WINDOW_MINUTES]) -> String {
-    let rates = buckets.map(|tokens| tokens as f64 / BUCKET_SECONDS as f64);
-    let peak = rates.iter().copied().fold(0.0_f64, f64::max);
-    let total = buckets.iter().copied().sum::<u64>();
-    let average = total as f64 / (WINDOW_MINUTES as i64 * BUCKET_SECONDS) as f64;
-    let current = rates[WINDOW_MINUTES - 1];
-    let mut output = String::new();
-
-    for level in (1..=GRAPH_HEIGHT).rev() {
-        let label = if level == GRAPH_HEIGHT {
-            format_rate(peak)
-        } else {
-            String::new()
-        };
-        let threshold = peak * level as f64 / GRAPH_HEIGHT as f64;
-        let bars = rates
+    let store = SqliteStore::open_run_ledger_read_only(path)
+        .map_err(|error| anyhow!("failed to read run ledger {}: {error}", path.display()))?;
+    Ok(store.read_run_ledger_snapshot(|store| {
+        let events = store.list_run_events_since(0)?;
+        let launches = store.agent_invocations_since(0)?;
+        let launch_ids = launches
             .iter()
-            .map(|rate| {
-                if *rate > 0.0 && *rate >= threshold {
-                    '█'
-                } else {
-                    ' '
-                }
-            })
-            .collect::<String>();
-        output.push_str(&format!("{label:>8} │{bars}\n"));
-    }
-    output.push_str(&format!("{:>8} └{}\n", "0.0", "─".repeat(WINDOW_MINUTES)));
-    output.push_str(&format!("          60m ago{:>53}\n", "now"));
-    output.push_str(&format!(
-        "total {} tokens · avg {} tok/s · peak {} tok/s · current {} tok/s\n",
-        format_int(total),
-        format_rate(average),
-        format_rate(peak),
-        format_rate(current),
-    ));
-    output
+            .filter(|launch| launch.ended_at.is_none() && launch.outcome == "running")
+            .map(|launch| launch.id.clone())
+            .collect::<Vec<_>>();
+        let turns = store.agent_turns_for_invocations(&launch_ids)?;
+        Ok(ActivityData {
+            events,
+            launches,
+            turns,
+        })
+    })?)
 }
 
-fn format_rate(rate: f64) -> String {
-    if rate > 0.0 && rate < 0.1 {
-        format!("{rate:.2}")
-    } else {
-        format!("{rate:.1}")
-    }
-}
-
-fn running_loopflow_processes() -> Result<Vec<RunningProcess>> {
+fn observe_processes(now: i64, lf_home: &Path) -> Result<ProcessSnapshot> {
     let output = Command::new("ps")
-        .args(["-axo", "pid=,etime=,command="])
+        .args(["-axo", "pid=,ppid=,pgid=,state=,etime=,command="])
         .output()
-        .map_err(|error| anyhow!("failed to inspect running processes: {error}"))?;
+        .context("failed to inspect processes")?;
     if !output.status.success() {
-        return Err(anyhow!("failed to inspect running processes with ps"));
+        return Err(anyhow!("ps failed while collecting Loopflow activity"));
     }
-    let mut processes =
-        parse_processes(&String::from_utf8_lossy(&output.stdout), std::process::id());
-    let workspaces = process_workspaces(&processes);
-    for process in &mut processes {
-        if process.kind != ProcessKind::Lf {
-            process.workspace = workspaces.get(&process.pid).cloned();
+    let processes = parse_processes(&String::from_utf8_lossy(&output.stdout), now);
+    let opencode_servers = match registered_opencode_servers_at(lf_home) {
+        Ok(servers) => servers,
+        Err(error) => {
+            tracing::warn!(error = %error, "OpenCode ownership registry unavailable");
+            Vec::new()
         }
-    }
-    Ok(processes)
+    };
+    Ok(ProcessSnapshot {
+        processes,
+        receipts: read_exec_process_receipts_at(lf_home)
+            .context("failed to read live Exec receipts")?,
+        opencode_servers,
+    })
 }
 
-fn parse_processes(output: &str, current_pid: u32) -> Vec<RunningProcess> {
-    let mut processes = output
+fn parse_processes(output: &str, now: i64) -> Vec<OsProcess> {
+    output
         .lines()
         .filter_map(|line| {
             let mut fields = line.split_whitespace();
             let pid = fields.next()?.parse::<u32>().ok()?;
-            let elapsed = fields.next()?.trim().to_string();
+            let ppid = fields.next()?.parse::<u32>().ok()?;
+            let process_group = fields.next()?.parse::<u32>().ok()?;
+            let kernel_state = fields.next()?.to_string();
+            let elapsed = fields.next()?;
             let command = fields.collect::<Vec<_>>().join(" ");
             if command.is_empty() {
                 return None;
             }
-            let kind = process_kind(&command)?;
-            if pid == current_pid {
-                return None;
-            }
-            Some(RunningProcess {
+            Some(OsProcess {
                 pid,
-                elapsed,
-                kind,
+                ppid,
+                process_group,
+                started_at: now.saturating_sub(elapsed_seconds(elapsed) as i64),
+                kernel_state,
+                kind: process_kind(&command),
                 command,
-                workspace: None,
             })
         })
-        .collect::<Vec<_>>();
-    processes.sort_by_key(|process| std::cmp::Reverse(elapsed_seconds(&process.elapsed)));
-    processes
+        .collect()
 }
 
 fn process_kind(command: &str) -> Option<ProcessKind> {
-    let executable = command
-        .split_whitespace()
-        .next()
+    let words = command.split_whitespace().collect::<Vec<_>>();
+    let executable = words
+        .first()
         .and_then(|word| Path::new(word).file_name())
         .and_then(|name| name.to_str())?;
     match executable {
@@ -215,46 +451,11 @@ fn process_kind(command: &str) -> Option<ProcessKind> {
         "codex" => Some(ProcessKind::Codex),
         "claude" => Some(ProcessKind::Claude),
         "gemini" => Some(ProcessKind::Gemini),
-        "opencode" => Some(ProcessKind::OpenCode),
+        "opencode" if words.iter().skip(1).any(|word| *word == "serve") => {
+            Some(ProcessKind::OpenCode)
+        }
         _ => None,
     }
-}
-
-fn process_workspaces(processes: &[RunningProcess]) -> HashMap<u32, String> {
-    let pids = processes
-        .iter()
-        .filter(|process| process.kind != ProcessKind::Lf)
-        .map(|process| process.pid.to_string())
-        .collect::<Vec<_>>()
-        .join(",");
-    if pids.is_empty() {
-        return HashMap::new();
-    }
-    let output = Command::new("lsof")
-        .args(["-a", "-p", &pids, "-d", "cwd", "-Fn"])
-        .output();
-    let Ok(output) = output else {
-        return HashMap::new();
-    };
-    if !output.status.success() {
-        return HashMap::new();
-    }
-    parse_lsof_workspaces(&String::from_utf8_lossy(&output.stdout))
-}
-
-fn parse_lsof_workspaces(output: &str) -> HashMap<u32, String> {
-    let mut workspaces = HashMap::new();
-    let mut pid = None;
-    for line in output.lines() {
-        if let Some(value) = line.strip_prefix('p') {
-            pid = value.parse::<u32>().ok();
-        } else if let (Some(pid), Some(path)) = (pid, line.strip_prefix('n')) {
-            if let Some(name) = Path::new(path).file_name().and_then(|name| name.to_str()) {
-                workspaces.insert(pid, name.to_string());
-            }
-        }
-    }
-    workspaces
 }
 
 fn elapsed_seconds(elapsed: &str) -> u64 {
@@ -278,216 +479,1082 @@ fn elapsed_seconds(elapsed: &str) -> u64 {
     days.saturating_mul(86_400).saturating_add(clock_seconds)
 }
 
-fn render_processes(processes: &[RunningProcess]) -> String {
-    if processes.is_empty() {
-        return "RUNNING LF + PROVIDER PROCESSES\nnone\n".to_string();
+fn collect_activity(
+    data: ActivityData,
+    processes: ProcessSnapshot,
+    now: i64,
+) -> Result<ActivitySnapshot> {
+    let execs = collect_execs(&data.events)
+        .into_values()
+        .collect::<Vec<_>>();
+
+    let process_by_pid = processes
+        .processes
+        .iter()
+        .map(|process| (process.pid, process))
+        .collect::<HashMap<_, _>>();
+    let current_pid = std::process::id();
+    let receipt_evidence = execs
+        .iter()
+        .map(|exec| {
+            (
+                exec.id.clone(),
+                receipt_evidence(exec, &processes.receipts, &process_by_pid),
+            )
+        })
+        .collect::<HashMap<_, _>>();
+    let live_execs = execs
+        .into_iter()
+        .filter(|exec| {
+            matches!(
+                receipt_evidence.get(&exec.id),
+                Some(ReceiptEvidence::Present(pid)) if *pid != current_pid
+            )
+        })
+        .collect::<Vec<_>>();
+    let live_exec_ids = live_execs
+        .iter()
+        .map(|exec| exec.id.clone())
+        .collect::<HashSet<_>>();
+    let owner_by_pid = receipt_evidence
+        .iter()
+        .filter_map(|(exec_id, evidence)| match evidence {
+            ReceiptEvidence::Present(pid) if live_exec_ids.contains(exec_id) => {
+                Some((*pid, exec_id.clone()))
+            }
+            ReceiptEvidence::Absent | ReceiptEvidence::Missing => None,
+            ReceiptEvidence::Present(_) => None,
+        })
+        .collect::<HashMap<_, _>>();
+
+    let (launch_pid, provider_processes) =
+        claim_provider_processes(&processes, &process_by_pid, &owner_by_pid, &data.launches);
+    let live_launch_ids = launch_pid
+        .keys()
+        .map(String::as_str)
+        .collect::<HashSet<_>>();
+    let turns = data
+        .turns
+        .into_iter()
+        .filter(|turn| live_launch_ids.contains(turn.invocation_id.as_str()))
+        .collect::<Vec<_>>();
+    let turns_by_launch = group_turns(&turns);
+    let mut nodes = Vec::new();
+    for exec in live_execs {
+        let evidence = receipt_evidence
+            .get(&exec.id)
+            .copied()
+            .unwrap_or(ReceiptEvidence::Missing);
+        nodes.push(ActivityNode {
+            id: exec_node_id(&exec.id),
+            parent_id: exec
+                .parent_id
+                .as_deref()
+                .filter(|parent| live_exec_ids.contains(*parent))
+                .map(exec_node_id),
+            kind: ActivityNodeKind::Exec,
+            label: exec.label,
+            pid: match evidence {
+                ReceiptEvidence::Present(pid) => Some(pid),
+                ReceiptEvidence::Absent | ReceiptEvidence::Missing => None,
+            },
+            started_at: exec.started_at,
+            last_progress_at: None,
+            state: ActivityState::Waiting,
+            direct: OutputActivity::default(),
+            cumulative: OutputActivity::default(),
+        });
+    }
+    for launch in data
+        .launches
+        .into_iter()
+        .filter(|launch| live_launch_ids.contains(launch.id.as_str()))
+    {
+        let launch_turns = turns_by_launch
+            .get(launch.id.as_str())
+            .map_or(&[][..], Vec::as_slice);
+        let direct = output_activity(launch_turns, now);
+        let last_progress_at = last_progress_at(&launch, launch_turns);
+        let state = launch_state(launch_turns, last_progress_at, now);
+        let pid = launch_pid.get(&launch.id).copied();
+        nodes.push(ActivityNode {
+            id: launch_node_id(&launch.id),
+            parent_id: Some(exec_node_id(&launch.process_id)),
+            kind: ActivityNodeKind::ProviderLaunch,
+            label: match pid {
+                Some(pid) => format!("{} {pid}", launch.provider),
+                None => launch.provider.clone(),
+            },
+            pid,
+            started_at: launch.started_at,
+            last_progress_at,
+            state,
+            cumulative: direct.clone(),
+            direct,
+        });
     }
 
-    let mut output = format!("RUNNING LF + PROVIDER PROCESSES ({})\n", processes.len());
-    output.push_str("     PID  ELAPSED       KIND      COMMAND / WORKTREE\n");
-    for process in processes {
-        let description = if process.kind == ProcessKind::Lf {
-            &process.command
-        } else {
-            process.workspace.as_deref().unwrap_or(process.kind.label())
+    fold_cumulative(&mut nodes)?;
+    nodes.sort_by(|left, right| left.id.cmp(&right.id));
+    let mut aggregate = OutputActivity::default();
+    for node in &nodes {
+        aggregate.add(&node.direct);
+    }
+    Ok(ActivitySnapshot {
+        schema_version: SCHEMA_VERSION,
+        observed_at: now,
+        fast_window_seconds: FAST_WINDOW_SECONDS,
+        slow_window_seconds: SLOW_WINDOW_SECONDS,
+        aggregate,
+        nodes,
+        provider_processes,
+    })
+}
+
+fn collect_execs(events: &[RunEventRow]) -> HashMap<String, ExecRecord> {
+    let mut execs = HashMap::new();
+    for event in events.iter().filter(|event| event.node == "run") {
+        let entry = execs
+            .entry(event.process_id.clone())
+            .or_insert_with(|| ExecRecord {
+                trace_id: event.run_id.clone(),
+                id: event.process_id.clone(),
+                parent_id: event.parent_process_id.clone(),
+                label: command_label(event.command.as_deref()),
+                started_at: event.ts,
+            });
+        entry.started_at = entry.started_at.min(event.ts);
+        if entry.label == "lf" && event.command.is_some() {
+            entry.label = command_label(event.command.as_deref());
+        }
+    }
+    execs
+}
+
+fn command_label(command: Option<&str>) -> String {
+    let Some(command) = command else {
+        return "lf".to_string();
+    };
+    let Ok(argv) = serde_json::from_str::<Vec<String>>(command) else {
+        return "lf".to_string();
+    };
+    let Some(command) = argv.get(1).filter(|value| !value.starts_with('-')) else {
+        return "lf".to_string();
+    };
+    let grouped = [
+        "__work", "home", "pm", "pr", "project", "radio", "task", "wave", "work",
+    ];
+    let operation = grouped
+        .contains(&command.as_str())
+        .then(|| argv.get(2))
+        .flatten()
+        .filter(|value| safe_command_word(value));
+    match operation {
+        Some(operation) => format!("lf {command} {operation}"),
+        None => format!("lf {command}"),
+    }
+}
+
+fn safe_command_word(value: &str) -> bool {
+    !value.is_empty()
+        && value.len() <= 32
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_'))
+}
+
+fn receipt_evidence(
+    exec: &ExecRecord,
+    receipts: &[ExecProcessReceipt],
+    process_by_pid: &HashMap<u32, &OsProcess>,
+) -> ReceiptEvidence {
+    let Some(receipt) = receipts
+        .iter()
+        .find(|receipt| receipt.exec_id == exec.id && receipt.trace_id == exec.trace_id)
+    else {
+        return ReceiptEvidence::Missing;
+    };
+    if receipt_matches_live_lf(receipt, process_by_pid) {
+        ReceiptEvidence::Present(receipt.pid)
+    } else {
+        ReceiptEvidence::Absent
+    }
+}
+
+fn receipt_matches_live_lf(
+    receipt: &ExecProcessReceipt,
+    process_by_pid: &HashMap<u32, &OsProcess>,
+) -> bool {
+    process_by_pid.get(&receipt.pid).is_some_and(|process| {
+        process.kind == Some(ProcessKind::Lf)
+            && (process.started_at - receipt.started_at).abs() <= PROCESS_START_TOLERANCE_SECONDS
+    })
+}
+
+fn claim_provider_processes(
+    snapshot: &ProcessSnapshot,
+    process_by_pid: &HashMap<u32, &OsProcess>,
+    owner_by_pid: &HashMap<u32, String>,
+    launches: &[AgentInvocationRow],
+) -> (HashMap<String, u32>, Vec<ProviderProcess>) {
+    let registry = snapshot
+        .opencode_servers
+        .iter()
+        .map(|entry| (entry.opencode_pid, entry))
+        .collect::<HashMap<_, _>>();
+    let mut launch_pid = HashMap::new();
+    let mut unclaimed = Vec::new();
+    for process in snapshot.processes.iter().filter(|process| {
+        process.kind.is_some_and(ProcessKind::is_provider)
+            && !has_provider_ancestor(process, process_by_pid)
+    }) {
+        let registered_owner = registry
+            .get(&process.pid)
+            .map(|entry| entry.owner_loopflow_pid);
+        if registered_owner.is_some_and(|owner| !process_by_pid.contains_key(&owner)) {
+            unclaimed.push(provider_process(process, ProviderClaim::Orphaned));
+            continue;
+        }
+        let owner = registered_owner
+            .and_then(|pid| owner_by_pid.get(&pid).cloned())
+            .or_else(|| nearest_exec_owner(process.ppid, process_by_pid, owner_by_pid));
+        let Some(owner) = owner else {
+            unclaimed.push(provider_process(process, ProviderClaim::Unclaimed));
+            continue;
         };
+        let provider = process.kind.expect("provider process has a kind").label();
+        let candidates = launches
+            .iter()
+            .filter(|launch| {
+                launch.process_id == owner
+                    && launch.ended_at.is_none()
+                    && launch.outcome == "running"
+                    && launch.provider.eq_ignore_ascii_case(provider)
+            })
+            .collect::<Vec<_>>();
+        if candidates.len() == 1 && !launch_pid.contains_key(&candidates[0].id) {
+            launch_pid.insert(candidates[0].id.clone(), process.pid);
+        } else {
+            unclaimed.push(provider_process(process, ProviderClaim::Unclaimed));
+        }
+    }
+    unclaimed.sort_by_key(|process| process.pid);
+    (launch_pid, unclaimed)
+}
+
+fn has_provider_ancestor(process: &OsProcess, process_by_pid: &HashMap<u32, &OsProcess>) -> bool {
+    let mut pid = process.ppid;
+    let mut seen = HashSet::new();
+    while pid != 0 && seen.insert(pid) {
+        let Some(parent) = process_by_pid.get(&pid) else {
+            break;
+        };
+        if parent.kind.is_some_and(ProcessKind::is_provider) {
+            return true;
+        }
+        pid = parent.ppid;
+    }
+    false
+}
+
+fn nearest_exec_owner(
+    mut pid: u32,
+    process_by_pid: &HashMap<u32, &OsProcess>,
+    owner_by_pid: &HashMap<u32, String>,
+) -> Option<String> {
+    let mut seen = HashSet::new();
+    while pid != 0 && seen.insert(pid) {
+        if let Some(owner) = owner_by_pid.get(&pid) {
+            return Some(owner.clone());
+        }
+        pid = process_by_pid.get(&pid)?.ppid;
+    }
+    None
+}
+
+fn provider_process(process: &OsProcess, claim: ProviderClaim) -> ProviderProcess {
+    ProviderProcess {
+        pid: process.pid,
+        ppid: process.ppid,
+        process_group: process.process_group,
+        started_at: process.started_at,
+        kernel_state: process.kernel_state.clone(),
+        provider: process
+            .kind
+            .expect("provider process has a kind")
+            .label()
+            .to_string(),
+        command: match process.kind.expect("provider process has a kind") {
+            ProcessKind::OpenCode => "opencode serve".to_string(),
+            kind => kind.label().to_string(),
+        },
+        claim,
+    }
+}
+
+fn group_turns(turns: &[AgentTurnRow]) -> HashMap<&str, Vec<&AgentTurnRow>> {
+    let mut by_launch = HashMap::<&str, Vec<&AgentTurnRow>>::new();
+    for turn in turns {
+        by_launch
+            .entry(turn.invocation_id.as_str())
+            .or_default()
+            .push(turn);
+    }
+    by_launch
+}
+
+fn output_activity(turns: &[&AgentTurnRow], now: i64) -> OutputActivity {
+    let mut activity = OutputActivity::default();
+    for turn in turns {
+        match (turn.ended_at, turn.provider_output_tokens) {
+            (Some(ended_at), Some(tokens)) => {
+                let tokens = tokens.max(0) as u64;
+                activity.measured_turns += 1;
+                activity.measured_output_tokens =
+                    activity.measured_output_tokens.saturating_add(tokens);
+                if ended_at > now - SLOW_WINDOW_SECONDS && ended_at <= now {
+                    activity.output_tokens_slow =
+                        activity.output_tokens_slow.saturating_add(tokens);
+                }
+                if ended_at > now - FAST_WINDOW_SECONDS && ended_at <= now {
+                    activity.output_tokens_fast =
+                        activity.output_tokens_fast.saturating_add(tokens);
+                }
+            }
+            _ => activity.unmeasured_turns += 1,
+        }
+    }
+    activity.finish_rates();
+    activity
+}
+
+fn last_progress_at(launch: &AgentInvocationRow, turns: &[&AgentTurnRow]) -> Option<i64> {
+    let durable = turns
+        .iter()
+        .flat_map(|turn| [Some(turn.started_at), turn.ended_at])
+        .flatten()
+        .chain(
+            [Some(launch.started_at), launch.ended_at]
+                .into_iter()
+                .flatten(),
+        )
+        .max();
+    if launch.ended_at.is_some() {
+        return durable;
+    }
+    let event = crate::trace::resolve_artifact(&launch.conversation_path)
+        .ok()
+        .and_then(|path| last_recorded_event_at(&path).ok().flatten());
+    durable.into_iter().chain(event).max()
+}
+
+fn last_recorded_event_at(path: &Path) -> Result<Option<i64>> {
+    let Some(line) = read_last_line(path)? else {
+        return Ok(None);
+    };
+    let value = serde_json::from_str::<serde_json::Value>(&line)?;
+    let Some(timestamp) = value.get("ts").and_then(serde_json::Value::as_str) else {
+        return Ok(None);
+    };
+    Ok(Some(
+        OffsetDateTime::parse(timestamp, &Rfc3339)?.unix_timestamp(),
+    ))
+}
+
+fn read_last_line(path: &Path) -> Result<Option<String>> {
+    let mut file = match File::open(path) {
+        Ok(file) => file,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(error.into()),
+    };
+    let mut position = file.metadata()?.len();
+    let mut reversed = Vec::new();
+    while position > 0 {
+        let count = position.min(8_192) as usize;
+        position -= count as u64;
+        file.seek(SeekFrom::Start(position))?;
+        let mut chunk = vec![0; count];
+        file.read_exact(&mut chunk)?;
+        for byte in chunk.into_iter().rev() {
+            if byte == b'\n' {
+                if !reversed.is_empty() {
+                    reversed.reverse();
+                    return String::from_utf8(reversed).map(Some).map_err(Into::into);
+                }
+            } else if byte != b'\r' {
+                reversed.push(byte);
+            }
+        }
+    }
+    if reversed.is_empty() {
+        Ok(None)
+    } else {
+        reversed.reverse();
+        String::from_utf8(reversed).map(Some).map_err(Into::into)
+    }
+}
+
+fn launch_state(turns: &[&AgentTurnRow], last_progress_at: Option<i64>, now: i64) -> ActivityState {
+    let open_turn = turns.iter().any(|turn| turn.ended_at.is_none());
+    if open_turn {
+        return if last_progress_at.is_some_and(|at| now - at > STALLED_AFTER_SECONDS) {
+            ActivityState::Stalled
+        } else {
+            ActivityState::Working
+        };
+    }
+    ActivityState::Waiting
+}
+
+fn fold_cumulative(nodes: &mut [ActivityNode]) -> Result<()> {
+    let index = nodes
+        .iter()
+        .enumerate()
+        .map(|(index, node)| (node.id.clone(), index))
+        .collect::<HashMap<_, _>>();
+    let mut children = HashMap::<String, Vec<String>>::new();
+    for node in nodes.iter() {
+        if let Some(parent) = &node.parent_id {
+            children
+                .entry(parent.clone())
+                .or_default()
+                .push(node.id.clone());
+        }
+    }
+    let ids = nodes.iter().map(|node| node.id.clone()).collect::<Vec<_>>();
+    let mut done = HashSet::new();
+    let mut visiting = HashSet::new();
+    for id in ids {
+        fold_node(&id, nodes, &index, &children, &mut done, &mut visiting)?;
+    }
+    Ok(())
+}
+
+fn fold_node(
+    id: &str,
+    nodes: &mut [ActivityNode],
+    index: &HashMap<String, usize>,
+    children: &HashMap<String, Vec<String>>,
+    done: &mut HashSet<String>,
+    visiting: &mut HashSet<String>,
+) -> Result<()> {
+    if done.contains(id) {
+        return Ok(());
+    }
+    if !visiting.insert(id.to_string()) {
+        return Err(anyhow!("activity tree contains a cycle at {id}"));
+    }
+    let node_index = *index
+        .get(id)
+        .ok_or_else(|| anyhow!("activity node {id} is missing"))?;
+    let child_ids = children.get(id).cloned().unwrap_or_default();
+    let mut cumulative = nodes[node_index].direct.clone();
+    let mut last_progress = nodes[node_index].last_progress_at;
+    let mut child_states = Vec::new();
+    for child_id in child_ids {
+        fold_node(&child_id, nodes, index, children, done, visiting)?;
+        let child = &nodes[*index
+            .get(&child_id)
+            .ok_or_else(|| anyhow!("activity child {child_id} is missing"))?];
+        cumulative.add(&child.cumulative);
+        last_progress = last_progress
+            .into_iter()
+            .chain(child.last_progress_at)
+            .max();
+        child_states.push(child.state);
+    }
+    let node = &mut nodes[node_index];
+    node.cumulative = cumulative;
+    node.last_progress_at = last_progress;
+    if node.kind == ActivityNodeKind::Exec {
+        node.state = fold_exec_state(node.state, &child_states);
+    }
+    visiting.remove(id);
+    done.insert(id.to_string());
+    Ok(())
+}
+
+fn fold_exec_state(base: ActivityState, children: &[ActivityState]) -> ActivityState {
+    for state in [
+        ActivityState::Working,
+        ActivityState::Stalled,
+        ActivityState::Waiting,
+    ] {
+        if children.contains(&state) {
+            return state;
+        }
+    }
+    base
+}
+
+fn exec_node_id(id: &str) -> String {
+    format!("exec:{id}")
+}
+
+fn launch_node_id(id: &str) -> String {
+    format!("launch:{id}")
+}
+
+fn print_snapshot(snapshot: &ActivitySnapshot, json: bool, sort: ActivitySort) -> Result<()> {
+    if json {
+        println!("{}", serde_json::to_string_pretty(snapshot)?);
+    } else {
+        print!("{}", render_snapshot(snapshot, sort));
+    }
+    Ok(())
+}
+
+fn render_snapshot(snapshot: &ActivitySnapshot, sort: ActivitySort) -> String {
+    let mut output = String::new();
+    output.push_str("LOOPFLOW ACTIVITY\n");
+    output.push_str(&format!(
+        "{} completed output tokens · 5m {} tok/s · 30m {} tok/s · {} unmeasured turns\n\n",
+        format_int(snapshot.aggregate.measured_output_tokens),
+        format_rate(snapshot.aggregate.output_tokens_per_second_fast),
+        format_rate(snapshot.aggregate.output_tokens_per_second_slow),
+        snapshot.aggregate.unmeasured_turns,
+    ));
+    output.push_str("  TOKENS  TOK/S 5M  TOK/S 30M  ELAPSED    IDLE  STATE      CALL\n");
+    if snapshot.nodes.is_empty() {
+        output.push_str("  no live call trees recorded in this Home\n");
+    } else {
+        let index = snapshot
+            .nodes
+            .iter()
+            .map(|node| (node.id.as_str(), node))
+            .collect::<HashMap<_, _>>();
+        let mut children = HashMap::<Option<&str>, Vec<&str>>::new();
+        for node in &snapshot.nodes {
+            let parent = node
+                .parent_id
+                .as_deref()
+                .filter(|parent| index.contains_key(parent));
+            children.entry(parent).or_default().push(&node.id);
+        }
+        for nodes in children.values_mut() {
+            sort_node_ids(nodes, &index, sort);
+        }
+        if let Some(roots) = children.get(&None) {
+            for root in roots {
+                render_node(
+                    root,
+                    "",
+                    None,
+                    &index,
+                    &children,
+                    snapshot.observed_at,
+                    &mut output,
+                );
+            }
+        }
+    }
+    if !snapshot.provider_processes.is_empty() {
         output.push_str(&format!(
-            "{:>8}  {:<12}  {:<8}  {}\n",
-            process.pid,
-            process.elapsed,
-            process.kind.label(),
-            truncate(description, PROCESS_COMMAND_WIDTH),
+            "\nUNATTRIBUTED PROVIDER PIDS ({}) · not counted above\n",
+            snapshot.provider_processes.len()
+        ));
+        output.push_str(
+            "unclaimed = no exact Loopflow receipt · orphaned = registered owner absent\n",
+        );
+        output.push_str("     PID  ELAPSED  OS       CLAIM       COMMAND\n");
+        for process in &snapshot.provider_processes {
+            output.push_str(&format!(
+                "{:>8}  {:>7}  {:<7}  {:<10}  {}\n",
+                process.pid,
+                format_duration(snapshot.observed_at.saturating_sub(process.started_at)),
+                kernel_state_label(&process.kernel_state),
+                match process.claim {
+                    ProviderClaim::Orphaned => "orphaned",
+                    ProviderClaim::Unclaimed => "unclaimed",
+                },
+                truncate(&process.command, COMMAND_WIDTH),
+            ));
+        }
+    }
+    output
+}
+
+fn render_prune_report(report: &ProcessPruneReport) -> String {
+    let action = if report.dry_run {
+        "WOULD PRUNE"
+    } else {
+        "PRUNED"
+    };
+    let mut output = format!("LOOPFLOW PROCESS PRUNE · {action}\n");
+    output.push_str(&format!(
+        "{} stale Exec receipts · {} orphaned OpenCode process groups · {} errors\n",
+        report.stale_exec_receipt_pids.len(),
+        report.orphaned_opencode_process_groups.len(),
+        report.errors,
+    ));
+    if !report.stale_exec_receipt_pids.is_empty() {
+        output.push_str(&format!(
+            "Exec receipt PIDs: {}\n",
+            report
+                .stale_exec_receipt_pids
+                .iter()
+                .map(u32::to_string)
+                .collect::<Vec<_>>()
+                .join(", ")
+        ));
+    }
+    if !report.orphaned_opencode_process_groups.is_empty() {
+        output.push_str(&format!(
+            "OpenCode process groups: {}\n",
+            report
+                .orphaned_opencode_process_groups
+                .iter()
+                .map(u32::to_string)
+                .collect::<Vec<_>>()
+                .join(", ")
+        ));
+    }
+    if !report.dry_run {
+        output.push_str(&format!(
+            "removed {} receipts · reaped {} process groups\n",
+            report.removed_exec_receipts, report.reaped_opencode_process_groups,
         ));
     }
     output
 }
 
+fn sort_node_ids(nodes: &mut [&str], index: &HashMap<&str, &ActivityNode>, sort: ActivitySort) {
+    nodes.sort_by(|left, right| {
+        let left_node = index[left];
+        let right_node = index[right];
+        let order = match sort {
+            ActivitySort::Tokens => right_node
+                .cumulative
+                .measured_output_tokens
+                .cmp(&left_node.cumulative.measured_output_tokens)
+                .then_with(|| {
+                    right_node
+                        .cumulative
+                        .output_tokens_fast
+                        .cmp(&left_node.cumulative.output_tokens_fast)
+                }),
+            ActivitySort::Rate5m => right_node
+                .cumulative
+                .output_tokens_fast
+                .cmp(&left_node.cumulative.output_tokens_fast)
+                .then_with(|| {
+                    right_node
+                        .cumulative
+                        .measured_output_tokens
+                        .cmp(&left_node.cumulative.measured_output_tokens)
+                }),
+        };
+        order.then_with(|| left.cmp(right))
+    });
+}
+
+fn render_node(
+    id: &str,
+    prefix: &str,
+    branch: Option<bool>,
+    index: &HashMap<&str, &ActivityNode>,
+    children: &HashMap<Option<&str>, Vec<&str>>,
+    now: i64,
+    output: &mut String,
+) {
+    let node = index[id];
+    let connector = match branch {
+        None => "",
+        Some(true) => "└─",
+        Some(false) => "├─",
+    };
+    output.push_str(&format!(
+        "{:>8}  {:>6}  {:>7}  {:>6}  {:>6}  {:<9}  {}{}{}\n",
+        format_int(node.cumulative.measured_output_tokens),
+        format_rate(node.cumulative.output_tokens_per_second_fast),
+        format_rate(node.cumulative.output_tokens_per_second_slow),
+        format_duration(now.saturating_sub(node.started_at)),
+        node.last_progress_at
+            .map(|at| format_duration(now.saturating_sub(at)))
+            .unwrap_or_else(|| "—".to_string()),
+        node.state.label(),
+        prefix,
+        connector,
+        truncate(&node.label, COMMAND_WIDTH),
+    ));
+    if let Some(child_ids) = children.get(&Some(id)) {
+        let child_prefix = match branch {
+            None => String::new(),
+            Some(true) => format!("{prefix}  "),
+            Some(false) => format!("{prefix}│ "),
+        };
+        for (position, child_id) in child_ids.iter().enumerate() {
+            let last = position + 1 == child_ids.len();
+            render_node(
+                child_id,
+                &child_prefix,
+                Some(last),
+                index,
+                children,
+                now,
+                output,
+            );
+        }
+    }
+}
+
+fn format_rate(rate: f64) -> String {
+    if rate > 0.0 && rate < 0.1 {
+        format!("{rate:.2}")
+    } else {
+        format!("{rate:.1}")
+    }
+}
+
+fn format_duration(seconds: i64) -> String {
+    let seconds = seconds.max(0) as u64;
+    if seconds < 60 {
+        format!("{seconds}s")
+    } else if seconds < 3_600 {
+        format!("{}m", seconds / 60)
+    } else if seconds < 86_400 {
+        format!("{}h", seconds / 3_600)
+    } else {
+        format!("{}d", seconds / 86_400)
+    }
+}
+
+fn kernel_state_label(state: &str) -> &'static str {
+    match state.chars().next() {
+        Some('R') => "running",
+        Some('S' | 'I') => "sleeping",
+        Some('T') => "stopped",
+        Some('U' | 'D') => "blocked",
+        Some('Z') => "zombie",
+        _ => "unknown",
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{
-        add_ledger_tokens, parse_lsof_workspaces, parse_processes, read_turn_spend,
-        render_dashboard, ProcessKind, RunningProcess, WINDOW_MINUTES,
-    };
-    use crate::store::{sqlite::SqliteStore, TurnSpendRow};
+    use super::*;
 
-    fn spend(recorded_at: i64, output: i64, provider: &str) -> TurnSpendRow {
-        TurnSpendRow {
-            turn_id: format!("turn-{recorded_at}"),
-            invocation_id: "invocation".to_string(),
-            trace_id: "trace".to_string(),
-            exec_id: "exec".to_string(),
+    fn run_event(
+        trace: &str,
+        exec: &str,
+        parent: Option<&str>,
+        at: i64,
+        event: &str,
+        command: &str,
+    ) -> RunEventRow {
+        RunEventRow {
+            run_id: trace.to_string(),
+            process_id: exec.to_string(),
+            parent_process_id: parent.map(str::to_string),
+            seq: 0,
+            ts: at,
+            repo: Some("/src/loopflow".to_string()),
+            worktree: Some("/src/loopflow".to_string()),
+            wave: None,
+            node: "run".to_string(),
+            event: event.to_string(),
+            command: Some(serde_json::to_string(&["lf", command]).unwrap()),
+            flow: None,
+            skill: None,
+            step_index: None,
+            error: None,
+        }
+    }
+
+    fn launch(id: &str, exec: &str, provider: &str, started_at: i64) -> AgentInvocationRow {
+        AgentInvocationRow {
+            id: id.to_string(),
+            run_id: "trace".to_string(),
+            answer_ask_id: None,
+            process_id: exec.to_string(),
+            started_at,
+            ended_at: None,
             repo: "/src/loopflow".to_string(),
+            worktree: "/src/loopflow".to_string(),
             wave: None,
             flow: None,
             skill: None,
+            project: None,
+            task: None,
             provider: provider.to_string(),
             model: None,
-            at: recorded_at,
-            input_tokens: Some(0),
-            output_tokens: Some(output),
-            cache_read_tokens: Some(0),
+            surface: "cli".to_string(),
+            capture_status: "capturing".to_string(),
+            incomplete_reason: None,
+            outcome: "running".to_string(),
+            artifact_dir: format!("trace/{id}"),
+            conversation_path: format!("trace/{id}/conversation.jsonl"),
+            provider_events_path: None,
+            provider_session_id: None,
+            provider_session_path: None,
+            conversation_event_count: 0,
+            conversation_bytes: 0,
+            supervision: None,
+        }
+    }
+
+    fn turn(
+        id: &str,
+        launch: &str,
+        started_at: i64,
+        ended_at: Option<i64>,
+        output: Option<i64>,
+    ) -> AgentTurnRow {
+        AgentTurnRow {
+            id: id.to_string(),
+            invocation_id: launch.to_string(),
+            ordinal: 1,
+            provider_turn_id: None,
+            started_at,
+            ended_at,
+            status: if ended_at.is_some() {
+                "completed"
+            } else {
+                "running"
+            }
+            .to_string(),
+            input_op: "initial".to_string(),
+            context_coverage: "assembled".to_string(),
+            tokenizer: "cl100k_base".to_string(),
+            system_prompt_path: None,
+            task_prompt_path: "task.md".to_string(),
+            system_tokens: 0,
+            task_tokens: 0,
+            supplied_context_tokens: 0,
+            provider_input_tokens: None,
+            provider_total_input_tokens: None,
+            peak_input_tokens: None,
+            context_window_tokens: None,
+            provider_output_tokens: output,
+            reasoning_tokens: None,
+            cache_read_tokens: None,
+            cache_write_tokens: None,
             cost_usd: None,
+            context_gather_ms: 0,
+            context_render_ms: 0,
+            context_persist_ms: 0,
+            first_event_seq: None,
+            last_event_seq: None,
+            root_output: None,
+            basis: None,
+        }
+    }
+
+    fn process(pid: u32, ppid: u32, started_at: i64, command: &str) -> OsProcess {
+        OsProcess {
+            pid,
+            ppid,
+            process_group: pid,
+            started_at,
+            kernel_state: "S".to_string(),
+            command: command.to_string(),
+            kind: process_kind(command),
+        }
+    }
+
+    fn receipt(exec: &str, pid: u32, started_at: i64) -> ExecProcessReceipt {
+        ExecProcessReceipt {
+            schema_version: 1,
+            trace_id: "trace".to_string(),
+            exec_id: exec.to_string(),
+            pid,
+            started_at,
+        }
+    }
+
+    fn sortable_node(id: &str, tokens: u64, fast: u64) -> ActivityNode {
+        let mut cumulative = OutputActivity {
+            measured_output_tokens: tokens,
+            output_tokens_fast: fast,
+            ..OutputActivity::default()
+        };
+        cumulative.finish_rates();
+        ActivityNode {
+            id: id.to_string(),
+            parent_id: None,
+            kind: ActivityNodeKind::Exec,
+            label: id.to_string(),
+            pid: None,
+            started_at: 0,
+            last_progress_at: None,
+            state: ActivityState::Waiting,
+            direct: OutputActivity::default(),
+            cumulative,
         }
     }
 
     #[test]
-    fn telemetry_reader_ignores_newer_migration_history_without_writing() {
-        let directory = tempfile::tempdir().unwrap();
-        let path = directory.path().join("loopflow.db");
-        drop(SqliteStore::new(&path).unwrap());
-        let connection = rusqlite::Connection::open(&path).unwrap();
-        connection
-            .execute(
-                "INSERT INTO schema_migrations (version, applied_at)
-                 VALUES ('99.99.999_future', unixepoch())",
-                [],
-            )
-            .unwrap();
-        drop(connection);
-
-        // `lf top` reads a ledger a newer `lf` may have migrated past. It must
-        // answer from what it can read, and must not migrate anything away.
-        read_turn_spend(&path, 0).unwrap();
-
-        let connection = rusqlite::Connection::open(&path).unwrap();
-        assert_eq!(
-            connection
-                .query_row(
-                    "SELECT COUNT(*) FROM schema_migrations WHERE version = '99.99.999_future'",
-                    [],
-                    |row| row.get::<_, i64>(0),
-                )
-                .unwrap(),
-            1
-        );
-    }
-
-    #[test]
-    fn ledger_buckets_every_provider_turn() {
+    fn call_tree_folds_completed_tokens_and_exact_rates_once() {
         let now = 10_000;
-        let mut buckets = [0; WINDOW_MINUTES];
-        add_ledger_tokens(
-            &mut buckets,
-            &[
-                spend(now - 3_599, 30, "claude"),
-                spend(now - 1, 60, "gemini"),
-                spend(now, 90, "codex"),
-                spend(now - 3_600, 9_999, "claude"),
+        let mut completed_launch = launch("launch-finished", "exec-5whys", "codex", 500);
+        completed_launch.ended_at = Some(now - 100);
+        completed_launch.outcome = "completed".to_string();
+        let data = ActivityData {
+            events: vec![
+                run_event("trace", "exec-5whys", None, 1_000, "started", "5whys"),
+                run_event(
+                    "trace",
+                    "exec-implement",
+                    Some("exec-5whys"),
+                    2_000,
+                    "started",
+                    "implement",
+                ),
             ],
-            now,
-        );
+            launches: vec![
+                launch("launch-5whys", "exec-5whys", "codex", 1_000),
+                launch("launch-implement", "exec-implement", "codex", 2_000),
+                completed_launch,
+            ],
+            turns: vec![
+                turn("turn-a", "launch-5whys", 1_000, Some(now - 600), Some(300)),
+                turn(
+                    "turn-b",
+                    "launch-implement",
+                    9_000,
+                    Some(now - 60),
+                    Some(600),
+                ),
+                turn("turn-open", "launch-implement", now - 30, None, None),
+                turn(
+                    "turn-finished",
+                    "launch-finished",
+                    now - 200,
+                    Some(now - 100),
+                    Some(5_000),
+                ),
+            ],
+        };
+        let processes = ProcessSnapshot {
+            processes: vec![
+                process(10, 1, 1_000, "lf 5whys"),
+                process(11, 10, 1_001, "codex app-server"),
+                process(20, 10, 2_000, "lf implement"),
+                process(30, 20, 2_001, "codex app-server"),
+            ],
+            receipts: vec![
+                receipt("exec-5whys", 10, 1_000),
+                receipt("exec-implement", 20, 2_000),
+            ],
+            opencode_servers: Vec::new(),
+        };
 
-        assert_eq!(buckets[0], 30);
-        assert_eq!(buckets[WINDOW_MINUTES - 1], 150);
-        assert_eq!(buckets.iter().sum::<u64>(), 180);
+        let snapshot = collect_activity(data, processes, now).unwrap();
+        let root = snapshot
+            .nodes
+            .iter()
+            .find(|node| node.id == "exec:exec-5whys")
+            .unwrap();
+        assert_eq!(root.cumulative.measured_output_tokens, 900);
+        assert_eq!(root.cumulative.output_tokens_fast, 600);
+        assert_eq!(root.cumulative.output_tokens_slow, 900);
+        assert_eq!(root.cumulative.unmeasured_turns, 1);
+        assert_eq!(root.state, ActivityState::Working);
+        assert_eq!(snapshot.aggregate.measured_output_tokens, 900);
+        assert_eq!(snapshot.aggregate.unmeasured_turns, 1);
+        assert!(!snapshot
+            .nodes
+            .iter()
+            .any(|node| node.id == "launch:launch-finished"));
+        assert!(snapshot.provider_processes.is_empty());
+        let json = serde_json::to_string(&snapshot).unwrap();
+        assert_eq!(
+            serde_json::from_str::<ActivitySnapshot>(&json).unwrap(),
+            snapshot
+        );
+        let rendered = render_snapshot(&snapshot, ActivitySort::Tokens);
+        assert!(rendered.contains("lf 5whys"));
+        assert!(rendered.contains("lf implement"));
+        assert!(rendered.contains("codex 30"));
+        assert!(rendered.contains("├─"));
+        assert!(rendered.contains("└─"));
+        assert!(!rendered.contains("\x1b"));
     }
 
     #[test]
-    fn dashboard_shows_rate_summary_and_live_processes() {
-        let mut buckets = [0; WINDOW_MINUTES];
-        buckets[WINDOW_MINUTES - 1] = 120;
-        let rendered = render_dashboard(
-            &buckets,
-            &[RunningProcess {
-                pid: 42,
-                elapsed: "01:12".to_string(),
-                kind: ProcessKind::Lf,
-                command: "lf __work task tsk_123".to_string(),
-                workspace: None,
+    fn dead_and_unknown_calls_are_absent_while_registered_orphans_remain_visible() {
+        let now = 10_000;
+        let data = ActivityData {
+            events: vec![
+                run_event("trace", "dead", None, 1_000, "started", "old"),
+                run_event("trace", "unknown", None, 2_000, "started", "legacy"),
+            ],
+            launches: Vec::new(),
+            turns: Vec::new(),
+        };
+        let processes = ProcessSnapshot {
+            processes: vec![process(99, 1, 1_000, "opencode serve --port 1234")],
+            receipts: vec![receipt("dead", 88, 1_000)],
+            opencode_servers: vec![OpenCodeServerEntry {
+                opencode_pid: 99,
+                owner_loopflow_pid: 88,
             }],
-        );
+        };
 
-        assert!(rendered.contains("LOOPFLOW THROUGHPUT · LAST 60 MINUTES"));
-        assert!(rendered.contains("persisted provider Turn output tokens/s"));
-        assert!(rendered
-            .contains("total 120 tokens · avg 0.03 tok/s · peak 2.0 tok/s · current 2.0 tok/s"));
-        assert!(rendered.contains("RUNNING LF + PROVIDER PROCESSES (1)"));
-        assert!(rendered.contains("42  01:12"));
-        assert!(rendered.contains("lf __work task tsk_123"));
+        let snapshot = collect_activity(data, processes, now).unwrap();
+        assert!(snapshot.nodes.is_empty());
+        assert_eq!(snapshot.aggregate.measured_output_tokens, 0);
+        assert_eq!(
+            snapshot.provider_processes[0].claim,
+            ProviderClaim::Orphaned
+        );
+        assert_eq!(snapshot.provider_processes[0].command, "opencode serve");
+        let rendered = render_snapshot(&snapshot, ActivitySort::Tokens);
+        assert!(rendered.contains("not counted above"));
+        assert!(rendered.contains("unclaimed = no exact Loopflow receipt"));
+        assert!(rendered.contains("sleeping"));
     }
 
     #[test]
-    fn process_snapshot_keeps_lf_and_provider_commands() {
+    fn process_parser_rejects_opencode_helpers_that_are_not_servers() {
         let processes = parse_processes(
-            "  10  01:00 /usr/local/bin/lf wave infrastructure\n  11  00:01 /usr/bin/ps -axo pid=,etime=,command=\n  12  00:02 lf top\n  13  00:03 /bin/zsh -lc lf task run INF-1\n  14  02:00 lf __work task tsk_123\n  15  03:00 /opt/codex app-server\n",
-            12,
+            "10 1 10 S 01:00 opencode serve --port 3000\n11 1 11 S 02:00 opencode run yaml-language-server\n",
+            10_000,
         );
 
-        assert_eq!(
-            processes,
-            vec![
-                RunningProcess {
-                    pid: 15,
-                    elapsed: "03:00".to_string(),
-                    kind: ProcessKind::Codex,
-                    command: "/opt/codex app-server".to_string(),
-                    workspace: None,
-                },
-                RunningProcess {
-                    pid: 14,
-                    elapsed: "02:00".to_string(),
-                    kind: ProcessKind::Lf,
-                    command: "lf __work task tsk_123".to_string(),
-                    workspace: None,
-                },
-                RunningProcess {
-                    pid: 10,
-                    elapsed: "01:00".to_string(),
-                    kind: ProcessKind::Lf,
-                    command: "/usr/local/bin/lf wave infrastructure".to_string(),
-                    workspace: None,
-                },
-            ]
-        );
-    }
-
-    // `lf top` is the machine-health view of the exact tree the OpenCode
-    // reaper manages: the `lf __resident` body, the `opencode serve` provider
-    // leader, and the descendants (MCP servers, model proxies) that live in the
-    // server's process group. The snapshot must keep the leader — that is the
-    // unit the reaper reaps, and showing it is accurate evidence of an orphan
-    // before a resident's boot sweep takes it down — and must filter the
-    // descendants, so the view never double-counts the tree as separate
-    // providers. After a reap the leader line disappears; this is the
-    // classification that keeps that honest.
-    #[test]
-    fn process_snapshot_classifies_the_opencode_tree_the_reaper_manages() {
-        let processes = parse_processes(
-            "  20  05:00 /usr/local/bin/lf __resident infrastructure\n  21  04:59 /usr/local/bin/opencode serve --port 33421\n  22  04:58 node /Users/jack/.opencode/mcp-servers/filesystem.js\n  23  04:57 /usr/bin/python -m opencode_proxy\n  24  00:01 /bin/ps -axo pid=,etime=,command=\n",
-            24,
-        );
-
-        assert_eq!(
-            processes,
-            vec![
-                RunningProcess {
-                    pid: 20,
-                    elapsed: "05:00".to_string(),
-                    kind: ProcessKind::Lf,
-                    command: "/usr/local/bin/lf __resident infrastructure".to_string(),
-                    workspace: None,
-                },
-                RunningProcess {
-                    pid: 21,
-                    elapsed: "04:59".to_string(),
-                    kind: ProcessKind::OpenCode,
-                    command: "/usr/local/bin/opencode serve --port 33421".to_string(),
-                    workspace: None,
-                },
-            ]
-        );
+        assert_eq!(processes[0].kind, Some(ProcessKind::OpenCode));
+        assert_eq!(processes[1].kind, None);
     }
 
     #[test]
-    fn process_workspaces_use_each_provider_cwd() {
-        let workspaces = parse_lsof_workspaces(
-            "p15\nfcwd\nn/Users/jack/src/loopflow.context-lab\np16\nfcwd\nn/Users/jack/src/manabot\n",
-        );
+    fn prune_targets_only_dead_receipts_and_registered_orphan_groups() {
+        let snapshot = ProcessSnapshot {
+            processes: vec![
+                process(10, 1, 1_000, "lf wave core"),
+                process(99, 1, 2_000, "opencode serve --port 1234"),
+                process(100, 1, 2_000, "codex app-server"),
+            ],
+            receipts: vec![receipt("live", 10, 1_000), receipt("dead", 88, 1_000)],
+            opencode_servers: vec![OpenCodeServerEntry {
+                opencode_pid: 99,
+                owner_loopflow_pid: 88,
+            }],
+        };
 
-        assert_eq!(
-            workspaces.get(&15).map(String::as_str),
-            Some("loopflow.context-lab")
-        );
-        assert_eq!(workspaces.get(&16).map(String::as_str), Some("manabot"));
+        let (receipts, process_groups) = resolve_prune_targets(&snapshot);
+
+        assert_eq!(receipts, [88]);
+        assert_eq!(process_groups, [99]);
+    }
+
+    #[test]
+    fn sibling_sort_uses_the_other_metric_before_stable_id() {
+        let nodes = [
+            sortable_node("a", 100, 20),
+            sortable_node("b", 200, 10),
+            sortable_node("c", 200, 20),
+        ];
+        let index = nodes
+            .iter()
+            .map(|node| (node.id.as_str(), node))
+            .collect::<HashMap<_, _>>();
+
+        let mut by_tokens = vec!["a", "b", "c"];
+        sort_node_ids(&mut by_tokens, &index, ActivitySort::Tokens);
+        assert_eq!(by_tokens, ["c", "b", "a"]);
+
+        let mut by_rate = vec!["a", "b", "c"];
+        sort_node_ids(&mut by_rate, &index, ActivitySort::Rate5m);
+        assert_eq!(by_rate, ["c", "a", "b"]);
     }
 }

--- a/rust/loopflow/src/lf/mod.rs
+++ b/rust/loopflow/src/lf/mod.rs
@@ -364,8 +364,33 @@ pub enum Commands {
         #[arg(long)]
         json: bool,
     },
-    /// Graph output-token throughput for the last hour and show running lf processes
-    Top,
+    /// Print one parseable snapshot of live Loopflow call trees
+    Ps {
+        /// Emit the versioned activity snapshot as JSON
+        #[arg(long)]
+        json: bool,
+        /// Rank siblings by cumulative completed tokens or five-minute rate
+        #[arg(long, value_enum, default_value_t)]
+        sort: commands::top::ActivitySort,
+    },
+    /// Refresh live Loopflow call trees on a terminal; print once when redirected
+    Top {
+        /// Emit one versioned activity snapshot as JSON
+        #[arg(long)]
+        json: bool,
+        /// Rank siblings by cumulative completed tokens or five-minute rate
+        #[arg(long, value_enum, default_value = "rate-5m")]
+        sort: commands::top::ActivitySort,
+    },
+    /// Reap registered orphan providers and remove dead process receipts
+    Prune {
+        /// Show exact targets without changing process or receipt state
+        #[arg(long)]
+        dry_run: bool,
+        /// Emit the versioned prune report as JSON
+        #[arg(long)]
+        json: bool,
+    },
     /// Inspect supplied agent context and its contributing assets
     Context {
         /// Window in days
@@ -2253,7 +2278,33 @@ mod tests {
     #[test]
     fn top_is_a_first_class_machine_dashboard() {
         let cli = Cli::try_parse_from(["lf", "top"]).expect("parse top");
-        assert!(matches!(cli.command, Some(Commands::Top)));
+        assert!(matches!(
+            cli.command,
+            Some(Commands::Top {
+                json: false,
+                sort: commands::top::ActivitySort::Rate5m,
+            })
+        ));
+
+        let cli =
+            Cli::try_parse_from(["lf", "ps", "--json", "--sort", "tokens"]).expect("parse ps");
+        assert!(matches!(
+            cli.command,
+            Some(Commands::Ps {
+                json: true,
+                sort: commands::top::ActivitySort::Tokens,
+            })
+        ));
+
+        let cli = Cli::try_parse_from(["lf", "prune", "--dry-run", "--json"])
+            .expect("parse process prune");
+        assert!(matches!(
+            cli.command,
+            Some(Commands::Prune {
+                dry_run: true,
+                json: true,
+            })
+        ));
     }
 
     #[test]

--- a/rust/loopflow/src/store/mod.rs
+++ b/rust/loopflow/src/store/mod.rs
@@ -129,6 +129,45 @@ pub(crate) fn production_database_path() -> PathBuf {
     machine_home_dir().join(".lf/loopflow.db")
 }
 
+/// Resolve the live Home evidence store for read-only operator surfaces.
+///
+/// Development builds normally isolate writes under `.lf-dev/worktrees`.
+/// Observability is different: it must describe the Home that launched the
+/// process, and opening it through `open_run_ledger_read_only` cannot migrate
+/// or otherwise mutate its schema. Explicit control authority wins, followed
+/// by an ordinary override, then the installed Home.
+pub(crate) fn observability_home_dir() -> PathBuf {
+    std::env::var_os(CONTROL_HOME_ENV)
+        .or_else(|| std::env::var_os("LF_HOME"))
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+        .unwrap_or_else(|| machine_home_dir().join(".lf"))
+}
+
+pub(crate) fn observability_database_path() -> Result<PathBuf, std::io::Error> {
+    let home = observability_home_dir();
+    let candidate = std::env::var_os(CONTROL_DB_PATH_ENV)
+        .or_else(|| std::env::var_os("LF_DB_PATH"))
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+        .unwrap_or_else(|| home.join("loopflow.db"));
+    if candidate.is_absolute() {
+        return Ok(candidate);
+    }
+    if candidate.components().any(|component| {
+        matches!(
+            component,
+            Component::ParentDir | Component::RootDir | Component::Prefix(_)
+        )
+    }) {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "observability database path must not escape its Home",
+        ));
+    }
+    Ok(home.join(candidate))
+}
+
 pub(crate) fn read_nonterminal_task_worktrees(path: &Path) -> StoreResult<Vec<PathBuf>> {
     sqlite::read_nonterminal_task_worktrees(path)
 }

--- a/rust/loopflow/src/store/sqlite.rs
+++ b/rust/loopflow/src/store/sqlite.rs
@@ -410,6 +410,38 @@ impl SqliteStore {
         })
     }
 
+    /// Run several ledger queries against one SQLite read snapshot.
+    ///
+    /// The store must not be cloned into the closure: each query briefly takes
+    /// the same connection lock while the connection-level transaction stays
+    /// open. Observability callers create a private read-only store for this
+    /// operation, so no unrelated reader can join the transaction.
+    pub(crate) fn read_run_ledger_snapshot<T>(
+        &self,
+        read: impl FnOnce(&Self) -> StoreResult<T>,
+    ) -> StoreResult<T> {
+        {
+            let conn = self.conn.lock().expect("store mutex poisoned");
+            conn.execute_batch("BEGIN DEFERRED TRANSACTION")?;
+        }
+        let result = read(self);
+        let finish = {
+            let conn = self.conn.lock().expect("store mutex poisoned");
+            if result.is_ok() {
+                conn.execute_batch("COMMIT")
+            } else {
+                conn.execute_batch("ROLLBACK")
+            }
+        };
+        match result {
+            Ok(value) => {
+                finish?;
+                Ok(value)
+            }
+            Err(error) => Err(error),
+        }
+    }
+
     pub fn put_pm_snapshot(&self, snapshot: &PmSnapshotRow) -> StoreResult<()> {
         let conn = self.conn.lock().expect("store mutex poisoned");
         conn.execute(

--- a/scripts/dev-lf
+++ b/scripts/dev-lf
@@ -33,7 +33,11 @@ run_dev_lf() {
         set -e
         set -o pipefail
 
-        export RUST_LOG="${RUST_LOG:-lf=debug,loopflow=debug}"
+        if [[ -z "${RUST_LOG:-}" && ( "${1:-}" == "ps" || "${1:-}" == "top" || "${1:-}" == "prune" ) ]]; then
+            export RUST_LOG="lf=info,loopflow=info"
+        else
+            export RUST_LOG="${RUST_LOG:-lf=debug,loopflow=debug}"
+        fi
         cargo build -p loopflow --bin lf --manifest-path "$repo/Cargo.toml" </dev/null 2>&1 |
             grep -E '^   Compiling|^    Finished|^error' >&2
         echo "running: $repo/target/debug/lf $*" >&2

--- a/tests/goldens/basic.md
+++ b/tests/goldens/basic.md
@@ -99,10 +99,20 @@ Task with `--stack-on <parent-task>`. Do not rotate the parent Task onto a secon
 simultaneously open PR; its multi-PR history remains serial. The child binds to
 the parent's active PR at launch and never follows later serial PRs implicitly.
 
-When work feels slow or stuck, run `lf top` before guessing. It shows provider-
-reported output-token throughput for the last hour and the currently running
-`lf` and provider processes; use it as machine-health evidence, not as a
-lifecycle control.
+When work feels slow or stuck, run `lf top` before guessing. It continuously
+ranks OS-live Loopflow call trees by five-minute completed-output throughput and
+shows cumulative tokens, age, idle time, health, and provider PIDs. Completed
+calls and launches disappear. Use it as machine-health evidence, not as a
+lifecycle control. Use `lf ps --json` for one stable, parseable frame;
+redirected `lf top` also emits once without ANSI. Both commands read the live
+Home's ledger and ownership registry without migrating or writing them,
+including when invoked through `scripts/dev-lf`.
+
+Rates count provider-reported output only when a Turn ends; they are completion
+throughput, not decoding speed. Time alone never means dead. `lf prune
+--dry-run` lists the separate cleanup boundary; plain `lf prune` removes dead
+Exec receipts and reaps registered orphan OpenCode process groups. Never kill
+an `unclaimed` provider PID from `lf ps`: ownership is not proven.
 
 ## Inspect
 

--- a/tests/goldens/builtin_debug.md
+++ b/tests/goldens/builtin_debug.md
@@ -99,10 +99,20 @@ Task with `--stack-on <parent-task>`. Do not rotate the parent Task onto a secon
 simultaneously open PR; its multi-PR history remains serial. The child binds to
 the parent's active PR at launch and never follows later serial PRs implicitly.
 
-When work feels slow or stuck, run `lf top` before guessing. It shows provider-
-reported output-token throughput for the last hour and the currently running
-`lf` and provider processes; use it as machine-health evidence, not as a
-lifecycle control.
+When work feels slow or stuck, run `lf top` before guessing. It continuously
+ranks OS-live Loopflow call trees by five-minute completed-output throughput and
+shows cumulative tokens, age, idle time, health, and provider PIDs. Completed
+calls and launches disappear. Use it as machine-health evidence, not as a
+lifecycle control. Use `lf ps --json` for one stable, parseable frame;
+redirected `lf top` also emits once without ANSI. Both commands read the live
+Home's ledger and ownership registry without migrating or writing them,
+including when invoked through `scripts/dev-lf`.
+
+Rates count provider-reported output only when a Turn ends; they are completion
+throughput, not decoding speed. Time alone never means dead. `lf prune
+--dry-run` lists the separate cleanup boundary; plain `lf prune` removes dead
+Exec receipts and reaps registered orphan OpenCode process groups. Never kill
+an `unclaimed` provider PID from `lf ps`: ownership is not proven.
 
 ## Inspect
 

--- a/tests/goldens/builtin_implement.md
+++ b/tests/goldens/builtin_implement.md
@@ -99,10 +99,20 @@ Task with `--stack-on <parent-task>`. Do not rotate the parent Task onto a secon
 simultaneously open PR; its multi-PR history remains serial. The child binds to
 the parent's active PR at launch and never follows later serial PRs implicitly.
 
-When work feels slow or stuck, run `lf top` before guessing. It shows provider-
-reported output-token throughput for the last hour and the currently running
-`lf` and provider processes; use it as machine-health evidence, not as a
-lifecycle control.
+When work feels slow or stuck, run `lf top` before guessing. It continuously
+ranks OS-live Loopflow call trees by five-minute completed-output throughput and
+shows cumulative tokens, age, idle time, health, and provider PIDs. Completed
+calls and launches disappear. Use it as machine-health evidence, not as a
+lifecycle control. Use `lf ps --json` for one stable, parseable frame;
+redirected `lf top` also emits once without ANSI. Both commands read the live
+Home's ledger and ownership registry without migrating or writing them,
+including when invoked through `scripts/dev-lf`.
+
+Rates count provider-reported output only when a Turn ends; they are completion
+throughput, not decoding speed. Time alone never means dead. `lf prune
+--dry-run` lists the separate cleanup boundary; plain `lf prune` removes dead
+Exec receipts and reaps registered orphan OpenCode process groups. Never kill
+an `unclaimed` provider PID from `lf ps`: ownership is not proven.
 
 ## Inspect
 

--- a/tests/goldens/builtin_review_slice.md
+++ b/tests/goldens/builtin_review_slice.md
@@ -99,10 +99,20 @@ Task with `--stack-on <parent-task>`. Do not rotate the parent Task onto a secon
 simultaneously open PR; its multi-PR history remains serial. The child binds to
 the parent's active PR at launch and never follows later serial PRs implicitly.
 
-When work feels slow or stuck, run `lf top` before guessing. It shows provider-
-reported output-token throughput for the last hour and the currently running
-`lf` and provider processes; use it as machine-health evidence, not as a
-lifecycle control.
+When work feels slow or stuck, run `lf top` before guessing. It continuously
+ranks OS-live Loopflow call trees by five-minute completed-output throughput and
+shows cumulative tokens, age, idle time, health, and provider PIDs. Completed
+calls and launches disappear. Use it as machine-health evidence, not as a
+lifecycle control. Use `lf ps --json` for one stable, parseable frame;
+redirected `lf top` also emits once without ANSI. Both commands read the live
+Home's ledger and ownership registry without migrating or writing them,
+including when invoked through `scripts/dev-lf`.
+
+Rates count provider-reported output only when a Turn ends; they are completion
+throughput, not decoding speed. Time alone never means dead. `lf prune
+--dry-run` lists the separate cleanup boundary; plain `lf prune` removes dead
+Exec receipts and reaps registered orphan OpenCode process groups. Never kill
+an `unclaimed` provider PID from `lf ps`: ownership is not proven.
 
 ## Inspect
 

--- a/tests/goldens/with_direction.md
+++ b/tests/goldens/with_direction.md
@@ -99,10 +99,20 @@ Task with `--stack-on <parent-task>`. Do not rotate the parent Task onto a secon
 simultaneously open PR; its multi-PR history remains serial. The child binds to
 the parent's active PR at launch and never follows later serial PRs implicitly.
 
-When work feels slow or stuck, run `lf top` before guessing. It shows provider-
-reported output-token throughput for the last hour and the currently running
-`lf` and provider processes; use it as machine-health evidence, not as a
-lifecycle control.
+When work feels slow or stuck, run `lf top` before guessing. It continuously
+ranks OS-live Loopflow call trees by five-minute completed-output throughput and
+shows cumulative tokens, age, idle time, health, and provider PIDs. Completed
+calls and launches disappear. Use it as machine-health evidence, not as a
+lifecycle control. Use `lf ps --json` for one stable, parseable frame;
+redirected `lf top` also emits once without ANSI. Both commands read the live
+Home's ledger and ownership registry without migrating or writing them,
+including when invoked through `scripts/dev-lf`.
+
+Rates count provider-reported output only when a Turn ends; they are completion
+throughput, not decoding speed. Time alone never means dead. `lf prune
+--dry-run` lists the separate cleanup boundary; plain `lf prune` removes dead
+Exec receipts and reaps registered orphan OpenCode process groups. Never kill
+an `unclaimed` provider PID from `lf ps`: ownership is not proven.
 
 ## Inspect
 

--- a/tests/goldens/with_docs.md
+++ b/tests/goldens/with_docs.md
@@ -99,10 +99,20 @@ Task with `--stack-on <parent-task>`. Do not rotate the parent Task onto a secon
 simultaneously open PR; its multi-PR history remains serial. The child binds to
 the parent's active PR at launch and never follows later serial PRs implicitly.
 
-When work feels slow or stuck, run `lf top` before guessing. It shows provider-
-reported output-token throughput for the last hour and the currently running
-`lf` and provider processes; use it as machine-health evidence, not as a
-lifecycle control.
+When work feels slow or stuck, run `lf top` before guessing. It continuously
+ranks OS-live Loopflow call trees by five-minute completed-output throughput and
+shows cumulative tokens, age, idle time, health, and provider PIDs. Completed
+calls and launches disappear. Use it as machine-health evidence, not as a
+lifecycle control. Use `lf ps --json` for one stable, parseable frame;
+redirected `lf top` also emits once without ANSI. Both commands read the live
+Home's ledger and ownership registry without migrating or writing them,
+including when invoked through `scripts/dev-lf`.
+
+Rates count provider-reported output only when a Turn ends; they are completion
+throughput, not decoding speed. Time alone never means dead. `lf prune
+--dry-run` lists the separate cleanup boundary; plain `lf prune` removes dead
+Exec receipts and reaps registered orphan OpenCode process groups. Never kill
+an `unclaimed` provider PID from `lf ps`: ownership is not proven.
 
 ## Inspect
 


### PR DESCRIPTION
## Usage

```bash
lf ps
lf ps --json
lf top --sort rate-5m
lf prune --dry-run
```

## Summary

Replaces the historical `lf top` throughput graph with process-exact, live call-tree observability. Operators can now distinguish active, waiting, and stalled work, inspect completed-output rates, and safely identify stale runtime state without treating elapsed time alone as failure.

## Changes

- Added `lf ps` for stable one-shot snapshots, including versioned JSON and configurable sibling sorting
- Made `lf top` refresh live call trees every two seconds on a TTY while preserving single-frame redirected and JSON output
- Added exact Exec process receipts and read-only correlation between the live Home ledger, provider ancestry, and completed Turns
- Added `lf prune` with dry-run support to remove stale receipts and reap only registered orphan OpenCode groups; unclaimed provider processes remain untouched