### PR TITLE
install: skip unchanged local refreshes

### DIFF
--- a/python/tests/test_install_script.py
+++ b/python/tests/test_install_script.py
@@ -267,9 +267,7 @@ def test_promotion_refuses_a_checkout_with_pending_draft_migrations(
     root = tmp_path / "repo"
     drafts = root / "rust/loopflow/src/store/migrations/drafts"
     drafts.mkdir(parents=True)
-    (drafts / "run_owns_execution__0123456789abcdef0123456789abcdef.sql").write_text(
-        "SELECT 1;\n"
-    )
+    (drafts / "run_owns_execution__0123456789abcdef0123456789abcdef.sql").write_text("SELECT 1;\n")
     monkeypatch.setattr(install, "ROOT", root)
 
     with pytest.raises(
@@ -295,7 +293,12 @@ def test_refresh_routes_default_no_pull_and_custom_dir_through_rust_promotion(
 
     monkeypatch.setattr(install, "ROOT", root)
     monkeypatch.setattr(install, "_build_cli_binaries", lambda: None)
-    monkeypatch.setattr(install, "_refresh_default_branch", refreshed.append)
+
+    def refresh_repo(repo: Path) -> bool:
+        refreshed.append(repo)
+        return True
+
+    monkeypatch.setattr(install, "_refresh_default_branch", refresh_repo)
     monkeypatch.setenv("PROMOTION_LOG", str(log))
     monkeypatch.setenv("PROMOTED_BINARY", str(immutable))
 
@@ -308,6 +311,102 @@ def test_refresh_routes_default_no_pull_and_custom_dir_through_rust_promotion(
     assert f"--cli-target {install_dir / 'lf'}" in command
     assert "--sync-skills" in command
     assert refreshed == ([] if no_pull else [root])
+
+
+def test_refresh_skips_build_and_promotion_when_main_is_unchanged(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    root = tmp_path / "repo"
+    install_dir = tmp_path / "bin"
+    install_dir.mkdir()
+    (install_dir / "lf").write_text("installed")
+    monkeypatch.setattr(install, "ROOT", root)
+    monkeypatch.setattr(install, "_refresh_default_branch", lambda _repo: False)
+    monkeypatch.setattr(
+        install,
+        "_git_stdout",
+        lambda args, repo=install.ROOT, check=True: "abc123" if "--short" in args else "",
+    )
+    monkeypatch.setattr(
+        install,
+        "_build_cli_binaries",
+        lambda: pytest.fail("unchanged refresh must not build"),
+    )
+    monkeypatch.setattr(
+        install,
+        "_promote_with_candidate",
+        lambda *_args: pytest.fail("unchanged refresh must not promote"),
+    )
+
+    install.refresh(no_pull=False, install_dir=install_dir)
+
+    assert "already current: abc123" in capsys.readouterr().out
+
+
+def test_refresh_builds_unchanged_main_when_lf_is_missing(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    root = tmp_path / "repo"
+    candidate = root / "target/release/lf"
+    _write_fake_promotion_boundary(candidate)
+    install_dir = tmp_path / "bin"
+    install_dir.mkdir()
+    log = tmp_path / "promotion.log"
+    immutable = tmp_path / "immutable-lf"
+    built: list[bool] = []
+
+    monkeypatch.setattr(install, "ROOT", root)
+    monkeypatch.setattr(install, "_refresh_default_branch", lambda _repo: False)
+    monkeypatch.setattr(install, "_build_cli_binaries", lambda: built.append(True))
+    monkeypatch.setenv("PROMOTION_LOG", str(log))
+    monkeypatch.setenv("PROMOTED_BINARY", str(immutable))
+
+    install.refresh(no_pull=False, install_dir=install_dir)
+
+    assert built == [True]
+    assert (install_dir / "lf").resolve() == immutable
+
+
+def test_refresh_refuses_pending_drafts_before_build(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    root = tmp_path / "repo"
+    drafts = root / "rust/loopflow/src/store/migrations/drafts"
+    drafts.mkdir(parents=True)
+    (drafts / "pending__0123456789abcdef0123456789abcdef.sql").write_text("SELECT 1;\n")
+    monkeypatch.setattr(install, "ROOT", root)
+    monkeypatch.setattr(install, "_refresh_default_branch", lambda _repo: True)
+    monkeypatch.setattr(
+        install,
+        "_build_cli_binaries",
+        lambda: pytest.fail("schema preflight must run before cargo"),
+    )
+
+    with pytest.raises(install.typer.Exit):
+        install.refresh(no_pull=False, install_dir=tmp_path / "bin")
+
+
+def test_local_use_refuses_pending_drafts_before_build(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    root = tmp_path / "repo"
+    drafts = root / "rust/loopflow/src/store/migrations/drafts"
+    drafts.mkdir(parents=True)
+    (drafts / "pending__0123456789abcdef0123456789abcdef.sql").write_text("SELECT 1;\n")
+    bundle_spec = install.default_bundle_spec(root)
+    monkeypatch.setattr(install, "ROOT", root)
+    monkeypatch.setattr(install, "LOCAL_BIN", root / "local-bin")
+    monkeypatch.setattr(install, "default_bundle_spec", lambda: bundle_spec)
+    monkeypatch.setattr(install, "_resolve_install_dir", lambda: tmp_path / "bin")
+    monkeypatch.setattr(install, "read_release_version", lambda _root: "9.9.9")
+    monkeypatch.setattr(
+        install,
+        "_run_parallel_builds",
+        lambda _skip: pytest.fail("schema preflight must run before local builds"),
+    )
+
+    with pytest.raises(install.typer.Exit):
+        install.local(use=True, dry_run=False, skip=[])
 
 
 def test_refresh_fast_forwards_default_branch_despite_pull_config(tmp_path: Path) -> None:
@@ -347,10 +446,11 @@ def test_refresh_fast_forwards_default_branch_despite_pull_config(tmp_path: Path
     _git(author, "commit", "-am", "update")
     _git(author, "push")
 
-    install._refresh_default_branch(checkout)
+    assert install._refresh_default_branch(checkout) is True
 
     assert (checkout / "version.txt").read_text() == "two\n"
     assert _git(checkout, "rev-parse", "HEAD") == _git(author, "rev-parse", "HEAD")
+    assert install._refresh_default_branch(checkout) is False
 
 
 def test_local_use_routes_cli_app_bundled_helper_and_skills_through_rust_promotion(

--- a/release/README.md
+++ b/release/README.md
@@ -14,17 +14,17 @@ lf cron list
 
 ```bash
 uv run python scripts/install.py local --use   # full build: lf + Loopflow.app -> local-bin/, make active
-uv run python scripts/install.py refresh       # CLI refresh: pull default branch, rebuild/install lf
+uv run python scripts/install.py refresh       # update/install lf; unchanged main is a no-op
 cat release/SCHEDULE.md      # hosted-build and cron-host release boundaries
 ```
 
 `install.py` is the local entry point. `local --use` builds this worktree's
 `lf` and `Loopflow.app` into `<worktree>/local-bin/`, then promotes that build.
-`refresh` is the fast CLI-only path: pull the default branch, rebuild `lf`, and
-install it into the local bin dir.
+`refresh` is the fast CLI-only path: pull the default branch, then rebuild and
+install `lf` only when main moved or the install target is missing.
 
-Promotion stops while draft migrations remain. Cut the release first so the
-binary embeds the schema its runtime code expects.
+Promotion stops before compilation while draft migrations remain. Cut the
+release first so the binary embeds the schema its runtime code expects.
 
 Use `release/` to keep the rationale and notes for each shipped version close
 to the code.

--- a/scripts/install.py
+++ b/scripts/install.py
@@ -5,7 +5,7 @@
     install.py local --use      # promote this worktree onto PATH and /Applications
     install.py local --skip swift
     install.py local -n         # dry run
-    install.py refresh          # pull default branch, rebuild lf, install to PATH
+    install.py refresh          # update lf when the default branch moves
 
 Remote releases happen via `lf release patch` -> merge -> auto-tag -> CI.
 """
@@ -149,7 +149,7 @@ def _git_stdout(args: list[str], repo: Path = ROOT, check: bool = True) -> str:
     return result.stdout.strip()
 
 
-def _refresh_default_branch(repo: Path = ROOT) -> None:
+def _refresh_default_branch(repo: Path = ROOT) -> bool:
     default_branch = _git_stdout(
         ["symbolic-ref", "--quiet", "--short", "refs/remotes/origin/HEAD"],
         repo=repo,
@@ -161,6 +161,7 @@ def _refresh_default_branch(repo: Path = ROOT) -> None:
             f"refusing to pull {current_branch}; checkout {default_branch} or pass --no-pull"
         )
 
+    before = _git_stdout(["rev-parse", "HEAD"], repo=repo)
     typer.echo(f"Pulling {repo}...")
     if default_branch:
         _run_or_raise(["git", "fetch", "origin", default_branch], "git", cwd=repo)
@@ -168,6 +169,7 @@ def _refresh_default_branch(repo: Path = ROOT) -> None:
     else:
         _run_or_raise(["git", "fetch"], "git", cwd=repo)
         _run_or_raise(["git", "merge", "--ff-only", "@{upstream}"], "git", cwd=repo)
+    return _git_stdout(["rev-parse", "HEAD"], repo=repo) != before
 
 
 # --- Builds ---
@@ -545,20 +547,24 @@ def refresh(
         None, "--install-dir", help="Install lf here instead of the resolved local bin dir"
     ),
 ) -> None:
-    """Pull the default branch, rebuild lf, and install it locally."""
+    """Pull the default branch and install lf when it moves."""
     resolved_install_dir = install_dir.expanduser() if install_dir else _resolve_install_dir()
 
     try:
-        if not no_pull:
-            _refresh_default_branch(ROOT)
+        target = resolved_install_dir / "lf"
+        if not no_pull and not _refresh_default_branch(ROOT) and target.exists():
+            revision = _git_stdout(["rev-parse", "--short", "HEAD"], repo=ROOT)
+            typer.echo(f"already current: {revision}")
+            return
+        _require_complete_schema_for_promotion(ROOT)
         _build_cli_binaries()
         _promote_with_candidate(ROOT / "target" / "release" / "lf", resolved_install_dir)
     except (subprocess.CalledProcessError, StageError) as exc:
         typer.echo(f"refresh failed: {exc}", err=True)
         raise typer.Exit(code=1) from exc
 
-    typer.echo(f"installed: {resolved_install_dir / 'lf'}")
-    result = subprocess.run([str(resolved_install_dir / "lf"), "--version"], text=True)
+    typer.echo(f"installed: {target}")
+    result = subprocess.run([str(target), "--version"], text=True)
     if result.returncode != 0:
         raise typer.Exit(code=result.returncode)
 
@@ -599,6 +605,8 @@ def local(
 
     total_start = time.monotonic()
     try:
+        if use:
+            _require_complete_schema_for_promotion(ROOT)
         _run_parallel_builds(skip_set)
 
         typer.echo(f"Staging lf + {APP_NAME}.app (v{version}) into {LOCAL_BIN}...")


### PR DESCRIPTION
## Try it!

```bash
uv run pytest python/tests/test_install_script.py -k 'refresh_skips or refresh_builds_unchanged or refuses_pending_drafts' -v
uv run python scripts/install.py refresh --no-pull --install-dir /tmp/loopflow-schema-check
```

The tests show unchanged main skipping both build and promotion, a missing
target still bootstrapping, and draft-bearing promotion paths stopping before a
build. This checkout contains drafts, so the second command refuses immediately
without printing `Building lf`. Before this change, the standalone updater spent
9m51s compiling the same unchanged draft-bearing HEAD before refusing; the
equivalent preflight now completes in 0.1s.

## Intent

Keep the maintained local `lf` updater cheap and schema-safe. The standalone
`studio.lf-refresh` LaunchAgent already schedules reliably every 30 minutes;
the broken boundary was `install.py refresh`, which rebuilt unchanged main and
did not inspect draft schema until after compilation.

## Assumptions

- The standalone updater owns pulls in its canonical main checkout. Use
  `refresh --no-pull` after manually moving that checkout when a forced build is
  desired.
- A normal unchanged refresh is an update operation with an existing `lf`.
  Missing or broken targets bypass the no-op and bootstrap current main.
- Draft SQL files mean the checkout is not promotable. The built candidate's
  Rust preflight remains the final authority for store compatibility.

## Key decisions

- Return HEAD movement from the existing fast-forward helper instead of adding
  updater-specific state.
- Run the source draft guard before cargo/Swift on every promotion path, while
  retaining the candidate-side defense before machine-global mutation.
- Leave non-promoting local builds available for migration development.

## Not included

The host wrapper and LaunchAgent are unchanged, and the standalone updater is
not migrated into `lf cron` in this incident closure.

