### PR TITLE
Make local lf schema-complete across migrations

### DIFF
--- a/python/tests/test_install_script.py
+++ b/python/tests/test_install_script.py
@@ -235,8 +235,9 @@ def test_stage_binaries_errors_on_missing_cargo_output(
 
 
 def test_only_canonical_or_tagged_installs_receive_migration_authority(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
+    repo = tmp_path / "repo"
     values = {
         ("rev-parse", "HEAD"): "branch-head",
         ("symbolic-ref", "--quiet", "refs/remotes/origin/HEAD"): "refs/remotes/origin/main",
@@ -250,14 +251,32 @@ def test_only_canonical_or_tagged_installs_receive_migration_authority(
         lambda args, repo=install.ROOT, check=True: values[tuple(args)],
     )
 
-    assert install._migration_authority() == "validation_only"
+    assert install._migration_authority(repo) == "validation_only"
     values[("rev-parse", "HEAD")] = "main-head"
-    assert install._migration_authority() == "published"
+    assert install._migration_authority(repo) == "published"
     values[("rev-parse", "HEAD")] = "tagged-head"
     values[("tag", "--points-at", "HEAD")] = "v0.11.2"
-    assert install._migration_authority() == "published"
+    assert install._migration_authority(repo) == "published"
     values[("status", "--porcelain")] = " M rust/loopflow/src/store/migrations.rs"
-    assert install._migration_authority() == "validation_only"
+    assert install._migration_authority(repo) == "validation_only"
+
+
+def test_promotion_refuses_a_checkout_with_pending_draft_migrations(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    root = tmp_path / "repo"
+    drafts = root / "rust/loopflow/src/store/migrations/drafts"
+    drafts.mkdir(parents=True)
+    (drafts / "run_owns_execution__0123456789abcdef0123456789abcdef.sql").write_text(
+        "SELECT 1;\n"
+    )
+    monkeypatch.setattr(install, "ROOT", root)
+
+    with pytest.raises(
+        install.StageError,
+        match="pending draft migrations: run_owns_execution; cut a release",
+    ):
+        install._promote_with_candidate(root / "lf", tmp_path / "bin")
 
 
 @pytest.mark.parametrize("no_pull", [False, True])

--- a/release/README.md
+++ b/release/README.md
@@ -23,6 +23,9 @@ cat release/SCHEDULE.md      # hosted-build and cron-host release boundaries
 `refresh` is the fast CLI-only path: pull the default branch, rebuild `lf`, and
 install it into the local bin dir.
 
+Promotion stops while draft migrations remain. Cut the release first so the
+binary embeds the schema its runtime code expects.
+
 Use `release/` to keep the rationale and notes for each shipped version close
 to the code.
 

--- a/rust/loopflow/build.rs
+++ b/rust/loopflow/build.rs
@@ -115,6 +115,7 @@ fn emit_build_provenance(manifest_dir: &Path) {
             "LOOPFLOW_MIGRATION_AUTHORITY must be `published` or `validation_only`, got `{migration_authority}`"
         );
     }
+    let pending_migration_drafts = pending_migration_drafts(manifest_dir);
     let source_revision = git_root
         .and_then(|root| {
             Command::new("git")
@@ -163,6 +164,10 @@ fn emit_build_provenance(manifest_dir: &Path) {
     println!("cargo:rustc-env=LOOPFLOW_BUILD_PROVENANCE={provenance}");
     println!("cargo:rustc-env=LOOPFLOW_BUILD_SOURCE_ROOT={}", source_root);
     println!("cargo:rustc-env=LOOPFLOW_MIGRATION_AUTHORITY={migration_authority}");
+    println!(
+        "cargo:rustc-env=LOOPFLOW_PENDING_MIGRATION_DRAFTS={}",
+        pending_migration_drafts.join(",")
+    );
     println!("cargo:rustc-env=LOOPFLOW_BUILD_SOURCE_REVISION={source_revision}");
     println!("cargo:rustc-env=LOOPFLOW_BUILD_VERSION={build_version}");
     println!("cargo:rerun-if-env-changed=LOOPFLOW_BUILD_PROVENANCE");
@@ -191,6 +196,44 @@ fn emit_build_provenance(manifest_dir: &Path) {
             }
         }
     }
+}
+
+fn pending_migration_drafts(manifest_dir: &Path) -> Vec<String> {
+    let drafts_dir = manifest_dir.join("src/store/migrations/drafts");
+    println!("cargo:rerun-if-changed={}", drafts_dir.display());
+    let entries = match fs::read_dir(&drafts_dir) {
+        Ok(entries) => entries,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Vec::new(),
+        Err(error) => panic!(
+            "read migration drafts from {}: {error}",
+            drafts_dir.display()
+        ),
+    };
+    let mut drafts = entries
+        .map(|entry| {
+            entry
+                .unwrap_or_else(|error| {
+                    panic!(
+                        "read migration draft entry from {}: {error}",
+                        drafts_dir.display()
+                    )
+                })
+                .path()
+        })
+        .filter(|path| path.extension().is_some_and(|extension| extension == "sql"))
+        .map(|path| {
+            println!("cargo:rerun-if-changed={}", path.display());
+            let stem = path
+                .file_stem()
+                .and_then(|stem| stem.to_str())
+                .unwrap_or("unreadable_draft");
+            stem.rsplit_once("__")
+                .map_or(stem, |(name, _)| name)
+                .to_string()
+        })
+        .collect::<Vec<_>>();
+    drafts.sort();
+    drafts
 }
 
 fn generate_map(dir: &Path, extension: &str, map_name: &str, out_path: &Path) {

--- a/rust/loopflow/src/build_info.rs
+++ b/rust/loopflow/src/build_info.rs
@@ -157,6 +157,16 @@ pub fn migration_authority() -> MigrationAuthority {
     }
 }
 
+/// Drafts present when this binary was compiled and therefore absent from its registry.
+pub fn pending_migration_drafts() -> Vec<&'static str> {
+    let drafts = env!("LOOPFLOW_PENDING_MIGRATION_DRAFTS");
+    if drafts.is_empty() {
+        Vec::new()
+    } else {
+        drafts.split(',').collect()
+    }
+}
+
 fn parse_provenance(value: &str) -> Option<BuildProvenance> {
     match value {
         "development" => Some(BuildProvenance::Development),
@@ -189,9 +199,9 @@ mod tests {
     use std::process::Command;
 
     use super::{
-        classify_revision, migration_authority, parse_provenance, provenance, short_revision,
-        source_identity_for, source_revision, source_root, BuildFreshness, BuildProvenance,
-        MigrationAuthority, BUILD_VERSION,
+        classify_revision, migration_authority, parse_provenance, pending_migration_drafts,
+        provenance, short_revision, source_identity_for, source_revision, source_root,
+        BuildFreshness, BuildProvenance, MigrationAuthority, BUILD_VERSION,
     };
 
     /// A throwaway `A -> B -> C` repo keeps classifier tests offline.
@@ -340,6 +350,9 @@ mod tests {
             migration_authority(),
             MigrationAuthority::Published | MigrationAuthority::ValidationOnly
         ));
+        assert!(pending_migration_drafts()
+            .iter()
+            .all(|name| !name.is_empty()));
         assert!(!source_revision().is_empty());
         let package_version = env!("CARGO_PKG_VERSION");
         assert!(

--- a/rust/loopflow/src/lf/commands/install.rs
+++ b/rust/loopflow/src/lf/commands/install.rs
@@ -119,11 +119,20 @@ pub struct PromotionPreview {
 /// unit-tested below.
 pub fn decide(
     authority: MigrationAuthority,
+    pending_migration_drafts: &[&str],
     compatibility: &Compatibility,
     active_runs: &[ActiveRun],
 ) -> Verdict {
     let mut reasons = Vec::new();
     let mut migrate = false;
+
+    if !pending_migration_drafts.is_empty() {
+        reasons.push(format!(
+            "candidate build does not embed its complete schema; pending draft migrations: {}; \
+             cut a release before promoting it",
+            pending_migration_drafts.join(", ")
+        ));
+    }
 
     match compatibility {
         Compatibility::Unreadable { reason } => reasons.push(format!(
@@ -330,7 +339,13 @@ pub fn build_preview(store_path: &Path) -> PromotionPreview {
     let candidate = CandidateIdentity::current();
     let database_path = store_path.display().to_string();
     let (compatibility, active_runs) = read_store_evidence(store_path);
-    let verdict = decide(candidate.authority, &compatibility, &active_runs);
+    let pending_migration_drafts = build_info::pending_migration_drafts();
+    let verdict = decide(
+        candidate.authority,
+        &pending_migration_drafts,
+        &compatibility,
+        &active_runs,
+    );
     PromotionPreview {
         candidate,
         database_path,
@@ -417,9 +432,20 @@ pub fn preflight(json: bool) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use super::{decide, read_active_runs, read_store_evidence, ActiveRun, Compatibility, Verdict};
+    use super::{
+        decide as decide_with_drafts, read_active_runs, read_store_evidence, ActiveRun,
+        Compatibility, Verdict,
+    };
     use crate::build_info::MigrationAuthority::{Published, ValidationOnly};
     use crate::store::migrations::latest_known_version;
+
+    fn decide(
+        authority: crate::build_info::MigrationAuthority,
+        compatibility: &Compatibility,
+        active_runs: &[ActiveRun],
+    ) -> Verdict {
+        decide_with_drafts(authority, &[], compatibility, active_runs)
+    }
 
     fn exact() -> Compatibility {
         Compatibility::Exact {
@@ -447,6 +473,21 @@ mod tests {
     fn an_exact_frontier_promotes_for_either_authority_when_no_runs_are_active() {
         assert_eq!(decide(ValidationOnly, &exact(), &[]), Verdict::Promote);
         assert_eq!(decide(Published, &exact(), &[]), Verdict::Promote);
+    }
+
+    #[test]
+    fn pending_drafts_refuse_promotion_even_at_the_exact_store_frontier() {
+        let Verdict::Reject { reasons } = decide_with_drafts(
+            Published,
+            &["run_owns_execution", "durable_asks"],
+            &exact(),
+            &[],
+        ) else {
+            panic!("runtime code newer than the embedded schema must never become global");
+        };
+        assert_eq!(reasons.len(), 1);
+        assert!(reasons[0].contains("run_owns_execution, durable_asks"));
+        assert!(reasons[0].contains("cut a release"));
     }
 
     #[test]

--- a/rust/loopflow/src/store/migrations.rs
+++ b/rust/loopflow/src/store/migrations.rs
@@ -3751,6 +3751,93 @@ mod tests {
     }
 
     #[test]
+    fn repair_durable_input_timestamp_units_preserves_rows_and_seconds() {
+        const LEGACY_NANOS: i64 = 1_784_521_517_123_456_789;
+        const EXPECTED_SECONDS: i64 = 1_784_521_517;
+        const EARLIEST_VALID_SECOND: i64 = -377_705_116_800;
+        const LATEST_VALID_SECOND: i64 = 253_402_300_799;
+
+        assert!(time::OffsetDateTime::from_unix_timestamp(EARLIEST_VALID_SECOND).is_ok());
+        assert!(time::OffsetDateTime::from_unix_timestamp(EARLIEST_VALID_SECOND - 1).is_err());
+        assert!(time::OffsetDateTime::from_unix_timestamp(LATEST_VALID_SECOND).is_ok());
+        assert!(time::OffsetDateTime::from_unix_timestamp(LATEST_VALID_SECOND + 1).is_err());
+
+        let conn = open();
+        apply_before_draft(&conn, "repair_durable_input_timestamp_units");
+        conn.execute_batch(&format!(
+            "PRAGMA foreign_keys = OFF;
+             INSERT INTO epoch_revisions (epoch_id, rev, kind, source_id, created_at)
+             VALUES
+                 ('epoch_legacy', 0, 'steer', 'steer_legacy', {LEGACY_NANOS}),
+                 ('epoch_legacy', 1, 'tool_response', 'response_legacy', {LEGACY_NANOS}),
+                 ('epoch_seconds', 0, 'steer', 'steer_seconds', {EXPECTED_SECONDS}),
+                 ('epoch_seconds', 1, 'tool_response', 'response_seconds', {EXPECTED_SECONDS}),
+                 ('epoch_seconds', 2, 'evidence', 'latest_valid', {LATEST_VALID_SECOND});
+             INSERT INTO steers (
+                 id, epoch_id, rev, author_kind, author_run_id, text, issued_at
+             ) VALUES
+                 ('steer_legacy', 'epoch_legacy', 0, 'user', NULL, 'legacy', {LEGACY_NANOS}),
+                 ('steer_seconds', 'epoch_seconds', 0, 'user', NULL, 'seconds', {EXPECTED_SECONDS});
+             INSERT INTO tool_responses (
+                 id, epoch_id, rev, request_id, choice, responded_at
+             ) VALUES
+                 ('response_legacy', 'epoch_legacy', 1, 'request_legacy', 'legacy', {LEGACY_NANOS}),
+                 ('response_seconds', 'epoch_seconds', 1, 'request_seconds', 'seconds', {EXPECTED_SECONDS});"
+        ))
+        .unwrap();
+
+        apply_draft(&conn, "repair_durable_input_timestamp_units");
+
+        let timestamp = |table: &str, column: &str, id_column: &str, id: &str| -> i64 {
+            conn.query_row(
+                &format!("SELECT {column} FROM {table} WHERE {id_column}=?1"),
+                [id],
+                |row| row.get(0),
+            )
+            .unwrap()
+        };
+        assert_eq!(
+            timestamp("epoch_revisions", "created_at", "source_id", "steer_legacy"),
+            EXPECTED_SECONDS
+        );
+        assert_eq!(
+            timestamp("steers", "issued_at", "id", "steer_legacy"),
+            EXPECTED_SECONDS
+        );
+        assert_eq!(
+            timestamp("tool_responses", "responded_at", "id", "response_legacy"),
+            EXPECTED_SECONDS
+        );
+        assert_eq!(
+            timestamp("epoch_revisions", "created_at", "source_id", "latest_valid"),
+            LATEST_VALID_SECOND,
+            "an already valid second at the OffsetDateTime boundary is untouched"
+        );
+        assert_eq!(
+            timestamp("steers", "issued_at", "id", "steer_seconds"),
+            EXPECTED_SECONDS
+        );
+        assert_eq!(
+            timestamp("tool_responses", "responded_at", "id", "response_seconds"),
+            EXPECTED_SECONDS
+        );
+        for (table, expected) in [
+            ("epoch_revisions", 5_i64),
+            ("steers", 2_i64),
+            ("tool_responses", 2_i64),
+        ] {
+            assert_eq!(
+                conn.query_row(&format!("SELECT COUNT(*) FROM {table}"), [], |row| {
+                    row.get::<_, i64>(0)
+                })
+                .unwrap(),
+                expected,
+                "the repair must preserve every {table} row"
+            );
+        }
+    }
+
+    #[test]
     fn wave_promotion_occurrence_does_not_backfill_existing_ancestry() {
         let conn = open();
         apply_before_draft(&conn, "wave_promotion_occurrence");

--- a/rust/loopflow/src/store/migrations/drafts/repair_durable_input_timestamp_units__01c2d06b29a984ae8b26fea3e5f4cd51.sql
+++ b/rust/loopflow/src/store/migrations/drafts/repair_durable_input_timestamp_units__01c2d06b29a984ae8b26fea3e5f4cd51.sql
@@ -1,0 +1,18 @@
+-- name: repair_durable_input_timestamp_units
+-- id: 01c2d06b29a984ae8b26fea3e5f4cd51
+-- depends_on: durable_input_spine
+
+-- `0.11.031_durable_input_spine` copied legacy nanosecond timestamps into
+-- columns read as Unix seconds. Preserve every row and normalize only values
+-- that cannot already be represented as an OffsetDateTime Unix second.
+UPDATE epoch_revisions
+SET created_at = created_at / 1000000000
+WHERE created_at < -377705116800 OR created_at > 253402300799;
+
+UPDATE steers
+SET issued_at = issued_at / 1000000000
+WHERE issued_at < -377705116800 OR issued_at > 253402300799;
+
+UPDATE tool_responses
+SET responded_at = responded_at / 1000000000
+WHERE responded_at < -377705116800 OR responded_at > 253402300799;

--- a/scripts/install.py
+++ b/scripts/install.py
@@ -332,6 +332,17 @@ def _stage_binaries(local_bin: Path) -> None:
     _atomic_install(ROOT / "target" / "release" / "lf", local_bin / "lf")
 
 
+def _require_complete_schema_for_promotion(repo: Path) -> None:
+    drafts = sorted((repo / "rust/loopflow/src/store/migrations/drafts").glob("*.sql"))
+    if not drafts:
+        return
+    names = ", ".join(path.stem.rsplit("__", 1)[0] for path in drafts)
+    raise StageError(
+        f"refusing to promote with pending draft migrations: {names}; "
+        "cut a release so the binary embeds the schema its runtime code requires"
+    )
+
+
 def _promote_with_candidate(
     candidate: Path,
     install_dir: Path,
@@ -339,6 +350,7 @@ def _promote_with_candidate(
     applications_dir: Path | None = None,
 ) -> None:
     """Delegate every machine-global mutation to the freshly built lf."""
+    _require_complete_schema_for_promotion(ROOT)
     # Resolve the /Applications target at call time so the module global stays
     # authoritative (a def-time default would freeze the real /Applications).
     if applications_dir is None:


### PR DESCRIPTION
## Try it!

```bash
uv run pytest python/tests/test_install_script.py -q
cargo test -p loopflow pending_drafts_refuse_promotion_even_at_the_exact_store_frontier --lib
uv run python scripts/check_migrations.py
```

The installer test shows the early error. The Rust test proves that an exact database frontier still cannot authorize a candidate compiled beside draft migrations. The migration check proves the timestamp repair is a new forward draft and all shipped SQL remains unchanged.

## Intent

A clean-main build replaced the tagged CLI even though its runtime queried draft schema absent from its embedded migration registry. Rolling back exposed nanosecond timestamps copied into durable-input columns read as Unix seconds. This change closes both halves: normalize the durable data forward, and make schema closure a build fact consumed by the promotion authority.

## Assumptions

- Release canonicalization is the only supported boundary that consumes draft migrations into the embedded registry.
- Values outside `time::OffsetDateTime`'s Unix-second range in the three affected columns came from the demonstrated nanosecond copy defect.
- Exact-frontier CLI repair remains valid with active Runs because it does not advance the shared database.

## Key decisions

- Keep source builds available for validation, but reject their promotion while drafts remain.
- Enforce twice: Python names the drafts early; Rust owns the final refusal under the promotion lock.
- Leave candidate preflight JSON backward-compatible so retained release binaries can still be evaluated for rollback.
- Repair only out-of-range timestamps and assert row counts, rather than rewriting every historical value.

## Not included

- Publishing a release or editing an already-applied migration.
- A general SQL query-to-schema analyzer beyond the pending-draft closure demonstrated by this incident.
