### PR TITLE
Converse with one Wave through one Discord channel

### DIFF
--- a/docs/waves.md
+++ b/docs/waves.md
@@ -94,6 +94,36 @@ lf wave s3            # the s3 (control) charter
 Writing a goal well — the weight of each section, frontmatter fields, KR
 craft — is covered in [Authoring → Goals](authoring.md#goals).
 
+### Discord chat
+
+Bind one existing guild text channel to one Wave:
+
+```yaml
+# wave/product/GOAL.md
+---
+chat:
+  provider: discord
+  home_id: "home_0123456789abcdef0123456789abcdef"
+  guild_id: "123456789012345678"
+  channel_id: "234567890123456789"
+---
+```
+
+Start the Wave with `LF_DISCORD_TOKEN` injected by Doppler:
+
+```bash
+doppler run -- lf wave product
+```
+
+The bot needs only **View Channel**, **Read Message History**, and **Send
+Messages**, with Message Content enabled in the Discord developer portal. The
+first start attaches at the channel's current head; later starts resume from
+the journaled cursor. Discord remains the shared company transcript. Loopflow
+retains source-linked Wave inputs, answering turns, and send receipts as Run
+evidence. `home_id` is the binding's durable owner (`lf home id`). Another Home
+fails before contacting Discord, while an OS-held lease prevents another
+checkout on the owner Home from consuming the same channel.
+
 ### Memory
 
 `MEMORY.md` is durable working context agents curate as Wave work moves —

--- a/rust/loopflow/src/engine/process.rs
+++ b/rust/loopflow/src/engine/process.rs
@@ -411,7 +411,7 @@ pub(crate) fn lf_session_shell_command(argv: &[String], env: &[(&str, &str)]) ->
         .map(|(key, value)| format!("{}={}", shell_escape(key), shell_escape(value)))
         .collect::<Vec<_>>()
         .join(" ");
-    let clear_context = "if [ -n \"${LF_FORWARDED_SECRET_NAMES:-}\" ]; then unset $LF_FORWARDED_SECRET_NAMES; fi; unset LF_TRACE_ID LF_PROCESS_ID LF_WAVE_ID LF_RUN_CONTEXT LF_RUN_LEASE LF_AGENT_INVOCATION_ID LF_BIN LF_HOME LF_DB_PATH LF_CONTROL_BIN LF_CONTROL_HOME LF_CONTROL_DB_PATH LF_ACCOUNT_LEASE LF_ACCOUNT_SELECTION LF_FORWARDED_PM_TOKEN LF_FORWARDED_PM_PROVIDER LF_FORWARDED_SECRET_NAMES LF_SSH_TARGET LF_LINEAR_WEBHOOK_SECRET LF_LINEAR_VIEWER_ID LF_GITHUB_WEBHOOK_SECRET LF_GITHUB_WEBHOOK_URL LF_LFD_ALLOW_NON_LOOPBACK GH_TOKEN OPENCODE_API_KEY CLAUDE_CODE_OAUTH_TOKEN ANTHROPIC_API_KEY CODEX_ACCESS_TOKEN OPENAI_API_KEY";
+    let clear_context = "if [ -n \"${LF_FORWARDED_SECRET_NAMES:-}\" ]; then unset $LF_FORWARDED_SECRET_NAMES; fi; unset LF_TRACE_ID LF_PROCESS_ID LF_WAVE_ID LF_RUN_CONTEXT LF_RUN_LEASE LF_AGENT_INVOCATION_ID LF_BIN LF_HOME LF_DB_PATH LF_CONTROL_BIN LF_CONTROL_HOME LF_CONTROL_DB_PATH LF_ACCOUNT_LEASE LF_ACCOUNT_SELECTION LF_FORWARDED_PM_TOKEN LF_FORWARDED_PM_PROVIDER LF_FORWARDED_SECRET_NAMES LF_SSH_TARGET LF_LINEAR_WEBHOOK_SECRET LF_LINEAR_VIEWER_ID LF_GITHUB_WEBHOOK_SECRET LF_GITHUB_WEBHOOK_URL LF_LFD_ALLOW_NON_LOOPBACK LF_DISCORD_TOKEN GH_TOKEN OPENCODE_API_KEY CLAUDE_CODE_OAUTH_TOKEN ANTHROPIC_API_KEY CODEX_ACCESS_TOKEN OPENAI_API_KEY";
     if env.is_empty() {
         format!("{clear_context}; exec {command}")
     } else {
@@ -466,6 +466,7 @@ fn forwarded_authority_env_names() -> Vec<String> {
         "LF_GITHUB_WEBHOOK_SECRET".to_string(),
         "LF_GITHUB_WEBHOOK_URL".to_string(),
         "LF_LFD_ALLOW_NON_LOOPBACK".to_string(),
+        crate::wave::discord::TOKEN_ENV.to_string(),
         "GH_TOKEN".to_string(),
         "OPENCODE_API_KEY".to_string(),
         "CLAUDE_CODE_OAUTH_TOKEN".to_string(),
@@ -630,6 +631,7 @@ mod tests {
         ));
         assert!(command.contains("LF_AGENT_INVOCATION_ID"));
         assert!(command.contains("LF_ACCOUNT_LEASE LF_ACCOUNT_SELECTION"));
+        assert!(command.contains("LF_DISCORD_TOKEN"));
         assert!(command.contains("GH_TOKEN OPENCODE_API_KEY"));
         assert!(command.ends_with(
             "exec env 'LF_RUN_CONTEXT'='agent' 'LF_WAVE_ID'='infra' 'lf' '__work' 'task' 'tsk_123'"
@@ -663,8 +665,19 @@ mod tests {
         assert!(names.iter().any(|name| name == "GH_TOKEN"));
         assert!(names.iter().any(|name| name == "LF_LINEAR_WEBHOOK_SECRET"));
         assert!(names.iter().any(|name| name == "LF_LFD_ALLOW_NON_LOOPBACK"));
+        assert!(names.iter().any(|name| name == "LF_DISCORD_TOKEN"));
         assert!(names.iter().any(|name| name == "SENTRY_TOKEN"));
         assert!(names.iter().any(|name| name == "STRIPE_KEY"));
+    }
+
+    #[test]
+    fn discord_chat_token_is_scrubbed_from_durable_provider_children() {
+        assert!(forwarded_authority_env_names()
+            .iter()
+            .any(|name| name == crate::wave::discord::TOKEN_ENV));
+        let command = lf_session_shell_command(&["lf".into(), "wave".into()], &[]);
+        assert!(command.contains("unset "));
+        assert!(command.contains(crate::wave::discord::TOKEN_ENV));
     }
 
     #[test]

--- a/rust/loopflow/src/engine/wave_config.rs
+++ b/rust/loopflow/src/engine/wave_config.rs
@@ -1,8 +1,24 @@
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 use serde_yaml_ng::{Mapping, Value};
 use std::collections::HashMap;
 use std::path::Path;
 use tracing::warn;
+
+use crate::durable::HomeId;
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum WaveConfigError {
+    #[error("failed to read {path}: {source}")]
+    Read {
+        path: std::path::PathBuf,
+        source: std::io::Error,
+    },
+    #[error("invalid wave goal frontmatter in {path}: {source}")]
+    Parse {
+        path: std::path::PathBuf,
+        source: serde_yaml_ng::Error,
+    },
+}
 
 /// One cron line from GOAL.md frontmatter: `crons: [{flow, schedule}]`.
 /// The wave's resident loop reads these and opens a system pass when a
@@ -26,6 +42,26 @@ pub struct WavePmConfig {
     pub linear_team: Option<String>,
 }
 
+/// One existing Discord guild text channel bound to this Wave's chat.
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(tag = "provider", rename_all = "snake_case")]
+pub enum WaveChatConfig {
+    Discord {
+        #[serde(deserialize_with = "deserialize_home_id")]
+        home_id: HomeId,
+        guild_id: String,
+        channel_id: String,
+    },
+}
+
+fn deserialize_home_id<'de, D>(deserializer: D) -> Result<HomeId, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let value = String::deserialize(deserializer)?;
+    HomeId::parse(&value).map_err(serde::de::Error::custom)
+}
+
 /// Machine policy read from `wave/<name>/GOAL.md` frontmatter.
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 pub struct WaveConfig {
@@ -38,6 +74,9 @@ pub struct WaveConfig {
     pub agent: Option<String>,
     pub skill_agents: Option<HashMap<String, String>>,
     pub pm: Option<WavePmConfig>,
+    /// One external presentation binding. Discord is the only supported
+    /// provider and remains a concrete variant rather than a registry.
+    pub chat: Option<WaveChatConfig>,
     /// The safety valve: `paused: true` in GOAL.md frontmatter tells the wave
     /// listener to refuse to START turns (message→turn, heartbeat, cron)
     /// while keeping the listener serving and queueing. File-first and re-read
@@ -56,25 +95,32 @@ pub struct WaveConfig {
 
 /// Read wave intent from `wave/<name>/GOAL.md` frontmatter.
 pub fn read_wave_config(repo: &Path, name: &str) -> Option<WaveConfig> {
+    match try_read_wave_config(repo, name) {
+        Ok(config) => config,
+        Err(err) => {
+            warn!(error = %err, "failed to read wave config");
+            None
+        }
+    }
+}
+
+/// Read wave machine policy and surface malformed frontmatter to callers that
+/// must fail closed before starting external side effects.
+pub(crate) fn try_read_wave_config(
+    repo: &Path,
+    name: &str,
+) -> Result<Option<WaveConfig>, WaveConfigError> {
     let path = goal_path(repo, name);
     let content = match std::fs::read_to_string(&path) {
         Ok(content) => content,
-        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return None,
-        Err(err) => {
-            warn!(path = %path.display(), error = %err, "failed to read wave config");
-            return None;
-        }
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(source) => return Err(WaveConfigError::Read { path, source }),
     };
-    Some(match split_frontmatter(&content) {
-        Some((frontmatter, _)) => match serde_yaml_ng::from_str::<WaveConfig>(&frontmatter) {
-            Ok(config) => config,
-            Err(err) => {
-                warn!(path = %path.display(), error = %err, "invalid wave goal frontmatter");
-                return None;
-            }
-        },
+    Ok(Some(match split_frontmatter(&content) {
+        Some((frontmatter, _)) => serde_yaml_ng::from_str::<WaveConfig>(&frontmatter)
+            .map_err(|source| WaveConfigError::Parse { path, source })?,
         None => WaveConfig::default(),
-    })
+    }))
 }
 
 /// One-line Wave objective for status, PM, and API projections.
@@ -310,6 +356,48 @@ mod tests {
         assert_eq!(pm.provider.as_deref(), Some("linear"));
         assert_eq!(pm.linear_initiative.as_deref(), Some("lin-123"));
         assert_eq!(pm.linear_team.as_deref(), Some("team-prd"));
+    }
+
+    #[test]
+    fn discord_chat_config_is_typed_and_invalid_bindings_fail_closed() {
+        let temp = tempdir().expect("temp dir");
+        let dir = temp.path().join("wave").join("scan");
+        fs::create_dir_all(&dir).expect("create dir");
+        fs::write(
+            dir.join("GOAL.md"),
+            "---\nchat:\n  provider: discord\n  home_id: home_39860354aaca640c2ccb50bf6ca609d8\n  guild_id: guild\n  channel_id: channel\n---\nDrive the work.\n",
+        )
+        .expect("write");
+        let config = try_read_wave_config(temp.path(), "scan")
+            .expect("valid config")
+            .expect("config");
+        assert!(matches!(
+            config.chat,
+            Some(WaveChatConfig::Discord { home_id, guild_id, channel_id })
+                if home_id.as_str() == "home_39860354aaca640c2ccb50bf6ca609d8"
+                    && guild_id == "guild"
+                    && channel_id == "channel"
+        ));
+
+        fs::write(
+            dir.join("GOAL.md"),
+            "---\nchat:\n  provider: discord\n  guild_id: guild\n---\nDrive the work.\n",
+        )
+        .expect("write invalid");
+        assert!(matches!(
+            try_read_wave_config(temp.path(), "scan"),
+            Err(WaveConfigError::Parse { .. })
+        ));
+
+        fs::write(
+            dir.join("GOAL.md"),
+            "---\nchat:\n  provider: discord\n  home_id: not-a-home\n  guild_id: guild\n  channel_id: channel\n---\nDrive the work.\n",
+        )
+        .expect("write invalid HomeId");
+        assert!(matches!(
+            try_read_wave_config(temp.path(), "scan"),
+            Err(WaveConfigError::Parse { .. })
+        ));
     }
 
     /// Crons live in GOAL.md frontmatter — the resident loop's schedule

--- a/rust/loopflow/src/flowloop/wave.rs
+++ b/rust/loopflow/src/flowloop/wave.rs
@@ -63,7 +63,7 @@ use crate::engine::flow::{available_flow_names, load_goal, render_goal, GoalRend
 use crate::engine::wave_config::{read_wave_config, WaveCronDef};
 use crate::harness::{default_create_harness, ApprovalPolicy, Harness, SendCurrentOutcome};
 use crate::store::{open_store, storage_config_from_env, Store};
-use crate::wave::journal::{MessageId, MessageOp, PendingMessage};
+use crate::wave::journal::{MessageDestination, MessageId, MessageOp, PendingMessage};
 use crate::wave::playhead::{BodyProvenance, StepKind, StepOutcome, StepRef};
 use crate::wave::resident::ListenerClient;
 use crate::wave::runtime::InboxItem;
@@ -561,8 +561,13 @@ impl WaveLoop {
     }
 
     async fn on_heartbeat(&mut self, inbox_rx: &mut mpsc::UnboundedReceiver<InboxItem>) {
-        self.run_pass(HEARTBEAT_PROMPT.to_string(), Vec::new(), inbox_rx)
-            .await;
+        self.run_pass(
+            HEARTBEAT_PROMPT.to_string(),
+            Vec::new(),
+            MessageDestination::Local,
+            inbox_rx,
+        )
+        .await;
     }
 
     async fn on_cron(&mut self, inbox_rx: &mut mpsc::UnboundedReceiver<InboxItem>) {
@@ -585,11 +590,12 @@ impl WaveLoop {
             self.cron_last_fired.insert(cron_key(cron), now);
         }
         let prompt = cron_prompt(&due);
-        self.run_pass(prompt, Vec::new(), inbox_rx).await;
+        self.run_pass(prompt, Vec::new(), MessageDestination::Local, inbox_rx)
+            .await;
     }
 
     async fn start_queued_pass(&mut self, inbox_rx: &mut mpsc::UnboundedReceiver<InboxItem>) {
-        let messages = std::mem::take(&mut self.queue);
+        let messages = take_destination_prefix(&mut self.queue);
         self.start_message_pass(messages, inbox_rx).await;
     }
 
@@ -604,12 +610,16 @@ impl WaveLoop {
         inbox_rx: &mut mpsc::UnboundedReceiver<InboxItem>,
     ) {
         let answers: Vec<MessageId> = messages.iter().map(|m| m.id.clone()).collect();
+        let destination = messages
+            .first()
+            .map(PendingMessage::destination)
+            .unwrap_or(MessageDestination::Local);
         let content = messages
             .iter()
             .map(|m| m.text.clone())
             .collect::<Vec<_>>()
             .join("\n\n");
-        self.run_pass(content, answers, inbox_rx).await;
+        self.run_pass(content, answers, destination, inbox_rx).await;
     }
 
     async fn capture_control(
@@ -690,6 +700,7 @@ impl WaveLoop {
         &mut self,
         wake: String,
         answers: Vec<MessageId>,
+        destination: MessageDestination,
         inbox_rx: &mut mpsc::UnboundedReceiver<InboxItem>,
     ) {
         let mut answers = answers.into_iter().map(|id| id.0).collect::<Vec<_>>();
@@ -713,7 +724,8 @@ impl WaveLoop {
             let live_skill = step.kind == StepKind::Skill
                 && matches!(&self.backend, BodyBackend::Harness { .. });
             if live_skill {
-                self.run_harness_pass(step, seed, answers, inbox_rx).await;
+                self.run_harness_pass(step, seed, answers, &destination, inbox_rx)
+                    .await;
             } else {
                 self.run_process_pass(step, seed, answers, inbox_rx).await;
             }
@@ -825,6 +837,7 @@ impl WaveLoop {
         step: StepRef,
         seed: String,
         answers: Vec<String>,
+        destination: &MessageDestination,
         inbox_rx: &mut mpsc::UnboundedReceiver<InboxItem>,
     ) {
         let mut body = body_provenance(&step, &self.cwd);
@@ -1002,11 +1015,15 @@ impl WaveLoop {
                         }
                         InboxAction::Deliver(item) => match *item {
                             InboxItem::Message(message) if message.op == MessageOp::Steer => {
-                                if self
-                                    .steer_harness(message, harness.as_mut())
-                                    .await
-                                {
-                                    timeout.as_mut().reset(Instant::now() + self.config.pass_timeout);
+                                if message.destination() == *destination {
+                                    if self
+                                        .steer_harness(message, harness.as_mut())
+                                        .await
+                                    {
+                                        timeout.as_mut().reset(Instant::now() + self.config.pass_timeout);
+                                    }
+                                } else {
+                                    self.on_inbox(InboxItem::Message(message)).await;
                                 }
                             }
                             item => self.on_inbox(item).await,
@@ -1177,6 +1194,9 @@ impl WaveLoop {
         }
         match harness.send_current(&message.text).await {
             SendCurrentOutcome::Sent { .. } => {
+                if message.source.is_some() {
+                    return true;
+                }
                 // Live delivery improves latency; it does not advance the
                 // Turn's immutable starting Basis. Keep the message pending so
                 // a later boundary can incorporate it durably.
@@ -1455,6 +1475,19 @@ impl WaveLoop {
     }
 }
 
+fn take_destination_prefix(queue: &mut Vec<PendingMessage>) -> Vec<PendingMessage> {
+    let destination = queue
+        .first()
+        .expect("a queued pass starts with a message")
+        .destination();
+    let split = queue
+        .iter()
+        .position(|message| message.destination() != destination)
+        .unwrap_or(queue.len());
+    let remaining = queue.split_off(split);
+    std::mem::replace(queue, remaining)
+}
+
 fn spawn_wave_step(
     cwd: &Path,
     step: &StepRef,
@@ -1484,11 +1517,62 @@ mod tests {
     use std::sync::{Arc, Mutex};
 
     use crate::chat::turns::{ChatRole, ChatTurn};
-    use crate::wave::journal::{journal_path, EventKind, Journal};
+    use crate::wave::journal::{
+        journal_path, DiscordChatBinding, DiscordMessageSource, EventKind, Journal,
+    };
     use crate::wave::runtime::WaveRuntime;
     use crate::wave::server::{self, ResidentDoor};
     use crate::wave::state::LoopState;
     use async_trait::async_trait;
+
+    fn queued_message(id: &str, source: Option<DiscordMessageSource>) -> PendingMessage {
+        PendingMessage {
+            id: MessageId(id.into()),
+            op: MessageOp::Message,
+            text: id.into(),
+            source,
+        }
+    }
+
+    fn discord_source(id: &str) -> DiscordMessageSource {
+        DiscordMessageSource {
+            binding: DiscordChatBinding {
+                guild_id: "guild".into(),
+                channel_id: "channel".into(),
+            },
+            message_id: id.into(),
+            author_id: "human".into(),
+        }
+    }
+
+    #[test]
+    fn discord_chat_batches_only_the_fifo_prefix_for_one_destination() {
+        let mut queue = vec![
+            queued_message("discord-1", Some(discord_source("1"))),
+            queued_message("discord-2", Some(discord_source("2"))),
+            queued_message("local", None),
+            queued_message("discord-3", Some(discord_source("3"))),
+        ];
+
+        let first = take_destination_prefix(&mut queue);
+        assert_eq!(
+            first
+                .iter()
+                .map(|message| message.id.0.as_str())
+                .collect::<Vec<_>>(),
+            vec!["discord-1", "discord-2"]
+        );
+        assert_eq!(
+            queue
+                .iter()
+                .map(|message| message.id.0.as_str())
+                .collect::<Vec<_>>(),
+            vec!["local", "discord-3"]
+        );
+        let second = take_destination_prefix(&mut queue);
+        assert_eq!(second[0].id.0, "local");
+        assert_eq!(queue[0].id.0, "discord-3");
+    }
 
     /// The rig: a REAL listener (runtime + router with the resident door)
     /// and a resident (subscription follower + `run_loop_with` and a

--- a/rust/loopflow/src/store/durable.rs
+++ b/rust/loopflow/src/store/durable.rs
@@ -180,6 +180,13 @@ impl Store {
         .await
     }
 
+    /// Release Wave Run authority from the process interrupt handler, which
+    /// exits before Tokio can drive the listener's async shutdown path.
+    pub(crate) fn stop_run_on_interrupt(&self, lease: &RunLease) -> StoreResult<StopReceipt> {
+        self.sqlite
+            .stop_run(lease, &StopCause::Requested, ContainmentObservation::Absent)
+    }
+
     pub(crate) async fn run_control(
         &self,
         lease: &RunLease,
@@ -752,6 +759,18 @@ mod tests {
         assert!(receipt.turn_ids.is_empty());
         assert!(store.current_run(&work).await.unwrap().is_none());
         assert_eq!(store.work_status(&work).await.unwrap(), WorkStatus::Ready);
+    }
+
+    #[tokio::test]
+    async fn listener_interrupt_releases_run_authority_for_restart() {
+        let (store, work) = wave_work().await;
+        let (_, lease) = store.reserve_run(&work, RunTrigger::User).await.unwrap();
+
+        let stopped = store.stop_run_on_interrupt(&lease).unwrap();
+
+        assert_eq!(stopped.run.state, RunState::Ended);
+        assert!(store.current_run(&work).await.unwrap().is_none());
+        assert!(store.reserve_run(&work, RunTrigger::User).await.is_ok());
     }
 
     #[tokio::test]

--- a/rust/loopflow/src/store/mod.rs
+++ b/rust/loopflow/src/store/mod.rs
@@ -136,12 +136,16 @@ pub(crate) fn production_database_path() -> PathBuf {
 /// process, and opening it through `open_run_ledger_read_only` cannot migrate
 /// or otherwise mutate its schema. Explicit control authority wins, followed
 /// by an ordinary override, then the installed Home.
-pub(crate) fn observability_home_dir() -> PathBuf {
+pub(crate) fn authority_home_dir() -> PathBuf {
     std::env::var_os(CONTROL_HOME_ENV)
         .or_else(|| std::env::var_os("LF_HOME"))
         .filter(|value| !value.is_empty())
         .map(PathBuf::from)
         .unwrap_or_else(|| machine_home_dir().join(".lf"))
+}
+
+pub(crate) fn observability_home_dir() -> PathBuf {
+    authority_home_dir()
 }
 
 pub(crate) fn observability_database_path() -> Result<PathBuf, std::io::Error> {

--- a/rust/loopflow/src/wave/README.md
+++ b/rust/loopflow/src/wave/README.md
@@ -40,6 +40,14 @@ The journal rebuilds the thread, playhead, and loop state after restart. The
 endpoint and resident token exist only while the listener owns that boot and
 are removed on shutdown.
 
+An optional Discord channel binding is also listener-owned. The listener
+preflights the binding before reserving a Run or opening the journal, then polls
+after the committed cursor, journals external inputs before advancing it, and
+journals deterministic send intents before posting. The resident receives only
+source-tagged authored input and never inherits `LF_DISCORD_TOKEN`. Binding
+ownership is explicit: the configured Home is the only Home allowed to attach,
+and an OS-held lease prevents concurrent listeners across its checkouts.
+
 The shared `~/.lf/loopflow.db` stores the Wave row and typed Project and Task
 observations. A Wave can still run when that store does not
 exist, but child observations are unavailable. The live endpoint enforces one

--- a/rust/loopflow/src/wave/discord.rs
+++ b/rust/loopflow/src/wave/discord.rs
@@ -1,0 +1,1103 @@
+//! One Discord guild text channel as a presentation surface for Wave chat.
+//!
+//! Discord owns the company transcript. This adapter polls only messages after
+//! the journal's committed cursor and writes source-linked inputs plus outbound
+//! delivery receipts through [`WaveRuntime`]. It never owns an inbox or writes
+//! the journal directly.
+
+use std::collections::HashMap;
+use std::fs::{File, OpenOptions};
+use std::path::Path;
+use std::time::Duration;
+
+use anyhow::{anyhow, Context, Result};
+use fs2::FileExt;
+use reqwest::header::{HeaderMap, HeaderValue, AUTHORIZATION, USER_AGENT};
+use reqwest::{Client, StatusCode};
+use secrecy::{ExposeSecret, SecretString};
+use serde::de::DeserializeOwned;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+use crate::durable::HomeId;
+use crate::wave::journal::{DiscordChatBinding, DiscordMessageSource};
+use crate::wave::runtime::WaveRuntime;
+
+pub const TOKEN_ENV: &str = "LF_DISCORD_TOKEN";
+const API_BASE: &str = "https://discord.com/api/v10";
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
+const POLL_CADENCE: Duration = Duration::from_secs(2);
+const ERROR_BACKOFF: Duration = Duration::from_secs(10);
+const VIEW_CHANNEL: u64 = 1 << 10;
+const SEND_MESSAGES: u64 = 1 << 11;
+const READ_MESSAGE_HISTORY: u64 = 1 << 16;
+const ADMINISTRATOR: u64 = 1 << 3;
+const MESSAGE_CONTENT: u64 = 1 << 18;
+const MESSAGE_CONTENT_LIMITED: u64 = 1 << 19;
+
+#[derive(Debug, thiserror::Error)]
+pub enum DiscordError {
+    #[error("{TOKEN_ENV} is required for a configured Discord chat binding")]
+    MissingToken,
+    #[error("Discord request failed: {0}")]
+    Transport(#[from] reqwest::Error),
+    #[error("Discord API returned {status}: {message}")]
+    Api { status: StatusCode, message: String },
+    #[error("Discord binding is invalid: {0}")]
+    Binding(String),
+    #[error("Discord Message Content intent is not enabled for this application")]
+    MissingMessageContent,
+    #[error("Discord channel is missing required permissions: {0}")]
+    MissingPermissions(String),
+    #[error("Discord returned an invalid permission value: {0}")]
+    InvalidPermission(String),
+    #[error("Discord chat binding is owned by Home {owner}; current Home is {current}")]
+    WrongHome { owner: String, current: String },
+    #[error(
+        "Discord chat binding {guild_id}/{channel_id} already has a live listener on Home {home_id}"
+    )]
+    AlreadyOwned {
+        guild_id: String,
+        channel_id: String,
+        home_id: String,
+    },
+    #[error("failed to claim Discord chat binding: {0}")]
+    Lease(#[from] std::io::Error),
+}
+
+impl DiscordError {
+    fn retryable(&self) -> bool {
+        matches!(self, Self::Transport(_))
+            || matches!(self, Self::Api { status, .. } if status.is_server_error())
+    }
+}
+
+/// Process-held ownership for one Discord binding on its configured Home.
+///
+/// The configured Home prevents a second Home from competing. The advisory
+/// lock prevents a second checkout or store on that Home from competing. The
+/// file may outlive the process; only the held OS lock carries authority.
+#[derive(Debug)]
+struct DiscordBindingLease {
+    _file: File,
+}
+
+impl DiscordBindingLease {
+    fn acquire(
+        binding: &DiscordChatBinding,
+        owner_home_id: &HomeId,
+        local_home_id: &HomeId,
+    ) -> Result<Self, DiscordError> {
+        if owner_home_id != local_home_id {
+            return Err(DiscordError::WrongHome {
+                owner: owner_home_id.to_string(),
+                current: local_home_id.to_string(),
+            });
+        }
+        Self::acquire_at(
+            &crate::store::authority_home_dir().join("chat-bindings"),
+            binding,
+            local_home_id,
+        )
+    }
+
+    fn acquire_at(
+        root: &Path,
+        binding: &DiscordChatBinding,
+        local_home_id: &HomeId,
+    ) -> Result<Self, DiscordError> {
+        std::fs::create_dir_all(root)?;
+        let mut digest = Sha256::new();
+        digest.update(b"discord\0");
+        digest.update(binding.guild_id.as_bytes());
+        digest.update(b"\0");
+        digest.update(binding.channel_id.as_bytes());
+        let name = format!("{:x}.lock", digest.finalize());
+        let file = OpenOptions::new()
+            .create(true)
+            .truncate(false)
+            .read(true)
+            .write(true)
+            .open(root.join(name))?;
+        match FileExt::try_lock_exclusive(&file) {
+            Ok(()) => Ok(Self { _file: file }),
+            Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                Err(DiscordError::AlreadyOwned {
+                    guild_id: binding.guild_id.clone(),
+                    channel_id: binding.channel_id.clone(),
+                    home_id: local_home_id.to_string(),
+                })
+            }
+            Err(error) => Err(DiscordError::Lease(error)),
+        }
+    }
+}
+
+#[derive(Clone)]
+struct DiscordClient {
+    http: Client,
+    base_url: String,
+}
+
+impl std::fmt::Debug for DiscordClient {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DiscordClient")
+            .field("base_url", &self.base_url)
+            .finish_non_exhaustive()
+    }
+}
+
+impl DiscordClient {
+    fn from_env() -> Result<Self, DiscordError> {
+        Self::from_token(std::env::var(TOKEN_ENV).ok(), API_BASE)
+    }
+
+    fn from_token(token: Option<String>, base_url: &str) -> Result<Self, DiscordError> {
+        let token = token
+            .filter(|value| !value.trim().is_empty())
+            .map(SecretString::new)
+            .ok_or(DiscordError::MissingToken)?;
+        Self::new(token, base_url)
+    }
+
+    fn new(token: SecretString, base_url: &str) -> Result<Self, DiscordError> {
+        let mut authorization = HeaderValue::from_str(&format!("Bot {}", token.expose_secret()))
+            .map_err(|_| DiscordError::Binding("token contains invalid header bytes".into()))?;
+        authorization.set_sensitive(true);
+        let mut headers = HeaderMap::new();
+        headers.insert(AUTHORIZATION, authorization);
+        headers.insert(
+            USER_AGENT,
+            HeaderValue::from_static("Loopflow (https://github.com/loopflowstudio/loopflow)"),
+        );
+        let http = Client::builder()
+            .default_headers(headers)
+            .timeout(REQUEST_TIMEOUT)
+            .build()?;
+        Ok(Self {
+            http,
+            base_url: base_url.trim_end_matches('/').to_string(),
+        })
+    }
+
+    async fn get<T: DeserializeOwned>(&self, path: &str) -> Result<T, DiscordError> {
+        self.request(self.http.get(format!("{}{path}", self.base_url)))
+            .await
+    }
+
+    async fn post<T: DeserializeOwned, B: Serialize + ?Sized>(
+        &self,
+        path: &str,
+        body: &B,
+    ) -> Result<T, DiscordError> {
+        self.request(
+            self.http
+                .post(format!("{}{path}", self.base_url))
+                .json(body),
+        )
+        .await
+    }
+
+    async fn request<T: DeserializeOwned>(
+        &self,
+        request: reqwest::RequestBuilder,
+    ) -> Result<T, DiscordError> {
+        let request = request.build()?;
+        loop {
+            let response = self
+                .http
+                .execute(request.try_clone().ok_or_else(|| {
+                    DiscordError::Binding("Discord request body was not replayable".into())
+                })?)
+                .await?;
+            if response.status() == StatusCode::TOO_MANY_REQUESTS {
+                let retry = response
+                    .json::<RateLimit>()
+                    .await
+                    .map(|limit| limit.retry_after)
+                    .unwrap_or(1.0);
+                tokio::time::sleep(Duration::from_secs_f64(retry.max(0.05))).await;
+                continue;
+            }
+            if !response.status().is_success() {
+                let status = response.status();
+                let message = response
+                    .json::<ApiError>()
+                    .await
+                    .map(|error| error.message)
+                    .unwrap_or_else(|_| "request rejected".to_string());
+                return Err(DiscordError::Api { status, message });
+            }
+            return Ok(response.json().await?);
+        }
+    }
+}
+
+/// A preflighted channel adapter. Construction performs every permanent
+/// binding/intent/permission check before the listener opens the journal.
+#[derive(Debug)]
+pub struct DiscordAdapter {
+    client: DiscordClient,
+    binding: DiscordChatBinding,
+    bot_user_id: String,
+    initial_head: Option<String>,
+    _lease: Option<DiscordBindingLease>,
+}
+
+impl DiscordAdapter {
+    pub async fn preflight(
+        binding: DiscordChatBinding,
+        owner_home_id: &HomeId,
+        local_home_id: &HomeId,
+    ) -> Result<Self, DiscordError> {
+        let lease = DiscordBindingLease::acquire(&binding, owner_home_id, local_home_id)?;
+        let mut adapter = Self::preflight_with_client(DiscordClient::from_env()?, binding).await?;
+        adapter._lease = Some(lease);
+        Ok(adapter)
+    }
+
+    async fn preflight_with_client(
+        client: DiscordClient,
+        binding: DiscordChatBinding,
+    ) -> Result<Self, DiscordError> {
+        let bot: User = client.get("/users/@me").await?;
+        let application: Application = client.get("/oauth2/applications/@me").await?;
+        if application.flags & (MESSAGE_CONTENT | MESSAGE_CONTENT_LIMITED) == 0 {
+            return Err(DiscordError::MissingMessageContent);
+        }
+        let guild: Guild = client.get(&format!("/guilds/{}", binding.guild_id)).await?;
+        if guild.id != binding.guild_id {
+            return Err(DiscordError::Binding(format!(
+                "configured guild {} resolved as {}",
+                binding.guild_id, guild.id
+            )));
+        }
+        let member: GuildMember = client
+            .get(&format!("/guilds/{}/members/{}", binding.guild_id, bot.id))
+            .await?;
+        let channel: Channel = client
+            .get(&format!("/channels/{}", binding.channel_id))
+            .await?;
+        if channel.kind != 0 {
+            return Err(DiscordError::Binding(format!(
+                "channel {} is type {}, expected GUILD_TEXT (0)",
+                channel.id, channel.kind
+            )));
+        }
+        if channel.guild_id.as_deref() != Some(binding.guild_id.as_str()) {
+            return Err(DiscordError::Binding(format!(
+                "channel {} does not belong to guild {}",
+                channel.id, binding.guild_id
+            )));
+        }
+        require_permissions(&guild, &member, &channel, &bot.id)?;
+        let _: Vec<Message> = client
+            .get(&format!(
+                "/channels/{}/messages?limit=1",
+                binding.channel_id
+            ))
+            .await?;
+        Ok(Self {
+            client,
+            binding,
+            bot_user_id: bot.id,
+            initial_head: channel.last_message_id,
+            _lease: None,
+        })
+    }
+
+    pub fn attach(&self, runtime: &WaveRuntime) -> Result<()> {
+        runtime
+            .try_attach_discord(
+                self.binding.clone(),
+                self.bot_user_id.clone(),
+                self.initial_head.clone(),
+            )
+            .context("journal Discord attachment")?;
+        Ok(())
+    }
+
+    pub async fn run(self, runtime: std::sync::Arc<WaveRuntime>) {
+        loop {
+            match self.sync_once(&runtime).await {
+                Ok(()) => tokio::time::sleep(POLL_CADENCE).await,
+                Err(error)
+                    if error
+                        .downcast_ref::<DiscordError>()
+                        .is_some_and(DiscordError::retryable) =>
+                {
+                    tracing::warn!(%error, "Discord chat sync failed; retrying");
+                    tokio::time::sleep(ERROR_BACKOFF).await;
+                }
+                Err(error) => {
+                    tracing::error!(%error, "Discord chat sync stopped; restart after correcting the binding or local journal");
+                    return;
+                }
+            }
+        }
+    }
+
+    async fn sync_once(&self, runtime: &WaveRuntime) -> Result<()> {
+        let attachment = runtime
+            .discord_snapshot()
+            .attachment
+            .ok_or_else(|| anyhow!("Discord binding is not attached"))?;
+        let channel: Channel = self
+            .client
+            .get(&format!("/channels/{}", self.binding.channel_id))
+            .await?;
+        if let Some(head) = channel.last_message_id.as_deref() {
+            if attachment.cursor.as_deref() != Some(head) {
+                let messages = self
+                    .messages_after(attachment.cursor.as_deref(), head)
+                    .await?;
+                for message in messages {
+                    self.accept_message(runtime, message)?;
+                }
+                runtime
+                    .try_advance_discord_cursor(&self.binding, head.to_string())
+                    .context("journal Discord cursor")?;
+            }
+        }
+        self.deliver_pending(runtime).await
+    }
+
+    async fn messages_after(&self, cursor: Option<&str>, head: &str) -> Result<Vec<Message>> {
+        let mut before = increment_snowflake(head)?;
+        let cursor = cursor.map(parse_snowflake).transpose()?;
+        let mut messages = Vec::new();
+        loop {
+            let page: Vec<Message> = self
+                .client
+                .get(&format!(
+                    "/channels/{}/messages?limit=100&before={before}",
+                    self.binding.channel_id
+                ))
+                .await?;
+            if page.is_empty() {
+                break;
+            }
+            let mut reached_cursor = false;
+            for message in &page {
+                let id = parse_snowflake(&message.id)?;
+                if cursor.is_some_and(|cursor| id <= cursor) {
+                    reached_cursor = true;
+                    break;
+                }
+                messages.push(message.clone());
+            }
+            if reached_cursor || page.len() < 100 {
+                break;
+            }
+            before = page
+                .last()
+                .map(|message| message.id.clone())
+                .expect("non-empty page has a last message");
+        }
+        messages.sort_by_key(|message| parse_snowflake(&message.id).unwrap_or_default());
+        Ok(messages)
+    }
+
+    fn accept_message(&self, runtime: &WaveRuntime, message: Message) -> Result<()> {
+        if message.author.id == self.bot_user_id {
+            self.reconcile_echo(runtime, &message)?;
+            return Ok(());
+        }
+        if message.author.bot == Some(true)
+            || message.webhook_id.is_some()
+            || message.kind != 0
+            || message.content.trim().is_empty()
+        {
+            return Ok(());
+        }
+        runtime
+            .try_deliver_discord(
+                message.content,
+                DiscordMessageSource {
+                    binding: self.binding.clone(),
+                    message_id: message.id,
+                    author_id: message.author.id,
+                },
+            )
+            .context("journal Discord input")?;
+        Ok(())
+    }
+
+    fn reconcile_echo(&self, runtime: &WaveRuntime, message: &Message) -> Result<()> {
+        let Some(reply_id) = message
+            .message_reference
+            .as_ref()
+            .and_then(|reference| reference.message_id.as_deref())
+        else {
+            return Ok(());
+        };
+        for delivery in runtime.discord_snapshot().deliveries {
+            let Some(reply_to) = delivery.reply_to() else {
+                continue;
+            };
+            if reply_to.binding != self.binding {
+                continue;
+            }
+            if reply_to.message_id != reply_id {
+                continue;
+            }
+            if let Some(part) = delivery
+                .parts
+                .iter()
+                .find(|part| !delivery.confirmed.contains_key(&part.part_id))
+                .filter(|part| part.content == message.content)
+            {
+                runtime
+                    .try_confirm_discord_part(
+                        &delivery.delivery_id,
+                        &part.part_id,
+                        message.id.clone(),
+                    )
+                    .context("journal reconciled Discord send")?;
+                break;
+            }
+        }
+        Ok(())
+    }
+
+    async fn deliver_pending(&self, runtime: &WaveRuntime) -> Result<()> {
+        for delivery in runtime.discord_snapshot().deliveries {
+            let reply_to = delivery.reply_to().ok_or_else(|| {
+                anyhow!(
+                    "Discord delivery {} has no authored source",
+                    delivery.delivery_id
+                )
+            })?;
+            if reply_to.binding != self.binding {
+                continue;
+            }
+            for part in &delivery.parts {
+                if delivery.confirmed.contains_key(&part.part_id) {
+                    continue;
+                }
+                let sent: Message = self
+                    .client
+                    .post(
+                        &format!("/channels/{}/messages", self.binding.channel_id),
+                        &CreateMessage {
+                            content: &part.content,
+                            nonce: &part.nonce,
+                            enforce_nonce: true,
+                            allowed_mentions: AllowedMentions { parse: Vec::new() },
+                            message_reference: MessageReference {
+                                message_id: &reply_to.message_id,
+                                fail_if_not_exists: false,
+                            },
+                        },
+                    )
+                    .await?;
+                runtime
+                    .try_confirm_discord_part(&delivery.delivery_id, &part.part_id, sent.id)
+                    .context("journal Discord send receipt")?;
+            }
+        }
+        Ok(())
+    }
+}
+
+fn require_permissions(
+    guild: &Guild,
+    member: &GuildMember,
+    channel: &Channel,
+    bot_user_id: &str,
+) -> Result<(), DiscordError> {
+    if guild.owner_id == bot_user_id {
+        return Ok(());
+    }
+    let roles = guild
+        .roles
+        .iter()
+        .map(|role| Ok((role.id.as_str(), parse_permission(&role.permissions)?)))
+        .collect::<Result<HashMap<_, _>, DiscordError>>()?;
+    let mut permissions = *roles.get(guild.id.as_str()).unwrap_or(&0);
+    for role in &member.roles {
+        permissions |= roles.get(role.as_str()).copied().unwrap_or(0);
+    }
+    if permissions & ADMINISTRATOR != 0 {
+        return Ok(());
+    }
+    if let Some(overwrite) = channel
+        .permission_overwrites
+        .iter()
+        .find(|overwrite| overwrite.kind == 0 && overwrite.id == guild.id)
+    {
+        apply_overwrite(&mut permissions, overwrite)?;
+    }
+    let mut role_allow = 0;
+    let mut role_deny = 0;
+    for overwrite in channel.permission_overwrites.iter().filter(|overwrite| {
+        overwrite.kind == 0 && member.roles.iter().any(|role| role == &overwrite.id)
+    }) {
+        role_allow |= parse_permission(&overwrite.allow)?;
+        role_deny |= parse_permission(&overwrite.deny)?;
+    }
+    permissions &= !role_deny;
+    permissions |= role_allow;
+    if let Some(overwrite) = channel
+        .permission_overwrites
+        .iter()
+        .find(|overwrite| overwrite.kind == 1 && overwrite.id == bot_user_id)
+    {
+        apply_overwrite(&mut permissions, overwrite)?;
+    }
+    let required = [
+        (VIEW_CHANNEL, "View Channel"),
+        (READ_MESSAGE_HISTORY, "Read Message History"),
+        (SEND_MESSAGES, "Send Messages"),
+    ];
+    let missing = required
+        .iter()
+        .filter_map(|(bit, name)| (permissions & bit == 0).then_some(*name))
+        .collect::<Vec<_>>();
+    if missing.is_empty() {
+        Ok(())
+    } else {
+        Err(DiscordError::MissingPermissions(missing.join(", ")))
+    }
+}
+
+fn apply_overwrite(
+    permissions: &mut u64,
+    overwrite: &PermissionOverwrite,
+) -> Result<(), DiscordError> {
+    *permissions &= !parse_permission(&overwrite.deny)?;
+    *permissions |= parse_permission(&overwrite.allow)?;
+    Ok(())
+}
+
+fn parse_permission(value: &str) -> Result<u64, DiscordError> {
+    value
+        .parse()
+        .map_err(|_| DiscordError::InvalidPermission(value.to_string()))
+}
+
+fn parse_snowflake(value: &str) -> Result<u64> {
+    value
+        .parse()
+        .with_context(|| format!("Discord returned invalid snowflake {value}"))
+}
+
+fn increment_snowflake(value: &str) -> Result<String> {
+    Ok(parse_snowflake(value)?
+        .checked_add(1)
+        .ok_or_else(|| anyhow!("Discord snowflake overflow"))?
+        .to_string())
+}
+
+#[derive(Debug, Deserialize)]
+struct RateLimit {
+    retry_after: f64,
+}
+
+#[derive(Debug, Deserialize)]
+struct ApiError {
+    message: String,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+struct User {
+    id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    bot: Option<bool>,
+}
+
+#[derive(Debug, Deserialize)]
+struct Application {
+    flags: u64,
+}
+
+#[derive(Debug, Deserialize)]
+struct Guild {
+    id: String,
+    owner_id: String,
+    roles: Vec<Role>,
+}
+
+#[derive(Debug, Deserialize)]
+struct Role {
+    id: String,
+    permissions: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct GuildMember {
+    roles: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct Channel {
+    id: String,
+    guild_id: Option<String>,
+    #[serde(rename = "type")]
+    kind: u8,
+    last_message_id: Option<String>,
+    permission_overwrites: Vec<PermissionOverwrite>,
+}
+
+#[derive(Debug, Deserialize)]
+struct PermissionOverwrite {
+    id: String,
+    #[serde(rename = "type")]
+    kind: u8,
+    allow: String,
+    deny: String,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+struct Message {
+    id: String,
+    author: User,
+    content: String,
+    #[serde(rename = "type")]
+    kind: u8,
+    webhook_id: Option<String>,
+    message_reference: Option<ReturnedMessageReference>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+struct ReturnedMessageReference {
+    message_id: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct CreateMessage<'a> {
+    content: &'a str,
+    nonce: &'a str,
+    enforce_nonce: bool,
+    allowed_mentions: AllowedMentions,
+    message_reference: MessageReference<'a>,
+}
+
+#[derive(Debug, Serialize)]
+struct AllowedMentions {
+    parse: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct MessageReference<'a> {
+    message_id: &'a str,
+    fail_if_not_exists: bool,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{Arc, Mutex};
+
+    use axum::body::{to_bytes, Body};
+    use axum::extract::State;
+    use axum::http::{Request, Response};
+    use axum::routing::any;
+    use axum::Router;
+    use serde_json::json;
+
+    use crate::chat::types::Lifecycle;
+    use crate::wave::wire::ResidentDelta;
+
+    #[derive(Debug)]
+    struct Fixture {
+        application_flags: u64,
+        permissions: u64,
+        channel_kind: u8,
+        messages: Vec<Message>,
+        posts: usize,
+        lose_next_post_response: bool,
+    }
+
+    impl Fixture {
+        fn human_message(id: u64) -> Message {
+            Message {
+                id: id.to_string(),
+                author: User {
+                    id: format!("human-{id}"),
+                    bot: None,
+                },
+                content: format!("message {id}"),
+                kind: 0,
+                webhook_id: None,
+                message_reference: None,
+            }
+        }
+    }
+
+    async fn fixture_server(fixture: Arc<Mutex<Fixture>>) -> (String, tokio::task::JoinHandle<()>) {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind fixture");
+        let address = listener.local_addr().expect("fixture address");
+        let app = Router::new()
+            .route("/{*path}", any(discord_fixture))
+            .with_state(fixture);
+        let task = tokio::spawn(async move {
+            axum::serve(listener, app).await.expect("serve fixture");
+        });
+        (format!("http://{address}"), task)
+    }
+
+    async fn discord_fixture(
+        State(fixture): State<Arc<Mutex<Fixture>>>,
+        request: Request<Body>,
+    ) -> Response<Body> {
+        if request
+            .headers()
+            .get(AUTHORIZATION)
+            .and_then(|value| value.to_str().ok())
+            != Some("Bot fixture-token")
+        {
+            return json_response(StatusCode::UNAUTHORIZED, json!({"message": "unauthorized"}));
+        }
+        let method = request.method().clone();
+        let path = request.uri().path().to_string();
+        let query = request.uri().query().unwrap_or_default().to_string();
+        match (method.as_str(), path.as_str()) {
+            ("GET", "/users/@me") => {
+                json_response(StatusCode::OK, json!({"id": "bot", "bot": true}))
+            }
+            ("GET", "/oauth2/applications/@me") => {
+                let flags = fixture.lock().expect("fixture").application_flags;
+                json_response(StatusCode::OK, json!({"flags": flags}))
+            }
+            ("GET", "/guilds/guild") => {
+                let permissions = fixture.lock().expect("fixture").permissions;
+                json_response(
+                    StatusCode::OK,
+                    json!({
+                        "id": "guild",
+                        "owner_id": "owner",
+                        "roles": [{"id": "guild", "permissions": permissions.to_string()}]
+                    }),
+                )
+            }
+            ("GET", "/guilds/guild/members/bot") => {
+                json_response(StatusCode::OK, json!({"roles": []}))
+            }
+            ("GET", "/channels/channel") => {
+                let fixture = fixture.lock().expect("fixture");
+                json_response(
+                    StatusCode::OK,
+                    json!({
+                        "id": "channel",
+                        "guild_id": "guild",
+                        "type": fixture.channel_kind,
+                        "last_message_id": fixture.messages.last().map(|message| &message.id),
+                        "permission_overwrites": []
+                    }),
+                )
+            }
+            ("GET", "/channels/channel/messages") => {
+                let before = query
+                    .split('&')
+                    .find_map(|part| part.strip_prefix("before="))
+                    .and_then(|value| value.parse::<u64>().ok());
+                let limit = query
+                    .split('&')
+                    .find_map(|part| part.strip_prefix("limit="))
+                    .and_then(|value| value.parse::<usize>().ok())
+                    .unwrap_or(50);
+                let mut messages = fixture.lock().expect("fixture").messages.clone();
+                messages.reverse();
+                if let Some(before) = before {
+                    messages.retain(|message| message.id.parse::<u64>().unwrap() < before);
+                }
+                messages.truncate(limit);
+                json_response(
+                    StatusCode::OK,
+                    serde_json::to_value(messages).expect("messages"),
+                )
+            }
+            ("POST", "/channels/channel/messages") => {
+                let body = to_bytes(request.into_body(), 16 * 1024)
+                    .await
+                    .expect("post body");
+                let body: serde_json::Value = serde_json::from_slice(&body).expect("message body");
+                assert_eq!(body["allowed_mentions"]["parse"], json!([]));
+                assert_eq!(body["enforce_nonce"], true);
+                assert!(body["nonce"].as_str().expect("nonce").len() <= 25);
+                let mut fixture = fixture.lock().expect("fixture");
+                fixture.posts += 1;
+                let id = fixture
+                    .messages
+                    .last()
+                    .and_then(|message| message.id.parse::<u64>().ok())
+                    .unwrap_or(0)
+                    + 1;
+                let message = Message {
+                    id: id.to_string(),
+                    author: User {
+                        id: "bot".into(),
+                        bot: Some(true),
+                    },
+                    content: body["content"].as_str().expect("content").to_string(),
+                    kind: 0,
+                    webhook_id: None,
+                    message_reference: Some(ReturnedMessageReference {
+                        message_id: body["message_reference"]["message_id"]
+                            .as_str()
+                            .map(str::to_string),
+                    }),
+                };
+                fixture.messages.push(message.clone());
+                if std::mem::take(&mut fixture.lose_next_post_response) {
+                    Response::builder()
+                        .status(StatusCode::OK)
+                        .body(Body::from("accepted but response lost"))
+                        .expect("response")
+                } else {
+                    json_response(
+                        StatusCode::OK,
+                        serde_json::to_value(message).expect("message"),
+                    )
+                }
+            }
+            _ => json_response(StatusCode::NOT_FOUND, json!({"message": "not found"})),
+        }
+    }
+
+    fn json_response(status: StatusCode, value: serde_json::Value) -> Response<Body> {
+        Response::builder()
+            .status(status)
+            .header("content-type", "application/json")
+            .body(Body::from(value.to_string()))
+            .expect("response")
+    }
+
+    fn binding() -> DiscordChatBinding {
+        DiscordChatBinding {
+            guild_id: "guild".into(),
+            channel_id: "channel".into(),
+        }
+    }
+
+    fn fixture(messages: Vec<Message>) -> Arc<Mutex<Fixture>> {
+        Arc::new(Mutex::new(Fixture {
+            application_flags: MESSAGE_CONTENT_LIMITED,
+            permissions: VIEW_CHANNEL | READ_MESSAGE_HISTORY | SEND_MESSAGES,
+            channel_kind: 0,
+            messages,
+            posts: 0,
+            lose_next_post_response: false,
+        }))
+    }
+
+    #[test]
+    fn discord_chat_requires_a_token_without_reading_or_printing_one() {
+        assert!(matches!(
+            DiscordClient::from_token(None, "http://unused"),
+            Err(DiscordError::MissingToken)
+        ));
+        let client = DiscordClient::from_token(Some("fixture-token".into()), "http://unused")
+            .expect("fixture client");
+        assert!(!format!("{client:?}").contains("fixture-token"));
+    }
+
+    #[test]
+    fn discord_chat_binding_has_one_local_listener() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let local = HomeId::new();
+
+        let first = DiscordBindingLease::acquire_at(temp.path(), &binding(), &local)
+            .expect("first listener claims binding");
+        assert!(matches!(
+            DiscordBindingLease::acquire_at(temp.path(), &binding(), &local),
+            Err(DiscordError::AlreadyOwned { .. })
+        ));
+        drop(first);
+        DiscordBindingLease::acquire_at(temp.path(), &binding(), &local)
+            .expect("binding is released with its listener");
+    }
+
+    #[tokio::test]
+    async fn discord_chat_rejects_the_wrong_home_before_provider_access() {
+        let local = HomeId::new();
+        let owner = HomeId::new();
+
+        let error = DiscordAdapter::preflight(binding(), &owner, &local)
+            .await
+            .expect_err("another Home must not reach token or Discord preflight");
+
+        assert!(matches!(error, DiscordError::WrongHome { .. }));
+    }
+
+    #[tokio::test]
+    async fn discord_chat_starts_at_head_catches_up_in_order_and_reconciles_a_lost_send() {
+        let fixture = fixture(vec![
+            Fixture::human_message(99),
+            Fixture::human_message(100),
+        ]);
+        let (base_url, server) = fixture_server(fixture.clone()).await;
+        let client = DiscordClient::from_token(Some("fixture-token".into()), &base_url)
+            .expect("fixture client");
+        let adapter = DiscordAdapter::preflight_with_client(client, binding())
+            .await
+            .expect("preflight");
+        let temp = tempfile::tempdir().expect("tempdir");
+        let runtime = WaveRuntime::open("ship".into(), temp.path().to_path_buf()).expect("runtime");
+        adapter.attach(&runtime).expect("attach at head");
+        adapter.sync_once(&runtime).await.expect("initial sync");
+        assert!(
+            runtime.pending_messages().is_empty(),
+            "history was not imported"
+        );
+
+        fixture
+            .lock()
+            .expect("fixture")
+            .messages
+            .extend((101..=205).map(Fixture::human_message));
+        adapter.sync_once(&runtime).await.expect("paged catch-up");
+        let pending = runtime.pending_messages();
+        assert_eq!(pending.len(), 105);
+        assert!(pending[0].text.ends_with("message 101"));
+        assert!(pending[104].text.ends_with("message 205"));
+        adapter.sync_once(&runtime).await.expect("duplicate fetch");
+        assert_eq!(runtime.pending_messages().len(), 105);
+
+        let answers = pending.iter().map(|message| message.id.0.clone()).collect();
+        runtime.apply_resident_delta(ResidentDelta::TurnOpened { answers });
+        runtime.apply_resident_delta(ResidentDelta::TurnText {
+            text: "x".repeat(2_001),
+        });
+        runtime.apply_resident_delta(ResidentDelta::TurnFinished {
+            status: Lifecycle::Completed,
+            cost_usd: None,
+            reason: None,
+        });
+        assert_eq!(
+            runtime.discord_snapshot().deliveries[0]
+                .reply_to()
+                .map(|source| source.message_id.as_str()),
+            Some("205"),
+            "the ordered source list makes the newest claim the reply target"
+        );
+        fixture.lock().expect("fixture").lose_next_post_response = true;
+        assert!(adapter.deliver_pending(&runtime).await.is_err());
+        assert_eq!(fixture.lock().expect("fixture").posts, 1);
+        assert!(runtime.discord_snapshot().deliveries[0]
+            .confirmed
+            .is_empty());
+
+        drop(runtime);
+        let client = DiscordClient::from_token(Some("fixture-token".into()), &base_url)
+            .expect("restart fixture client");
+        let adapter = DiscordAdapter::preflight_with_client(client, binding())
+            .await
+            .expect("restart preflight");
+        let runtime =
+            WaveRuntime::open("ship".into(), temp.path().to_path_buf()).expect("restart runtime");
+        adapter.attach(&runtime).expect("reattach after restart");
+        adapter
+            .sync_once(&runtime)
+            .await
+            .expect("restart reconciles accepted send");
+        assert_eq!(
+            fixture.lock().expect("fixture").posts,
+            2,
+            "the accepted first part was reconciled; only the second part posted"
+        );
+        assert_eq!(runtime.discord_snapshot().deliveries[0].confirmed.len(), 2);
+        assert!(
+            runtime.pending_messages().is_empty(),
+            "self echo is not input"
+        );
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn discord_chat_preflight_rejects_missing_message_content() {
+        let fixture = fixture(Vec::new());
+        fixture.lock().expect("fixture").application_flags = 0;
+        let (base_url, server) = fixture_server(fixture).await;
+        let client = DiscordClient::from_token(Some("fixture-token".into()), &base_url)
+            .expect("fixture client");
+        assert!(matches!(
+            DiscordAdapter::preflight_with_client(client, binding()).await,
+            Err(DiscordError::MissingMessageContent)
+        ));
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn discord_chat_preflight_rejects_non_text_channels() {
+        let fixture = fixture(Vec::new());
+        fixture.lock().expect("fixture").channel_kind = 11;
+        let (base_url, server) = fixture_server(fixture).await;
+        let client = DiscordClient::from_token(Some("fixture-token".into()), &base_url)
+            .expect("fixture client");
+        let error = DiscordAdapter::preflight_with_client(client, binding())
+            .await
+            .expect_err("thread channel must fail")
+            .to_string();
+        assert!(error.contains("GUILD_TEXT"), "{error}");
+        server.abort();
+    }
+
+    #[test]
+    fn discord_chat_permission_overwrites_are_applied_in_discord_order() {
+        let guild = Guild {
+            id: "1".into(),
+            owner_id: "owner".into(),
+            roles: vec![
+                Role {
+                    id: "1".into(),
+                    permissions: (VIEW_CHANNEL | READ_MESSAGE_HISTORY).to_string(),
+                },
+                Role {
+                    id: "2".into(),
+                    permissions: "0".into(),
+                },
+            ],
+        };
+        let member = GuildMember {
+            roles: vec!["2".into()],
+        };
+        let channel = Channel {
+            id: "3".into(),
+            guild_id: Some("1".into()),
+            kind: 0,
+            last_message_id: None,
+            permission_overwrites: vec![PermissionOverwrite {
+                id: "2".into(),
+                kind: 0,
+                allow: SEND_MESSAGES.to_string(),
+                deny: "0".into(),
+            }],
+        };
+        assert!(require_permissions(&guild, &member, &channel, "bot").is_ok());
+    }
+
+    #[test]
+    fn discord_chat_reports_each_missing_permission() {
+        let channel = Channel {
+            id: "3".into(),
+            guild_id: Some("1".into()),
+            kind: 0,
+            last_message_id: None,
+            permission_overwrites: Vec::new(),
+        };
+        for (missing, name) in [
+            (VIEW_CHANNEL, "View Channel"),
+            (READ_MESSAGE_HISTORY, "Read Message History"),
+            (SEND_MESSAGES, "Send Messages"),
+        ] {
+            let guild = Guild {
+                id: "1".into(),
+                owner_id: "owner".into(),
+                roles: vec![Role {
+                    id: "1".into(),
+                    permissions: ((VIEW_CHANNEL | READ_MESSAGE_HISTORY | SEND_MESSAGES) & !missing)
+                        .to_string(),
+                }],
+            };
+            let error =
+                require_permissions(&guild, &GuildMember { roles: Vec::new() }, &channel, "bot")
+                    .expect_err("permissions must fail")
+                    .to_string();
+            assert!(error.contains(name), "{error}");
+        }
+    }
+}

--- a/rust/loopflow/src/wave/journal.rs
+++ b/rust/loopflow/src/wave/journal.rs
@@ -114,6 +114,80 @@ pub struct PendingMessage {
     pub id: MessageId,
     pub op: MessageOp,
     pub text: String,
+    pub source: Option<DiscordMessageSource>,
+}
+
+impl PendingMessage {
+    pub fn destination(&self) -> MessageDestination {
+        self.source
+            .as_ref()
+            .map(|source| MessageDestination::Discord(source.binding.clone()))
+            .unwrap_or(MessageDestination::Local)
+    }
+}
+
+/// The authored-chat destination a resident pass is allowed to answer.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MessageDestination {
+    Local,
+    Discord(DiscordChatBinding),
+}
+
+/// One configured Discord guild text channel.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct DiscordChatBinding {
+    pub guild_id: String,
+    pub channel_id: String,
+}
+
+/// Provider identity retained with one imported human message.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct DiscordMessageSource {
+    pub binding: DiscordChatBinding,
+    pub message_id: String,
+    pub author_id: String,
+}
+
+impl DiscordMessageSource {
+    pub fn uri(&self) -> String {
+        format!(
+            "discord://{}/{}/{}",
+            self.binding.guild_id, self.binding.channel_id, self.message_id
+        )
+    }
+}
+
+/// One deterministic Discord message part recorded before delivery.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DiscordMessagePart {
+    pub part_id: String,
+    pub nonce: String,
+    pub content: String,
+}
+
+/// One journal-folded outbound delivery and its provider receipts.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DiscordDelivery {
+    pub delivery_id: String,
+    pub turn_id: String,
+    pub sources: Vec<DiscordMessageSource>,
+    pub parts: Vec<DiscordMessagePart>,
+    pub confirmed: HashMap<String, String>,
+}
+
+impl DiscordDelivery {
+    /// Discord replies target the newest authored source claimed by the turn.
+    pub fn reply_to(&self) -> Option<&DiscordMessageSource> {
+        self.sources.last()
+    }
+}
+
+/// The last committed binding attachment.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DiscordAttachment {
+    pub binding: DiscordChatBinding,
+    pub bot_user_id: String,
+    pub cursor: Option<String>,
 }
 
 /// One journal row.
@@ -147,6 +221,31 @@ pub enum EventKind {
         id: MessageId,
         op: MessageOp,
         text: String,
+    },
+    DiscordChatAttached {
+        binding: DiscordChatBinding,
+        bot_user_id: String,
+        cursor: Option<String>,
+    },
+    DiscordUserMessage {
+        id: MessageId,
+        text: String,
+        source: DiscordMessageSource,
+    },
+    DiscordChatCursorAdvanced {
+        binding: DiscordChatBinding,
+        message_id: String,
+    },
+    DiscordChatSendPlanned {
+        delivery_id: String,
+        turn_id: String,
+        sources: Vec<DiscordMessageSource>,
+        parts: Vec<DiscordMessagePart>,
+    },
+    DiscordChatSendConfirmed {
+        delivery_id: String,
+        part_id: String,
+        provider_message_id: String,
     },
     TurnStarted {
         turn_id: String,
@@ -405,6 +504,34 @@ impl Narrator {
                 };
                 info(format!("chat ← {op_tag}\"{}\" ({id})", ellipsize(text, 60)))
             }
+            EventKind::DiscordChatAttached {
+                binding, cursor, ..
+            } => info(format!(
+                "discord attached · channel {} · cursor {}",
+                binding.channel_id,
+                cursor.as_deref().unwrap_or("empty")
+            )),
+            EventKind::DiscordUserMessage { id, text, source } => info(format!(
+                "discord ← \"{}\" ({id}, {})",
+                ellipsize(text, 60),
+                source.message_id
+            )),
+            EventKind::DiscordChatCursorAdvanced { message_id, .. } => {
+                debug(format!("discord cursor → {message_id}"))
+            }
+            EventKind::DiscordChatSendPlanned {
+                delivery_id, parts, ..
+            } => info(format!(
+                "discord send planned · {delivery_id} · {} part(s)",
+                parts.len()
+            )),
+            EventKind::DiscordChatSendConfirmed {
+                delivery_id,
+                part_id,
+                provider_message_id,
+            } => info(format!(
+                "discord send confirmed · {delivery_id}/{part_id} → {provider_message_id}"
+            )),
             EventKind::TurnStarted {
                 turn_id, answers, ..
             } => {
@@ -863,6 +990,12 @@ pub struct ThreadFold {
     /// Every journaled input by id — `MessagesRequeued` restores pending
     /// entries from it.
     pub messages: HashMap<MessageId, PendingMessage>,
+    /// The attached Discord channel and its committed cursor.
+    pub discord: Option<DiscordAttachment>,
+    /// Outbound intents and receipts, keyed by deterministic delivery id.
+    pub discord_deliveries: HashMap<String, DiscordDelivery>,
+    /// Completed assistant turns and the authored inputs they answered.
+    pub completed_claims: HashMap<String, Vec<MessageId>>,
     /// Typed Task observations indexed by their synthetic consumption id.
     pub tasks: HashMap<MessageId, TaskObservation>,
     /// Typed Project observations indexed by their synthetic consumption id.
@@ -935,6 +1068,9 @@ pub fn fold_thread(events: &[Event]) -> ThreadFold {
     let mut playhead: Option<Playhead> = None;
     let mut pending_messages: Vec<PendingMessage> = Vec::new();
     let mut messages: HashMap<MessageId, PendingMessage> = HashMap::new();
+    let mut discord: Option<DiscordAttachment> = None;
+    let mut discord_deliveries: HashMap<String, DiscordDelivery> = HashMap::new();
+    let mut completed_claims: HashMap<String, Vec<MessageId>> = HashMap::new();
     let mut tasks: HashMap<MessageId, TaskObservation> = HashMap::new();
     let mut projects: HashMap<MessageId, ProjectObservation> = HashMap::new();
     let mut promotions: HashMap<MessageId, PromotionWake> = HashMap::new();
@@ -953,11 +1089,75 @@ pub fn fold_thread(events: &[Event]) -> ThreadFold {
                     id: id.clone(),
                     op: *op,
                     text: text.clone(),
+                    source: None,
                 };
                 if !consumed_messages.contains(id) {
                     pending_messages.push(message.clone());
                 }
                 messages.insert(id.clone(), message);
+            }
+            EventKind::DiscordChatAttached {
+                binding,
+                bot_user_id,
+                cursor,
+            } => {
+                discord = Some(DiscordAttachment {
+                    binding: binding.clone(),
+                    bot_user_id: bot_user_id.clone(),
+                    cursor: cursor.clone(),
+                });
+            }
+            EventKind::DiscordUserMessage { id, text, source } => {
+                let mut turn = ChatTurn::user(format!("turn-{}", event.seq), text.clone());
+                turn.created_at = event.at_rfc3339();
+                turns.push(turn);
+                let message = PendingMessage {
+                    id: id.clone(),
+                    op: MessageOp::Message,
+                    text: format!("[{}]\n{}", source.uri(), text),
+                    source: Some(source.clone()),
+                };
+                if !consumed_messages.contains(id) {
+                    pending_messages.push(message.clone());
+                }
+                messages.insert(id.clone(), message);
+            }
+            EventKind::DiscordChatCursorAdvanced {
+                binding,
+                message_id,
+            } => {
+                if let Some(attached) = discord.as_mut() {
+                    if &attached.binding == binding {
+                        attached.cursor = Some(message_id.clone());
+                    }
+                }
+            }
+            EventKind::DiscordChatSendPlanned {
+                delivery_id,
+                turn_id,
+                sources,
+                parts,
+            } => {
+                discord_deliveries
+                    .entry(delivery_id.clone())
+                    .or_insert_with(|| DiscordDelivery {
+                        delivery_id: delivery_id.clone(),
+                        turn_id: turn_id.clone(),
+                        sources: sources.clone(),
+                        parts: parts.clone(),
+                        confirmed: HashMap::new(),
+                    });
+            }
+            EventKind::DiscordChatSendConfirmed {
+                delivery_id,
+                part_id,
+                provider_message_id,
+            } => {
+                if let Some(delivery) = discord_deliveries.get_mut(delivery_id) {
+                    delivery
+                        .confirmed
+                        .insert(part_id.clone(), provider_message_id.clone());
+                }
             }
             EventKind::TaskObserved { observation } => {
                 let message = task_observation_message(observation);
@@ -1048,7 +1248,10 @@ pub fn fold_thread(events: &[Event]) -> ThreadFold {
                 let mut turn = open.remove(pos);
                 turn.status = *status;
                 turn.close_body(event.at_rfc3339(), termination_reason.clone());
-                claims_by_open_turn.remove(turn_id);
+                let claims = claims_by_open_turn.remove(turn_id).unwrap_or_default();
+                if *status == Lifecycle::Completed {
+                    completed_claims.insert(turn_id.clone(), claims);
+                }
                 turns.push(turn);
             }
             EventKind::LoopState { to, .. } => {
@@ -1113,6 +1316,9 @@ pub fn fold_thread(events: &[Event]) -> ThreadFold {
         playhead,
         pending_messages,
         messages,
+        discord,
+        discord_deliveries,
+        completed_claims,
         tasks,
         projects,
         promotions,
@@ -1125,6 +1331,7 @@ pub fn task_observation_message(observation: &TaskObservation) -> PendingMessage
         id: MessageId(observation.inbox_id()),
         op: MessageOp::Message,
         text: observation.prompt(),
+        source: None,
     }
 }
 
@@ -1133,6 +1340,7 @@ pub fn project_observation_message(observation: &ProjectObservation) -> PendingM
         id: MessageId(observation.inbox_id()),
         op: MessageOp::Message,
         text: observation.prompt(),
+        source: None,
     }
 }
 
@@ -1141,6 +1349,7 @@ pub(crate) fn promotion_wake_message(wake: &PromotionWake) -> PendingMessage {
         id: MessageId(wake.inbox_id()),
         op: MessageOp::Message,
         text: wake.prompt(),
+        source: None,
     }
 }
 
@@ -1186,6 +1395,29 @@ mod tests {
                 resumable: true,
             },
         }
+    }
+
+    fn discord_binding() -> DiscordChatBinding {
+        DiscordChatBinding {
+            guild_id: "guild".into(),
+            channel_id: "channel".into(),
+        }
+    }
+
+    fn discord_source() -> DiscordMessageSource {
+        DiscordMessageSource {
+            binding: discord_binding(),
+            message_id: "101".into(),
+            author_id: "human".into(),
+        }
+    }
+
+    fn discord_parts() -> Vec<DiscordMessagePart> {
+        vec![DiscordMessagePart {
+            part_id: "part-1".into(),
+            nonce: "lf-nonce-1".into(),
+            content: "answer".into(),
+        }]
     }
 
     #[test]
@@ -1271,6 +1503,31 @@ mod tests {
     fn event_round_trips_every_kind() {
         let kinds = vec![
             user_message(1, "hi"),
+            EventKind::DiscordChatAttached {
+                binding: discord_binding(),
+                bot_user_id: "bot".into(),
+                cursor: Some("100".into()),
+            },
+            EventKind::DiscordUserMessage {
+                id: MessageId("msg-2".into()),
+                text: "question".into(),
+                source: discord_source(),
+            },
+            EventKind::DiscordChatCursorAdvanced {
+                binding: discord_binding(),
+                message_id: "101".into(),
+            },
+            EventKind::DiscordChatSendPlanned {
+                delivery_id: "delivery-1".into(),
+                turn_id: "turn-3".into(),
+                sources: vec![discord_source()],
+                parts: discord_parts(),
+            },
+            EventKind::DiscordChatSendConfirmed {
+                delivery_id: "delivery-1".into(),
+                part_id: "part-1".into(),
+                provider_message_id: "102".into(),
+            },
             EventKind::TurnStarted {
                 turn_id: "turn-2".into(),
                 answers: vec![MessageId("msg-1".into())],
@@ -1365,6 +1622,31 @@ mod tests {
     fn narration_renders_every_event_kind() {
         let kinds = vec![
             user_message(1, "hi"),
+            EventKind::DiscordChatAttached {
+                binding: discord_binding(),
+                bot_user_id: "bot".into(),
+                cursor: Some("100".into()),
+            },
+            EventKind::DiscordUserMessage {
+                id: MessageId("msg-2".into()),
+                text: "question".into(),
+                source: discord_source(),
+            },
+            EventKind::DiscordChatCursorAdvanced {
+                binding: discord_binding(),
+                message_id: "101".into(),
+            },
+            EventKind::DiscordChatSendPlanned {
+                delivery_id: "delivery-1".into(),
+                turn_id: "turn-3".into(),
+                sources: vec![discord_source()],
+                parts: discord_parts(),
+            },
+            EventKind::DiscordChatSendConfirmed {
+                delivery_id: "delivery-1".into(),
+                part_id: "part-1".into(),
+                provider_message_id: "102".into(),
+            },
             EventKind::TurnStarted {
                 turn_id: "turn-2".into(),
                 answers: vec![],

--- a/rust/loopflow/src/wave/mod.rs
+++ b/rust/loopflow/src/wave/mod.rs
@@ -47,6 +47,7 @@
 //! exists on the machine, child observations wait durably; the listener remains
 //! functional and acquires the registry when it appears.
 
+pub(crate) mod discord;
 pub mod journal;
 pub(crate) mod memory;
 pub mod playhead;
@@ -71,6 +72,7 @@ use std::sync::Arc;
 use anyhow::{anyhow, Result};
 
 use crate::engine::repo::find_repo_root;
+use crate::engine::wave_config::{try_read_wave_config, WaveChatConfig};
 use crate::engine::worktrees::main_repo_root;
 use crate::ops::util::normalize_wave_name;
 use crate::store::{open_existing_store, SharedStore};
@@ -236,30 +238,42 @@ fn resident_spawner(
     resident_env: Vec<(String, String)>,
 ) -> supervisor::SpawnResident {
     Box::new(move || {
-        let exe = std::env::current_exe()?;
-        let mut command = tokio::process::Command::new(exe);
-        command
-            .arg(RESIDENT_SUBCOMMAND)
-            .arg(&wave)
-            .current_dir(&repo_root)
-            .env(WAVE_SERVER_ENDPOINT_ENV, &endpoint)
-            .env(wire::RESIDENT_TOKEN_ENV, &token)
-            // The resident's children must resolve `lf` to this binary.
-            .env("PATH", crate::flowloop::wave::path_for_children())
-            .env_remove(crate::durable::RUN_CONTEXT_ENV)
-            .env_remove(crate::durable::RUN_LEASE_ENV)
-            .stdin(std::process::Stdio::null());
+        let mut command = resident_command(&wave, &repo_root, &endpoint, &token, &resident_env)?;
         // No kill_on_drop: shutdown stops the supervisor FIRST (so a TERM'd
         // resident's exit isn't journaled as a failure), then SIGTERMs the
         // resident by pid — its hooks stop the vendor process group. A
         // SIGKILL-on-drop here would orphan the codex group instead.
-        for (key, value) in &resident_env {
-            command.env(key, value);
-        }
         #[cfg(unix)]
         command.process_group(0);
         command.spawn()
     })
+}
+
+fn resident_command(
+    wave: &str,
+    repo_root: &Path,
+    endpoint: &str,
+    token: &str,
+    resident_env: &[(String, String)],
+) -> std::io::Result<tokio::process::Command> {
+    let exe = std::env::current_exe()?;
+    let mut command = tokio::process::Command::new(exe);
+    command
+        .arg(RESIDENT_SUBCOMMAND)
+        .arg(wave)
+        .current_dir(repo_root)
+        .env(WAVE_SERVER_ENDPOINT_ENV, endpoint)
+        .env(wire::RESIDENT_TOKEN_ENV, token)
+        // The resident's children must resolve `lf` to this binary.
+        .env("PATH", crate::flowloop::wave::path_for_children())
+        .env_remove(crate::durable::RUN_CONTEXT_ENV)
+        .env_remove(crate::durable::RUN_LEASE_ENV)
+        .stdin(std::process::Stdio::null());
+    for (key, value) in resident_env {
+        command.env(key, value);
+    }
+    command.env_remove(discord::TOKEN_ENV);
+    Ok(command)
 }
 
 /// Serve the wave until `shutdown` resolves. Vendor-free by construction:
@@ -304,6 +318,26 @@ pub(crate) async fn run_listener(
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
     let addr = listener.local_addr()?;
 
+    let discord_adapter =
+        match try_read_wave_config(&repo_root, &wave)?.and_then(|config| config.chat) {
+            Some(WaveChatConfig::Discord {
+                home_id,
+                guild_id,
+                channel_id,
+            }) => {
+                let registry = registry_config.as_ref().ok_or_else(|| {
+                    anyhow!("Discord chat requires the local registry to verify its owner Home")
+                })?;
+                let local_home = registry.store.local_home().await?;
+                let binding = journal::DiscordChatBinding {
+                    guild_id,
+                    channel_id,
+                };
+                Some(discord::DiscordAdapter::preflight(binding, &home_id, &local_home.id).await?)
+            }
+            None => None,
+        };
+
     let registered = registry_config
         .as_ref()
         .map(|config| (config.store.clone(), config.wave.id().clone()));
@@ -347,6 +381,9 @@ pub(crate) async fn run_listener(
     // Refusals are behind us: NOW open the journal for writing and mark the
     // boot. The store-polling observer starts once the runtime exists.
     let runtime = WaveRuntime::open(wave.clone(), repo_root.clone())?;
+    if let Some(adapter) = discord_adapter.as_ref() {
+        adapter.attach(&runtime)?;
+    }
     // Boot marker, once per life, after replay: restarts are visible in the
     // journal itself (the boot janitor already leaks process lifecycle into
     // the record; make it honest and forensically legible).
@@ -361,6 +398,7 @@ pub(crate) async fn run_listener(
     });
     let observer = Arc::new(registry::ObserverSlot::new(runtime.clone(), observer));
     let observer_task = tokio::spawn(Arc::clone(&observer).run(registry::POLL_CADENCE));
+    let discord_task = discord_adapter.map(|adapter| tokio::spawn(adapter.run(runtime.clone())));
 
     // The resident door: a per-boot token, published beside the endpoint
     // pointer so the resident can attach (same trust domain).
@@ -404,9 +442,17 @@ pub(crate) async fn run_listener(
     let cleanup_addr = own_addr.clone();
     let cleanup_token = token.clone();
     let cleanup_door = door.clone();
+    let cleanup_run = wave_run
+        .as_ref()
+        .map(|(store, lease)| (Arc::clone(store), lease.clone()));
     crate::engine::agent::register_interrupt_cleanup(move || {
         if let Some(pid) = cleanup_door.seat_pid() {
             supervisor::terminate_resident_blocking(pid);
+        }
+        if let Some((store, lease)) = cleanup_run.as_ref() {
+            if let Err(error) = store.stop_run_on_interrupt(lease) {
+                tracing::warn!(%error, "failed to release Wave Run authority on interrupt");
+            }
         }
         server::remove_endpoint(&cleanup_repo, &cleanup_wave, &cleanup_addr);
         server::remove_resident_token(&cleanup_repo, &cleanup_wave, &cleanup_token);
@@ -440,11 +486,14 @@ pub(crate) async fn run_listener(
         .with_graceful_shutdown(graceful_shutdown)
         .await;
 
-    // Shutdown: stand the keeper down FIRST (so the resident's exit below
-    // is not journaled as a failure), then ask the resident to leave
+    // Shutdown: stop external delivery and stand the keeper down FIRST (so
+    // the resident's exit below is not journaled as a failure), then ask the resident to leave
     // (SIGTERM → its interrupt hooks stop the harness; SIGKILL after a
     // grace), mark the registry row terminal, drop the discovery files.
     // Workers are their own tmux sessions — nothing here owns them.
+    if let Some(task) = discord_task {
+        task.abort();
+    }
     supervisor_task.abort();
     if let Some(pid) = door.seat_pid() {
         supervisor::terminate_resident(pid).await;
@@ -510,6 +559,22 @@ mod tests {
                 .command,
             Some(Commands::External(parts)) if parts[0] == "loop"
         ));
+    }
+
+    #[test]
+    fn discord_chat_token_is_explicitly_scrubbed_from_the_resident() {
+        let command = resident_command(
+            "goals",
+            Path::new("/tmp"),
+            "127.0.0.1:1234",
+            "resident-token",
+            &[(discord::TOKEN_ENV.to_string(), "must-not-pass".to_string())],
+        )
+        .expect("resident command");
+        assert!(command
+            .as_std()
+            .get_envs()
+            .any(|(name, value)| { name == discord::TOKEN_ENV && value.is_none() }));
     }
 
     #[tokio::test]

--- a/rust/loopflow/src/wave/resident.rs
+++ b/rust/loopflow/src/wave/resident.rs
@@ -207,10 +207,16 @@ pub async fn follow_inbox(endpoint: String, inbox_tx: mpsc::UnboundedSender<Inbo
 
 fn inbox_item(frame: InboxFrame) -> InboxItem {
     match frame {
-        InboxFrame::Message { id, op, text } => InboxItem::Message(PendingMessage {
+        InboxFrame::Message {
+            id,
+            op,
+            text,
+            source,
+        } => InboxItem::Message(PendingMessage {
             id: MessageId(id),
             op,
             text,
+            source,
         }),
         InboxFrame::Task { observation } => InboxItem::Task(observation),
         InboxFrame::Project { observation } => InboxItem::Project(observation),
@@ -502,6 +508,7 @@ mod tests {
             id: "msg-3".into(),
             op: crate::wave::journal::MessageOp::Steer,
             text: "focus".into(),
+            source: None,
         });
         let InboxItem::Message(message) = message else {
             panic!("expected message");

--- a/rust/loopflow/src/wave/runtime.rs
+++ b/rust/loopflow/src/wave/runtime.rs
@@ -27,6 +27,7 @@ use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex, MutexGuard};
 
+use sha2::{Digest, Sha256};
 use tokio::sync::broadcast;
 
 use crate::chat::turns::{ChatRole, ChatTurn, TurnDelta};
@@ -38,8 +39,9 @@ use crate::task::TaskObservation;
 use crate::wave::journal::JournalAppendStage;
 use crate::wave::journal::{
     fold_thread, journal_path, project_observation_message, promotion_wake_message,
-    restore_pending, task_observation_message, EventKind, Journal, JournalAppendError, MessageId,
-    MessageOp, PendingMessage, Usage,
+    restore_pending, task_observation_message, DiscordAttachment, DiscordChatBinding,
+    DiscordDelivery, DiscordMessagePart, DiscordMessageSource, EventKind, Journal,
+    JournalAppendError, MessageId, MessageOp, PendingMessage, Usage,
 };
 use crate::wave::playhead::{
     now_rfc3339, BodyProvenance, Playhead, PlayheadEvent, PlayheadView, QueuedInvocation,
@@ -183,6 +185,13 @@ pub struct Subscription {
     pub inbox_rx: broadcast::Receiver<InboxItem>,
 }
 
+/// Durable Discord state the listener-owned adapter needs to resume.
+#[derive(Debug, Clone)]
+pub struct DiscordSnapshot {
+    pub attachment: Option<DiscordAttachment>,
+    pub deliveries: Vec<DiscordDelivery>,
+}
+
 /// The assistant turn in progress. `turn` is the snapshot the wire watches
 /// grow (status `Running`), re-broadcast on every content delta and committed
 /// to `thread` under the same id at finalization; the rest is bookkeeping that
@@ -225,6 +234,8 @@ struct Inner {
     pending_messages: Vec<PendingMessage>,
     /// Every journaled input by id — requeues restore pending entries from it.
     messages: HashMap<MessageId, PendingMessage>,
+    discord: Option<DiscordAttachment>,
+    discord_deliveries: HashMap<String, DiscordDelivery>,
     tasks: HashMap<MessageId, TaskObservation>,
     projects: HashMap<MessageId, ProjectObservation>,
     promotions: HashMap<MessageId, PromotionWake>,
@@ -335,6 +346,31 @@ impl WaveRuntime {
             LoopState::Idle
         };
 
+        let planned_turns = fold
+            .discord_deliveries
+            .values()
+            .map(|delivery| delivery.turn_id.clone())
+            .collect::<std::collections::HashSet<_>>();
+        for (turn_id, claims) in &fold.completed_claims {
+            if planned_turns.contains(turn_id) {
+                continue;
+            }
+            let Some(turn) = fold.turns.iter().find(|turn| &turn.id == turn_id) else {
+                continue;
+            };
+            let Some(delivery) = build_discord_delivery(turn, claims, &fold.messages) else {
+                continue;
+            };
+            journal.append(|_| EventKind::DiscordChatSendPlanned {
+                delivery_id: delivery.delivery_id.clone(),
+                turn_id: delivery.turn_id.clone(),
+                sources: delivery.sources.clone(),
+                parts: delivery.parts.clone(),
+            });
+            fold.discord_deliveries
+                .insert(delivery.delivery_id.clone(), delivery);
+        }
+
         let (turn_tx, _) = broadcast::channel(TURN_BROADCAST_CAPACITY);
         let (state_tx, _) = broadcast::channel(STATE_BROADCAST_CAPACITY);
         let (playhead_tx, _) = broadcast::channel(PLAYHEAD_BROADCAST_CAPACITY);
@@ -352,6 +388,8 @@ impl WaveRuntime {
                 last_assistant_turn_id,
                 pending_messages: fold.pending_messages,
                 messages: fold.messages,
+                discord: fold.discord,
+                discord_deliveries: fold.discord_deliveries,
                 tasks: fold.tasks,
                 projects: fold.projects,
                 promotions: fold.promotions,
@@ -370,6 +408,150 @@ impl WaveRuntime {
 
     pub fn repo_root(&self) -> &std::path::Path {
         &self.repo_root
+    }
+
+    pub fn discord_snapshot(&self) -> DiscordSnapshot {
+        let inner = self.inner();
+        let mut deliveries = inner
+            .discord_deliveries
+            .values()
+            .cloned()
+            .collect::<Vec<_>>();
+        deliveries.sort_by_key(|delivery| {
+            delivery
+                .turn_id
+                .strip_prefix("turn-")
+                .and_then(|value| value.parse::<u64>().ok())
+                .unwrap_or(u64::MAX)
+        });
+        DiscordSnapshot {
+            attachment: inner.discord.clone(),
+            deliveries,
+        }
+    }
+
+    /// Record the initial channel head before any history can be imported.
+    pub fn try_attach_discord(
+        &self,
+        binding: DiscordChatBinding,
+        bot_user_id: String,
+        cursor: Option<String>,
+    ) -> Result<(), JournalAppendError> {
+        let mut inner = self.inner();
+        let cursor = match inner.discord.as_ref() {
+            Some(attached)
+                if attached.binding == binding && attached.bot_user_id == bot_user_id =>
+            {
+                return Ok(())
+            }
+            Some(attached) if attached.binding == binding => attached.cursor.clone(),
+            _ => cursor,
+        };
+        inner
+            .journal
+            .try_append(|_| EventKind::DiscordChatAttached {
+                binding: binding.clone(),
+                bot_user_id: bot_user_id.clone(),
+                cursor: cursor.clone(),
+            })?;
+        inner.discord = Some(DiscordAttachment {
+            binding,
+            bot_user_id,
+            cursor,
+        });
+        Ok(())
+    }
+
+    /// Journal a Discord input before a cursor can advance. Re-fetching the
+    /// same provider identity is an idempotent no-op.
+    pub fn try_deliver_discord(
+        &self,
+        text: String,
+        source: DiscordMessageSource,
+    ) -> Result<bool, JournalAppendError> {
+        let mut inner = self.inner();
+        if inner.messages.values().any(|known| {
+            known.source.as_ref().is_some_and(|known| {
+                known.binding == source.binding && known.message_id == source.message_id
+            })
+        }) {
+            return Ok(false);
+        }
+        let event = inner
+            .journal
+            .try_append(|seq| EventKind::DiscordUserMessage {
+                id: MessageId(format!("msg-{seq}")),
+                text: text.clone(),
+                source: source.clone(),
+            })?;
+        let id = MessageId(format!("msg-{}", event.seq));
+        let mut turn = ChatTurn::user(format!("turn-{}", event.seq), text.clone());
+        turn.created_at = event.at_rfc3339();
+        self.commit_locked(&mut inner, turn);
+        let pending = PendingMessage {
+            id,
+            op: MessageOp::Message,
+            text: format!("[{}]\n{}", source.uri(), text),
+            source: Some(source.clone()),
+        };
+        inner.messages.insert(pending.id.clone(), pending.clone());
+        inner.pending_messages.push(pending.clone());
+        let _ = self.inbox_tx.send(InboxItem::Message(pending));
+        Ok(true)
+    }
+
+    pub fn try_advance_discord_cursor(
+        &self,
+        binding: &DiscordChatBinding,
+        message_id: String,
+    ) -> Result<(), JournalAppendError> {
+        let mut inner = self.inner();
+        let Some(attached) = inner.discord.as_ref() else {
+            return Ok(());
+        };
+        if &attached.binding != binding || attached.cursor.as_deref() == Some(&message_id) {
+            return Ok(());
+        }
+        inner
+            .journal
+            .try_append(|_| EventKind::DiscordChatCursorAdvanced {
+                binding: binding.clone(),
+                message_id: message_id.clone(),
+            })?;
+        if let Some(attached) = inner.discord.as_mut() {
+            attached.cursor = Some(message_id);
+        }
+        Ok(())
+    }
+
+    pub fn try_confirm_discord_part(
+        &self,
+        delivery_id: &str,
+        part_id: &str,
+        provider_message_id: String,
+    ) -> Result<(), JournalAppendError> {
+        let mut inner = self.inner();
+        let already_confirmed = inner
+            .discord_deliveries
+            .get(delivery_id)
+            .and_then(|delivery| delivery.confirmed.get(part_id))
+            .is_some();
+        if already_confirmed {
+            return Ok(());
+        }
+        inner
+            .journal
+            .try_append(|_| EventKind::DiscordChatSendConfirmed {
+                delivery_id: delivery_id.to_string(),
+                part_id: part_id.to_string(),
+                provider_message_id: provider_message_id.clone(),
+            })?;
+        if let Some(delivery) = inner.discord_deliveries.get_mut(delivery_id) {
+            delivery
+                .confirmed
+                .insert(part_id.to_string(), provider_message_id);
+        }
+        Ok(())
     }
 
     /// Whether the wave is paused, from GOAL.md frontmatter (`paused: true`).
@@ -823,7 +1005,12 @@ impl WaveRuntime {
         let turn = self.commit_locked(&mut inner, turn);
         // The pending fold stays live (not boot-only): it is the replay the
         // resident's subscription serves and the validator for its `answers`.
-        let pending = PendingMessage { id, op, text };
+        let pending = PendingMessage {
+            id,
+            op,
+            text,
+            source: None,
+        };
         inner.messages.insert(pending.id.clone(), pending.clone());
         inner.pending_messages.push(pending.clone());
         // Inbox broadcast still under the lock, so inbox order == journal
@@ -1218,7 +1405,33 @@ impl WaveRuntime {
         turn.status = status;
         turn.close_body(now_rfc3339(), reason);
         self.transition_locked(&mut inner, LoopState::Idle, "turn finalized");
-        self.commit_locked(&mut inner, turn);
+        let committed = self.commit_locked(&mut inner, turn);
+        if status == Lifecycle::Completed {
+            self.plan_discord_delivery_locked(&mut inner, &committed, &claims);
+        }
+    }
+
+    fn plan_discord_delivery_locked(
+        &self,
+        inner: &mut Inner,
+        turn: &ChatTurn,
+        claims: &[MessageId],
+    ) {
+        let Some(delivery) = build_discord_delivery(turn, claims, &inner.messages) else {
+            return;
+        };
+        if inner.discord_deliveries.contains_key(&delivery.delivery_id) {
+            return;
+        }
+        inner.journal.append(|_| EventKind::DiscordChatSendPlanned {
+            delivery_id: delivery.delivery_id.clone(),
+            turn_id: delivery.turn_id.clone(),
+            sources: delivery.sources.clone(),
+            parts: delivery.parts.clone(),
+        });
+        inner
+            .discord_deliveries
+            .insert(delivery.delivery_id.clone(), delivery);
     }
 
     /// Steer consumption (`TurnSteered.answers`). Normally the live turn
@@ -1327,6 +1540,69 @@ fn snapshot_tail_locked(inner: &Inner, limit: Option<usize>) -> Vec<ChatTurn> {
         turns.extend(inner.open.as_ref().map(|open| open.turn.clone()));
     }
     turns
+}
+
+fn build_discord_delivery(
+    turn: &ChatTurn,
+    claims: &[MessageId],
+    messages: &HashMap<MessageId, PendingMessage>,
+) -> Option<DiscordDelivery> {
+    if claims.is_empty() || turn.text.trim().is_empty() {
+        return None;
+    }
+    let sources = claims
+        .iter()
+        .map(|claim| {
+            messages
+                .get(claim)
+                .and_then(|message| message.source.clone())
+        })
+        .collect::<Option<Vec<_>>>()?;
+    let binding = &sources.first()?.binding;
+    if sources.iter().any(|source| &source.binding != binding) {
+        return None;
+    }
+    let mut hasher = Sha256::new();
+    hasher.update(binding.guild_id.as_bytes());
+    hasher.update(binding.channel_id.as_bytes());
+    hasher.update(turn.id.as_bytes());
+    let digest = format!("{:x}", hasher.finalize());
+    let delivery_id = format!("discord-{}", &digest[..24]);
+    let parts = split_discord_content(&turn.text)
+        .into_iter()
+        .enumerate()
+        .map(|(index, content)| DiscordMessagePart {
+            part_id: format!("part-{}", index + 1),
+            nonce: format!("lf-{}-{index}", &digest[..16]),
+            content,
+        })
+        .collect();
+    Some(DiscordDelivery {
+        delivery_id,
+        turn_id: turn.id.clone(),
+        sources,
+        parts,
+        confirmed: HashMap::new(),
+    })
+}
+
+fn split_discord_content(content: &str) -> Vec<String> {
+    let mut parts = Vec::new();
+    let mut start = 0;
+    let mut utf16_units = 0;
+    for (index, character) in content.char_indices() {
+        let units = character.len_utf16();
+        if utf16_units + units > 2_000 {
+            parts.push(content[start..index].to_string());
+            start = index;
+            utf16_units = 0;
+        }
+        utf16_units += units;
+    }
+    if start < content.len() {
+        parts.push(content[start..].to_string());
+    }
+    parts
 }
 
 fn add_opt(a: Option<u64>, b: Option<u64>) -> Option<u64> {
@@ -2387,6 +2663,147 @@ mod tests {
         assert_eq!(
             inbox_ids, journal_ids,
             "inbox consumption order == journal fold order"
+        );
+    }
+
+    #[test]
+    fn discord_chat_input_is_durable_before_cursor_and_deduplicates_after_restart() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let binding = DiscordChatBinding {
+            guild_id: "guild".into(),
+            channel_id: "channel".into(),
+        };
+        let source = DiscordMessageSource {
+            binding: binding.clone(),
+            message_id: "101".into(),
+            author_id: "human".into(),
+        };
+        let rt = open_runtime(tmp.path());
+        rt.try_attach_discord(binding.clone(), "bot".into(), Some("100".into()))
+            .expect("attach at current head");
+        assert!(rt
+            .try_deliver_discord("hello".into(), source.clone())
+            .expect("journal input"));
+        assert!(!rt
+            .try_deliver_discord("hello".into(), source.clone())
+            .expect("duplicate input"));
+        assert_eq!(
+            rt.discord_snapshot()
+                .attachment
+                .expect("attached")
+                .cursor
+                .as_deref(),
+            Some("100"),
+            "input commit does not advance the fetch cursor"
+        );
+
+        let reopened = open_runtime(tmp.path());
+        assert!(!reopened
+            .try_deliver_discord("hello".into(), source)
+            .expect("refetched input"));
+        assert_eq!(reopened.pending_messages().len(), 1);
+        assert!(reopened.pending_messages()[0]
+            .text
+            .starts_with("[discord://guild/channel/101]"));
+        reopened
+            .try_advance_discord_cursor(&binding, "101".into())
+            .expect("commit cursor");
+        assert_eq!(
+            open_runtime(tmp.path())
+                .discord_snapshot()
+                .attachment
+                .expect("attached")
+                .cursor
+                .as_deref(),
+            Some("101")
+        );
+    }
+
+    #[test]
+    fn discord_chat_answer_is_planned_in_chunks_before_receipts() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let rt = open_runtime(tmp.path());
+        let binding = DiscordChatBinding {
+            guild_id: "guild".into(),
+            channel_id: "channel".into(),
+        };
+        rt.try_attach_discord(binding.clone(), "bot".into(), None)
+            .expect("attach");
+        rt.try_deliver_discord(
+            "question".into(),
+            DiscordMessageSource {
+                binding,
+                message_id: "101".into(),
+                author_id: "human".into(),
+            },
+        )
+        .expect("deliver");
+        let message_id = rt.pending_messages()[0].id.0.clone();
+        rt.apply_resident_delta(d_opened(&[&message_id]));
+        rt.apply_resident_delta(d_text(&"x".repeat(2_001)));
+        rt.apply_resident_delta(d_finished(Lifecycle::Completed));
+
+        let delivery = rt
+            .discord_snapshot()
+            .deliveries
+            .into_iter()
+            .next()
+            .expect("send intent");
+        assert_eq!(delivery.parts.len(), 2);
+        assert_eq!(delivery.parts[0].content.chars().count(), 2_000);
+        assert!(delivery.parts.iter().all(|part| part.nonce.len() <= 25));
+        assert!(delivery.confirmed.is_empty());
+
+        rt.try_confirm_discord_part(
+            &delivery.delivery_id,
+            &delivery.parts[0].part_id,
+            "provider-1".into(),
+        )
+        .expect("confirm first part");
+        let reopened = open_runtime(tmp.path());
+        let resumed = &reopened.discord_snapshot().deliveries[0];
+        assert_eq!(resumed.confirmed.len(), 1);
+        assert_eq!(resumed.parts.len(), 2);
+    }
+
+    #[test]
+    fn discord_chat_never_sends_a_turn_that_claims_local_input() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let rt = open_runtime(tmp.path());
+        let binding = DiscordChatBinding {
+            guild_id: "guild".into(),
+            channel_id: "channel".into(),
+        };
+        rt.try_attach_discord(binding.clone(), "bot".into(), None)
+            .expect("attach");
+        rt.try_deliver_discord(
+            "question from Discord".into(),
+            DiscordMessageSource {
+                binding,
+                message_id: "101".into(),
+                author_id: "human".into(),
+            },
+        )
+        .expect("deliver Discord input");
+        let local = rt
+            .deliver(MessageOp::Message, "local correction".into())
+            .expect("deliver local input");
+        let pending = rt.pending_messages();
+        let discord_id = pending
+            .iter()
+            .find(|message| message.source.is_some())
+            .expect("Discord input remains pending")
+            .id
+            .0
+            .clone();
+
+        rt.apply_resident_delta(d_opened(&[&discord_id, &msg_id(&local)]));
+        rt.apply_resident_delta(d_text("one combined answer"));
+        rt.apply_resident_delta(d_finished(Lifecycle::Completed));
+
+        assert!(
+            rt.discord_snapshot().deliveries.is_empty(),
+            "a turn that incorporated local input must stay inside Loopflow"
         );
     }
 }

--- a/rust/loopflow/src/wave/server.rs
+++ b/rust/loopflow/src/wave/server.rs
@@ -710,6 +710,7 @@ fn pending_inbox_frame(message: &PendingMessage) -> InboxFrame {
         id: message.id.0.clone(),
         op: message.op,
         text: message.text.clone(),
+        source: message.source.clone(),
     }
 }
 

--- a/rust/loopflow/src/wave/wire.rs
+++ b/rust/loopflow/src/wave/wire.rs
@@ -39,7 +39,7 @@ use serde::{Deserialize, Serialize};
 use crate::chat::types::{ConversationItem, Lifecycle};
 use crate::project::ProjectObservation;
 use crate::task::TaskObservation;
-use crate::wave::journal::MessageOp;
+use crate::wave::journal::{DiscordMessageSource, MessageOp};
 use crate::wave::playhead::{BodyProvenance, PlayheadView, StepOutcome};
 
 /// Header carrying the resident token on every `/resident/*` request.
@@ -184,6 +184,7 @@ pub enum InboxFrame {
         id: String,
         op: MessageOp,
         text: String,
+        source: Option<DiscordMessageSource>,
     },
     Task {
         observation: TaskObservation,

--- a/wave/product/GOAL.md
+++ b/wave/product/GOAL.md
@@ -2,6 +2,11 @@
 crons:
 - flow: wave
   schedule: 0 0 8 * * * *
+chat:
+  provider: discord
+  home_id: "home_39860354aaca640c2ccb50bf6ca609d8"
+  guild_id: "1333122108699709535"
+  channel_id: "1528936130748223519"
 pm:
   provider: linear
   linear_initiative: 33e774b0-ec3b-4bd6-a4f8-07676f9e897b


### PR DESCRIPTION
## Try it!

Bind an existing guild text channel in the Wave goal:

```yaml
---
chat:
  provider: discord
  home_id: "home_0123456789abcdef0123456789abcdef"
  guild_id: "123456789012345678"
  channel_id: "234567890123456789"
---
```

Set `home_id` from `lf home id` on the Home that owns this company channel. A
different Home fails before contacting Discord, and a second checkout on the
owner Home fails while the first listener holds the binding.

Then start the branch build with the bot token injected from Doppler:

```bash
doppler run --project loopflow --config dev -- scripts/dev-lf wave product
```

On a fresh journal, startup attaches at the current channel head without
importing history. Post `summarize your current objective`, receive one Wave
reply, stop the listener with Ctrl-C, start it again, then post a second message.
Inspect the Wave projection and exact Discord evidence:

```bash
scripts/dev-lf chat --history --json -w product
jq -c 'select(.kind.type | startswith("discord_"))' \
  .lf/journal/waves/product/journal.jsonl
```

Run the production-like local proof without Discord credentials:

```bash
cargo test -p loopflow discord_chat
```

## Intent

Let one real running Wave stand in for human judgment in one existing company
Discord channel. Human text becomes durable Wave input, the resident answers
through the existing Wave runtime, and Discord receives one restart-safe reply.
Discord remains the shared company conversation; Loopflow keeps only the
source-linked inputs, outputs, and delivery evidence needed to explain the Run.

## Assumptions

- The existing channel is dedicated to this one Wave; every ordinary non-empty
  human text post addresses it.
- `LF_DISCORD_TOKEN` is injected through Doppler or the process environment and
  is never stored in the repository.
- The Discord application has Message Content enabled. Its bot needs only View
  Channel, Read Message History, and Send Messages in the configured guild text
  channel.
- Correcting a binding, intent, or permission failure requires restarting the
  listener so preflight runs again.
- One durable Home owns the binding. Moving that ownership requires changing
  the typed `home_id` before starting the listener on the replacement Home.

## Key decisions

- Keep Discord concrete: one typed binding and REST adapter, not a generic
  provider registry or restored message bus.
- Poll every two seconds instead of adding Gateway machinery before load proves
  it necessary.
- Commit inbound input before its cursor and outbound intent before its POST.
  Reconcile uncertain sends by reply source, exact content, and part order in
  addition to Discord's short-lived nonce protection.
- Partition authored input by answer destination. Only a completed turn whose
  claims all share one Discord binding can produce an external send.
- Preflight before Run reservation or resident spawn so a deaf Wave never
  appears healthy.
- Reject a non-owner Home before token access, and hold one OS lease across
  checkouts for the listener's lifetime.
- Release the exact leased Wave Run from the process interrupt hook. Ctrl-C
  exits before Tokio can drive async listener shutdown, so restart safety cannot
  depend on destructors or the graceful server path.

## Durable learning

Treat an external chat binding as a source-and-destination boundary around the
existing Wave runtime, never as a second inbox, transcript, or judgment loop.
Journal input before its provider cursor, preserve the source through resident
claims, and fail closed when a completed turn mixes local and external input.
`discord_chat_input_is_durable_before_cursor_and_deduplicates_after_restart`,
`discord_chat_batches_only_the_fifo_prefix_for_one_destination`, and
`discord_chat_never_sends_a_turn_that_claims_local_input` enforce this in the
Wave runtime and pending scheduler; `rust/loopflow/src/wave/README.md` and
`docs/waves.md` document the ownership boundary.

A process interrupt path that calls `std::process::exit` must synchronously
release the exact durable Run lease; async shutdown and destructors cannot be
its correctness boundary. The live same-store restart exposed this, and
`listener_interrupt_releases_run_authority_for_restart` now enforces it through
`Store::stop_run_on_interrupt` and the Wave listener's interrupt hook.

An external binding also needs authority outside one repo checkout. A typed
Home owner prevents cross-Home competition; a process-held lease closes the
same-Home checkout race without making stale lock files authoritative.

## Not included

Gateway delivery, provisioning, categories, threads, DMs, shared rooms,
multiple bindings, mention routing, webhooks, Wave-specific bot identities,
typing, reactions, edits, attachments, commands, or generic bus.
