### PR TITLE
lf pm: scope Linear teams to repositories

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -89,7 +89,7 @@ Path → suite mapping:
 
 | Changed | Suite | Runs |
 |---------|-------|------|
-| `rust/`, `Cargo.toml/lock` | rust | `cargo fmt`, `cargo clippy`, then `cargo nextest run --all` (falls back to `cargo test --all`) |
+| `rust/`, `Cargo.toml/lock` | rust | `cargo fmt`, `cargo clippy`, then draft materialization in a disposable exact-tree worktree and `cargo nextest run --all` (falls back to `cargo test --all`) |
 | `python/`, top-level `*.py`, `pyproject.toml` | python | `uv run pytest python/tests/` (scoped to changed `test_*.py` when no source moved) |
 | `website/`, `docs/` | website | `cd website && uv run python dev.py test` |
 | `swift/` | swift | `swift test --package-path swift -Xswiftc -gnone`, then the multiplatform boundary check |

--- a/docs/authoring.md
+++ b/docs/authoring.md
@@ -165,7 +165,17 @@ when to design first, what never to touch.
 | `agent` | Preferred agent harness/model |
 | `crons` | Supplementary flow schedules, fired by the wave's resident loop |
 | `pm.linear_initiative` | Linear Initiative id backing the wave (written by `lf pm init`) |
-| `pm.linear_team` | Linear team id owning the Wave's Project and Task prefixes |
+
+The repository owns PM provider and Team authority in `.lf/config.yaml`:
+
+```yaml
+pm:
+  provider: linear
+  linear_team: "stable-team-uuid"
+```
+
+Do not copy provider or Team bindings into Wave frontmatter. Every Wave reuses
+the repository Team and owns only its Initiative.
 
 `owner` and `home` say where automatic startup is wanted. Both are optional and
 independent. They are policy, not authorization or observed runtime state.

--- a/docs/lf.md
+++ b/docs/lf.md
@@ -778,7 +778,7 @@ refreshes the local SQLite read model used by every other read surface.
 
 ```bash
 lf pm status                                # linked waves and task counts
-lf pm init --wave designer --team-key DSG   # connect or rebind Initiative + team
+lf pm init --wave designer --team-key DSG   # connect Wave; establish repo Team once
 lf pm sync --wave designer                  # refresh SQLite from Linear
 lf pm sync --plan                           # report drift without writing
 lf pm show --wave designer                  # read; refresh when stale
@@ -794,34 +794,44 @@ lf pm task update --id 1207... --title "Refine dark mode"
 lf pm task done --id 1207... --pr "https://github.com/acme/app/pull/42"
 lf pm task move --id 1207... --wave designer --project api
 lf pm rename --wave designer --title "Designer"   # rename the Initiative
-lf pm reteam --wave designer --apply    # move the hierarchy when no body is writing
-lf pm doctor                            # flag issues stranded in the old team
+lf pm reteam                            # dry-run the repository-wide Team migration
+lf pm reteam --apply                    # migrate when no Task Run can write old ids
+lf pm doctor                            # flag ownership and title drift
 ```
 
 Connect Linear first with `lf auth linear`. `lf pm init` pins the Initiative
-and a Wave-owned team into `GOAL.md` frontmatter; the team key becomes each
-Task's prefix (`PRD-1`, `INF-1`) so every wave owns its identifiers. When no
-id is pinned, init links one exact Initiative-title match, creates one when
-absent, and fails on duplicates. Creation fails closed: `project create` and
-`task create` require a bound team and error with the `lf pm init` recovery
-rather than silently attaching work to a shared team. Reads stay
-team-agnostic.
+into `GOAL.md` and the repository Team into `.lf/config.yaml`. Every Wave in
+that repository reuses the Team and Task prefix (`LOO-1`, `LOO-2`); Initiatives
+and Project membership decide which Wave owns a Task. `pm init --all` discovers
+nested `GOAL.md` files recursively and initializes them against the same Team.
+When no Initiative is pinned, init links one exact title match, creates one
+when absent, and fails on duplicates. Creation fails closed unless the
+repository Team and its Git-origin claim both validate.
 
-Linear's Projects view is flat, so provider titles use `<Wave> — <Project>`;
-Loopflow strips that display prefix and keeps the canonical slug
-(`Product — Loopflow API` remains `project:loopflow-api`). `show` serves
+```yaml
+# .lf/config.yaml
+pm:
+  provider: linear
+  linear_team: "stable-team-uuid"
+```
+
+Linear's Projects view is flat, so provider titles use
+`<canonical Wave path> — <Project>`; nested Waves remain legible as
+`Survival / Infrastructure — Gmail`. Loopflow resolves ownership from stable
+Initiative and Project ids, then strips that presentation prefix and keeps the
+canonical slug. `show` serves
 snapshots younger than an hour without a network request, tries a
 five-second refresh for older ones, and refuses to silently serve a snapshot
 older than a week. Use `--no-sync` in agents and UI paths so rendering never
 waits on Linear.
 
-`lf pm reteam` migrates a wave's existing issues into its own team. It
+`lf pm reteam` migrates every linked Wave onto the repository Team. It
 **defaults to a dry run** and only mutates with `--apply`; it defers an issue
-only while a Task body can write in its worktree. Completed issues move too:
-Linear cannot remove the shared team from a Project while any issue in that
-Project still belongs to it. Before each issue moves, Loopflow records its old
-identifier in a comment; after every issue is on the wave team, it narrows the
-Projects to that team and reconciles cached Task identifiers. Interrupted runs
+while a Task Run can still write its old identifier. Completed issues move too.
+Loopflow first attaches the destination Team to every Project, comments and
+moves Issues by UUID, narrows Projects to exactly that Team, repairs Wave-path
+titles, verifies every association, refreshes every snapshot, and only then
+removes legacy Wave Team fields. Interrupted runs keep a legacy sentinel and
 resume without duplicating comments or moves.
 
 ## lf release

--- a/docs/waves.md
+++ b/docs/waves.md
@@ -236,16 +236,23 @@ carries the craft and examples.
 
 Tasks live in Linear; there are no local task lists. A wave maps to an
 Initiative, each project to a Linear Project, each task to an Issue. Connect
-once — `lf pm init` links or creates the Initiative and wave-owned team and
-writes both ids into `GOAL.md` frontmatter. Don't paste ids by hand.
+once — `lf pm init` links or creates the Wave Initiative and establishes one
+repository Team in `.lf/config.yaml`. Every Wave reuses that Team and issue-key
+namespace. Don't paste ids by hand.
 
 ```bash
-lf pm init --wave infra --team-key INF     # connect or rebind
+lf pm init --wave infra --team-key LOO     # first Wave establishes the repo Team
+lf pm init --all                           # all nested Waves reuse it
 lf pm sync --wave infra                    # refresh the local SQLite snapshot
 lf pm show --wave infra --no-sync          # deterministic cache-only read
 lf pm task create --wave infra --project stability --title "Daemon data integrity"
 lf pm task done --id 1207... --pr "https://github.com/acme/app/pull/42"
 ```
+
+A managed Project belongs to exactly one Initiative and exactly the repository
+Team. Project titles include the canonical Wave ancestry for orientation
+(`Survival / Infrastructure — Gmail`), but stable ids and Project membership —
+never titles or issue prefixes — resolve Work.
 
 ## Tasks
 

--- a/python/tests/test_materialize_rust_tests.py
+++ b/python/tests/test_materialize_rust_tests.py
@@ -1,0 +1,113 @@
+"""Local Rust tests use CI's schema without changing the active checkout."""
+
+import ast
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "scripts/materialize_rust_tests.py"
+AMBIENT_WORK_AUTHORITY = (
+    "LF_RUN_CONTEXT",
+    "LF_RUN_LEASE",
+    "LF_WAVE_ID",
+    "LF_ACCOUNT_LEASE",
+)
+
+
+def test_wrapper_preserves_the_declared_python_38_floor() -> None:
+    assert 'requires-python = ">=3.8"' in (ROOT / "pyproject.toml").read_text()
+    source = SCRIPT.read_text()
+    tree = ast.parse(source, filename=str(SCRIPT), feature_version=8)
+    imports = {
+        alias.name
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Import)
+        for alias in node.names
+    }
+    imports.update(
+        node.module
+        for node in ast.walk(tree)
+        if isinstance(node, ast.ImportFrom) and node.module is not None
+    )
+    assert "tomllib" not in imports
+
+
+def _git(repo: Path, *arguments: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *arguments],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    (tmp_path / "scripts").mkdir()
+    (tmp_path / "scripts/materialize_rust_tests.py").write_bytes(SCRIPT.read_bytes())
+    (tmp_path / "scripts/canonicalize_migrations.py").write_text(
+        """from pathlib import Path
+import sys
+
+assert sys.argv[1:] == ["0.12.3", "--materialize-for-tests"]
+Path("materialized.txt").write_text("ready")
+"""
+    )
+    (tmp_path / "Cargo.toml").write_text('[workspace.package]\nversion = "0.12.3"\n')
+    (tmp_path / "tracked.txt").write_text("committed\n")
+    _git(tmp_path, "init", "-b", "main")
+    _git(tmp_path, "config", "user.name", "Loopflow Tests")
+    _git(tmp_path, "config", "user.email", "tests@loopflow.local")
+    _git(tmp_path, "add", ".")
+    _git(tmp_path, "commit", "-m", "fixture")
+    return tmp_path
+
+
+@pytest.mark.parametrize("exit_code", [0, 7])
+def test_materialized_command_sees_exact_tree_and_always_cleans_up(
+    repo: Path, exit_code: int
+) -> None:
+    (repo / "tracked.txt").write_text("dirty\n")
+    _git(repo, "add", "tracked.txt")
+    (repo / "untracked.txt").write_text("new\n")
+    probe = (
+        "from pathlib import Path; import os; import sys; "
+        "assert Path('tracked.txt').read_text() == 'dirty\\n'; "
+        "assert Path('untracked.txt').read_text() == 'new\\n'; "
+        "assert Path('materialized.txt').read_text() == 'ready'; "
+        f"assert all(name not in os.environ for name in {AMBIENT_WORK_AUTHORITY!r}); "
+        "Path('command-ran.txt').write_text('yes'); "
+        f"sys.exit({exit_code})"
+    )
+    environment = os.environ.copy()
+    environment.update(
+        {name: "must-not-escape" for name in AMBIENT_WORK_AUTHORITY}
+    )
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/materialize_rust_tests.py",
+            "--",
+            sys.executable,
+            "-c",
+            probe,
+        ],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        env=environment,
+    )
+
+    assert result.returncode == exit_code, result.stderr
+    assert (repo / "tracked.txt").read_text() == "dirty\n"
+    assert (repo / "untracked.txt").read_text() == "new\n"
+    assert not (repo / "materialized.txt").exists()
+    assert not (repo / "command-ran.txt").exists()
+    worktrees = _git(repo, "worktree", "list", "--porcelain").stdout
+    assert "loopflow-materialized-" not in worktrees

--- a/python/tests/test_release_automation.py
+++ b/python/tests/test_release_automation.py
@@ -314,6 +314,7 @@ def test_changed_aware_runner_includes_ci_static_checks():
 
     assert "cargo fmt --all -- --check" in result.stdout
     assert "cargo clippy --all-targets -- -D warnings" in result.stdout
+    assert "scripts/materialize_rust_tests.py -- cargo" in result.stdout
     assert "cargo nextest run --all" in result.stdout or "cargo test --all" in result.stdout
     assert "uv run python scripts/check_swift_multiplatform_boundaries.py" in result.stdout
 

--- a/rust/loopflow/src/bin/lf.rs
+++ b/rust/loopflow/src/bin/lf.rs
@@ -1335,6 +1335,8 @@ fn main() -> anyhow::Result<()> {
                 let message = format!(
                     "Promote project '{slug}' from parent wave '{parent}'. Complete the authored migration, PM move, parent link, and residency checks."
                 );
+                loopflow::ops::project::prepare_promotion(repo, &parent, slug)
+                    .map_err(anyhow::Error::from)?;
                 run_target("project-promote", Some(&message), &cli, &args)?;
                 let residency = loopflow::ops::project::complete_promotion(repo, &parent, slug)
                     .map_err(anyhow::Error::from)?;

--- a/rust/loopflow/src/engine/builtins/ops/skill/init.md
+++ b/rust/loopflow/src/engine/builtins/ops/skill/init.md
@@ -147,11 +147,14 @@ lf pm show --wave <wave> --no-sync
 If PM is not bound and Linear is connected, offer the explicit binding command:
 
 ```bash
-lf pm init --wave <wave> --team-key <KEY>
+lf pm init --wave <wave>
 ```
 
-Creating or rebinding Linear state requires the human's choice. Do not infer a
-team key, Initiative, Project, or KR.
+The first Wave establishes the repository Team and defaults its key from the
+repository name; `--team-key <KEY>` is an explicit override. Later Waves must
+reuse that binding. Choosing the initial repository Team requires the human's
+choice. Do not invent another Team, Initiative, Project, or KR; an existing
+repository binding changes only through the repository-wide migration.
 
 ### New durable Wave
 
@@ -173,7 +176,7 @@ Projects carry definitions and KRs, while Tasks carry concrete work.
 ### Existing Linear Task
 
 Require its exact issue identifier. If Linear is connected and the Task belongs
-to a Wave-owned Project, the durable execution path is:
+to the repository Team and one Wave-owned Project, the durable execution path is:
 
 ```bash
 lf task run <ISSUE-ID>

--- a/rust/loopflow/src/engine/builtins/project/skill/project-promote.md
+++ b/rust/loopflow/src/engine/builtins/project/skill/project-promote.md
@@ -21,12 +21,15 @@ child's work.
    Use a weekly pursue cadence when the Project gives no sharper signal.
 3. Create an empty `wave/<slug>/MEMORY.md`. Never copy parent memory: the
    runtime inherits it through `parent_wave_id`.
-4. Initialize the child's Linear Initiative with `lf pm init --wave <slug>`,
-   recreate the measured bet there with `lf pm project create`, and move every
-   source task with `lf pm task move --id <id> --wave <slug> --project <slug>`.
-   Only after the child snapshot is complete, remove the duplicate parent bet
-   with `lf pm project archive --wave <parent> --project <slug>`.
-6. Add a child `Process` instruction requiring its first pass to report the
+4. Initialize the child's Linear Initiative with `lf pm init --wave <slug>`;
+   it reuses the repository Team. Recreate the measured bet there with
+   `lf pm project create`, and move every source task with
+   `lf pm task move --id <id> --wave <slug> --project <slug>`. Loopflow already
+   prepared durable ancestry before this flow, so the first Project title uses
+   the full Wave path. Only after the child snapshot is complete, remove the
+   duplicate parent bet with
+   `lf pm project archive --wave <parent> --project <slug>`.
+5. Add a child `Process` instruction requiring its first pass to report the
    newly owned definition and KRs in its own thread. Parent/child continuity
    is already represented by the typed Wave and Project relationship.
 

--- a/rust/loopflow/src/engine/builtins/wave/skill/update-wave.md
+++ b/rust/loopflow/src/engine/builtins/wave/skill/update-wave.md
@@ -116,7 +116,6 @@ When `scratch/` holds a proposal and no wave exists yet, create one:
 ```yaml
 ---
 pm:
-  provider: linear
   linear_initiative: "8c4ba3f9-cf23-4136-87ed-37847aa7dc82" # written by `lf pm init`
 ---
 ```

--- a/rust/loopflow/src/engine/config.rs
+++ b/rust/loopflow/src/engine/config.rs
@@ -164,6 +164,8 @@ pub struct LinearConfig {
 pub struct PmConfig {
     #[serde(default)]
     pub provider: Option<String>,
+    #[serde(default)]
+    pub linear_team: Option<String>,
 }
 
 /// Main configuration struct.
@@ -407,6 +409,19 @@ pub fn load_config(repo_root: Option<&Path>) -> Result<Option<Config>, LoadError
         .map_err(|e| LoadError::InvalidFlow(format!("Config validation error: {}", e)))?;
 
     Ok(Some(config))
+}
+
+/// Load only the repository-owned config, without inheriting user-global values.
+///
+/// PM identity uses this path because a global Team binding must never become a
+/// repository's authority implicitly.
+pub fn load_repo_config(repo_root: &Path) -> Result<Option<Config>, LoadError> {
+    let Some(value) = load_yaml_file(&repo_root.join(".lf/config.yaml"))? else {
+        return Ok(None);
+    };
+    serde_yaml_ng::from_value(value)
+        .map(Some)
+        .map_err(|error| LoadError::InvalidFlow(format!("Config validation error: {error}")))
 }
 
 /// Get config or default if no config files exist.
@@ -959,5 +974,22 @@ supported_harnesses:
 
         let config = load_config_or_default(Some(temp.path()));
         assert_eq!(config.agent.as_deref(), Some("codex"));
+    }
+
+    #[test]
+    fn load_repo_config_reads_repository_pm_authority() {
+        let temp = tempfile::tempdir().expect("create temp dir");
+        let config_dir = temp.path().join(".lf");
+        std::fs::create_dir_all(&config_dir).expect("create .lf dir");
+        std::fs::write(
+            config_dir.join("config.yaml"),
+            "pm:\n  provider: linear\n  linear_team: team-loo\n",
+        )
+        .expect("write config");
+
+        let config = load_repo_config(temp.path()).unwrap().unwrap();
+        let pm = config.pm.unwrap();
+        assert_eq!(pm.provider.as_deref(), Some("linear"));
+        assert_eq!(pm.linear_team.as_deref(), Some("team-loo"));
     }
 }

--- a/rust/loopflow/src/engine/wave_config.rs
+++ b/rust/loopflow/src/engine/wave_config.rs
@@ -29,9 +29,11 @@ pub struct WaveCronDef {
     pub schedule: String,
 }
 
-/// The Linear Initiative and team representing a wave, from `pm.*` in GOAL.md.
-/// The Initiative is the durable middle tier; the team owns the Task prefix
-/// (`PRD-*`, `INF-*`, …). Both store stable provider ids, not presentation.
+/// The Linear Initiative representing a wave, from `pm.*` in GOAL.md.
+///
+/// `provider` and `linear_team` remain decodable only as repository-Team
+/// migration sentinels. Normal PM authority reads provider and Team from the
+/// repository's `.lf/config.yaml`.
 #[derive(Debug, Clone, Deserialize, Serialize, Default, PartialEq, Eq)]
 pub struct WavePmConfig {
     #[serde(default)]

--- a/rust/loopflow/src/lf/commands/ops/mod.rs
+++ b/rust/loopflow/src/lf/commands/ops/mod.rs
@@ -524,26 +524,6 @@ fn abandon_current(branch: Option<&str>, force: bool, progress: &impl Progress) 
 pub fn run_pm(cmd: &PmCommand) -> Result<()> {
     let progress = &CliProgress;
     let repo_root = find_repo_root()?;
-    let list_all_waves = || -> Result<Vec<String>> {
-        let wave_dir = repo_root.join("wave");
-        if !wave_dir.is_dir() {
-            return Err(anyhow!("no wave/ directory found"));
-        }
-        let mut waves = Vec::new();
-        for entry in std::fs::read_dir(&wave_dir)? {
-            let entry = entry?;
-            if entry.file_type()?.is_dir() {
-                if let Some(name) = entry.file_name().to_str() {
-                    waves.push(name.to_string());
-                }
-            }
-        }
-        waves.sort();
-        if waves.is_empty() {
-            return Err(anyhow!("no waves found in wave/"));
-        }
-        Ok(waves)
-    };
     // The one ambient-Wave rule for every PM arm: `--wave` wins, else
     // `LF_WAVE_ID` (durable UUID → registry name, hand-set name as fallback).
     // `NoContext` stays `None` so a bare command keeps its "all waves" / "pass
@@ -565,13 +545,8 @@ pub fn run_pm(cmd: &PmCommand) -> Result<()> {
             team_key,
             team_name,
         } => {
-            if *all && (team_key.is_some() || team_name.is_some()) {
-                return Err(anyhow!(
-                    "--team-key/--team-name apply to one wave; omit them with --all so each wave keys off its own name"
-                ));
-            }
             let targets = if *all {
-                list_all_waves()?
+                crate::ops::pm::list_local_waves(&repo_root)?
             } else {
                 let explicit = wave.as_deref().or(wave_flag.as_deref());
                 // pm init is a creation flow: an explicit --wave may name a
@@ -598,10 +573,16 @@ pub fn run_pm(cmd: &PmCommand) -> Result<()> {
                     progress,
                 )?;
                 let initiative_state = if result.created { "created" } else { "linked" };
-                let team_state = match (&result.team_key, result.team_created) {
-                    (Some(key), true) => format!(", team {} created ({key}-*)", result.team_id),
-                    (Some(key), false) => format!(", team {} adopted ({key}-*)", result.team_id),
-                    (None, _) => format!(", team {} linked", result.team_id),
+                let team_state = if result.team_created {
+                    format!(
+                        ", repository Team {} created ({}-*)",
+                        result.team_id, result.team_key
+                    )
+                } else {
+                    format!(
+                        ", repository Team {} adopted ({}-*)",
+                        result.team_id, result.team_key
+                    )
                 };
                 println!(
                     "{}: Linear Initiative {} ({initiative_state}){team_state}",
@@ -855,18 +836,15 @@ pub fn run_pm(cmd: &PmCommand) -> Result<()> {
             )?;
             print_pm_sync_result(&result);
         }
-        PmCommand::Reteam { wave, apply } => {
+        PmCommand::Reteam { apply } => {
             let result = crate::ops::pm::pm_reteam(
                 &repo_root,
-                &crate::ops::pm::PmReteamOptions {
-                    wave: ambient_wave(wave.as_deref())?,
-                    apply: *apply,
-                },
+                &crate::ops::pm::PmReteamOptions { apply: *apply },
                 progress,
             )?;
             print_pm_reteam_result(&result);
         }
-        PmCommand::Webhook { cmd } => run_pm_webhook(&repo_root, cmd, &ambient_wave)?,
+        PmCommand::Webhook { cmd } => run_pm_webhook(&repo_root, cmd)?,
     }
     Ok(())
 }
@@ -874,11 +852,7 @@ pub fn run_pm(cmd: &PmCommand) -> Result<()> {
 /// The Linear webhook receiver and its one-time registration. The signing secret
 /// is read from the environment (sourced from Doppler), never a flag or the
 /// store, so a raw value never lands in shell history or a process listing.
-fn run_pm_webhook(
-    repo_root: &std::path::Path,
-    cmd: &crate::lf::PmWebhookCommand,
-    ambient_wave: &impl Fn(Option<&str>) -> Result<Option<String>>,
-) -> Result<()> {
+fn run_pm_webhook(repo_root: &std::path::Path, cmd: &crate::lf::PmWebhookCommand) -> Result<()> {
     use crate::lf::PmWebhookCommand;
 
     let secret = std::env::var("LF_LINEAR_WEBHOOK_SECRET").unwrap_or_default();
@@ -887,17 +861,9 @@ fn run_pm_webhook(
             "set LF_LINEAR_WEBHOOK_SECRET to a non-empty value (source it from Doppler: `doppler run -- lf pm webhook ...`)"
         ));
     }
-    let wave_arg = match cmd {
-        PmWebhookCommand::Serve { wave, .. } | PmWebhookCommand::Register { wave, .. } => {
-            wave.as_deref()
-        }
-    };
-    let wave = ambient_wave(wave_arg)?
-        .ok_or_else(|| anyhow!("cannot determine wave; pass --wave <name>"))?;
-
     let runtime = tokio::runtime::Runtime::new()?;
     runtime.block_on(async {
-        let client = crate::ops::pm::linear_client(repo_root, &wave).await?;
+        let client = crate::ops::pm::linear_client(repo_root).await?;
         match cmd {
             PmWebhookCommand::Register { url, .. } => {
                 let id = client.create_webhook(url, &secret).await?;
@@ -926,8 +892,9 @@ fn run_pm_webhook(
 fn print_pm_reteam_result(result: &crate::ops::pm::PmReteamResult) {
     let verb = if result.applied { "moved" } else { "will move" };
     println!(
-        "wave/{} → team {} ({}-*){}",
-        result.wave,
+        "repository {} (waves: {}) → team {} ({}-*){}",
+        result.repository,
+        result.waves.join(", "),
         result.team_id,
         result.team_key,
         if result.applied {
@@ -945,7 +912,10 @@ fn print_pm_reteam_result(result: &crate::ops::pm::PmReteamResult) {
             } else {
                 format!("team(s) [{}]", pm.from_teams.join(", "))
             };
-            println!("    {}  (from {from})", pm.name);
+            println!(
+                "    wave/{}: {} → {}  (from {from})",
+                pm.wave, pm.name, pm.target_name
+            );
         }
     }
 
@@ -955,10 +925,13 @@ fn print_pm_reteam_result(result: &crate::ops::pm::PmReteamResult) {
         println!("  {verb} ({}):", result.moves.len());
         for mv in &result.moves {
             match &mv.new_identifier {
-                Some(new_id) => println!("    {} → {new_id}  {}", mv.old_identifier, mv.title),
+                Some(new_id) => println!(
+                    "    wave/{}: {} → {new_id}  {}",
+                    mv.wave, mv.old_identifier, mv.title
+                ),
                 None => println!(
-                    "    {}  {}  (Linear assigns the new number at move time)",
-                    mv.old_identifier, mv.title
+                    "    wave/{}: {}  {}  (Linear assigns the new number at move time)",
+                    mv.wave, mv.old_identifier, mv.title
                 ),
             }
         }
@@ -971,8 +944,8 @@ fn print_pm_reteam_result(result: &crate::ops::pm::PmReteamResult) {
         );
         for deferral in &result.deferrals {
             println!(
-                "    {}  {}  ({})",
-                deferral.identifier, deferral.title, deferral.reason
+                "    wave/{}: {}  {}  ({})",
+                deferral.wave, deferral.identifier, deferral.title, deferral.reason
             );
         }
     }
@@ -980,7 +953,7 @@ fn print_pm_reteam_result(result: &crate::ops::pm::PmReteamResult) {
         println!("  reconciled Task identifiers: {}", result.task_updates);
     }
     if result.already > 0 {
-        println!("  already in team: {} (skipped)", result.already);
+        println!("  already in repository Team: {} (skipped)", result.already);
     }
 }
 
@@ -1035,7 +1008,7 @@ fn format_pm_task_table(items: &[crate::pm::PmItem]) -> Vec<String> {
         .map(|item| PmTaskRow {
             status: if item.completed { "done" } else { "open" },
             title: item.name.split_whitespace().collect::<Vec<_>>().join(" "),
-            project: item.project.clone().unwrap_or_else(|| "-".to_string()),
+            project: item.project.clone(),
             assignee: item.assignee.clone().unwrap_or_else(|| "-".to_string()),
             id: item.id.clone(),
             completed: item.completed,
@@ -1079,7 +1052,9 @@ mod pm_output_tests {
                 description: String::new(),
                 rank: 0,
                 completed: true,
-                project: None,
+                project_id: "project-done".to_string(),
+                project: "-".to_string(),
+                team_id: "team-loo".to_string(),
                 assignee: None,
             },
             PmItem {
@@ -1090,7 +1065,9 @@ mod pm_output_tests {
                 description: String::new(),
                 rank: 1,
                 completed: false,
-                project: Some("wave-chat".to_string()),
+                project_id: "project-chat".to_string(),
+                project: "wave-chat".to_string(),
+                team_id: "team-loo".to_string(),
                 assignee: Some("me".to_string()),
             },
         ]);

--- a/rust/loopflow/src/lf/commands/waves.rs
+++ b/rust/loopflow/src/lf/commands/waves.rs
@@ -25,7 +25,7 @@ use crate::durable::{Containment, Home, WorkRef, WorkStatus};
 use crate::engine::wave_home::{HomeActionDto, HomeRuntimeDto, HomeState};
 use crate::lf::commands::runs::{format_tokens, SkillRunEntry};
 use crate::lf::output::Colors;
-use crate::pm::{PmItem, PmKr, PmProject, ProjectFlowPlan};
+use crate::pm::{PmItem, PmKr, PmPortfolioValidator, PmProject, PmSnapshot, ProjectFlowPlan};
 use crate::project::Project;
 use crate::store::{open_existing_store, SharedStore};
 use crate::task::{
@@ -543,6 +543,11 @@ pub fn status(wave: Option<&str>, json: bool) -> Result<()> {
             return no_registry(json, "null");
         };
         let wave = resolve_status_wave(&store, wave).await?;
+        let repository_waves = store
+            .list_waves(Some(wave.repo()))
+            .await
+            .map_err(|err| anyhow!("failed to read repository Waves: {err}"))?;
+        validate_pm_portfolio(&store, &repository_waves).await?;
         let snapshot = snapshot_wave(&store, &wave).await?;
         let loop_state = match &snapshot.endpoint {
             Some(endpoint) => loop_state(endpoint).await,
@@ -557,7 +562,12 @@ pub fn status(wave: Option<&str>, json: bool) -> Result<()> {
             .await
             .map_err(|err| anyhow!("failed to read Tasks: {err}"))?;
         let liveness = TmuxLiveness::snapshot().await;
-        let planning = read_pm_planning(&store, &wave).await?.unwrap_or_default();
+        let planning = read_pm_planning(&store, &wave)
+            .await?
+            .unwrap_or(PmSnapshot {
+                projects: Vec::new(),
+                items: Vec::new(),
+            });
         let project_snapshots = snapshot_projects(
             &store,
             &wave,
@@ -641,6 +651,16 @@ pub fn roadmap(wave: Option<&str>, json: bool) -> Result<()> {
         };
         // One tmux reading for every Work process on the machine, taken once.
         let liveness = TmuxLiveness::snapshot().await;
+        // A Wave filter narrows presentation, not repository ownership checks.
+        let ownership_waves = if waves.len() == 1 {
+            store
+                .list_waves(Some(waves[0].repo()))
+                .await
+                .map_err(|err| anyhow!("failed to read repository Waves: {err}"))?
+        } else {
+            waves.clone()
+        };
+        validate_pm_portfolio(&store, &ownership_waves).await?;
         let mut roadmaps = Vec::with_capacity(waves.len());
         for wave in &waves {
             let snapshot = snapshot_wave(&store, wave).await?;
@@ -1162,17 +1182,11 @@ async fn child_run_alive(
     })
 }
 
-#[derive(Debug, Default, Deserialize)]
-struct CachedPmSnapshot {
-    projects: Vec<PmProject>,
-    items: Vec<PmItem>,
-}
-
 /// The wave's local PM snapshot, or `None` when none has been synced. `None` is
 /// a real, readable state ("no plan on this machine yet") — a caller that must
 /// tell it apart from "the plan is empty" keeps the `Option`; `lf status`
 /// flattens it to an empty plan, `lf roadmap` renders it as unavailable.
-async fn read_pm_planning(store: &SharedStore, wave: &Wave) -> Result<Option<CachedPmSnapshot>> {
+async fn read_pm_planning(store: &SharedStore, wave: &Wave) -> Result<Option<PmSnapshot>> {
     let repo = crate::engine::worktrees::main_repo_root(Path::new(wave.repo()))
         .unwrap_or_else(|_| Path::new(wave.repo()).to_path_buf());
     let repo = std::fs::canonicalize(&repo).unwrap_or(repo);
@@ -1183,13 +1197,42 @@ async fn read_pm_planning(store: &SharedStore, wave: &Wave) -> Result<Option<Cac
     else {
         return Ok(None);
     };
-    let planning = serde_json::from_str::<CachedPmSnapshot>(&row.payload).map_err(|err| {
+    Ok(Some(decode_pm_planning(wave, &row.payload)?))
+}
+
+fn decode_pm_planning(wave: &Wave, payload: &str) -> Result<PmSnapshot> {
+    serde_json::from_str(payload).map_err(|err| {
         anyhow!(
             "invalid PM snapshot for wave/{}; run `lf pm sync`: {err}",
             wave.name()
         )
-    })?;
-    Ok(Some(planning))
+    })
+}
+
+async fn validate_pm_portfolio(store: &SharedStore, waves: &[Wave]) -> Result<()> {
+    let mut ownership = PmPortfolioValidator::default();
+    for wave in waves {
+        let repo = crate::engine::worktrees::main_repo_root(Path::new(wave.repo()))
+            .unwrap_or_else(|_| Path::new(wave.repo()).to_path_buf());
+        let repo = std::fs::canonicalize(&repo).unwrap_or(repo);
+        let Some(row) = store
+            .pm_snapshot(repo.to_string_lossy().into_owned(), wave.name().to_string())
+            .await
+            .map_err(|err| anyhow!("failed to read PM snapshot: {err}"))?
+        else {
+            continue;
+        };
+        let planning = decode_pm_planning(wave, &row.payload)?;
+        let expected_team = crate::ops::pm::repository_team_for_snapshot_validation(&repo)?;
+        ownership.validate(
+            wave.name(),
+            &row.initiative,
+            expected_team.as_deref(),
+            &planning.projects,
+            &planning.items,
+        )?;
+    }
+    Ok(())
 }
 
 async fn snapshot_projects(
@@ -1197,7 +1240,7 @@ async fn snapshot_projects(
     wave: &Wave,
     projects: Vec<Project>,
     tasks: Vec<Task>,
-    planning: CachedPmSnapshot,
+    planning: PmSnapshot,
     liveness: &TmuxLiveness,
     probe_pr_empty: bool,
 ) -> Result<ProjectSnapshots> {
@@ -1235,14 +1278,7 @@ async fn snapshot_projects(
     }
 
     for item in planning.items {
-        let project_slug = item.project.as_deref().ok_or_else(|| {
-            anyhow!(
-                "Task {} belongs to no Project in the PM snapshot; fix it in Linear and run `lf pm sync --wave {}`",
-                item.identifier,
-                wave.name()
-            )
-        })?;
-        let index = project_index(&details, project_slug, project_slug)?;
+        let index = project_index(&details, &item.project_id, &item.project)?;
         let runtime_task = tasks.iter().find(|task| {
             task.plan.id.as_str() == item.id || task.plan.identifier == item.identifier
         });
@@ -1296,7 +1332,9 @@ async fn snapshot_projects(
             description: runtime_task.plan.description.clone(),
             rank: u32::MAX,
             completed: work_status_is_terminal(&status),
-            project: Some(parent.plan.slug.clone()),
+            project_id: parent.plan.id.as_str().to_string(),
+            project: parent.plan.slug.clone(),
+            team_id: String::new(),
             assignee: None,
         };
         details[project_index].tasks.push(

--- a/rust/loopflow/src/lf/mod.rs
+++ b/rust/loopflow/src/lf/mod.rs
@@ -1154,20 +1154,20 @@ pub enum CronCommand {
 
 #[derive(Subcommand, Debug)]
 pub enum PmCommand {
-    /// Connect a wave to its Linear Initiative and team (Task prefix)
+    /// Connect a Wave to its Initiative and the repository's Team (Task prefix)
     Init {
         /// Wave name (auto-detected if omitted)
         wave: Option<String>,
         /// Wave name (flag form; same as positional wave)
         #[arg(short = 'w', long = "wave", conflicts_with_all = ["wave", "all"])]
         wave_flag: Option<String>,
-        /// Initialize all waves under wave/
+        /// Recursively initialize every Wave under wave/
         #[arg(long, conflicts_with_all = ["wave", "wave_flag"])]
         all: bool,
-        /// Team key = Task prefix (e.g. PRD). Defaults from the wave name.
+        /// Repository Team key = Task prefix (e.g. LOO). Defaults from the repository name.
         #[arg(long = "team-key")]
         team_key: Option<String>,
-        /// Team display name. Defaults to the title-cased wave name.
+        /// Repository Team display name. Defaults to the repository name.
         #[arg(long = "team-name")]
         team_name: Option<String>,
     },
@@ -1197,11 +1197,8 @@ pub enum PmCommand {
     },
     /// Compare Linear with local wave bindings
     Doctor,
-    /// Move a wave's existing settled issues into its own Linear team
+    /// Move every linked wave onto the repository's one Linear team
     Reteam {
-        /// Wave name (auto-detected if omitted)
-        #[arg(short = 'w', long = "wave")]
-        wave: Option<String>,
         /// Execute the moves; without it, `reteam` only prints the plan (dry run)
         #[arg(long)]
         apply: bool,
@@ -1249,9 +1246,6 @@ pub enum PmWebhookCommand {
         /// Address to bind (a reverse proxy gives Linear the public HTTPS URL)
         #[arg(long, default_value = "127.0.0.1:8899")]
         addr: String,
-        /// Wave whose Linear token identifies Loopflow's own actor
-        #[arg(short = 'w', long = "wave")]
-        wave: Option<String>,
     },
     /// Register the Issue/Comment webhook with Linear (one-time). Reads the
     /// signing secret from LF_LINEAR_WEBHOOK_SECRET.
@@ -1259,9 +1253,6 @@ pub enum PmWebhookCommand {
         /// Public HTTPS URL Linear will POST deliveries to
         #[arg(long)]
         url: String,
-        /// Wave whose Linear token authorizes the registration
-        #[arg(short = 'w', long = "wave")]
-        wave: Option<String>,
     },
 }
 
@@ -2731,19 +2722,18 @@ mod tests {
 
     #[test]
     fn pm_reteam_defaults_to_dry_run() {
-        let cli = Cli::try_parse_from(["lf", "pm", "reteam", "--wave", "product"]).expect("parse");
+        let cli = Cli::try_parse_from(["lf", "pm", "reteam"]).expect("parse");
         let Some(Commands::Pm {
-            cmd: PmCommand::Reteam { wave, apply },
+            cmd: PmCommand::Reteam { apply },
         }) = cli.command
         else {
             panic!("expected pm reteam command");
         };
-        assert_eq!(wave.as_deref(), Some("product"));
         assert!(!apply);
 
         let cli = Cli::try_parse_from(["lf", "pm", "reteam", "--apply"]).expect("parse apply");
         let Some(Commands::Pm {
-            cmd: PmCommand::Reteam { apply, .. },
+            cmd: PmCommand::Reteam { apply },
         }) = cli.command
         else {
             panic!("expected pm reteam command");

--- a/rust/loopflow/src/ops/ask_comments.rs
+++ b/rust/loopflow/src/ops/ask_comments.rs
@@ -33,13 +33,14 @@ pub(crate) async fn publish_pending_ask_comments(store: &Store) -> OpsResult<()>
         else {
             continue;
         };
-        let client = match super::pm::linear_client(Path::new(&write.repo), &write.wave).await {
-            Ok(client) => client,
-            Err(error) => {
-                record_failure(store, &write, &error.to_string()).await?;
-                continue;
-            }
-        };
+        let client =
+            match super::pm::linear_issue_client(Path::new(&write.repo), &write.issue_id).await {
+                Ok(client) => client,
+                Err(error) => {
+                    record_failure(store, &write, &error.to_string()).await?;
+                    continue;
+                }
+            };
         publish_claimed_ask_comment(store, &client, write).await?;
     }
     Ok(())

--- a/rust/loopflow/src/ops/pm.rs
+++ b/rust/loopflow/src/ops/pm.rs
@@ -11,31 +11,32 @@ use std::path::Path;
 
 use futures_util::future::try_join_all;
 
-use crate::engine::config::load_config_or_default;
+use crate::engine::config::load_repo_config;
 use crate::engine::wave_config::{read_wave_config, update_wave_goal_config, WavePmConfig};
 use crate::ops::error::{OpsError, OpsResult};
 use crate::ops::progress::Progress;
 use crate::ops::util::normalize_wave_name;
 use crate::pm::linear::LinearClient;
 use crate::pm::{
-    PmError, PmItem, PmItemCreate, PmItemUpdate, PmKr, PmProject, PmProviderKind, PmResult, PmWave,
-    ProjectContent, ProjectFlowPlan, TeamBinding,
+    PmError, PmItem, PmItemCreate, PmItemUpdate, PmKr, PmPortfolioValidator, PmProject,
+    PmProviderKind, PmSnapshot, PmWave, ProjectContent, ProjectFlowPlan,
 };
 use crate::provider_auth::{
     provider_token_refresh_due, refresh_stored_provider_token, Provider, TokenRefreshError,
 };
-use crate::store::{open_store, PmSnapshotRow, ProviderToken, Store, TaskWriterState};
-#[cfg(test)]
-use crate::task::Task;
+use crate::repository::RepoId;
+use crate::store::{
+    open_existing_store, open_store, PmSnapshotRow, ProviderToken, Store, TaskWriterState,
+};
 
 // ── Options and results ─────────────────────────────────────────────
 
 #[derive(Debug, Clone, Default)]
 pub struct PmInitOptions {
     pub wave: Option<String>,
-    /// Team key (Task prefix, e.g. `PRD`). Defaults to one derived from the wave.
+    /// Repository Team key (Task prefix, e.g. `LOO`). Defaults from the repository name.
     pub team_key: Option<String>,
-    /// Team display name. Defaults to the title-cased wave name.
+    /// Repository Team display name. Defaults to the repository name.
     pub team_name: Option<String>,
 }
 
@@ -44,10 +45,10 @@ pub struct PmInitResult {
     pub wave: String,
     pub initiative_id: String,
     pub created: bool,
-    /// Stable id of the wave's team (owns the Task prefix).
+    /// Stable id of the repository Team (owns the Task prefix).
     pub team_id: String,
-    /// The team's key, when this run resolved it (`None` on a full no-op re-init).
-    pub team_key: Option<String>,
+    /// The repository Team's current display key (Task prefix).
+    pub team_key: String,
     /// Whether this run created the team (vs. adopted an existing one).
     pub team_created: bool,
 }
@@ -71,7 +72,7 @@ pub enum PmRefresh {
     Never,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct PmShowResult {
     pub wave: String,
     pub provider: PmProviderKind,
@@ -137,15 +138,16 @@ pub struct PmSyncResult {
 
 #[derive(Debug, Clone, Default)]
 pub struct PmReteamOptions {
-    pub wave: Option<String>,
     /// Execute the moves. Without it, `reteam` only prints the plan (dry run).
     pub apply: bool,
 }
 
-/// One issue that moves into the wave's team. `new_identifier` is filled only
+/// One issue that moves into the repository Team. `new_identifier` is filled only
 /// after an applied move (Linear assigns the number then).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PmReteamMove {
+    pub wave: String,
+    pub project_id: String,
     pub id: String,
     pub old_identifier: String,
     pub title: String,
@@ -155,34 +157,38 @@ pub struct PmReteamMove {
 /// One issue left in place while a Task Run can still write its old id.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PmReteamDeferral {
+    pub wave: String,
     pub identifier: String,
     pub title: String,
     pub reason: String,
 }
 
-/// One Project narrowed onto the wave's team. Projects keep their id and slug on
+/// One Project narrowed onto the repository Team. Projects keep their id and slug on
 /// a team move (Linear only renumbers issues), so there is no new identifier to
 /// carry — `from_teams` records where it came from for the plan output.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PmReteamProjectMove {
+    pub wave: String,
     pub id: String,
     pub name: String,
+    pub target_name: String,
     pub from_teams: Vec<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PmReteamResult {
-    pub wave: String,
+    pub repository: String,
+    pub waves: Vec<String>,
     pub team_id: String,
     pub team_key: String,
     /// True when moves were executed; false for a dry run.
     pub applied: bool,
-    /// Projects narrowed onto the wave's team (narrowed after their issues moved
+    /// Projects narrowed onto the repository Team (after their issues moved
     /// off the legacy team).
     pub project_moves: Vec<PmReteamProjectMove>,
     pub moves: Vec<PmReteamMove>,
     pub deferrals: Vec<PmReteamDeferral>,
-    /// Issues already carrying the target team key (skipped — idempotency).
+    /// Issues already carrying the target Team id (skipped — idempotency).
     pub already: usize,
     /// Durable Tasks whose cached display identifier was reconciled.
     pub task_updates: usize,
@@ -277,9 +283,8 @@ async fn pm_create_project_async(
     title: &str,
 ) -> OpsResult<PmResolvedProject> {
     let wave = resolve_wave(wave)?;
-    require_creation_team(repo, &wave, resolve_provider(repo, &wave)?)?;
     let ctx = resolve_context(repo, &wave).await?;
-    let projects = checked_projects(&ctx.client, &ctx.initiative, &wave).await?;
+    let projects = checked_projects(repo, &ctx, &wave).await?;
     if let Some(project) = projects
         .into_iter()
         .find(|project| project.name.eq_ignore_ascii_case(title))
@@ -298,7 +303,7 @@ async fn pm_create_project_async(
         flows: ProjectFlowPlan::empty(),
         krs: Vec::new(),
     };
-    let linear_name = linear_project_name(&wave, &seed.name);
+    let linear_name = linear_project_name(repo, &wave, &seed.name).await?;
     let id = match ctx
         .client
         .create_project(
@@ -313,7 +318,7 @@ async fn pm_create_project_async(
         .await
     {
         Ok(id) => id,
-        Err(create_error) => checked_projects(&ctx.client, &ctx.initiative, &wave)
+        Err(create_error) => checked_projects(repo, &ctx, &wave)
             .await?
             .into_iter()
             .find(|project| project.name.eq_ignore_ascii_case(title))
@@ -331,18 +336,12 @@ async fn pm_create_project_async(
             definition: seed.definition,
             flows: Some(seed.flows),
             krs: seed.krs,
-            initiative_ids: vec![ctx.initiative],
+            initiative_ids: vec![ctx.initiative.clone()],
             // The create result is transient — the next sync resolves the
             // authoritative teams from Linear.
-            team_ids: None,
+            team_ids: vec![ctx.team_id.clone()],
         },
     })
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-struct PmSnapshot {
-    projects: Vec<PmProject>,
-    items: Vec<PmItem>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -357,189 +356,25 @@ struct LocalProject {
 
 // ── Client + Linear project resolution ──────────────────────────────
 
-/// A wave's PM client bound to its provider Linear Initiative.
-pub(crate) struct PmContext {
-    pub client: PmClient,
+#[derive(Clone)]
+pub(crate) struct RepositoryPmContext {
+    pub client: LinearClient,
     pub provider: PmProviderKind,
+    pub repo_id: RepoId,
+    pub team_id: String,
+}
+
+/// A Wave's Initiative inside its repository-owned PM authority.
+pub(crate) struct PmContext {
+    pub repository: RepositoryPmContext,
     pub initiative: String,
 }
 
-#[derive(Clone)]
-pub(crate) enum PmClient {
-    Linear(LinearClient),
-}
+impl std::ops::Deref for PmContext {
+    type Target = RepositoryPmContext;
 
-impl PmClient {
-    async fn create_wave(&self, name: &str, summary: &str) -> PmResult<String> {
-        match self {
-            Self::Linear(client) => client.create_wave(name, summary).await,
-        }
-    }
-
-    async fn ensure_team(&self, name: &str, key: &str) -> PmResult<TeamBinding> {
-        match self {
-            Self::Linear(client) => client.ensure_team(name, key).await,
-        }
-    }
-
-    async fn rename_wave(&self, initiative_id: &str, name: &str) -> PmResult<()> {
-        match self {
-            Self::Linear(client) => client.rename_wave(initiative_id, name).await,
-        }
-    }
-
-    async fn list_waves(&self) -> PmResult<Vec<PmWave>> {
-        match self {
-            Self::Linear(client) => client.list_waves().await,
-        }
-    }
-
-    async fn list_projects(&self, initiative_id: &str) -> PmResult<Vec<PmProject>> {
-        match self {
-            Self::Linear(client) => client.list_projects(initiative_id).await,
-        }
-    }
-
-    async fn create_project(
-        &self,
-        initiative_id: &str,
-        name: &str,
-        content: &ProjectContent,
-    ) -> PmResult<String> {
-        match self {
-            Self::Linear(client) => {
-                client
-                    .create_project(
-                        initiative_id,
-                        name,
-                        &first_paragraph(&content.definition),
-                        content,
-                    )
-                    .await
-            }
-        }
-    }
-
-    async fn update_project(
-        &self,
-        project_id: &str,
-        name: &str,
-        content: &ProjectContent,
-    ) -> PmResult<()> {
-        match self {
-            Self::Linear(client) => {
-                client
-                    .update_project(
-                        project_id,
-                        name,
-                        &first_paragraph(&content.definition),
-                        content,
-                    )
-                    .await
-            }
-        }
-    }
-
-    async fn archive_project(&self, project_id: &str) -> PmResult<()> {
-        match self {
-            Self::Linear(client) => client.archive_project(project_id).await,
-        }
-    }
-
-    async fn list_items(&self, project_id: &str) -> PmResult<Vec<PmItem>> {
-        match self {
-            Self::Linear(client) => client.list_items(project_id).await,
-        }
-    }
-
-    async fn create_item(&self, project_id: &str, item: &PmItemCreate) -> PmResult<String> {
-        match self {
-            Self::Linear(client) => client.create_item(project_id, item).await,
-        }
-    }
-
-    async fn update_item(&self, item_id: &str, update: &PmItemUpdate) -> PmResult<()> {
-        match self {
-            Self::Linear(client) => client.update_item(item_id, update).await,
-        }
-    }
-
-    async fn move_item_to_project(&self, item_id: &str, project_id: &str) -> PmResult<()> {
-        match self {
-            Self::Linear(client) => client.move_item_to_project(item_id, project_id).await,
-        }
-    }
-
-    async fn move_item_to_team(&self, item_id: &str, team_id: &str) -> PmResult<String> {
-        match self {
-            Self::Linear(client) => client.move_item_to_team(item_id, team_id).await,
-        }
-    }
-
-    async fn move_project_to_team(&self, project_id: &str, team_id: &str) -> PmResult<()> {
-        match self {
-            Self::Linear(client) => client.move_project_to_team(project_id, team_id).await,
-        }
-    }
-
-    async fn team_key(&self, team_id: &str) -> PmResult<String> {
-        match self {
-            Self::Linear(client) => client.team_key(team_id).await,
-        }
-    }
-
-    async fn complete_item(&self, item_id: &str) -> PmResult<()> {
-        match self {
-            Self::Linear(client) => client.complete_item(item_id).await,
-        }
-    }
-
-    async fn comment(&self, item_id: &str, body: &str) -> PmResult<String> {
-        match self {
-            Self::Linear(client) => client.comment(item_id, body).await,
-        }
-    }
-
-    /// The bodies of an issue's existing comments, newest page first. `reteam`
-    /// reads these to make its traceability comment idempotent: it re-posts only
-    /// when this migration's marker is absent.
-    async fn issue_comment_bodies(&self, item_id: &str) -> PmResult<Vec<String>> {
-        match self {
-            Self::Linear(client) => Ok(client
-                .observe_issue(item_id)
-                .await?
-                .comments
-                .into_iter()
-                .map(|comment| comment.body)
-                .collect()),
-        }
-    }
-
-    async fn update_comment(&self, comment_id: &str, body: &str) -> PmResult<()> {
-        match self {
-            Self::Linear(client) => client.update_comment(comment_id, body).await,
-        }
-    }
-
-    async fn link_attachment(&self, issue_id: &str, url: &str, title: &str) -> PmResult<String> {
-        match self {
-            Self::Linear(client) => client.link_attachment(issue_id, url, title).await,
-        }
-    }
-
-    async fn update_attachment(
-        &self,
-        attachment_id: &str,
-        title: &str,
-        subtitle: &str,
-    ) -> PmResult<()> {
-        match self {
-            Self::Linear(client) => {
-                client
-                    .update_attachment(attachment_id, title, subtitle)
-                    .await
-            }
-        }
+    fn deref(&self) -> &Self::Target {
+        &self.repository
     }
 }
 
@@ -556,16 +391,10 @@ fn parse_provider(value: &str) -> OpsResult<PmProviderKind> {
     value.parse::<PmProviderKind>().map_err(pm_to_ops)
 }
 
-fn resolve_provider(repo: &Path, wave: &str) -> OpsResult<PmProviderKind> {
-    let config = load_config_or_default(Some(repo));
-    let wave_pm = read_wave_pm_config(repo, wave);
-    if let Some(provider) = wave_pm
-        .as_ref()
-        .and_then(|pm| pm.provider.as_deref())
-        .filter(|provider| !provider.trim().is_empty())
-    {
-        return parse_provider(provider);
-    }
+fn resolve_provider(repo: &Path) -> OpsResult<PmProviderKind> {
+    let config = load_repo_config(repo)
+        .map_err(|error| OpsError::Message(format!("failed to read .lf/config.yaml: {error}")))?
+        .unwrap_or_default();
     if let Some(provider) = config
         .pm
         .as_ref()
@@ -585,71 +414,137 @@ fn read_initiative(repo: &Path, wave: &str, provider: PmProviderKind) -> Option<
     Some(initiative).filter(|initiative| !initiative.trim().is_empty())
 }
 
-/// The team id bound to a wave in GOAL.md, if any (`pm.linear_team`).
-fn read_team(repo: &Path, wave: &str, provider: PmProviderKind) -> Option<String> {
-    let pm = read_wave_pm_config(repo, wave)?;
+fn read_repository_team(repo: &Path, provider: PmProviderKind) -> OpsResult<Option<String>> {
+    let config = load_repo_config(repo)
+        .map_err(|error| OpsError::Message(format!("failed to read .lf/config.yaml: {error}")))?
+        .unwrap_or_default();
     let team = match provider {
-        PmProviderKind::Linear => pm.linear_team,
-    }?;
-    Some(team).filter(|team| !team.trim().is_empty())
+        PmProviderKind::Linear => config.pm.and_then(|pm| pm.linear_team),
+    };
+    Ok(team.filter(|team| !team.trim().is_empty()))
 }
 
-/// The team a wave's PM client should act in: its own `pm.linear_team` binding,
-/// falling back to the machine-global `config.linear.team` for waves not yet
-/// bound (keeps unmigrated waves working on the shared team). Reads follow
-/// Initiative → Project → Issue and ignore the team, so an unbound wave still
-/// syncs its existing issues; the team only steers *creation*.
-fn resolve_team(repo: &Path, wave: &str, provider: PmProviderKind) -> Option<String> {
-    read_team(repo, wave, provider)
-        .or_else(|| load_config_or_default(Some(repo)).linear.team.clone())
-}
-
-/// The team *creation* must act in. Fail closed: creation resolves a wave's
-/// explicit `pm.linear_team` binding and never borrows `config.linear.team` or
-/// Linear's auto-created default team, so a Project/Task cannot silently land
-/// on a foreign team. An unbound wave errors with the exact recovery and no
-/// Linear side effect; reads keep [`resolve_team`]'s fallback so an unbound
-/// wave still syncs its existing issues.
-fn require_creation_team(repo: &Path, wave: &str, provider: PmProviderKind) -> OpsResult<String> {
-    read_team(repo, wave, provider).ok_or_else(|| {
-        OpsError::Message(format!(
-            "wave/{wave}/GOAL.md has no `pm.{key}`, so creating work would fall \
-             back to the shared team. Bind the wave's team first: \
-             `lf pm init --wave {wave} --team-key <KEY>`.",
-            key = provider.team_key()
-        ))
+fn require_repository_team(repo: &Path, provider: PmProviderKind) -> OpsResult<String> {
+    read_repository_team(repo, provider)?.ok_or_else(|| {
+        OpsError::Message(
+            ".lf/config.yaml has no repository `pm.linear_team`. \
+             Run `lf pm init --wave <wave> --team-key <KEY>` before creating or mutating work."
+                .to_string(),
+        )
     })
 }
 
 /// Whether a wave has a Linear Initiative pinned for its resolved provider.
 fn wave_has_pm_initiative(repo: &Path, wave: &str) -> bool {
-    resolve_provider(repo, wave)
+    resolve_provider(repo)
         .ok()
         .is_some_and(|provider| read_initiative(repo, wave, provider).is_some())
+}
+
+fn legacy_pm_sentinels(repo: &Path) -> OpsResult<Vec<String>> {
+    let config = load_repo_config(repo)
+        .map_err(|error| OpsError::Message(format!("failed to read .lf/config.yaml: {error}")))?
+        .unwrap_or_default();
+    let mut sentinels = Vec::new();
+    if config.linear.team.is_some() {
+        sentinels.push(".lf/config.yaml `linear.team`".to_string());
+    }
+    for wave in list_local_waves(repo)? {
+        let Some(pm) = read_wave_pm_config(repo, &wave) else {
+            continue;
+        };
+        if pm.provider.is_some() {
+            sentinels.push(format!("wave/{wave}/GOAL.md `pm.provider`"));
+        }
+        if pm.linear_team.is_some() {
+            sentinels.push(format!("wave/{wave}/GOAL.md `pm.linear_team`"));
+        }
+    }
+    Ok(sentinels)
+}
+
+pub(crate) fn require_repository_pm_ready(repo: &Path) -> OpsResult<()> {
+    let sentinels = legacy_pm_sentinels(repo)?;
+    if sentinels.is_empty() {
+        return Ok(());
+    }
+    Err(OpsError::Message(format!(
+        "repository PM migration is required before this mutation; legacy authority remains at {}. \
+         Run `lf pm reteam` to inspect the repository-wide plan, then `lf pm reteam --apply`. \
+         Loopflow's live migration is owned by PRD-44.",
+        sentinels.join(", ")
+    )))
+}
+
+pub(crate) fn repository_team_id(repo: &Path) -> OpsResult<String> {
+    require_repository_pm_ready(repo)?;
+    let provider = resolve_provider(repo)?;
+    require_repository_team(repo, provider)
+}
+
+/// Expected Team for strict cached reads after migration. During the deliberate
+/// PRD-43/PRD-44 mixed state, legacy snapshots remain inspectable and validate
+/// their own singular Team rather than pretending they already carry the new one.
+pub(crate) fn repository_team_for_snapshot_validation(repo: &Path) -> OpsResult<Option<String>> {
+    if !legacy_pm_sentinels(repo)?.is_empty() {
+        return Ok(None);
+    }
+    let provider = resolve_provider(repo)?;
+    read_repository_team(repo, provider)
 }
 
 async fn build_client(
     _repo: &Path,
     provider: PmProviderKind,
     team: Option<String>,
-) -> OpsResult<PmClient> {
+) -> OpsResult<LinearClient> {
     let token = resolve_pm_token(provider).await?;
     match provider {
-        PmProviderKind::Linear => Ok(PmClient::Linear(LinearClient::new(token, team))),
+        PmProviderKind::Linear => Ok(LinearClient::new(token, team)),
     }
 }
 
-/// A configured Linear client for a wave, for webhook serve/register. Resolves
-/// and refreshes the wave's OAuth token exactly like every other `lf pm` read.
-pub async fn linear_client(repo: &Path, wave: &str) -> OpsResult<LinearClient> {
-    let provider = resolve_provider(repo, wave)?;
-    let PmClient::Linear(client) =
-        build_client(repo, provider, resolve_team(repo, wave, provider)).await?;
-    Ok(client)
+fn repository_id(repo: &Path) -> OpsResult<RepoId> {
+    RepoId::discover(repo).map_err(|error| {
+        OpsError::Message(format!(
+            "cannot establish repository PM identity from Git origin: {error}. \
+             Configure an origin before running `lf pm init`."
+        ))
+    })
+}
+
+async fn resolve_repository_context(repo: &Path) -> OpsResult<RepositoryPmContext> {
+    require_repository_pm_ready(repo)?;
+    let provider = resolve_provider(repo)?;
+    let team_id = require_repository_team(repo, provider)?;
+    let repo_id = repository_id(repo)?;
+    let client = build_client(repo, provider, Some(team_id.clone())).await?;
+    client
+        .validate_team_claim(&team_id, repo_id.as_str())
+        .await
+        .map_err(pm_to_ops)?;
+    Ok(RepositoryPmContext {
+        client,
+        provider,
+        repo_id,
+        team_id: team_id.clone(),
+    })
+}
+
+/// A configured Linear client for repository-scoped webhook and exact-Issue operations.
+pub async fn linear_client(repo: &Path) -> OpsResult<LinearClient> {
+    Ok(resolve_repository_context(repo).await?.client)
+}
+
+pub(crate) async fn linear_issue_client(repo: &Path, issue_id: &str) -> OpsResult<LinearClient> {
+    let context = resolve_repository_context(repo).await?;
+    resolve_owned_issue(repo, &context, issue_id).await?;
+    Ok(context.client)
 }
 
 async fn resolve_context(repo: &Path, wave: &str) -> OpsResult<PmContext> {
-    let provider = resolve_provider(repo, wave)?;
+    let repository = resolve_repository_context(repo).await?;
+    let provider = repository.provider;
     let initiative = read_initiative(repo, wave, provider).ok_or_else(|| {
         OpsError::Message(format!(
             "wave/{wave}/GOAL.md has no `pm.{}`. \
@@ -657,10 +552,8 @@ async fn resolve_context(repo: &Path, wave: &str) -> OpsResult<PmContext> {
             provider.initiative_key()
         ))
     })?;
-    let client = build_client(repo, provider, resolve_team(repo, wave, provider)).await?;
     Ok(PmContext {
-        client,
-        provider,
+        repository,
         initiative,
     })
 }
@@ -828,7 +721,7 @@ async fn read_pm_snapshot(repo: &Path, wave: &str) -> OpsResult<PmSnapshotRow> {
 fn decode_snapshot(wave: &str, payload: &str) -> OpsResult<PmSnapshot> {
     serde_json::from_str(payload).map_err(|err| {
         OpsError::Message(format!(
-            "invalid PM snapshot for wave/{wave}; run `lf pm sync`: {err}"
+            "PM snapshot schema changed for wave/{wave}; run `lf pm sync`: {err}"
         ))
     })
 }
@@ -934,8 +827,15 @@ async fn load_show_snapshot(
     }
 }
 
-async fn fetch_pm_snapshot(wave: &str, ctx: &PmContext) -> OpsResult<PmSnapshot> {
-    let projects = checked_projects(&ctx.client, &ctx.initiative, wave).await?;
+async fn fetch_pm_snapshot(repo: &Path, wave: &str, ctx: &PmContext) -> OpsResult<PmSnapshot> {
+    let projects = checked_projects(repo, ctx, wave).await?;
+    fetch_pm_snapshot_for_projects(ctx, projects).await
+}
+
+async fn fetch_pm_snapshot_for_projects(
+    ctx: &PmContext,
+    projects: Vec<PmProject>,
+) -> OpsResult<PmSnapshot> {
     let project_items = try_join_all(projects.iter().cloned().map(|project| async move {
         let mut items = ctx
             .client
@@ -943,7 +843,8 @@ async fn fetch_pm_snapshot(wave: &str, ctx: &PmContext) -> OpsResult<PmSnapshot>
             .await
             .map_err(pm_to_ops)?;
         for item in &mut items {
-            item.project = Some(project.slug.clone());
+            item.project_id = project.id.clone();
+            item.project = project.slug.clone();
         }
         Ok::<_, OpsError>(items)
     }))
@@ -990,7 +891,7 @@ async fn store_pm_snapshot_with_store(
 }
 
 async fn refresh_pm_snapshot(repo: &Path, wave: &str, ctx: &PmContext) -> OpsResult<PmSnapshot> {
-    let snapshot = fetch_pm_snapshot(wave, ctx).await?;
+    let snapshot = fetch_pm_snapshot(repo, wave, ctx).await?;
     store_pm_snapshot(repo, wave, ctx, &snapshot).await?;
     Ok(snapshot)
 }
@@ -1018,35 +919,39 @@ async fn pm_init_async(
         )));
     }
 
-    let provider = resolve_provider(repo, &wave)?;
+    let provider = resolve_provider(repo)?;
+    let repo_id = repository_id(repo)?;
     let existing_initiative = read_initiative(repo, &wave, provider);
-    let existing_team = read_team(repo, &wave, provider);
-
-    let explicit_team = options.team_key.is_some() || options.team_name.is_some();
-
-    // Full no-op fast path: both bindings present and the caller did not ask
-    // to adopt a different team. An explicit team selection is a rebind.
-    if let (Some(initiative_id), Some(team_id)) =
-        (existing_initiative.as_ref(), existing_team.as_ref())
-    {
-        if !explicit_team {
-            progress.status(&format!(
-                "wave/{wave} already linked to {provider} Initiative {initiative_id} and team {team_id}"
-            ));
-            return Ok(PmInitResult {
-                wave,
-                initiative_id: initiative_id.clone(),
-                created: false,
-                team_id: team_id.clone(),
-                team_key: None,
-                team_created: false,
-            });
-        }
-    }
+    let existing_team = read_repository_team(repo, provider)?;
 
     let summary = wave_summary(repo, &wave)?;
     let title = title_case(&wave);
-    let client = build_client(repo, provider, resolve_team(repo, &wave, provider)).await?;
+    let client = build_client(repo, provider, existing_team.clone()).await?;
+
+    let team_name = options
+        .team_name
+        .clone()
+        .unwrap_or_else(|| title_case(repo_id.name()));
+    let team_key = options
+        .team_key
+        .clone()
+        .unwrap_or_else(|| default_team_key(repo_id.name()));
+    let team = match existing_team.as_deref() {
+        Some(team_id) => client
+            .claim_configured_team(
+                team_id,
+                repo_id.as_str(),
+                options.team_name.as_deref(),
+                options.team_key.as_deref(),
+            )
+            .await
+            .map_err(pm_to_ops)?,
+        None => client
+            .ensure_team(&team_name, &team_key, repo_id.as_str())
+            .await
+            .map_err(pm_to_ops)?,
+    };
+    let team_changed = existing_team.as_deref() != Some(team.id.as_str());
 
     // Initiative: keep an existing binding, else find or create it.
     let initiative_missing = existing_initiative.is_none();
@@ -1079,39 +984,8 @@ async fn pm_init_async(
     if initiative_missing {
         write_initiative_to_goal(repo, &wave, provider, &initiative_id)?;
     }
-
-    // Team: an explicit key/name rebinds an existing Wave; otherwise keep its
-    // binding or create the default one when missing.
-    let resolve_requested_team = explicit_team || existing_team.is_none();
-    let (team_id, team_key, team_created) = if resolve_requested_team {
-        let name = options.team_name.clone().unwrap_or_else(|| title.clone());
-        let key = options
-            .team_key
-            .clone()
-            .unwrap_or_else(|| default_team_key(&wave));
-        progress.status(&format!(
-            "resolving {provider} team `{name}` (key {key}) for wave/{wave}"
-        ));
-        let team = client.ensure_team(&name, &key).await.map_err(pm_to_ops)?;
-        progress.status(&format!(
-            "{} {provider} team {} (key {})",
-            if team.created { "created" } else { "adopted" },
-            team.id,
-            team.key
-        ));
-        (team.id, Some(team.key), team.created)
-    } else {
-        (
-            existing_team
-                .clone()
-                .expect("an unrequested existing team was checked above"),
-            None,
-            false,
-        )
-    };
-    let team_changed = existing_team.as_deref() != Some(team_id.as_str());
     if team_changed {
-        write_team_to_goal(repo, &wave, provider, &team_id)?;
+        write_repository_pm_config(repo, provider, &team.id)?;
     }
 
     if initiative_missing || team_changed {
@@ -1130,9 +1004,9 @@ async fn pm_init_async(
         wave,
         initiative_id,
         created,
-        team_id,
-        team_key,
-        team_created,
+        team_id: team.id,
+        team_key: team.key,
+        team_created: team.created,
     })
 }
 
@@ -1165,11 +1039,7 @@ pub(crate) async fn pm_show_async(
     let items = snapshot
         .items
         .into_iter()
-        .filter(|item| {
-            item.project
-                .as_deref()
-                .is_some_and(|project| slugs.contains(project))
-        })
+        .filter(|item| slugs.contains(item.project.as_str()))
         .collect();
     Ok(PmShowResult {
         wave,
@@ -1221,9 +1091,8 @@ async fn pm_create_task_idempotent_async(
     marker: &str,
     progress: &impl Progress,
 ) -> OpsResult<PmUpdateResult> {
-    require_creation_team(repo, wave, resolve_provider(repo, wave)?)?;
     let ctx = resolve_context(repo, wave).await?;
-    let projects = checked_projects(&ctx.client, &ctx.initiative, wave).await?;
+    let projects = checked_projects(repo, &ctx, wave).await?;
     let project = find_project(&projects, wave, project_slug)?;
     let find_existing = |items: Vec<PmItem>| {
         items
@@ -1294,19 +1163,31 @@ pub(crate) async fn pm_update_async(
     progress: &impl Progress,
 ) -> OpsResult<PmUpdateResult> {
     let wave = resolve_wave(options.wave.as_deref())?;
-    // A create (no `--id`) must bind an explicit team; an update on an existing
-    // issue does not attach to a team, so it stays team-agnostic.
-    if options.id.is_none() {
-        require_creation_team(repo, &wave, resolve_provider(repo, &wave)?)?;
-    }
     let ctx = resolve_context(repo, &wave).await?;
-    let result = apply_update(&wave, options.project.as_deref(), &ctx, options, progress).await?;
+    if let Some(issue_id) = options.id.as_deref() {
+        let (owning_wave, _, _, _) = resolve_owned_issue(repo, &ctx.repository, issue_id).await?;
+        if owning_wave != wave {
+            return Err(OpsError::Message(format!(
+                "Linear task {issue_id} belongs to wave/{owning_wave}, not wave/{wave}"
+            )));
+        }
+    }
+    let result = apply_update(
+        repo,
+        &wave,
+        options.project.as_deref(),
+        &ctx,
+        options,
+        progress,
+    )
+    .await?;
     progress.status(&format!("refreshing local PM snapshot for wave/{wave}"));
     refresh_pm_snapshot(repo, &wave, &ctx).await?;
     Ok(result)
 }
 
 async fn apply_update(
+    repo: &Path,
     wave: &str,
     project_slug: Option<&str>,
     ctx: &PmContext,
@@ -1314,7 +1195,7 @@ async fn apply_update(
     progress: &impl Progress,
 ) -> OpsResult<PmUpdateResult> {
     let mark_done = parse_done_status(options.status.as_deref())?;
-    let projects = checked_projects(&ctx.client, &ctx.initiative, wave).await?;
+    let projects = checked_projects(repo, ctx, wave).await?;
     let project = project_slug
         .map(|slug| find_project(&projects, wave, slug))
         .transpose()?;
@@ -1458,11 +1339,29 @@ pub(crate) async fn pm_link_pr_async(
             }
         }
     };
+    match resolve_owned_issue(repo, &ctx.repository, &request.issue_id).await {
+        Ok((owning_wave, _, _, _)) if owning_wave == wave => {}
+        Ok((owning_wave, _, _, _)) => {
+            return PrLinkageOutcome {
+                ids: prior.clone(),
+                error: Some(format!(
+                    "Linear issue {} belongs to wave/{owning_wave}, not wave/{wave}",
+                    request.issue_id
+                )),
+            }
+        }
+        Err(error) => {
+            return PrLinkageOutcome {
+                ids: prior.clone(),
+                error: Some(error.to_string()),
+            }
+        }
+    }
     link_pr_with_client(&ctx.client, request, prior).await
 }
 
 async fn link_pr_with_client(
-    client: &PmClient,
+    client: &LinearClient,
     request: &PrLinkRequest,
     prior: &PrLinkageIds,
 ) -> PrLinkageOutcome {
@@ -1555,10 +1454,21 @@ async fn pm_status_async(
         list_pm_waves(repo)?
     };
 
+    let expected_team = repository_team_for_snapshot_validation(repo)?;
+    let mut ownership = PmPortfolioValidator::default();
     let mut results = Vec::new();
     for wave in waves {
         let row = read_pm_snapshot(repo, &wave).await?;
         let snapshot = decode_snapshot(&wave, &row.payload)?;
+        ownership
+            .validate(
+                &wave,
+                &row.initiative,
+                expected_team.as_deref(),
+                &snapshot.projects,
+                &snapshot.items,
+            )
+            .map_err(pm_to_ops)?;
         let total = snapshot.items.len();
         let open = snapshot.items.iter().filter(|item| !item.completed).count();
         let mut open_by_project = BTreeMap::new();
@@ -1566,9 +1476,7 @@ async fn pm_status_async(
             let project_open = snapshot
                 .items
                 .iter()
-                .filter(|item| {
-                    !item.completed && item.project.as_deref() == Some(project.slug.as_str())
-                })
+                .filter(|item| !item.completed && item.project == project.slug)
                 .count();
             open_by_project.insert(project.slug, project_open);
         }
@@ -1597,36 +1505,42 @@ pub fn pm_resolve_task(repo: &Path, issue: &str) -> OpsResult<PmResolvedTask> {
 }
 
 async fn pm_resolve_task_async(repo: &Path, issue: &str) -> OpsResult<PmResolvedTask> {
-    let mut matches = Vec::new();
-    for wave in list_pm_waves(repo)? {
-        let ctx = resolve_context(repo, &wave).await?;
-        for project in checked_projects(&ctx.client, &ctx.initiative, &wave).await? {
-            let items = ctx
-                .client
-                .list_items(&project.id)
-                .await
-                .map_err(pm_to_ops)?;
-            for item in items {
-                if item.id == issue || item.identifier.eq_ignore_ascii_case(issue) {
-                    matches.push(PmResolvedTask {
-                        wave: wave.clone(),
-                        initiative_id: ctx.initiative.clone(),
-                        project: project.clone(),
-                        item,
-                    });
-                }
-            }
-        }
+    let repository = resolve_repository_context(repo).await?;
+    let (wave, initiative_id, mut item, mut project) =
+        resolve_owned_issue(repo, &repository, issue).await?;
+    let title_path = canonical_wave_title_path_async(repo, &wave).await?;
+    project.name = canonical_project_name(&title_path, &wave, &project.name)?;
+    project.slug = crate::pm::project_slug(&project.name);
+    item.project_id = project.id.clone();
+    item.project = project.slug.clone();
+    Ok(PmResolvedTask {
+        wave,
+        initiative_id,
+        project,
+        item,
+    })
+}
+
+async fn resolve_owned_issue(
+    repo: &Path,
+    repository: &RepositoryPmContext,
+    issue: &str,
+) -> OpsResult<(String, String, PmItem, PmProject)> {
+    let (item, project) = repository
+        .client
+        .issue_ownership(issue)
+        .await
+        .map_err(pm_to_ops)?;
+    if item.team_id != repository.team_id {
+        return Err(OpsError::Message(format!(
+            "Linear task {} belongs to Team {}, not repository {} Team {}",
+            item.identifier, item.team_id, repository.repo_id, repository.team_id
+        )));
     }
-    match matches.len() {
-        0 => Err(OpsError::Message(format!(
-            "Linear task {issue:?} does not belong to a known Loopflow Project and Wave"
-        ))),
-        1 => Ok(matches.pop().expect("one task match")),
-        count => Err(OpsError::Message(format!(
-            "Linear task {issue:?} belongs to {count} known Loopflow Waves; repair PM ownership before running it"
-        ))),
-    }
+    let initiative_id = singular_project_initiative(&project)?;
+    let wave = wave_for_initiative(repo, &initiative_id)?;
+    validate_project_ownership(&project, &wave, &initiative_id, &repository.team_id)?;
+    Ok((wave, initiative_id, item, project))
 }
 
 pub fn pm_resolve_project(repo: &Path, project_id: &str) -> OpsResult<PmResolvedProject> {
@@ -1634,42 +1548,63 @@ pub fn pm_resolve_project(repo: &Path, project_id: &str) -> OpsResult<PmResolved
 }
 
 async fn pm_resolve_project_async(repo: &Path, project_id: &str) -> OpsResult<PmResolvedProject> {
-    let mut matches = Vec::new();
-    for wave in list_pm_waves(repo)? {
-        let ctx = resolve_context(repo, &wave).await?;
-        for project in checked_projects(&ctx.client, &ctx.initiative, &wave).await? {
-            if project.id == project_id {
-                matches.push(PmResolvedProject {
-                    wave: wave.clone(),
-                    initiative_id: ctx.initiative.clone(),
-                    project,
-                });
-            }
-        }
-    }
-    match matches.len() {
-        0 => Err(OpsError::Message(format!(
-            "Linear Project {project_id:?} does not belong to a known Loopflow Wave"
+    let repository = resolve_repository_context(repo).await?;
+    let mut project = repository
+        .client
+        .project_ownership(project_id)
+        .await
+        .map_err(pm_to_ops)?;
+    let initiative_id = singular_project_initiative(&project)?;
+    let wave = wave_for_initiative(repo, &initiative_id)?;
+    validate_project_ownership(&project, &wave, &initiative_id, &repository.team_id)?;
+    let title_path = canonical_wave_title_path_async(repo, &wave).await?;
+    project.name = canonical_project_name(&title_path, &wave, &project.name)?;
+    project.slug = crate::pm::project_slug(&project.name);
+    Ok(PmResolvedProject {
+        wave,
+        initiative_id,
+        project,
+    })
+}
+
+fn singular_project_initiative(project: &PmProject) -> OpsResult<String> {
+    match project.initiative_ids.as_slice() {
+        [initiative] => Ok(initiative.clone()),
+        initiatives => Err(OpsError::Message(format!(
+            "Linear Project `{}` ({}) belongs to {} Initiatives [{}]; expected exactly one",
+            project.name,
+            project.id,
+            initiatives.len(),
+            project.initiative_ids.join(", ")
         ))),
-        1 => Ok(matches.pop().expect("one project match")),
-        count => Err(OpsError::Message(format!(
-            "Linear Project {project_id:?} belongs to {count} known Loopflow Waves; each Project must belong to exactly one Wave"
+    }
+}
+
+fn wave_for_initiative(repo: &Path, initiative_id: &str) -> OpsResult<String> {
+    let provider = resolve_provider(repo)?;
+    let matches = list_local_waves(repo)?
+        .into_iter()
+        .filter(|wave| read_initiative(repo, wave, provider).as_deref() == Some(initiative_id))
+        .collect::<Vec<_>>();
+    match matches.as_slice() {
+        [wave] => Ok(wave.clone()),
+        [] => Err(OpsError::Message(format!(
+            "Linear Initiative {initiative_id} is not bound by any local Wave"
+        ))),
+        waves => Err(OpsError::Message(format!(
+            "Linear Initiative {initiative_id} is bound by multiple local Waves: {}; repair GOAL.md ownership",
+            waves.join(", ")
         ))),
     }
 }
 
 // ── reteam ──────────────────────────────────────────────────────────
 
-/// How `reteam` treats one issue. Pure classification, so it is unit-tested
-/// without a live Linear.
+/// How repository-wide `reteam` treats one issue.
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum ReteamClass {
-    /// Already carries the target team key → skip the move; only reconcile a
-    /// stale cached Task identifier.
     Already,
-    /// An active Task Run owns it → defer until the Run stops.
     Defer(String),
-    /// On the legacy team and not being written → move onto the wave's team.
     Move,
 }
 
@@ -1694,18 +1629,12 @@ impl ReteamWriterState<'_> {
     }
 }
 
-/// Every foreign-team issue moves — completed included — unless a Task Run can
-/// still write the old identifier back. Completion is not a shield: a Project
-/// cannot narrow to one team while any of its issues (completed or not) stay on
-/// the legacy team, so completed issues migrate like the rest. Protection keys on
-/// an active Run, not on Linear completion. Open Work without a Run is safe to
-/// renumber once its cached identifier is reconciled.
 fn classify_reteam_item(
     item: &PmItem,
-    team_key: &str,
+    team_id: &str,
     writer: Option<ReteamWriterState<'_>>,
 ) -> ReteamClass {
-    let already = identifier_has_team_prefix(&item.identifier, team_key);
+    let already = item.team_id == team_id;
     let identifier_needs_update = writer.is_some_and(|writer| writer.identifier != item.identifier);
     if let Some(reason) = writer
         .filter(|_| !already || identifier_needs_update)
@@ -1719,23 +1648,8 @@ fn classify_reteam_item(
     ReteamClass::Move
 }
 
-/// Whether an identifier already belongs to the team keyed by `team_key`. The
-/// trailing `-` guards against a prefix collision (`PRD-` must not match a
-/// `PRODUCT-1` identifier).
-fn identifier_has_team_prefix(identifier: &str, team_key: &str) -> bool {
-    let prefix = format!("{}-", team_key.trim().to_ascii_uppercase());
-    identifier.trim().to_ascii_uppercase().starts_with(&prefix)
-}
-
-/// Whether a Project's resolved ownership differs from exactly the wave's team.
-/// `None` means the read did not resolve teams (an older snapshot) — unknown,
-/// not a mismatch, so no false positive. Empty, foreign, and multi-team sets all
-/// need repair because one Project belongs to one Wave-owned team.
-fn project_needs_reteam(bound_team: &str, project_team_ids: Option<&[String]>) -> bool {
-    match project_team_ids {
-        None => false,
-        Some(team_ids) => team_ids.len() != 1 || team_ids[0] != bound_team,
-    }
+fn project_needs_reteam(bound_team: &str, project_team_ids: &[String]) -> bool {
+    project_team_ids.len() != 1 || project_team_ids[0] != bound_team
 }
 
 /// Refuse the whole apply when any Task Run can still write the old identifier.
@@ -1750,8 +1664,8 @@ fn ensure_reteam_apply_safe(deferrals: &[PmReteamDeferral]) -> OpsResult<()> {
         .iter()
         .map(|deferral| {
             format!(
-                "{} `{}` ({})",
-                deferral.identifier, deferral.title, deferral.reason
+                "{} `{}` (wave/{}; {})",
+                deferral.identifier, deferral.title, deferral.wave, deferral.reason
             )
         })
         .collect::<Vec<_>>()
@@ -1759,37 +1673,6 @@ fn ensure_reteam_apply_safe(deferrals: &[PmReteamDeferral]) -> OpsResult<()> {
     Err(OpsError::Message(format!(
         "cannot apply reteam while {} Task Run(s) can still write the old identifier: {protected}. No Projects or Tasks were moved; stop those Runs and rerun the dry-run.",
         deferrals.len()
-    )))
-}
-
-/// Moving an issue to `target_team` keeps it in its Project only when that
-/// Project already carries the target team. Refuse unresolved and missing-team
-/// Projects before the first store or provider mutation.
-fn ensure_move_projects_carry_target_team(
-    projects: &[PmProject],
-    moving_project_ids: &BTreeSet<String>,
-    target_team: &str,
-) -> OpsResult<()> {
-    let unsafe_projects = projects
-        .iter()
-        .filter(|project| moving_project_ids.contains(&project.id))
-        .filter_map(|project| match project.team_ids.as_deref() {
-            Some(team_ids) if team_ids.iter().any(|team| team == target_team) => None,
-            Some(team_ids) => Some(format!(
-                "`{}` (teams [{}])",
-                project.name,
-                team_ids.join(", ")
-            )),
-            None => Some(format!("`{}` (teams unresolved)", project.name)),
-        })
-        .collect::<Vec<_>>();
-    if unsafe_projects.is_empty() {
-        return Ok(());
-    }
-
-    Err(OpsError::Message(format!(
-        "cannot apply reteam because Project(s) containing issues to move do not already carry target team {target_team}: {}. No Projects or Tasks were moved; attach the target team and rerun the dry-run.",
-        unsafe_projects.join("; ")
     )))
 }
 
@@ -1801,11 +1684,15 @@ struct ReteamIdentifierUpdate {
 }
 
 struct ResolvedReteamContext {
-    wave: String,
-    team_id: String,
+    repository: RepositoryPmContext,
     team_key: String,
-    pm: PmContext,
     store: Store,
+}
+
+#[derive(Debug, Clone)]
+struct ReteamProjectState {
+    project: PmProject,
+    target_name: String,
 }
 
 fn reteam_comment_marker(old_identifier: &str, team_key: &str) -> String {
@@ -1819,41 +1706,33 @@ fn reteam_comment_body(old_identifier: &str, team_key: &str) -> String {
     )
 }
 
-async fn resolve_reteam_context(
-    repo: &Path,
-    wave: Option<&str>,
-) -> OpsResult<ResolvedReteamContext> {
-    let wave = resolve_wave(wave)?;
-    let provider = resolve_provider(repo, &wave)?;
-    let team_id = read_team(repo, &wave, provider).ok_or_else(|| {
-        OpsError::Message(format!(
-            "wave/{wave}/GOAL.md has no `pm.{}`. \
-             Run `lf pm init --wave {wave} --team-key <KEY>` to bind its team first.",
-            provider.team_key()
-        ))
+async fn resolve_reteam_context(repo: &Path) -> OpsResult<ResolvedReteamContext> {
+    let provider = resolve_provider(repo)?;
+    let team_id = read_repository_team(repo, provider)?.ok_or_else(|| {
+        OpsError::Message(
+            ".lf/config.yaml has no repository `pm.linear_team`. \
+             Run `lf pm init --wave <wave> --team-key <KEY>` to establish the migration target."
+                .to_string(),
+        )
     })?;
-    let initiative = read_initiative(repo, &wave, provider).ok_or_else(|| {
-        OpsError::Message(format!(
-            "wave/{wave}/GOAL.md has no `pm.{}`. \
-             Run `lf pm init --wave {wave}` to connect its Linear Initiative.",
-            provider.initiative_key()
-        ))
-    })?;
+    let repo_id = repository_id(repo)?;
     let client = build_client(repo, provider, Some(team_id.clone())).await?;
-    let team_key = client.team_key(&team_id).await.map_err(pm_to_ops)?;
+    let binding = client
+        .validate_team_claim(&team_id, repo_id.as_str())
+        .await
+        .map_err(pm_to_ops)?;
     let store = open_store(&storage_config_from_env()?)
         .await
         .map_err(|err| OpsError::Message(format!("failed to open task registry: {err}")))?;
 
     Ok(ResolvedReteamContext {
-        wave,
-        team_id,
-        team_key,
-        pm: PmContext {
+        repository: RepositoryPmContext {
             client,
             provider,
-            initiative,
+            repo_id,
+            team_id,
         },
+        team_key: binding.key,
         store,
     })
 }
@@ -1871,110 +1750,175 @@ async fn pm_reteam_async(
     options: &PmReteamOptions,
     progress: &impl Progress,
 ) -> OpsResult<PmReteamResult> {
-    let resolved = resolve_reteam_context(repo, options.wave.as_deref()).await?;
-    apply_or_plan_reteam(
-        &resolved.pm,
-        &resolved.store,
-        repo,
-        &resolved.wave,
-        &resolved.team_id,
-        &resolved.team_key,
-        options.apply,
-        progress,
-    )
-    .await
+    let resolved = resolve_reteam_context(repo).await?;
+    apply_or_plan_repository_reteam(&resolved, repo, options.apply, progress).await
 }
 
-#[allow(clippy::too_many_arguments)]
-async fn apply_or_plan_reteam(
-    ctx: &PmContext,
-    store: &Store,
+async fn apply_or_plan_repository_reteam(
+    resolved: &ResolvedReteamContext,
     repo: &Path,
-    wave: &str,
-    team_id: &str,
-    team_key: &str,
     apply: bool,
     progress: &impl Progress,
 ) -> OpsResult<PmReteamResult> {
-    progress.status(&format!(
-        "listing wave/{wave} issues under {} Initiative {}",
-        ctx.provider, ctx.initiative
-    ));
-    let projects = ctx
-        .client
-        .list_projects(&ctx.initiative)
-        .await
-        .map_err(pm_to_ops)?;
-
+    let team_id = &resolved.repository.team_id;
+    let team_key = &resolved.team_key;
+    let store = &resolved.store;
+    let waves = list_pm_waves(repo)?;
+    if waves.is_empty() {
+        return Err(OpsError::Message(
+            "repository has no Waves linked to Linear Initiatives".to_string(),
+        ));
+    }
     let mut project_moves = Vec::new();
     let mut moves = Vec::new();
     let mut deferrals = Vec::new();
-    let mut moving_project_ids = BTreeSet::new();
     let mut identifier_updates = Vec::new();
+    let mut states = Vec::new();
+    let mut seen_initiatives = BTreeMap::new();
+    let mut seen_projects = BTreeSet::new();
     let mut already = 0usize;
     let mut task_updates = 0usize;
 
-    for project in &projects {
-        // A Project without exactly the wave's team is moved onto it. A
-        // multi-team Project is repaired too: ownership is singular, not merely
-        // membership. An unresolved team set (`None`, older snapshot) is skipped,
-        // never guessed.
-        if project_needs_reteam(team_id, project.team_ids.as_deref()) {
-            project_moves.push(PmReteamProjectMove {
-                id: project.id.clone(),
-                name: project.name.clone(),
-                from_teams: project.team_ids.clone().unwrap_or_default(),
-            });
+    if apply && repo.join(".git").exists() && !crate::engine::git::is_clean(repo)? {
+        return Err(OpsError::Message(
+            "`lf pm reteam --apply` requires a clean Git checkout so its repository PM config and Wave bindings can commit atomically; commit or stash existing changes, then rerun the dry-run"
+                .to_string(),
+        ));
+    }
+
+    for wave in &waves {
+        let initiative =
+            read_initiative(repo, wave, resolved.repository.provider).ok_or_else(|| {
+                OpsError::Message(format!(
+                    "wave/{wave} has no Linear Initiative; initialize every Wave before reteam"
+                ))
+            })?;
+        if let Some(owner) = seen_initiatives.insert(initiative.clone(), wave.clone()) {
+            return Err(OpsError::Message(format!(
+                "Linear Initiative {initiative} is bound by both wave/{owner} and wave/{wave}; repair GOAL.md ownership before reteam"
+            )));
         }
-        let items = ctx
+        progress.status(&format!("preflighting wave/{wave} Initiative {initiative}"));
+        let projects = resolved
+            .repository
             .client
-            .list_items(&project.id)
+            .list_projects(&initiative)
             .await
             .map_err(pm_to_ops)?;
-        for item in items {
-            // Resolve protection from stable Task Work and its active Run.
-            let writer = store
-                .task_writer_state(&item.id)
+        let title_path = canonical_wave_title_path_with_store(repo, wave, store).await?;
+        for project in projects {
+            if !seen_projects.insert(project.id.clone()) {
+                return Err(OpsError::Message(format!(
+                    "Linear Project `{}` ({}) appears under multiple Wave Initiatives",
+                    project.name, project.id
+                )));
+            }
+            if project.initiative_ids.as_slice() != [initiative.as_str()] {
+                return Err(OpsError::Message(format!(
+                    "Linear Project `{}` ({}) in wave/{wave} belongs to Initiatives [{}]; \
+                     reteam requires exactly {initiative} before any provider mutation",
+                    project.name,
+                    project.id,
+                    project.initiative_ids.join(", ")
+                )));
+            }
+            let canonical_name = canonical_project_name(&title_path, wave, &project.name)?;
+            let target_name = format!("{title_path} — {canonical_name}");
+            if project_needs_reteam(team_id, &project.team_ids) || project.name != target_name {
+                project_moves.push(PmReteamProjectMove {
+                    wave: wave.clone(),
+                    id: project.id.clone(),
+                    name: project.name.clone(),
+                    target_name: target_name.clone(),
+                    from_teams: project.team_ids.clone(),
+                });
+            }
+            let items = resolved
+                .repository
+                .client
+                .list_items(&project.id)
                 .await
-                .map_err(|err| OpsError::Message(format!("failed to read task registry: {err}")))?;
-            match classify_reteam_item(
-                &item,
-                team_key,
-                writer.as_ref().map(ReteamWriterState::from),
-            ) {
-                ReteamClass::Already => {
-                    already += 1;
-                    if let Some(writer) =
-                        writer.filter(|writer| writer.identifier != item.identifier)
-                    {
-                        identifier_updates.push(ReteamIdentifierUpdate {
-                            issue_id: item.id,
-                            old_identifier: writer.identifier,
-                            new_identifier: item.identifier,
-                        });
-                    }
+                .map_err(pm_to_ops)?;
+            for item in items {
+                if item.project_id != project.id {
+                    return Err(OpsError::Message(format!(
+                        "Linear task {} resolves to Project {}, expected {}",
+                        item.identifier, item.project_id, project.id
+                    )));
                 }
-                ReteamClass::Defer(reason) => deferrals.push(PmReteamDeferral {
-                    identifier: item.identifier,
-                    title: item.name,
-                    reason,
-                }),
-                ReteamClass::Move => {
-                    moving_project_ids.insert(project.id.clone());
-                    moves.push(PmReteamMove {
+                if !project.team_ids.iter().any(|team| team == &item.team_id) {
+                    return Err(OpsError::Message(format!(
+                        "Linear task {} belongs to Team {}, but Project {} carries teams [{}]",
+                        item.identifier,
+                        item.team_id,
+                        project.id,
+                        project.team_ids.join(", ")
+                    )));
+                }
+                let writer = store.task_writer_state(&item.id).await.map_err(|error| {
+                    OpsError::Message(format!("failed to read task registry: {error}"))
+                })?;
+                match classify_reteam_item(
+                    &item,
+                    team_id,
+                    writer.as_ref().map(ReteamWriterState::from),
+                ) {
+                    ReteamClass::Already => {
+                        already += 1;
+                        if let Some(writer) =
+                            writer.filter(|writer| writer.identifier != item.identifier)
+                        {
+                            identifier_updates.push(ReteamIdentifierUpdate {
+                                issue_id: item.id,
+                                old_identifier: writer.identifier,
+                                new_identifier: item.identifier,
+                            });
+                        }
+                    }
+                    ReteamClass::Defer(reason) => deferrals.push(PmReteamDeferral {
+                        wave: wave.clone(),
+                        identifier: item.identifier,
+                        title: item.name,
+                        reason,
+                    }),
+                    ReteamClass::Move => moves.push(PmReteamMove {
+                        wave: wave.clone(),
+                        project_id: project.id.clone(),
                         id: item.id,
                         old_identifier: item.identifier,
                         title: item.name,
                         new_identifier: None,
-                    });
+                    }),
                 }
             }
+            states.push(ReteamProjectState {
+                project,
+                target_name,
+            });
         }
     }
 
     if apply {
         ensure_reteam_apply_safe(&deferrals)?;
-        ensure_move_projects_carry_target_team(&projects, &moving_project_ids, team_id)?;
+
+        // Linear requires the destination Team on a Project before its Issues
+        // can move. Expand first; narrowing is the final provider phase.
+        for state in &states {
+            if !state.project.team_ids.iter().any(|team| team == team_id) {
+                let mut teams = state.project.team_ids.clone();
+                teams.push(team_id.clone());
+                progress.status(&format!(
+                    "attaching team {team_key} to Project `{}`",
+                    state.project.name
+                ));
+                resolved
+                    .repository
+                    .client
+                    .set_project_teams(&state.project.id, &teams)
+                    .await
+                    .map_err(pm_to_ops)?;
+            }
+        }
 
         for update in identifier_updates {
             task_updates += usize::from(
@@ -1996,13 +1940,20 @@ async fn apply_or_plan_reteam(
 
         for mv in &mut moves {
             let marker = reteam_comment_marker(&mv.old_identifier, team_key);
-            let comment_bodies = ctx
+            let comment_bodies = resolved
+                .repository
                 .client
-                .issue_comment_bodies(&mv.id)
+                .observe_issue(&mv.id)
                 .await
-                .map_err(pm_to_ops)?;
+                .map_err(pm_to_ops)?
+                .comments
+                .into_iter()
+                .map(|comment| comment.body)
+                .collect::<Vec<_>>();
             if !comment_bodies.iter().any(|body| body.contains(&marker)) {
-                ctx.client
+                resolved
+                    .repository
+                    .client
                     .comment(&mv.id, &reteam_comment_body(&mv.old_identifier, team_key))
                     .await
                     .map_err(pm_to_ops)?;
@@ -2011,7 +1962,8 @@ async fn apply_or_plan_reteam(
                 "moving {} into team {team_key}",
                 mv.old_identifier
             ));
-            let new_identifier = ctx
+            let new_identifier = resolved
+                .repository
                 .client
                 .move_item_to_team(&mv.id, team_id)
                 .await
@@ -2030,30 +1982,73 @@ async fn apply_or_plan_reteam(
             mv.new_identifier = Some(new_identifier);
         }
 
-        // Linear refuses to remove a team from a Project while that team's
-        // issues remain in it, so narrowing is necessarily the final provider
-        // phase. `teamIds` is a set replacement: exactly the wave's team.
-        for pm in &project_moves {
-            progress.status(&format!(
-                "narrowing Project `{}` onto team {team_key}",
-                pm.name
-            ));
-            ctx.client
-                .move_project_to_team(&pm.id, team_id)
-                .await
-                .map_err(pm_to_ops)?;
+        for state in &states {
+            if project_needs_reteam(team_id, &state.project.team_ids) {
+                progress.status(&format!(
+                    "narrowing Project `{}` onto team {team_key}",
+                    state.project.name
+                ));
+                resolved
+                    .repository
+                    .client
+                    .move_project_to_team(&state.project.id, team_id)
+                    .await
+                    .map_err(pm_to_ops)?;
+            }
+            if state.project.name != state.target_name {
+                let flows = state.project.flows.clone().ok_or_else(|| {
+                    OpsError::Message(format!(
+                        "Project {} has no flow payload; refresh before reteam",
+                        state.project.id
+                    ))
+                })?;
+                resolved
+                    .repository
+                    .client
+                    .update_project(
+                        &state.project.id,
+                        &state.target_name,
+                        &ProjectContent {
+                            definition: state.project.definition.clone(),
+                            flows,
+                            krs: state.project.krs.clone(),
+                        },
+                    )
+                    .await
+                    .map_err(pm_to_ops)?;
+            }
         }
 
-        // Always refresh after a successful explicit apply. A prior run may have
-        // completed every provider mutation and then failed while refreshing;
-        // its retry classifies everything as Already and must still repair the
-        // local snapshot.
-        let snapshot = fetch_pm_snapshot(wave, ctx).await?;
-        store_pm_snapshot_with_store(repo, wave, ctx, &snapshot, store).await?;
+        // Re-fetch and validate the complete repository before deleting any
+        // migration sentinel. A crash before cleanup remains loudly resumable.
+        for wave in &waves {
+            let initiative = read_initiative(repo, wave, resolved.repository.provider)
+                .expect("preflight required every Initiative");
+            let ctx = PmContext {
+                repository: resolved.repository.clone(),
+                initiative,
+            };
+            let projects = checked_projects_with_store(repo, &ctx, wave, store).await?;
+            let snapshot = fetch_pm_snapshot_for_projects(&ctx, projects).await?;
+            store_pm_snapshot_with_store(repo, wave, &ctx, &snapshot, store).await?;
+        }
+        remove_legacy_pm_sentinels(repo, &waves)?;
+        if repo.join(".git").exists() {
+            let _ = crate::ops::commit_workflow(
+                repo,
+                &crate::ops::CommitOptions {
+                    add: true,
+                    message: Some("lf pm: migrate repository to one Linear Team".to_string()),
+                    ..crate::ops::CommitOptions::for_task("pm")
+                },
+                progress,
+            )?;
+        }
     }
 
     Ok(PmReteamResult {
-        wave: wave.to_string(),
+        repository: resolved.repository.repo_id.to_string(),
+        waves,
         team_id: team_id.to_string(),
         team_key: team_key.to_string(),
         applied: apply,
@@ -2087,40 +2082,81 @@ async fn pm_sync_async(
     };
     let mut actions = Vec::new();
     let mut diagnostics = Vec::new();
+    let mut blocking = Vec::new();
+    let provider = resolve_provider(repo)?;
+    let team_id = read_repository_team(repo, provider)?;
 
-    let mut linked_initiative_ids = BTreeSet::new();
-    let mut provider_by_kind = BTreeMap::new();
-    for wave in &all_waves {
-        let provider = resolve_provider(repo, wave)?;
-        provider_by_kind.insert(provider.as_str().to_string(), provider);
-        if let Some(initiative) = read_initiative(repo, wave, provider) {
-            linked_initiative_ids.insert(initiative);
-        } else {
-            diagnostics.push(format!("wave/{wave} has no Linear Initiative"));
-        }
-        // Every wave must bind a team explicitly so creation never falls back to
-        // the shared team. Sharing one team across a product's waves (each with
-        // its own Initiative, as Cadenza does) is allowed — the Task prefix is
-        // per team, not per wave — so no "waves share a team" diagnostic here.
-        if read_team(repo, wave, provider).is_none() {
-            diagnostics.push(format!(
-                "wave/{wave} has no `pm.{}`; run `lf pm init --wave {wave} --team-key <KEY>` \
-                 so its work lands on an explicit team",
-                provider.team_key()
-            ));
+    if let Some(store) = open_existing_store().await {
+        let origin = crate::engine::wave_context::wave_origin(repo);
+        for wave in store
+            .list_waves(Some(&origin.display().to_string()))
+            .await
+            .map_err(|error| {
+                OpsError::Message(format!("failed to inspect Wave registry: {error}"))
+            })?
+        {
+            if wave.parent_wave_id().is_some()
+                && wave.promoted_at().is_none()
+                && !origin
+                    .join("wave")
+                    .join(wave.name())
+                    .join("GOAL.md")
+                    .is_file()
+            {
+                diagnostics.push(format!(
+                    "prepared child wave/{} has no GOAL.md; resume or abandon its promotion",
+                    wave.name()
+                ));
+            }
         }
     }
 
-    let provider = provider_by_kind
-        .values()
-        .next()
-        .copied()
-        .unwrap_or(PmProviderKind::Linear);
-    // Machine-wide diff over many waves; reads follow Initiative → Project →
-    // Issue and are team-agnostic, so no per-wave team is resolved here.
-    let client = build_client(repo, provider, None).await?;
+    for sentinel in legacy_pm_sentinels(repo)? {
+        diagnostics.push(format!(
+            "legacy PM authority remains at {sentinel}; run repository-wide `lf pm reteam`"
+        ));
+    }
+    if !options.plan {
+        require_repository_pm_ready(repo)?;
+    }
+    if team_id.is_none() {
+        let message = ".lf/config.yaml has no repository `pm.linear_team`; run `lf pm init --wave <wave> --team-key <KEY>`".to_string();
+        diagnostics.push(message.clone());
+        blocking.push(message);
+    }
+
+    let mut initiative_waves: BTreeMap<String, Vec<String>> = BTreeMap::new();
+    for wave in &all_waves {
+        if let Some(initiative) = read_initiative(repo, wave, provider) {
+            initiative_waves
+                .entry(initiative)
+                .or_default()
+                .push(wave.clone());
+        } else {
+            diagnostics.push(format!("wave/{wave} has no Linear Initiative"));
+        }
+    }
+    for (initiative, owners) in &initiative_waves {
+        if owners.len() > 1 {
+            let message = format!(
+                "Linear Initiative {initiative} is bound by multiple local Waves: {}",
+                owners.join(", ")
+            );
+            diagnostics.push(message.clone());
+            blocking.push(message);
+        }
+    }
+
+    let client = build_client(repo, provider, team_id.clone()).await?;
+    let repo_id = repository_id(repo)?;
+    if let Some(team_id) = &team_id {
+        client
+            .validate_team_claim(team_id, repo_id.as_str())
+            .await
+            .map_err(pm_to_ops)?;
+    }
     progress.status(&format!(
-        "checking {provider} Linear Initiatives and Projects"
+        "checking {provider} repository Initiatives, Projects, and Tasks"
     ));
     let linear_waves = client.list_waves().await.map_err(pm_to_ops)?;
     let linear_waves_by_id: BTreeMap<String, String> = linear_waves
@@ -2128,7 +2164,7 @@ async fn pm_sync_async(
         .map(|wave| (wave.id.clone(), wave.name.clone()))
         .collect();
     for linear_wave in &linear_waves {
-        if !linked_initiative_ids.contains(&linear_wave.id) {
+        if !initiative_waves.contains_key(&linear_wave.id) {
             diagnostics.push(format!(
                 "Linear Initiative `{}` ({}) is not linked by any local wave",
                 linear_wave.name, linear_wave.id
@@ -2136,9 +2172,10 @@ async fn pm_sync_async(
         }
     }
 
+    let mut seen_projects: BTreeMap<String, String> = BTreeMap::new();
     for wave in &waves {
-        let provider = resolve_provider(repo, wave)?;
         let Some(initiative_id) = read_initiative(repo, wave, provider) else {
+            blocking.push(format!("wave/{wave} has no Linear Initiative"));
             continue;
         };
         let expected_initiative_name = title_case(wave);
@@ -2147,85 +2184,170 @@ async fn pm_sync_async(
                 let message = format!(
                     "rename Linear Initiative `{actual}` ({initiative_id}) to `{expected_initiative_name}` for wave/{wave}"
                 );
-                if !options.plan {
-                    client
-                        .rename_wave(&initiative_id, &expected_initiative_name)
-                        .await
-                        .map_err(pm_to_ops)?;
-                }
                 actions.push(message);
             }
-            None => diagnostics.push(format!(
-                "wave/{wave} points at missing Linear Initiative {initiative_id}"
-            )),
+            None => {
+                let message =
+                    format!("wave/{wave} points at missing Linear Initiative {initiative_id}");
+                diagnostics.push(message.clone());
+                blocking.push(message);
+                continue;
+            }
             _ => {}
         }
 
-        let ctx = PmContext {
-            client: client.clone(),
-            provider,
-            initiative: initiative_id.clone(),
-        };
-        let snapshot = fetch_pm_snapshot(wave, &ctx).await?;
-        let bound_team = read_team(repo, wave, provider);
-        for project in &snapshot.projects {
-            let managed_initiatives = project
-                .initiative_ids
-                .iter()
-                .filter(|id| linked_initiative_ids.contains(*id))
-                .count();
-            if managed_initiatives != 1 {
-                diagnostics.push(format!(
-                    "Linear Project `{}` ({}) belongs to {managed_initiatives} Loopflow-managed Initiatives; expected exactly one",
+        let title_path = canonical_wave_title_path_async(repo, wave).await?;
+        let projects = client
+            .list_projects(&initiative_id)
+            .await
+            .map_err(pm_to_ops)?;
+        let mut slugs = BTreeMap::new();
+        for project in projects {
+            if let Some(existing_wave) = seen_projects.insert(project.id.clone(), wave.clone()) {
+                let message = format!(
+                    "Linear Project `{}` ({}) appears under both wave/{existing_wave} and wave/{wave}",
                     project.name, project.id
-                ));
+                );
+                diagnostics.push(message.clone());
+                blocking.push(message);
             }
-            // A Project stranded on a foreign team (or simultaneously attached
-            // to the bound and a legacy team) violates singular Wave ownership.
-            if let Some(team_id) = &bound_team {
-                if project_needs_reteam(team_id, project.team_ids.as_deref()) {
-                    let teams = project.team_ids.as_deref().unwrap_or_default().join(", ");
-                    diagnostics.push(format!(
-                        "Linear Project `{}` ({}) in wave/{wave} belongs to team(s) [{teams}], \
-                         not the wave's team {team_id}; run `lf pm reteam --wave {wave}` to move it",
+            if project.initiative_ids.as_slice() != [initiative_id.as_str()] {
+                let message = format!(
+                    "Linear Project `{}` ({}) in wave/{wave} belongs to Initiatives [{}]; expected exactly {initiative_id}",
+                    project.name,
+                    project.id,
+                    project.initiative_ids.join(", ")
+                );
+                diagnostics.push(message.clone());
+                blocking.push(message);
+            }
+            if let Some(team_id) = &team_id {
+                if project.team_ids.as_slice() != [team_id.as_str()] {
+                    let message = format!(
+                        "Linear Project `{}` ({}) in wave/{wave} belongs to Teams [{}]; expected exactly repository Team {team_id}. Run `lf pm reteam`.",
+                        project.name,
+                        project.id,
+                        project.team_ids.join(", ")
+                    );
+                    diagnostics.push(message.clone());
+                    blocking.push(message);
+                }
+            }
+            let canonical_name = match canonical_project_name(&title_path, wave, &project.name) {
+                Ok(name) => name,
+                Err(error) => {
+                    let message = error.to_string();
+                    diagnostics.push(message.clone());
+                    blocking.push(message);
+                    continue;
+                }
+            };
+            let slug = crate::pm::project_slug(&canonical_name);
+            if let Some(existing) = slugs.insert(slug.clone(), canonical_name.clone()) {
+                let message = format!(
+                    "Linear Projects `{existing}` and `{canonical_name}` in wave/{wave} both derive slug `{slug}`"
+                );
+                diagnostics.push(message.clone());
+                blocking.push(message);
+            }
+            let expected_project_name = format!("{title_path} — {canonical_name}");
+            if project.name != expected_project_name {
+                if project.flows.is_none() {
+                    let message = format!(
+                        "Linear Project `{}` ({}) has no flow payload, so its title cannot be repaired safely",
+                        project.name, project.id
+                    );
+                    diagnostics.push(message.clone());
+                    blocking.push(message);
+                } else {
+                    actions.push(format!(
+                        "rename Linear Project `{}` ({}) to `{expected_project_name}`",
                         project.name, project.id
                     ));
                 }
             }
-            let items: Vec<_> = snapshot
-                .items
-                .iter()
-                .filter(|item| item.project.as_deref() == Some(project.slug.as_str()))
-                .collect();
+
+            let items = client.list_items(&project.id).await.map_err(pm_to_ops)?;
             if items.iter().all(|item| item.completed) {
                 diagnostics.push(format!(
-                    "Linear Project `{}` ({}) in wave/{wave} has no open tasks",
-                    project.name, project.id
+                    "Linear Project `{canonical_name}` ({}) in wave/{wave} has no open tasks",
+                    project.id
                 ));
             }
-        }
-        // Stranded issues: a team-bound wave whose open issues still carry a
-        // foreign prefix are `reteam` candidates not yet moved.
-        if let Some(team_id) = &bound_team {
-            let team_key = client.team_key(team_id).await.map_err(pm_to_ops)?;
-            let stranded = snapshot
-                .items
-                .iter()
-                .filter(|item| {
-                    !item.completed && !identifier_has_team_prefix(&item.identifier, &team_key)
-                })
-                .count();
-            if stranded > 0 {
-                diagnostics.push(format!(
-                    "wave/{wave} has {stranded} open issue(s) not in team {team_key}; \
-                     run `lf pm reteam --wave {wave}` to plan their migration"
-                ));
+            for item in items {
+                if item.project_id != project.id {
+                    let message = format!(
+                        "Linear task {} resolves to Project {}, expected {}",
+                        item.identifier, item.project_id, project.id
+                    );
+                    diagnostics.push(message.clone());
+                    blocking.push(message);
+                }
+                if let Some(team_id) = &team_id {
+                    if item.team_id != *team_id {
+                        let message = format!(
+                            "Linear task {} belongs to Team {}, expected repository Team {team_id}. Run `lf pm reteam`.",
+                            item.identifier, item.team_id
+                        );
+                        diagnostics.push(message.clone());
+                        blocking.push(message);
+                    }
+                }
             }
         }
         actions.push(format!(
             "refresh wave/{wave} PM snapshot from Linear Initiative {initiative_id}"
         ));
-        if !options.plan {
+    }
+
+    if !options.plan && !blocking.is_empty() {
+        return Err(OpsError::Message(format!(
+            "PM ownership validation failed before mutation: {}",
+            blocking.join("; ")
+        )));
+    }
+
+    if !options.plan {
+        let team_id = team_id.expect("non-plan sync requires repository Team");
+        for wave in &waves {
+            let initiative = read_initiative(repo, wave, provider)
+                .expect("preflight required every selected Initiative");
+            let expected_initiative_name = title_case(wave);
+            if linear_waves_by_id.get(&initiative) != Some(&expected_initiative_name) {
+                client
+                    .rename_wave(&initiative, &expected_initiative_name)
+                    .await
+                    .map_err(pm_to_ops)?;
+            }
+            let title_path = canonical_wave_title_path_async(repo, wave).await?;
+            for project in client.list_projects(&initiative).await.map_err(pm_to_ops)? {
+                let canonical_name = canonical_project_name(&title_path, wave, &project.name)?;
+                let expected_name = format!("{title_path} — {canonical_name}");
+                if project.name != expected_name {
+                    client
+                        .update_project(
+                            &project.id,
+                            &expected_name,
+                            &ProjectContent {
+                                definition: project.definition.clone(),
+                                flows: project.flows.clone().expect("preflight required flows"),
+                                krs: project.krs.clone(),
+                            },
+                        )
+                        .await
+                        .map_err(pm_to_ops)?;
+                }
+            }
+            let ctx = PmContext {
+                repository: RepositoryPmContext {
+                    client: client.clone(),
+                    provider,
+                    repo_id: repo_id.clone(),
+                    team_id: team_id.clone(),
+                },
+                initiative,
+            };
+            let snapshot = fetch_pm_snapshot(repo, wave, &ctx).await?;
             store_pm_snapshot(repo, wave, &ctx, &snapshot).await?;
         }
     }
@@ -2261,7 +2383,7 @@ async fn pm_project_archive_async(
 ) -> OpsResult<PmProjectArchiveResult> {
     let wave = resolve_wave(options.wave.as_deref())?;
     let ctx = resolve_context(repo, &wave).await?;
-    let projects = checked_projects(&ctx.client, &ctx.initiative, &wave).await?;
+    let projects = checked_projects(repo, &ctx, &wave).await?;
     let project = find_project(&projects, &wave, &options.project)?;
     progress.status(&format!("archiving Linear Project `{}`", project.name));
     ctx.client
@@ -2285,9 +2407,6 @@ async fn pm_project_write_async(
     let wave = resolve_wave(options.wave.as_deref())?;
     // Creating a Project (no `--project` slug to update) must bind an explicit
     // team; updating an existing Project does not move it between teams.
-    if options.project.is_none() {
-        require_creation_team(repo, &wave, resolve_provider(repo, &wave)?)?;
-    }
     let ctx = resolve_context(repo, &wave).await?;
     let requested_krs = options
         .krs
@@ -2313,7 +2432,7 @@ async fn pm_project_write_async(
         ));
     }
 
-    let projects = checked_projects(&ctx.client, &ctx.initiative, &wave).await?;
+    let projects = checked_projects(repo, &ctx, &wave).await?;
     let (id, slug, created) = if let Some(slug) = options.project.as_deref() {
         let project = find_project(&projects, &wave, slug)?;
         let name = options
@@ -2330,7 +2449,7 @@ async fn pm_project_write_async(
             )));
         }
         progress.status(&format!("updating Linear Project `{}`", project.name));
-        let linear_name = linear_project_name(&wave, &name);
+        let linear_name = linear_project_name(repo, &wave, &name).await?;
         let content = ProjectContent {
             definition: options
                 .definition
@@ -2374,7 +2493,7 @@ async fn pm_project_write_async(
             )));
         }
         progress.status(&format!("creating Linear Project `{name}`"));
-        let linear_name = linear_project_name(&wave, &name);
+        let linear_name = linear_project_name(repo, &wave, &name).await?;
         let content = ProjectContent {
             definition: options.definition.clone().ok_or_else(|| {
                 OpsError::Message("`lf pm project create --definition` is required".to_string())
@@ -2450,8 +2569,9 @@ async fn pm_task_move_async(
 ) -> OpsResult<PmTaskMoveResult> {
     let wave = resolve_wave(options.wave.as_deref())?;
     let ctx = resolve_context(repo, &wave).await?;
-    let projects = checked_projects(&ctx.client, &ctx.initiative, &wave).await?;
+    let projects = checked_projects(repo, &ctx, &wave).await?;
     let project = find_project(&projects, &wave, &options.project)?;
+    resolve_owned_issue(repo, &ctx.repository, &options.id).await?;
     progress.status(&format!(
         "moving {} task {} to wave/{wave} Linear Project {}",
         ctx.provider, options.id, project.id
@@ -2475,17 +2595,30 @@ pub fn list_local_waves(repo: &Path) -> OpsResult<Vec<String>> {
         return Ok(Vec::new());
     }
     let mut waves = Vec::new();
-    for entry in std::fs::read_dir(&wave_dir)? {
+    collect_local_waves(&wave_dir, &wave_dir, &mut waves)?;
+    waves.sort();
+    Ok(waves)
+}
+
+fn collect_local_waves(root: &Path, directory: &Path, waves: &mut Vec<String>) -> OpsResult<()> {
+    for entry in std::fs::read_dir(directory)? {
         let entry = entry?;
         if !entry.file_type()?.is_dir() {
             continue;
         }
-        if let Some(name) = entry.file_name().to_str() {
-            waves.push(name.to_string());
+        let path = entry.path();
+        if path.join("GOAL.md").is_file() {
+            let relative = path.strip_prefix(root).expect("walk remains below wave/");
+            let name = relative
+                .components()
+                .map(|component| component.as_os_str().to_string_lossy())
+                .collect::<Vec<_>>()
+                .join("/");
+            waves.push(name);
         }
+        collect_local_waves(root, &path, waves)?;
     }
-    waves.sort();
-    Ok(waves)
+    Ok(())
 }
 
 // ── helpers ─────────────────────────────────────────────────────────
@@ -2504,10 +2637,6 @@ fn write_initiative_to_goal(
             .cloned()
             .unwrap_or_default();
         pm_map.insert(
-            serde_yaml_ng::Value::String("provider".to_string()),
-            serde_yaml_ng::Value::String(provider.as_str().to_string()),
-        );
-        pm_map.insert(
             serde_yaml_ng::Value::String(provider.initiative_key().to_string()),
             serde_yaml_ng::Value::String(initiative_id.to_string()),
         );
@@ -2517,37 +2646,121 @@ fn write_initiative_to_goal(
     .map_err(OpsError::Message)
 }
 
-fn write_team_to_goal(
+fn write_repository_pm_config(
     repo: &Path,
-    wave: &str,
     provider: PmProviderKind,
     team_id: &str,
 ) -> OpsResult<()> {
-    update_wave_goal_config(repo, wave, |map| {
-        let pm_key = serde_yaml_ng::Value::String("pm".to_string());
-        let mut pm_map = map
-            .get(&pm_key)
-            .and_then(serde_yaml_ng::Value::as_mapping)
-            .cloned()
-            .unwrap_or_default();
-        pm_map.insert(
-            serde_yaml_ng::Value::String("provider".to_string()),
-            serde_yaml_ng::Value::String(provider.as_str().to_string()),
-        );
-        pm_map.insert(
-            serde_yaml_ng::Value::String(provider.team_key().to_string()),
-            serde_yaml_ng::Value::String(team_id.to_string()),
-        );
-        map.insert(pm_key, serde_yaml_ng::Value::Mapping(pm_map));
-        Ok(())
-    })
-    .map_err(OpsError::Message)
+    let path = repo.join(".lf/config.yaml");
+    let mut root = match std::fs::read_to_string(&path) {
+        Ok(content) if !content.trim().is_empty() => {
+            serde_yaml_ng::from_str::<serde_yaml_ng::Value>(&content).map_err(|error| {
+                OpsError::Message(format!(
+                    "invalid repository config {}: {error}",
+                    path.display()
+                ))
+            })?
+        }
+        Ok(_) => serde_yaml_ng::Value::Mapping(serde_yaml_ng::Mapping::new()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            serde_yaml_ng::Value::Mapping(serde_yaml_ng::Mapping::new())
+        }
+        Err(error) => return Err(error.into()),
+    };
+    let root_map = root.as_mapping_mut().ok_or_else(|| {
+        OpsError::Message(format!(
+            "repository config {} must be a YAML mapping",
+            path.display()
+        ))
+    })?;
+    let pm_key = serde_yaml_ng::Value::String("pm".to_string());
+    let mut pm = root_map
+        .get(&pm_key)
+        .and_then(serde_yaml_ng::Value::as_mapping)
+        .cloned()
+        .unwrap_or_default();
+    pm.insert(
+        serde_yaml_ng::Value::String("provider".to_string()),
+        serde_yaml_ng::Value::String(provider.as_str().to_string()),
+    );
+    pm.insert(
+        serde_yaml_ng::Value::String("linear_team".to_string()),
+        serde_yaml_ng::Value::String(team_id.to_string()),
+    );
+    root_map.insert(pm_key, serde_yaml_ng::Value::Mapping(pm));
+    std::fs::create_dir_all(path.parent().expect("config path has parent"))?;
+    std::fs::write(
+        &path,
+        serde_yaml_ng::to_string(&root).map_err(|error| {
+            OpsError::Message(format!("failed to encode {}: {error}", path.display()))
+        })?,
+    )?;
+    Ok(())
 }
 
-/// A default team key (Task prefix) derived from the wave name: the first three
+fn remove_legacy_pm_sentinels(repo: &Path, waves: &[String]) -> OpsResult<()> {
+    for wave in waves {
+        update_wave_goal_config(repo, wave, |root| {
+            let pm_key = serde_yaml_ng::Value::String("pm".to_string());
+            let Some(mut pm) = root
+                .get(&pm_key)
+                .and_then(serde_yaml_ng::Value::as_mapping)
+                .cloned()
+            else {
+                return Ok(());
+            };
+            pm.remove(serde_yaml_ng::Value::String("provider".to_string()));
+            pm.remove(serde_yaml_ng::Value::String("linear_team".to_string()));
+            if pm.is_empty() {
+                root.remove(&pm_key);
+            } else {
+                root.insert(pm_key, serde_yaml_ng::Value::Mapping(pm));
+            }
+            Ok(())
+        })
+        .map_err(OpsError::Message)?;
+    }
+
+    let path = repo.join(".lf/config.yaml");
+    let content = std::fs::read_to_string(&path)?;
+    let mut root: serde_yaml_ng::Value = serde_yaml_ng::from_str(&content).map_err(|error| {
+        OpsError::Message(format!(
+            "invalid repository config {}: {error}",
+            path.display()
+        ))
+    })?;
+    let root_map = root.as_mapping_mut().ok_or_else(|| {
+        OpsError::Message(format!(
+            "repository config {} must be a YAML mapping",
+            path.display()
+        ))
+    })?;
+    let linear_key = serde_yaml_ng::Value::String("linear".to_string());
+    if let Some(mut linear) = root_map
+        .get(&linear_key)
+        .and_then(serde_yaml_ng::Value::as_mapping)
+        .cloned()
+    {
+        linear.remove(serde_yaml_ng::Value::String("team".to_string()));
+        if linear.is_empty() {
+            root_map.remove(&linear_key);
+        } else {
+            root_map.insert(linear_key, serde_yaml_ng::Value::Mapping(linear));
+        }
+    }
+    std::fs::write(
+        &path,
+        serde_yaml_ng::to_string(&root).map_err(|error| {
+            OpsError::Message(format!("failed to encode {}: {error}", path.display()))
+        })?,
+    )?;
+    Ok(())
+}
+
+/// A default team key (Task prefix) derived from the repository name: the first three
 /// alphanumeric characters, uppercased. `--team-key` overrides it.
-fn default_team_key(wave: &str) -> String {
-    let key: String = wave
+fn default_team_key(repository: &str) -> String {
+    let key: String = repository
         .chars()
         .filter(char::is_ascii_alphanumeric)
         .take(3)
@@ -2562,14 +2775,6 @@ fn default_team_key(wave: &str) -> String {
 
 fn wave_summary(repo: &Path, wave: &str) -> OpsResult<String> {
     Ok(crate::engine::wave_config::read_wave_summary(repo, wave)?)
-}
-
-fn first_paragraph(content: &str) -> String {
-    content
-        .split("\n\n")
-        .map(|paragraph| paragraph.split_whitespace().collect::<Vec<_>>().join(" "))
-        .find(|paragraph| !paragraph.is_empty())
-        .unwrap_or_default()
 }
 
 fn matching_wave_id(waves: &[PmWave], title: &str) -> OpsResult<Option<String>> {
@@ -2606,19 +2811,46 @@ fn ensure_unique_project_slugs(projects: &[PmProject], wave: &str) -> OpsResult<
     Ok(())
 }
 
-/// List an initiative's Linear Projects and validate their slugs are unique.
-async fn checked_projects(
-    client: &PmClient,
-    initiative: &str,
+/// List a Wave's Projects and enforce repository Team + singular Initiative ownership.
+async fn checked_projects(repo: &Path, ctx: &PmContext, wave: &str) -> OpsResult<Vec<PmProject>> {
+    let store = pm_store().await?;
+    checked_projects_with_store(repo, ctx, wave, &store).await
+}
+
+async fn checked_projects_with_store(
+    repo: &Path,
+    ctx: &PmContext,
     wave: &str,
+    store: &Store,
 ) -> OpsResult<Vec<PmProject>> {
-    let mut projects = client.list_projects(initiative).await.map_err(pm_to_ops)?;
+    let title_path = canonical_wave_title_path_with_store(repo, wave, store).await?;
+    let mut projects = ctx
+        .client
+        .list_projects(&ctx.initiative)
+        .await
+        .map_err(pm_to_ops)?;
     for project in &mut projects {
-        project.name = canonical_project_name(wave, &project.name).to_string();
+        validate_project_ownership(project, wave, &ctx.initiative, &ctx.team_id)?;
+        project.name = canonical_project_name(&title_path, wave, &project.name)?;
         project.slug = crate::pm::project_slug(&project.name);
     }
     ensure_unique_project_slugs(&projects, wave)?;
     Ok(projects)
+}
+
+fn validate_project_ownership(
+    project: &PmProject,
+    wave: &str,
+    initiative_id: &str,
+    team_id: &str,
+) -> OpsResult<()> {
+    crate::pm::validate_project_ownership(wave, initiative_id, Some(team_id), project).map_err(
+        |error| {
+            OpsError::Message(format!(
+                "{error}. Repair the associations and run `lf pm sync --wave {wave}`."
+            ))
+        },
+    )
 }
 
 fn find_project<'a>(projects: &'a [PmProject], wave: &str, slug: &str) -> OpsResult<&'a PmProject> {
@@ -2649,16 +2881,100 @@ fn title_case(slug: &str) -> String {
         .join(" ")
 }
 
-fn linear_project_name(wave: &str, canonical_name: &str) -> String {
-    format!("{} — {}", title_case(wave), canonical_name.trim())
+async fn linear_project_name(repo: &Path, wave: &str, canonical_name: &str) -> OpsResult<String> {
+    Ok(format!(
+        "{} — {}",
+        canonical_wave_title_path_async(repo, wave).await?,
+        canonical_name.trim()
+    ))
 }
 
-fn canonical_project_name<'a>(wave: &str, linear_name: &'a str) -> &'a str {
-    let prefix = format!("{} — ", title_case(wave));
-    linear_name
-        .strip_prefix(&prefix)
-        .unwrap_or(linear_name)
-        .trim()
+fn canonical_project_name(title_path: &str, wave: &str, linear_name: &str) -> OpsResult<String> {
+    let expected = format!("{title_path} — ");
+    if let Some(name) = linear_name.strip_prefix(&expected) {
+        return Ok(name.trim().to_string());
+    }
+    let leaf = wave.rsplit('/').next().unwrap_or(wave);
+    for legacy in [title_case(wave), title_case(leaf)] {
+        let prefix = format!("{legacy} — ");
+        if let Some(name) = linear_name.strip_prefix(&prefix) {
+            return Ok(name.trim().to_string());
+        }
+    }
+    if linear_name.contains(" — ") {
+        return Err(OpsError::Message(format!(
+            "Linear Project title {linear_name:?} has an unrecognized Wave prefix; \
+             run `lf pm project update --wave {wave} --project <slug> --title <name>` explicitly"
+        )));
+    }
+    Ok(linear_name.trim().to_string())
+}
+
+pub fn canonical_wave_title_path(repo: &Path, wave: &str) -> OpsResult<String> {
+    block_on_pm(canonical_wave_title_path_async(repo, wave))
+}
+
+async fn canonical_wave_title_path_async(repo: &Path, wave: &str) -> OpsResult<String> {
+    let store = pm_store().await?;
+    canonical_wave_title_path_with_store(repo, wave, &store).await
+}
+
+async fn canonical_wave_title_path_with_store(
+    repo: &Path,
+    wave: &str,
+    store: &Store,
+) -> OpsResult<String> {
+    let Some(mut current) = store
+        .get_wave_by_name(wave)
+        .await
+        .map_err(|error| OpsError::Message(format!("failed to read Wave ancestry: {error}")))?
+    else {
+        if wave.contains('/') {
+            return Err(OpsError::Message(format!(
+                "nested wave/{wave} has no durable registry ancestry; start or prepare its promotion first"
+            )));
+        }
+        return Ok(title_case(wave));
+    };
+
+    let main =
+        crate::engine::worktrees::main_repo_root(repo).unwrap_or_else(|_| repo.to_path_buf());
+    let main = std::fs::canonicalize(&main).unwrap_or(main);
+    let mut seen = BTreeSet::new();
+    let mut segments = Vec::new();
+    loop {
+        if !seen.insert(current.id().as_str().to_string()) {
+            return Err(OpsError::Message(format!(
+                "Wave ancestry for wave/{wave} contains a cycle at {}",
+                current.id()
+            )));
+        }
+        let current_repo = std::fs::canonicalize(current.repo())
+            .unwrap_or_else(|_| Path::new(current.repo()).to_path_buf());
+        if current_repo != main {
+            return Err(OpsError::Message(format!(
+                "Wave ancestry for wave/{wave} crosses repositories at {} ({})",
+                current.name(),
+                current.repo()
+            )));
+        }
+        let leaf = current.name().rsplit('/').next().unwrap_or(current.name());
+        segments.push(title_case(leaf));
+        let Some(parent_id) = current.parent_wave_id().cloned() else {
+            break;
+        };
+        current = store
+            .get_wave(&parent_id)
+            .await
+            .map_err(|error| OpsError::Message(format!("failed to read Wave ancestry: {error}")))?
+            .ok_or_else(|| {
+                OpsError::Message(format!(
+                    "Wave ancestry for wave/{wave} is incomplete: parent {parent_id} is missing"
+                ))
+            })?;
+    }
+    segments.reverse();
+    Ok(segments.join(" / "))
 }
 
 fn block_on_pm<T>(future: impl Future<Output = OpsResult<T>>) -> OpsResult<T> {
@@ -2676,19 +2992,10 @@ mod tests {
     use super::*;
     use crate::id::WaveId;
     use crate::ops::NullProgress;
-    use crate::planning::{LinearIssueId, LinearProjectId, ProjectPlan, TaskPlan};
     use crate::pm::test_server::{self, json_response, QueuedResponse};
-    use crate::project::{Project, ProjectId};
-    use crate::task::{
-        Observation, PmWritebackState, TaskId, TaskLifecyclePhase, TaskLifecyclePlan, TaskPr,
-        TaskPrId,
-    };
-
     use crate::wave::Wave;
     use axum::http::StatusCode;
     use serde_json::{json, Value};
-    use std::path::PathBuf;
-    use time::OffsetDateTime;
 
     #[test]
     fn idempotent_task_description_preserves_the_report() {
@@ -2705,12 +3012,16 @@ mod tests {
 
     fn linear_test_ctx(base_url: String, initiative: &str) -> PmContext {
         PmContext {
-            client: PmClient::Linear(crate::pm::linear::LinearClient::with_base_url(
-                "linear-secret".to_string(),
-                Some("team-9".to_string()),
-                base_url,
-            )),
-            provider: PmProviderKind::Linear,
+            repository: RepositoryPmContext {
+                client: crate::pm::linear::LinearClient::with_base_url(
+                    "linear-secret".to_string(),
+                    Some("team-123".to_string()),
+                    base_url,
+                ),
+                provider: PmProviderKind::Linear,
+                repo_id: RepoId::parse("loopflowstudio/loopflow").unwrap(),
+                team_id: "team-123".to_string(),
+            },
             initiative: initiative.to_string(),
         }
     }
@@ -2756,23 +3067,25 @@ mod tests {
         )
     }
 
-    fn reteam_project_node(id: &str, name: &str, team_ids: &[&str]) -> serde_json::Value {
+    fn migration_project_node(id: &str, name: &str, initiative: &str, teams: &[&str]) -> Value {
         json!({
             "id": id,
             "name": name,
-            "description": "",
-            "content": "## Definition\n\nA measured bet.\n\n## KRs\n",
-            "initiatives": { "nodes": [{ "id": "initiative-123" }] },
-            "teams": {
-                "nodes": team_ids
-                    .iter()
-                    .map(|id| json!({ "id": id }))
-                    .collect::<Vec<_>>()
-            }
+            "description": "A measured bet.",
+            "content": "## Definition\n\nA measured bet.\n\n## Flows\n\n- first: (none)\n- loop: (none)\n- finally: (none)\n\n## KRs\n\n- [ ] Ownership holds",
+            "initiatives": { "nodes": [{ "id": initiative }] },
+            "teams": { "nodes": teams.iter().map(|id| json!({ "id": id })).collect::<Vec<_>>() }
         })
     }
 
-    fn reteam_issue_node(id: &str, identifier: &str, completed: bool) -> serde_json::Value {
+    fn migration_issue_node(
+        id: &str,
+        identifier: &str,
+        project_id: &str,
+        project_name: &str,
+        team_id: &str,
+        completed: bool,
+    ) -> Value {
         json!({
             "id": id,
             "identifier": identifier,
@@ -2781,345 +3094,44 @@ mod tests {
             "description": "",
             "prioritySortOrder": 0.0,
             "sortOrder": 0.0,
-            "state": { "type": if completed { "completed" } else { "unstarted" } }
+            "assignee": null,
+            "state": { "type": if completed { "completed" } else { "unstarted" } },
+            "project": { "id": project_id, "name": project_name },
+            "team": { "id": team_id }
         })
     }
 
-    fn issue_observation_response(comments: &[&str]) -> QueuedResponse {
+    fn issue_comments_response() -> QueuedResponse {
+        issue_comments_response_with(None)
+    }
+
+    fn issue_comments_response_with(body: Option<&str>) -> QueuedResponse {
+        let nodes = body
+            .map(|body| vec![json!({ "id": "comment-reteam", "body": body, "user": null })])
+            .unwrap_or_default();
         json_response(
             StatusCode::OK,
             json!({ "data": { "issue": {
-                "updatedAt": "2026-07-17T00:00:00.000Z",
-                "title": "Legacy task",
-                "description": "",
-                "comments": {
-                    "nodes": comments
-                        .iter()
-                        .enumerate()
-                        .map(|(index, body)| json!({
-                            "id": format!("comment-{index}"),
-                            "body": body,
-                            "user": null
-                        }))
-                        .collect::<Vec<_>>()
-                }
+                "updatedAt": "2026-07-20T00:00:00.000Z",
+                "title": "Task", "description": "",
+                "comments": { "nodes": nodes }
             } } }),
         )
     }
 
-    fn reteam_comment_create_response(id: &str) -> QueuedResponse {
-        json_response(
-            StatusCode::OK,
-            json!({ "data": { "commentCreate": { "comment": { "id": id } } } }),
-        )
-    }
-
-    fn issue_team_move_response(id: &str, identifier: &str) -> QueuedResponse {
-        json_response(
-            StatusCode::OK,
-            json!({ "data": { "issueUpdate": { "issue": {
-                "id": id,
-                "identifier": identifier
-            } } } }),
-        )
-    }
-
-    fn project_team_move_response(id: &str) -> QueuedResponse {
+    fn project_update_response(id: &str) -> QueuedResponse {
         json_response(
             StatusCode::OK,
             json!({ "data": { "projectUpdate": { "project": { "id": id } } } }),
         )
     }
 
-    async fn reteam_test_store() -> (tempfile::TempDir, Store) {
-        let directory = tempfile::tempdir().expect("temp store directory");
-        let store = open_store(&crate::store::StorageConfig::sqlite(
-            directory.path().join("registry.db"),
-        ))
-        .await
-        .expect("open reteam store");
-        (directory, store)
+    fn write_repo_config(repo: &Path, content: &str) {
+        std::fs::create_dir_all(repo.join(".lf")).unwrap();
+        std::fs::write(repo.join(".lf/config.yaml"), content).unwrap();
     }
 
-    async fn seed_reteam_task(store: &Store, issue_id: &str, identifier: &str) -> TaskId {
-        let now = OffsetDateTime::now_utc();
-        let wave = Wave::new(
-            WaveId::new(),
-            "infrastructure".to_string(),
-            "/repo".to_string(),
-        );
-        store.create_wave(&wave).await.expect("create wave");
-        let project_definition = ProjectPlan {
-            id: LinearProjectId::new("project-uuid").expect("project id"),
-            slug: "developer-efficiency".to_string(),
-            name: "Developer Efficiency".to_string(),
-            prompt_context: "Keep development fast.".to_string(),
-            pm_snapshot_synced_at: now.unix_timestamp(),
-        };
-        let project = Project {
-            id: ProjectId::new(),
-            plan: project_definition,
-            wave_id: wave.id().clone(),
-            iteration: 1,
-            observation_cursor: 0,
-            last_state_fingerprint: None,
-            agent: "codex".to_string(),
-            provider: "codex".to_string(),
-            provider_session_id: None,
-            abandon_intent: None,
-            created_at: now,
-            updated_at: now,
-        };
-        store
-            .create_project(&project)
-            .await
-            .expect("create Project Work");
-
-        let task_id = TaskId::new();
-        let task = Task {
-            id: task_id.clone(),
-            plan: TaskPlan {
-                id: LinearIssueId::new(issue_id).expect("issue id"),
-                identifier: identifier.to_string(),
-                title: format!("Task {identifier}"),
-                description: String::new(),
-                pm_snapshot_synced_at: now.unix_timestamp(),
-            },
-            pm_writeback: PmWritebackState::Current,
-            wave_id: wave.id().clone(),
-            project_id: project.id,
-            worktree: PathBuf::from(format!("/repo.{identifier}")),
-            workspace_slug: identifier.to_ascii_lowercase(),
-            lifecycle: TaskLifecyclePlan::defaults(),
-            lifecycle_phase: TaskLifecyclePhase::Loop,
-            phase_epoch: 1,
-            phase_cursor: 0,
-            phase_iteration: 0,
-            gate_cycle: 0,
-            gate_proposal: None,
-            agent: "codex".to_string(),
-            provider: "codex".to_string(),
-            provider_session_id: None,
-            abandon_intent: None,
-            created_at: now,
-            updated_at: now,
-            observation: Observation::NotRequired,
-        };
-        let pr = TaskPr {
-            id: TaskPrId::new(),
-            task_id: task.id.clone(),
-            sequence: 1,
-            slug: task.workspace_slug.clone(),
-            branch: format!("jack/{}", task.workspace_slug),
-            base_commit: "deadbeef".to_string(),
-            parent_pr_id: None,
-            publication: None,
-            merge_commit: None,
-            abandoned_at: None,
-            ci_observation: None,
-            github_observation: None,
-            linear_attachment_id: None,
-            linear_comment_id: None,
-            linear_link_error: None,
-            created_at: now,
-            updated_at: now,
-        };
-        store
-            .create_task(&task, &pr)
-            .await
-            .expect("create Task Work");
-        task_id
-    }
-
-    #[test]
-    fn resolve_provider_defaults_to_linear() {
-        let repo = tempfile::tempdir().expect("temp dir");
-        write_goal(repo.path(), "goals", "pm:\n  provider: \"\"\n");
-        assert_eq!(
-            resolve_provider(repo.path(), "goals").unwrap(),
-            PmProviderKind::Linear
-        );
-    }
-
-    #[test]
-    fn resolve_provider_selects_linear_from_frontmatter() {
-        let repo = tempfile::tempdir().expect("temp dir");
-        write_goal(
-            repo.path(),
-            "scan",
-            "pm:\n  provider: linear\n  linear_initiative: \"lin-1\"\n",
-        );
-        assert_eq!(
-            resolve_provider(repo.path(), "scan").unwrap(),
-            PmProviderKind::Linear
-        );
-    }
-
-    #[test]
-    fn title_case_humanizes_wave_slug() {
-        assert_eq!(title_case("wave-repo-split"), "Wave Repo Split");
-        assert_eq!(title_case("concerto"), "Concerto");
-    }
-
-    #[test]
-    fn initiative_title_discovery_requires_an_exact_unique_match() {
-        let waves = vec![
-            PmWave {
-                id: "product-1".to_string(),
-                name: "Product".to_string(),
-                summary: String::new(),
-            },
-            PmWave {
-                id: "lowercase".to_string(),
-                name: "product".to_string(),
-                summary: String::new(),
-            },
-        ];
-
-        assert_eq!(
-            matching_wave_id(&waves, "Product").expect("unique match"),
-            Some("product-1".to_string())
-        );
-        assert_eq!(matching_wave_id(&waves, "Missing").expect("no match"), None);
-
-        let duplicates = vec![waves[0].clone(), waves[0].clone()];
-        let error = matching_wave_id(&duplicates, "Product").expect_err("duplicates must fail");
-        assert!(error.to_string().contains("product-1, product-1"));
-    }
-
-    #[test]
-    fn initiative_write_persists_only_the_stable_binding() {
-        let repo = tempfile::tempdir().expect("temp dir");
-        write_goal(repo.path(), "product", "pm:\n  provider: linear\n");
-
-        write_initiative_to_goal(
-            repo.path(),
-            "product",
-            PmProviderKind::Linear,
-            "initiative-1",
-        )
-        .expect("write initiative");
-
-        let pm = read_wave_pm_config(repo.path(), "product").expect("pm config");
-        assert_eq!(pm.provider.as_deref(), Some("linear"));
-        assert_eq!(pm.linear_initiative.as_deref(), Some("initiative-1"));
-    }
-
-    #[test]
-    fn team_write_persists_alongside_the_initiative_binding() {
-        let repo = tempfile::tempdir().expect("temp dir");
-        write_goal(
-            repo.path(),
-            "product",
-            "pm:\n  provider: linear\n  linear_initiative: \"initiative-1\"\n",
-        );
-
-        write_team_to_goal(repo.path(), "product", PmProviderKind::Linear, "team-prd")
-            .expect("write team");
-
-        let pm = read_wave_pm_config(repo.path(), "product").expect("pm config");
-        // Both bindings coexist; the team write never disturbs the Initiative.
-        assert_eq!(pm.linear_initiative.as_deref(), Some("initiative-1"));
-        assert_eq!(pm.linear_team.as_deref(), Some("team-prd"));
-        assert_eq!(
-            read_team(repo.path(), "product", PmProviderKind::Linear).as_deref(),
-            Some("team-prd")
-        );
-    }
-
-    #[test]
-    fn team_write_rebinds_without_disturbing_the_initiative() {
-        let repo = tempfile::tempdir().expect("temp dir");
-        write_goal(
-            repo.path(),
-            "product",
-            "pm:\n  provider: linear\n  linear_initiative: \"initiative-1\"\n  linear_team: \"team-shared\"\n",
-        );
-
-        write_team_to_goal(repo.path(), "product", PmProviderKind::Linear, "team-prd")
-            .expect("replace team");
-
-        let pm = read_wave_pm_config(repo.path(), "product").expect("pm config");
-        assert_eq!(pm.linear_initiative.as_deref(), Some("initiative-1"));
-        assert_eq!(pm.linear_team.as_deref(), Some("team-prd"));
-    }
-
-    #[test]
-    fn resolve_team_prefers_wave_binding_over_config() {
-        let repo = tempfile::tempdir().expect("temp dir");
-        write_goal(
-            repo.path(),
-            "product",
-            "pm:\n  provider: linear\n  linear_team: \"team-prd\"\n",
-        );
-
-        // A wave with its own binding ignores any global fallback.
-        assert_eq!(
-            resolve_team(repo.path(), "product", PmProviderKind::Linear).as_deref(),
-            Some("team-prd")
-        );
-        // An unbound wave has no team here (no global config in the temp repo),
-        // which is safe: reads are team-agnostic and only creation needs one.
-        assert_eq!(
-            resolve_team(repo.path(), "unbound", PmProviderKind::Linear),
-            None
-        );
-    }
-
-    #[test]
-    fn require_creation_team_fails_closed_on_an_unbound_wave() {
-        let repo = tempfile::tempdir().expect("temp dir");
-        write_goal(
-            repo.path(),
-            "product",
-            "pm:\n  provider: linear\n  linear_team: \"team-prd\"\n",
-        );
-
-        // A bound wave yields its explicit team — never a fallback.
-        assert_eq!(
-            require_creation_team(repo.path(), "product", PmProviderKind::Linear)
-                .expect("bound wave resolves a team"),
-            "team-prd"
-        );
-
-        // An unbound wave errors with the `lf pm init` recovery instead of
-        // silently borrowing the shared team.
-        let err = require_creation_team(repo.path(), "unbound", PmProviderKind::Linear)
-            .expect_err("unbound wave fails closed");
-        let message = err.to_string();
-        assert!(message.contains("lf pm init --wave unbound"));
-        assert!(message.contains("linear_team"));
-    }
-
-    #[test]
-    fn default_team_key_derives_from_wave_name() {
-        assert_eq!(default_team_key("product"), "PRO");
-        assert_eq!(default_team_key("infrastructure"), "INF");
-        assert_eq!(default_team_key("intelligence"), "INT");
-        assert_eq!(default_team_key("x"), "LF");
-    }
-
-    #[test]
-    fn linear_project_prefix_is_presentation_only() {
-        assert_eq!(
-            linear_project_name("product", "Loopflow API"),
-            "Product — Loopflow API"
-        );
-        assert_eq!(
-            canonical_project_name("product", "Product — Loopflow API"),
-            "Loopflow API"
-        );
-        assert_eq!(
-            crate::pm::project_slug(canonical_project_name("product", "Product — Loopflow API")),
-            "loopflow-api"
-        );
-        assert_eq!(
-            canonical_project_name("product", "Unprefixed migration input"),
-            "Unprefixed migration input"
-        );
-    }
-
-    fn reteam_item(identifier: &str, completed: bool) -> PmItem {
+    fn reteam_item(identifier: &str, team_id: &str, completed: bool) -> PmItem {
         PmItem {
             id: format!("uuid-of-{identifier}"),
             identifier: identifier.to_string(),
@@ -3128,7 +3140,9 @@ mod tests {
             description: String::new(),
             rank: 0,
             completed,
-            project: None,
+            project_id: "project-1".to_string(),
+            project: "project-one".to_string(),
+            team_id: team_id.to_string(),
             assignee: None,
         }
     }
@@ -3138,502 +3152,389 @@ mod tests {
     }
 
     #[test]
-    fn identifier_prefix_needs_the_trailing_dash() {
-        assert!(identifier_has_team_prefix("PRD-4", "PRD"));
-        assert!(identifier_has_team_prefix("prd-4", "prd"));
-        // A shared leading substring must not false-match.
-        assert!(!identifier_has_team_prefix("PRODUCT-1", "PRD"));
-        assert!(!identifier_has_team_prefix("W2-155", "PRD"));
-    }
-
-    #[test]
-    fn project_needs_reteam_requires_exactly_one_bound_team() {
-        // Unknown teams (older snapshot) → never a mismatch.
-        assert!(!project_needs_reteam("team-prd", None));
-        // Exactly the bound team → owned.
-        assert!(!project_needs_reteam(
-            "team-prd",
-            Some(&["team-prd".to_string()])
-        ));
-        // The bound team plus a legacy team still violates one-team ownership.
-        assert!(project_needs_reteam(
-            "team-prd",
-            Some(&["team-prd".to_string(), "team-shared".to_string()])
-        ));
-        // Bound team absent → stranded.
-        assert!(project_needs_reteam(
-            "team-prd",
-            Some(&["team-shared".to_string()])
-        ));
-        // Belongs to no team at all → stranded.
-        assert!(project_needs_reteam("team-prd", Some(&[])));
-    }
-
-    #[test]
-    fn reteam_apply_stops_before_mutation_when_any_task_run_is_active() {
-        let deferrals = vec![
-            PmReteamDeferral {
-                identifier: "W2-157".to_string(),
-                title: "Unify practice targets".to_string(),
-                reason: "active Run run-one".to_string(),
-            },
-            PmReteamDeferral {
-                identifier: "W2-166".to_string(),
-                title: "Resolve team ownership".to_string(),
-                reason: "active Run run-two".to_string(),
-            },
-        ];
-
-        let error = ensure_reteam_apply_safe(&deferrals).expect_err("apply must stop");
-        let message = error.to_string();
-        assert!(message.contains("W2-157 `Unify practice targets` (active Run run-one)"));
-        assert!(message.contains("W2-166 `Resolve team ownership` (active Run run-two)"));
-        assert!(message.contains("No Projects or Tasks were moved"));
-    }
-
-    #[test]
-    fn reteam_classifies_completed_move_defer_and_skip() {
-        // Completion does not exempt a foreign-team issue from migration.
-        assert_eq!(
-            classify_reteam_item(&reteam_item("W2-1", true), "PRD", None),
-            ReteamClass::Move
+    fn repository_team_config_is_the_only_normal_authority() {
+        let repo = tempfile::tempdir().unwrap();
+        write_repo_config(
+            repo.path(),
+            "pm:\n  provider: linear\n  linear_team: team-loo\n",
         );
-        // A completed issue with an active Run remains protected.
-        assert!(matches!(
-            classify_reteam_item(
-                &reteam_item("W2-5", true),
-                "PRD",
-                Some(reteam_writer("W2-5", Some("run-one")))
-            ),
-            ReteamClass::Defer(_)
-        ));
-        // Already in the target team → skip (idempotency).
-        assert_eq!(
-            classify_reteam_item(&reteam_item("PRD-7", false), "PRD", None),
-            ReteamClass::Already
-        );
-        // Open with an active Run → defer with the Run as reason.
-        assert_eq!(
-            classify_reteam_item(
-                &reteam_item("W2-2", false),
-                "PRD",
-                Some(reteam_writer("W2-2", Some("run-two")))
-            ),
-            ReteamClass::Defer("active Run run-two".to_string())
-        );
-        // Open Work without a Run → move and reconcile its display id.
-        assert_eq!(
-            classify_reteam_item(
-                &reteam_item("W2-3", false),
-                "PRD",
-                Some(reteam_writer("W2-3", None))
-            ),
-            ReteamClass::Move
-        );
-        // Open with no active Work → move.
-        assert_eq!(
-            classify_reteam_item(&reteam_item("W2-4", false), "PRD", None),
-            ReteamClass::Move
-        );
-    }
-
-    #[test]
-    fn reteam_moving_issues_requires_the_target_team_on_every_project() {
-        let project = |id: &str, name: &str, team_ids: Option<Vec<&str>>| PmProject {
-            id: id.to_string(),
-            slug: crate::pm::project_slug(name),
-            name: name.to_string(),
-            summary: String::new(),
-            definition: String::new(),
-            flows: Some(ProjectFlowPlan::empty()),
-            krs: Vec::new(),
-            initiative_ids: vec!["initiative-1".to_string()],
-            team_ids: team_ids.map(|ids| ids.into_iter().map(str::to_string).collect()),
-        };
-        let projects = vec![
-            project("safe", "Safe", Some(vec!["team-prd", "team-shared"])),
-            project("missing", "Missing target", Some(vec!["team-shared"])),
-            project("unknown", "Unknown teams", None),
-        ];
-
-        ensure_move_projects_carry_target_team(
-            &projects,
-            &BTreeSet::from(["safe".to_string()]),
-            "team-prd",
-        )
-        .expect("safe Project carries target team");
-
-        let error = ensure_move_projects_carry_target_team(
-            &projects,
-            &BTreeSet::from(["missing".to_string(), "unknown".to_string()]),
-            "team-prd",
-        )
-        .expect_err("missing and unresolved target teams fail closed");
-        let message = error.to_string();
-        assert!(message.contains("`Missing target` (teams [team-shared])"));
-        assert!(message.contains("`Unknown teams` (teams unresolved)"));
-        assert!(message.contains("No Projects or Tasks were moved"));
-    }
-
-    #[tokio::test]
-    async fn reteam_apply_moves_completed_issues_before_narrowing_projects() {
-        let initial_project = reteam_project_node(
-            "project-1",
-            "Developer Efficiency",
-            &["team-prd", "team-shared"],
-        );
-        let completed_issue = reteam_issue_node("issue-1", "W2-41", true);
-        let (base_url, requests) = test_server::spawn(vec![
-            projects_response(json!([initial_project])),
-            issues_response(json!([completed_issue])),
-            issue_observation_response(&[]),
-            reteam_comment_create_response("comment-1"),
-            issue_team_move_response("issue-1", "PRD-7"),
-            project_team_move_response("project-1"),
-            projects_response(json!([reteam_project_node(
-                "project-1",
-                "Developer Efficiency",
-                &["team-prd"],
-            )])),
-            issues_response(json!([reteam_issue_node("issue-1", "PRD-7", true)])),
-        ])
-        .await;
-        let ctx = linear_test_ctx(base_url, "initiative-123");
-        let (_directory, store) = reteam_test_store().await;
-
-        let result = apply_or_plan_reteam(
-            &ctx,
-            &store,
-            Path::new("/repo"),
+        write_goal(
+            repo.path(),
             "product",
-            "team-prd",
-            "PRD",
-            true,
-            &NullProgress,
-        )
-        .await
-        .expect("reteam apply succeeds");
-
-        assert_eq!(result.moves.len(), 1);
-        assert_eq!(result.moves[0].old_identifier, "W2-41");
-        assert_eq!(result.moves[0].new_identifier.as_deref(), Some("PRD-7"));
-
-        let requests = requests.lock().await;
-        let bodies = requests
-            .iter()
-            .map(|request| {
-                serde_json::from_str::<serde_json::Value>(&request.body)
-                    .expect("GraphQL request body")
-            })
-            .collect::<Vec<_>>();
-        let comment = bodies
-            .iter()
-            .position(|body| {
-                body["query"]
-                    .as_str()
-                    .is_some_and(|query| query.contains("mutation CreateComment"))
-            })
-            .expect("traceability comment");
-        let issue_move = bodies
-            .iter()
-            .position(|body| {
-                body["query"]
-                    .as_str()
-                    .is_some_and(|query| query.contains("mutation MoveIssueToTeam"))
-            })
-            .expect("completed issue move");
-        let project_move = bodies
-            .iter()
-            .position(|body| {
-                body["query"]
-                    .as_str()
-                    .is_some_and(|query| query.contains("mutation MoveProjectToTeam"))
-            })
-            .expect("Project narrow");
-        assert!(
-            comment < issue_move,
-            "old identifier is recorded before move"
+            "pm:\n  linear_initiative: initiative-product\n",
         );
-        assert!(
-            issue_move < project_move,
-            "every issue moves before Project narrowing"
+
+        assert_eq!(
+            read_repository_team(repo.path(), PmProviderKind::Linear)
+                .unwrap()
+                .as_deref(),
+            Some("team-loo")
         );
-        assert_eq!(bodies[issue_move]["variables"]["id"], "issue-1");
-        assert!(bodies[comment]["variables"]["body"]
-            .as_str()
-            .expect("comment body")
-            .contains("was W2-41; moving onto team PRD"));
+        assert_eq!(
+            read_initiative(repo.path(), "product", PmProviderKind::Linear).as_deref(),
+            Some("initiative-product")
+        );
+        assert!(legacy_pm_sentinels(repo.path()).unwrap().is_empty());
     }
 
-    #[tokio::test]
-    async fn reteam_apply_refuses_unsafe_project_before_any_mutation() {
-        let (base_url, requests) = test_server::spawn(vec![
-            projects_response(json!([reteam_project_node(
-                "project-1",
-                "Developer Efficiency",
-                &["team-shared"],
-            )])),
-            issues_response(json!([reteam_issue_node("issue-1", "W2-41", false)])),
-        ])
-        .await;
-        let ctx = linear_test_ctx(base_url, "initiative-123");
-        let (_directory, store) = reteam_test_store().await;
-
-        let error = apply_or_plan_reteam(
-            &ctx,
-            &store,
-            Path::new("/repo"),
+    #[test]
+    fn legacy_wave_team_authority_blocks_mutations_with_prd_44_recovery() {
+        let repo = tempfile::tempdir().unwrap();
+        write_repo_config(
+            repo.path(),
+            "pm:\n  provider: linear\n  linear_team: team-loo\nlinear:\n  team: team-old\n",
+        );
+        write_goal(
+            repo.path(),
             "product",
-            "team-prd",
-            "PRD",
-            true,
-            &NullProgress,
-        )
-        .await
-        .expect_err("missing target team refuses apply");
+            "pm:\n  provider: linear\n  linear_initiative: initiative-product\n  linear_team: team-old\n",
+        );
 
-        assert!(error.to_string().contains("Developer Efficiency"));
-        let requests = requests.lock().await;
-        assert_eq!(requests.len(), 2);
-        assert!(requests
-            .iter()
-            .all(|request| !request.body.contains("mutation")));
+        let error = require_repository_pm_ready(repo.path()).unwrap_err();
+        assert!(error.to_string().contains("lf pm reteam --apply"));
+        assert!(error.to_string().contains("PRD-44"));
     }
 
-    #[tokio::test]
-    async fn reteam_apply_refuses_completed_issue_with_an_active_run() {
-        let (_directory, store) = reteam_test_store().await;
-        let task_id = seed_reteam_task(&store, "issue-live", "W2-42").await;
-        let task = store
-            .get_task(&task_id)
-            .await
-            .expect("read task")
-            .expect("task exists");
-        let work = store
-            .work_for_child(&crate::child::ChildRef::Task(task.id.clone()))
-            .await
-            .expect("resolve Task Work");
-        store
-            .reserve_run(&work, crate::durable::RunTrigger::User)
-            .await
-            .expect("reserve active Run");
-        let (base_url, requests) = test_server::spawn(vec![
-            projects_response(json!([reteam_project_node(
-                "project-1",
-                "Developer Efficiency",
-                &["team-prd", "team-shared"],
-            )])),
-            issues_response(json!([reteam_issue_node("issue-live", "W2-42", true)])),
-        ])
-        .await;
-        let ctx = linear_test_ctx(base_url, "initiative-123");
-
-        let error = apply_or_plan_reteam(
-            &ctx,
-            &store,
-            Path::new("/repo"),
-            "product",
-            "team-prd",
-            "PRD",
-            true,
-            &NullProgress,
-        )
-        .await
-        .expect_err("active Run refuses the whole apply");
-
-        assert!(error.to_string().contains("W2-42"));
-        assert!(error
-            .to_string()
-            .contains("No Projects or Tasks were moved"));
-        let requests = requests.lock().await;
-        assert_eq!(requests.len(), 2);
-        assert!(requests
-            .iter()
-            .all(|request| !request.body.contains("mutation")));
-    }
-
-    #[tokio::test]
-    async fn reteam_retry_reuses_pre_move_comment_then_moves_and_rebinds() {
-        let (_directory, store) = reteam_test_store().await;
-        let task_id = seed_reteam_task(&store, "issue-legacy", "W2-9").await;
-        let initial_project = || {
-            reteam_project_node(
-                "project-1",
-                "Developer Efficiency",
-                &["team-prd", "team-shared"],
+    #[test]
+    fn project_titles_strip_only_recognized_wave_paths() {
+        assert_eq!(
+            canonical_project_name("Survival", "survival", "Survival — A real task").unwrap(),
+            "A real task"
+        );
+        assert_eq!(
+            canonical_project_name(
+                "Survival / Infrastructure",
+                "infrastructure",
+                "Infrastructure — Gmail",
             )
-        };
-        let legacy_issue = || reteam_issue_node("issue-legacy", "W2-9", false);
+            .unwrap(),
+            "Gmail"
+        );
+        assert!(canonical_project_name(
+            "Survival / Infrastructure",
+            "infrastructure",
+            "Another Wave — Gmail",
+        )
+        .is_err());
+        assert_eq!(default_team_key("loopflow"), "LOO");
+    }
 
-        let (base_url, first_requests) = test_server::spawn(vec![
-            projects_response(json!([initial_project()])),
-            issues_response(json!([legacy_issue()])),
-            issue_observation_response(&[]),
-            reteam_comment_create_response("comment-1"),
+    #[tokio::test]
+    async fn repository_team_reteam_migrates_open_and_completed_issues_before_cleanup() {
+        let repo = tempfile::tempdir().unwrap();
+        write_repo_config(
+            repo.path(),
+            "pm:\n  provider: linear\n  linear_team: team-loo\nlinear:\n  team: team-old\n",
+        );
+        write_goal(
+            repo.path(),
+            "survival",
+            "pm:\n  provider: linear\n  linear_initiative: initiative-survival\n  linear_team: team-old\n",
+        );
+        write_goal(
+            repo.path(),
+            "infrastructure",
+            "pm:\n  provider: linear\n  linear_initiative: initiative-infrastructure\n  linear_team: team-old\n",
+        );
+
+        let database = repo.path().join("registry.db");
+        let store = open_store(&crate::store::StorageConfig::sqlite(database.clone()))
+            .await
+            .unwrap();
+        let survival = Wave::new(
+            WaveId::new(),
+            "survival".to_string(),
+            repo.path().display().to_string(),
+        );
+        let infrastructure = Wave::new(
+            WaveId::new(),
+            "infrastructure".to_string(),
+            repo.path().display().to_string(),
+        )
+        .with_parent(survival.id().clone());
+        store.create_wave(&survival).await.unwrap();
+        store.create_wave(&infrastructure).await.unwrap();
+
+        let old_survival = migration_project_node(
+            "project-survival",
+            "Survival — A real task reaches done",
+            "initiative-survival",
+            &["team-old"],
+        );
+        let old_infrastructure = migration_project_node(
+            "project-infrastructure",
+            "Infrastructure — Gmail",
+            "initiative-infrastructure",
+            &["team-old"],
+        );
+        let new_survival = migration_project_node(
+            "project-survival",
+            "Survival — A real task reaches done",
+            "initiative-survival",
+            &["team-loo"],
+        );
+        let new_infrastructure = migration_project_node(
+            "project-infrastructure",
+            "Survival / Infrastructure — Gmail",
+            "initiative-infrastructure",
+            &["team-loo"],
+        );
+        let responses = vec![
+            projects_response(json!([old_infrastructure])),
+            issues_response(json!([migration_issue_node(
+                "issue-done",
+                "OLD-2",
+                "project-infrastructure",
+                "Infrastructure — Gmail",
+                "team-old",
+                true,
+            )])),
+            projects_response(json!([old_survival])),
+            issues_response(json!([migration_issue_node(
+                "issue-open",
+                "OLD-1",
+                "project-survival",
+                "Survival — A real task reaches done",
+                "team-old",
+                false,
+            )])),
+            project_update_response("project-survival"),
+            project_update_response("project-infrastructure"),
+            issue_comments_response(),
             json_response(
                 StatusCode::OK,
-                json!({ "errors": [{ "message": "issue move failed" }] }),
+                json!({ "data": { "commentCreate": { "comment": { "id": "comment-done" } } } }),
             ),
-        ])
-        .await;
-        let first_ctx = linear_test_ctx(base_url, "initiative-123");
-        let error = apply_or_plan_reteam(
-            &first_ctx,
-            &store,
-            Path::new("/repo"),
-            "product",
-            "team-prd",
-            "PRD",
-            true,
-            &NullProgress,
-        )
-        .await
-        .expect_err("first move fails after comment");
-        assert!(error.to_string().contains("issue move failed"));
-        assert_eq!(
-            store
-                .get_task(&task_id)
-                .await
-                .expect("read task")
-                .expect("task exists")
-                .plan
-                .identifier,
-            "W2-9"
-        );
-
-        let existing_comment = reteam_comment_body("W2-9", "PRD");
-        let (base_url, second_requests) = test_server::spawn(vec![
-            projects_response(json!([initial_project()])),
-            issues_response(json!([legacy_issue()])),
-            issue_observation_response(&[&existing_comment]),
-            issue_team_move_response("issue-legacy", "PRD-9"),
-            project_team_move_response("project-1"),
-            projects_response(json!([reteam_project_node(
-                "project-1",
-                "Developer Efficiency",
-                &["team-prd"],
+            json_response(
+                StatusCode::OK,
+                json!({ "data": { "issueUpdate": { "issue": { "id": "issue-done", "identifier": "LOO-2" } } } }),
+            ),
+            issue_comments_response(),
+            json_response(
+                StatusCode::OK,
+                json!({ "data": { "commentCreate": { "comment": { "id": "comment-open" } } } }),
+            ),
+            json_response(
+                StatusCode::OK,
+                json!({ "data": { "issueUpdate": { "issue": { "id": "issue-open", "identifier": "LOO-1" } } } }),
+            ),
+            project_update_response("project-survival"),
+            project_update_response("project-infrastructure"),
+            project_update_response("project-infrastructure"),
+            projects_response(json!([new_infrastructure])),
+            issues_response(json!([migration_issue_node(
+                "issue-done",
+                "LOO-2",
+                "project-infrastructure",
+                "Survival / Infrastructure — Gmail",
+                "team-loo",
+                true,
             )])),
-            issues_response(json!([reteam_issue_node("issue-legacy", "PRD-9", false,)])),
-        ])
-        .await;
-        let second_ctx = linear_test_ctx(base_url, "initiative-123");
-        let result = apply_or_plan_reteam(
-            &second_ctx,
-            &store,
-            Path::new("/repo"),
-            "product",
-            "team-prd",
-            "PRD",
-            true,
-            &NullProgress,
-        )
-        .await
-        .expect("retry succeeds");
+            projects_response(json!([new_survival])),
+            issues_response(json!([migration_issue_node(
+                "issue-open",
+                "LOO-1",
+                "project-survival",
+                "Survival — A real task reaches done",
+                "team-loo",
+                false,
+            )])),
+        ];
+        let (base_url, requests) = test_server::spawn(responses).await;
+        let client = crate::pm::linear::LinearClient::with_base_url(
+            "linear-secret".to_string(),
+            Some("team-loo".to_string()),
+            base_url,
+        );
+        let resolved = ResolvedReteamContext {
+            repository: RepositoryPmContext {
+                client,
+                provider: PmProviderKind::Linear,
+                repo_id: RepoId::parse("loopflowstudio/fixture").unwrap(),
+                team_id: "team-loo".to_string(),
+            },
+            team_key: "LOO".to_string(),
+            store,
+        };
 
-        assert_eq!(result.task_updates, 1);
+        let result = apply_or_plan_repository_reteam(&resolved, repo.path(), true, &NullProgress)
+            .await
+            .unwrap();
+
+        assert!(result.applied);
+        assert_eq!(result.moves.len(), 2);
+        let identifiers = result
+            .moves
+            .iter()
+            .filter_map(|item| item.new_identifier.as_deref())
+            .collect::<BTreeSet<_>>();
+        assert_eq!(identifiers, BTreeSet::from(["LOO-1", "LOO-2"]));
+        assert!(legacy_pm_sentinels(repo.path()).unwrap().is_empty());
         assert_eq!(
-            store
-                .get_task(&task_id)
-                .await
-                .expect("read task")
-                .expect("task exists")
-                .plan
-                .identifier,
-            "PRD-9"
+            read_repository_team(repo.path(), PmProviderKind::Linear)
+                .unwrap()
+                .as_deref(),
+            Some("team-loo")
         );
-        let first_requests = first_requests.lock().await;
-        let second_requests = second_requests.lock().await;
-        assert_eq!(
-            first_requests
-                .iter()
-                .filter(|request| request.body.contains("mutation CreateComment"))
-                .count(),
-            1
-        );
-        assert_eq!(
-            second_requests
-                .iter()
-                .filter(|request| request.body.contains("mutation CreateComment"))
-                .count(),
-            0,
-            "retry must reuse this migration's existing comment"
-        );
+        for wave in ["survival", "infrastructure"] {
+            let pm = read_wave_pm_config(repo.path(), wave).unwrap();
+            assert!(pm.provider.is_none());
+            assert!(pm.linear_team.is_none());
+            assert!(pm.linear_initiative.is_some());
+        }
+
+        let requests = requests.lock().await;
+        let first_move = requests
+            .iter()
+            .position(|request| request.body.contains("MoveIssueToTeam"))
+            .unwrap();
+        let attached_before_move = requests[..first_move]
+            .iter()
+            .filter(|request| request.body.contains("SetProjectTeams"))
+            .count();
+        assert_eq!(attached_before_move, 2);
+        assert!(requests
+            .iter()
+            .any(|request| { request.body.contains("Survival / Infrastructure — Gmail") }));
     }
 
     #[tokio::test]
-    async fn reteam_already_moved_issue_only_rebinds_a_stale_task() {
-        let (_directory, store) = reteam_test_store().await;
-        let task_id = seed_reteam_task(&store, "issue-moved", "W2-10").await;
-        let (base_url, requests) = test_server::spawn(vec![
-            projects_response(json!([reteam_project_node(
-                "project-1",
-                "Developer Efficiency",
-                &["team-prd"],
-            )])),
-            issues_response(json!([
-                reteam_issue_node("issue-moved", "PRD-10", false),
-                reteam_issue_node("issue-direct", "PRD-11", false)
-            ])),
-            projects_response(json!([reteam_project_node(
-                "project-1",
-                "Developer Efficiency",
-                &["team-prd"],
-            )])),
-            issues_response(json!([
-                reteam_issue_node("issue-moved", "PRD-10", false),
-                reteam_issue_node("issue-direct", "PRD-11", false)
-            ])),
-        ])
-        .await;
-        let ctx = linear_test_ctx(base_url, "initiative-123");
-
-        let result = apply_or_plan_reteam(
-            &ctx,
-            &store,
-            Path::new("/repo"),
-            "product",
-            "team-prd",
-            "PRD",
-            true,
-            &NullProgress,
-        )
-        .await
-        .expect("already-moved reconciliation succeeds");
-
-        assert_eq!(result.already, 2);
-        assert_eq!(result.task_updates, 1);
-        assert!(result.moves.is_empty());
-        assert_eq!(
-            store
-                .get_task(&task_id)
-                .await
-                .expect("read task")
-                .expect("task exists")
-                .plan
-                .identifier,
-            "PRD-10"
+    async fn repository_team_reteam_resumes_after_an_interrupted_issue_move() {
+        let repo = tempfile::tempdir().unwrap();
+        write_repo_config(
+            repo.path(),
+            "pm:\n  provider: linear\n  linear_team: team-loo\nlinear:\n  team: team-old\n",
         );
+        write_goal(
+            repo.path(),
+            "survival",
+            "pm:\n  provider: linear\n  linear_initiative: initiative-survival\n  linear_team: team-old\n",
+        );
+
+        let database = repo.path().join("registry.db");
+        let store = open_store(&crate::store::StorageConfig::sqlite(database.clone()))
+            .await
+            .unwrap();
+        store
+            .create_wave(&Wave::new(
+                WaveId::new(),
+                "survival".to_string(),
+                repo.path().display().to_string(),
+            ))
+            .await
+            .unwrap();
+
+        let old_project = migration_project_node(
+            "project-survival",
+            "Survival — A real task reaches done",
+            "initiative-survival",
+            &["team-old"],
+        );
+        let expanded_project = migration_project_node(
+            "project-survival",
+            "Survival — A real task reaches done",
+            "initiative-survival",
+            &["team-old", "team-loo"],
+        );
+        let migrated_project = migration_project_node(
+            "project-survival",
+            "Survival — A real task reaches done",
+            "initiative-survival",
+            &["team-loo"],
+        );
+        let old_issue = migration_issue_node(
+            "issue-open",
+            "OLD-1",
+            "project-survival",
+            "Survival — A real task reaches done",
+            "team-old",
+            false,
+        );
+        let migrated_issue = migration_issue_node(
+            "issue-open",
+            "LOO-1",
+            "project-survival",
+            "Survival — A real task reaches done",
+            "team-loo",
+            false,
+        );
+        let marker = reteam_comment_body("OLD-1", "LOO");
+        let responses = vec![
+            projects_response(json!([old_project])),
+            issues_response(json!([old_issue.clone()])),
+            project_update_response("project-survival"),
+            issue_comments_response(),
+            json_response(
+                StatusCode::OK,
+                json!({ "data": { "commentCreate": { "comment": { "id": "comment-reteam" } } } }),
+            ),
+            json_response(
+                StatusCode::OK,
+                json!({ "errors": [{ "message": "move interrupted" }] }),
+            ),
+            projects_response(json!([expanded_project])),
+            issues_response(json!([old_issue])),
+            issue_comments_response_with(Some(&marker)),
+            json_response(
+                StatusCode::OK,
+                json!({ "data": { "issueUpdate": { "issue": { "id": "issue-open", "identifier": "LOO-1" } } } }),
+            ),
+            project_update_response("project-survival"),
+            projects_response(json!([migrated_project])),
+            issues_response(json!([migrated_issue])),
+        ];
+        let (base_url, requests) = test_server::spawn(responses).await;
+        let resolved = ResolvedReteamContext {
+            repository: RepositoryPmContext {
+                client: crate::pm::linear::LinearClient::with_base_url(
+                    "linear-secret".to_string(),
+                    Some("team-loo".to_string()),
+                    base_url,
+                ),
+                provider: PmProviderKind::Linear,
+                repo_id: RepoId::parse("loopflowstudio/fixture").unwrap(),
+                team_id: "team-loo".to_string(),
+            },
+            team_key: "LOO".to_string(),
+            store,
+        };
+
+        let first = apply_or_plan_repository_reteam(&resolved, repo.path(), true, &NullProgress)
+            .await
+            .unwrap_err();
+        assert!(first.to_string().contains("move interrupted"));
+        assert!(!legacy_pm_sentinels(repo.path()).unwrap().is_empty());
+
+        let resumed = apply_or_plan_repository_reteam(&resolved, repo.path(), true, &NullProgress)
+            .await
+            .unwrap();
+        assert_eq!(resumed.moves[0].new_identifier.as_deref(), Some("LOO-1"));
+        assert!(legacy_pm_sentinels(repo.path()).unwrap().is_empty());
         let requests = requests.lock().await;
-        assert_eq!(requests.len(), 4);
-        assert!(requests
-            .iter()
-            .all(|request| !request.body.contains("mutation")));
+        assert_eq!(
+            requests
+                .iter()
+                .filter(|request| request.body.contains("commentCreate"))
+                .count(),
+            1,
+            "the resumed migration reuses its first traceability comment"
+        );
     }
 
     #[test]
     fn reteam_protects_only_tasks_with_an_active_run() {
         assert_eq!(
             classify_reteam_item(
-                &reteam_item("W2-9", false),
-                "PRD",
+                &reteam_item("W2-9", "team-old", false),
+                "team-loo",
                 Some(reteam_writer("W2-9", None))
             ),
             ReteamClass::Move
         );
         assert_eq!(
             classify_reteam_item(
-                &reteam_item("W2-9", false),
-                "PRD",
+                &reteam_item("W2-9", "team-old", false),
+                "team-loo",
                 Some(reteam_writer("W2-9", Some("run-active")))
             ),
             ReteamClass::Defer("active Run run-active".to_string())
@@ -3644,16 +3545,16 @@ mod tests {
     fn reteam_reconciles_only_when_already_moved_work_has_no_run() {
         assert_eq!(
             classify_reteam_item(
-                &reteam_item("PRD-8", false),
-                "PRD",
+                &reteam_item("LOO-8", "team-loo", false),
+                "team-loo",
                 Some(reteam_writer("W2-9", None))
             ),
             ReteamClass::Already
         );
         assert!(matches!(
             classify_reteam_item(
-                &reteam_item("PRD-8", false),
-                "PRD",
+                &reteam_item("LOO-8", "team-loo", false),
+                "team-loo",
                 Some(reteam_writer("W2-9", Some("run-active")))
             ),
             ReteamClass::Defer(_)
@@ -3671,7 +3572,7 @@ mod tests {
             flows: Some(ProjectFlowPlan::empty()),
             krs: Vec::new(),
             initiative_ids: vec!["initiative-1".to_string()],
-            team_ids: None,
+            team_ids: vec!["team-loo".to_string()],
         };
         let projects = vec![project("one", "Wave Chat"), project("two", "Wave-Chat")];
 
@@ -3704,7 +3605,7 @@ mod tests {
                     holds: true,
                 }],
                 initiative_ids: vec!["initiative-1".to_string()],
-                team_ids: Some(vec!["team-prd".to_string()]),
+                team_ids: vec!["team-prd".to_string()],
             }],
             items: Vec::new(),
         };
@@ -3751,21 +3652,25 @@ mod tests {
         let (base_url, requests) = test_server::spawn(vec![
             projects_response(json!([project_node("project-123", "Scan")])),
             issues_response(json!([
-                { "id": "issue-1", "title": "First", "description": "one",
+                { "id": "issue-1", "identifier": "LOO-1", "url": null,
+                  "title": "First", "description": "one",
                   "prioritySortOrder": 0.0, "sortOrder": 0.0,
-                  "state": { "type": "unstarted" } }
+                  "state": { "type": "unstarted" },
+                  "project": { "id": "project-123", "name": "Scan" },
+                  "team": { "id": "team-123" } }
             ])),
         ])
         .await;
         let ctx = linear_test_ctx(base_url, "initiative-123");
+        let repo = tempfile::tempdir().unwrap();
 
-        let result = fetch_pm_snapshot("scan", &ctx)
+        let result = fetch_pm_snapshot(repo.path(), "scan", &ctx)
             .await
             .expect("fetch succeeds");
         assert_eq!(result.projects.len(), 1);
         assert_eq!(result.items.len(), 1);
         assert_eq!(result.items[0].name, "First");
-        assert_eq!(result.items[0].project.as_deref(), Some("scan"));
+        assert_eq!(result.items[0].project, "scan");
         assert_eq!(
             requests.lock().await[1].authorization.as_deref(),
             Some("Bearer linear-secret")
@@ -3776,6 +3681,7 @@ mod tests {
     async fn apply_update_requires_a_project_when_creating() {
         let (base_url, _requests) = test_server::spawn(vec![projects_response(json!([]))]).await;
         let ctx = linear_test_ctx(base_url, "initiative-123");
+        let repo = tempfile::tempdir().unwrap();
         let options = PmUpdateOptions {
             wave: None,
             project: None,
@@ -3786,7 +3692,7 @@ mod tests {
             pr: None,
         };
 
-        let error = apply_update("goals", None, &ctx, &options, &NullProgress)
+        let error = apply_update(repo.path(), "goals", None, &ctx, &options, &NullProgress)
             .await
             .expect_err("project is required");
         assert!(error.to_string().contains("--project <slug>"));
@@ -3807,6 +3713,7 @@ mod tests {
         ])
         .await;
         let ctx = linear_test_ctx(base_url, "initiative-123");
+        let repo = tempfile::tempdir().unwrap();
         let options = PmUpdateOptions {
             wave: None,
             project: Some("wave-chat".to_string()),
@@ -3817,9 +3724,16 @@ mod tests {
             pr: None,
         };
 
-        let result = apply_update("product", Some("wave-chat"), &ctx, &options, &NullProgress)
-            .await
-            .expect("update succeeds");
+        let result = apply_update(
+            repo.path(),
+            "product",
+            Some("wave-chat"),
+            &ctx,
+            &options,
+            &NullProgress,
+        )
+        .await
+        .expect("update succeeds");
 
         assert!(result.created);
         let requests = requests.lock().await;
@@ -3850,6 +3764,7 @@ mod tests {
         ])
         .await;
         let ctx = linear_test_ctx(base_url, "initiative-123");
+        let repo = tempfile::tempdir().unwrap();
         let options = PmUpdateOptions {
             wave: None,
             project: None,
@@ -3860,7 +3775,7 @@ mod tests {
             pr: None,
         };
 
-        let result = apply_update("goals", None, &ctx, &options, &NullProgress)
+        let result = apply_update(repo.path(), "goals", None, &ctx, &options, &NullProgress)
             .await
             .expect("update succeeds");
         assert!(!result.created);
@@ -3900,6 +3815,7 @@ mod tests {
         ])
         .await;
         let ctx = linear_test_ctx(base_url, "initiative-123");
+        let repo = tempfile::tempdir().unwrap();
         let options = PmUpdateOptions {
             wave: None,
             project: None,
@@ -3910,7 +3826,7 @@ mod tests {
             pr: Some("https://github.com/acme/repo/pull/42".to_string()),
         };
 
-        let result = apply_update("goals", None, &ctx, &options, &NullProgress)
+        let result = apply_update(repo.path(), "goals", None, &ctx, &options, &NullProgress)
             .await
             .expect("update succeeds");
         assert!(result.completed);
@@ -3980,7 +3896,7 @@ mod tests {
             comment_create_response("comment-1"),
         ])
         .await;
-        let client = linear_test_ctx(base_url, "initiative-1").client;
+        let client = linear_test_ctx(base_url, "initiative-1").client.clone();
 
         let outcome = link_pr_with_client(
             &client,
@@ -4017,7 +3933,7 @@ mod tests {
             comment_update_response("comment-1"),
         ])
         .await;
-        let client = linear_test_ctx(base_url, "initiative-1").client;
+        let client = linear_test_ctx(base_url, "initiative-1").client.clone();
         let prior = PrLinkageIds {
             attachment_id: Some("att-1".to_string()),
             comment_id: Some("comment-1".to_string()),
@@ -4064,7 +3980,7 @@ mod tests {
             ),
         ])
         .await;
-        let client = linear_test_ctx(base_url, "initiative-1").client;
+        let client = linear_test_ctx(base_url, "initiative-1").client.clone();
 
         let degraded = link_pr_with_client(
             &client,
@@ -4085,7 +4001,7 @@ mod tests {
             comment_create_response("comment-1"),
         ])
         .await;
-        let client = linear_test_ctx(base_url, "initiative-1").client;
+        let client = linear_test_ctx(base_url, "initiative-1").client.clone();
 
         let healed =
             link_pr_with_client(&client, &link_request("Open · published"), &degraded.ids).await;

--- a/rust/loopflow/src/ops/project.rs
+++ b/rust/loopflow/src/ops/project.rs
@@ -753,6 +753,69 @@ pub(crate) async fn wake_project(project_id: &ProjectId) -> OpsResult<()> {
 pub(crate) async fn wake_task_project_route(_store: &Store, task: &Task) -> OpsResult<()> {
     wake_project(&task.project_id).await
 }
+
+/// Persist the child's ancestry before the authored promotion flow creates its
+/// first Initiative or Project. Completion records the promotion occurrence.
+pub fn prepare_promotion(repo: &Path, parent: &str, child: &str) -> OpsResult<()> {
+    let origin = crate::engine::wave_context::wave_origin(repo);
+    block_on_project(async {
+        let store = open_existing_store().await.ok_or_else(|| {
+            OpsError::Message(
+                "project promotion requires the wave registry; start the parent wave first"
+                    .to_string(),
+            )
+        })?;
+        prepare_promotion_with_store(&store, &origin, parent, child).await
+    })
+}
+
+async fn prepare_promotion_with_store(
+    store: &Store,
+    repo: &Path,
+    parent: &str,
+    child: &str,
+) -> OpsResult<()> {
+    let parent = store
+        .get_wave_by_name(parent)
+        .await
+        .map_err(|error| project_error(format!("failed to read parent Wave: {error}")))?
+        .ok_or_else(|| project_error(format!("parent Wave '{parent}' is not registered")))?;
+    let existing = store
+        .get_wave_by_name(child)
+        .await
+        .map_err(|error| project_error(format!("failed to read child Wave: {error}")))?;
+    if let Some(mut child_wave) = existing {
+        if child_wave
+            .parent_wave_id()
+            .is_some_and(|id| id != parent.id())
+        {
+            return Err(project_error(format!(
+                "child Wave '{child}' already belongs to another parent"
+            )));
+        }
+        if Path::new(child_wave.repo()) != repo {
+            return Err(project_error(format!(
+                "child Wave '{child}' is registered to another repository ({})",
+                child_wave.repo()
+            )));
+        }
+        if child_wave.parent_wave_id().is_none() {
+            child_wave = child_wave.with_parent(parent.id().clone());
+            store.update_wave(&child_wave).await.map_err(|error| {
+                project_error(format!("failed to prepare child Wave ancestry: {error}"))
+            })?;
+        }
+        return Ok(());
+    }
+
+    let child_wave = Wave::new(WaveId::new(), child.to_string(), repo.display().to_string())
+        .with_parent(parent.id().clone());
+    store
+        .create_wave(&child_wave)
+        .await
+        .map_err(|error| project_error(format!("failed to prepare child Wave ancestry: {error}")))
+}
+
 /// Complete the mechanical half of an authored project-promotion flow: record
 /// the promotion and ancestry, start the child residency, and wait for its endpoint.
 pub fn complete_promotion(repo: &Path, parent: &str, child: &str) -> OpsResult<String> {
@@ -831,6 +894,12 @@ async fn record_promotion(store: &Store, repo: &Path, parent: &str, child: &str)
         Some(wave) => wave,
         None => Wave::new(WaveId::new(), child.to_string(), repo.display().to_string()),
     };
+    if Path::new(child_wave.repo()) != repo {
+        return Err(OpsError::Message(format!(
+            "child Wave '{child}' is registered to another repository ({})",
+            child_wave.repo()
+        )));
+    }
     child_wave
         .record_promotion(parent.id(), time::OffsetDateTime::now_utc())
         .map_err(OpsError::Message)?;
@@ -1058,9 +1127,51 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn prepare_promotion_persists_ancestry_without_occurrence() {
+        let tmp = tempfile::tempdir().unwrap();
+        let database = tmp.path().join("loopflow.db");
+        let store = open_store(&StorageConfig::sqlite(database.clone()))
+            .await
+            .unwrap();
+        let parent = Wave::new(
+            WaveId::new(),
+            "survival".into(),
+            tmp.path().display().to_string(),
+        );
+        store.create_wave(&parent).await.unwrap();
+
+        prepare_promotion_with_store(&store, tmp.path(), "survival", "infrastructure")
+            .await
+            .unwrap();
+        prepare_promotion_with_store(&store, tmp.path(), "survival", "infrastructure")
+            .await
+            .unwrap();
+
+        let child = store
+            .get_wave_by_name("infrastructure")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(child.parent_wave_id(), Some(parent.id()));
+        assert_eq!(child.promoted_at(), None);
+
+        let other = Wave::new(
+            WaveId::new(),
+            "other".into(),
+            tmp.path().display().to_string(),
+        );
+        store.create_wave(&other).await.unwrap();
+        let error = prepare_promotion_with_store(&store, tmp.path(), "other", "infrastructure")
+            .await
+            .unwrap_err();
+        assert!(error.to_string().contains("another parent"));
+    }
+
+    #[tokio::test]
     async fn record_promotion_persists_occurrence_and_ancestry() {
         let tmp = tempfile::tempdir().unwrap();
-        let store = open_store(&StorageConfig::sqlite(tmp.path().join("loopflow.db")))
+        let database = tmp.path().join("loopflow.db");
+        let store = open_store(&StorageConfig::sqlite(database.clone()))
             .await
             .unwrap();
         let parent = Wave::new(

--- a/rust/loopflow/src/ops/task_pm.rs
+++ b/rust/loopflow/src/ops/task_pm.rs
@@ -2,7 +2,7 @@ use std::path::Path;
 
 use crate::ops::error::{OpsError, OpsResult};
 use crate::ops::pm::{PmRefresh, PmShowOptions, PmShowResult, PmUpdateOptions};
-use crate::pm::{PmItem, PmProject};
+use crate::pm::{PmItem, PmPortfolioValidator, PmProject};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ResolvedTask {
@@ -43,17 +43,14 @@ async fn load_wave_async(repo: &Path, wave: &str, refresh: PmRefresh) -> OpsResu
 }
 
 pub fn resolve_task(repo: &Path, issue: &str, refresh: PmRefresh) -> OpsResult<ResolvedTask> {
+    let team_id = crate::ops::pm::repository_team_id(repo)?;
     let mut matches = Vec::new();
-    for wave in crate::ops::pm::list_pm_waves(repo)? {
-        let Ok(snapshot) = load_wave(repo, &wave, PmRefresh::Never) else {
-            continue;
-        };
+    for snapshot in repository_snapshots(repo, &team_id)? {
         if let Some(item) = snapshot
             .items
             .iter()
             .find(|item| item.id == issue || item.identifier.eq_ignore_ascii_case(issue))
         {
-            project_for_item(&snapshot, item)?;
             matches.push((snapshot.wave.clone(), item.id.clone()));
         }
     }
@@ -87,7 +84,7 @@ pub fn resolve_task(repo: &Path, issue: &str, refresh: PmRefresh) -> OpsResult<R
             item.identifier
         )));
     }
-    let project = project_for_item(&snapshot, &item)?;
+    let project = project_for_item(&snapshot, &item, &team_id)?;
     Ok(ResolvedTask {
         snapshot,
         project,
@@ -100,11 +97,9 @@ pub fn resolve_project(
     project_id: &str,
     refresh: PmRefresh,
 ) -> OpsResult<ResolvedProject> {
+    let team_id = crate::ops::pm::repository_team_id(repo)?;
     let mut matches = Vec::new();
-    for wave in crate::ops::pm::list_pm_waves(repo)? {
-        let Ok(snapshot) = load_wave(repo, &wave, PmRefresh::Never) else {
-            continue;
-        };
+    for snapshot in repository_snapshots(repo, &team_id)? {
         if snapshot
             .projects
             .iter()
@@ -133,7 +128,31 @@ pub fn resolve_project(
         .find(|project| project.id == project_id || project.slug == project_id)
         .cloned()
         .ok_or_else(|| OpsError::Message(format!("Linear Project {project_id:?} disappeared")))?;
+    validate_project_ownership(&snapshot, &project, &team_id)?;
     Ok(ResolvedProject { snapshot, project })
+}
+
+fn repository_snapshots(repo: &Path, team_id: &str) -> OpsResult<Vec<PmShowResult>> {
+    let mut snapshots = Vec::new();
+    let mut ownership = PmPortfolioValidator::default();
+    for wave in crate::ops::pm::list_pm_waves(repo)? {
+        let snapshot = match load_wave(repo, &wave, PmRefresh::Never) {
+            Ok(snapshot) => snapshot,
+            Err(error) if error.to_string().contains("has no local PM snapshot") => continue,
+            Err(error) => return Err(error),
+        };
+        ownership
+            .validate(
+                &snapshot.wave,
+                &snapshot.initiative,
+                Some(team_id),
+                &snapshot.projects,
+                &snapshot.items,
+            )
+            .map_err(|error| OpsError::Message(error.to_string()))?;
+        snapshots.push(snapshot);
+    }
+    Ok(snapshots)
 }
 
 pub fn create_and_load_task(
@@ -210,22 +229,45 @@ pub async fn retry_complete_task(
     complete_task(repo, wave, item_id, pr).await
 }
 
-fn project_for_item(snapshot: &PmShowResult, item: &PmItem) -> OpsResult<PmProject> {
-    let slug = item.project.as_deref().ok_or_else(|| {
-        OpsError::Message(format!(
-            "task {} has no Project in wave/{}",
-            item.identifier, snapshot.wave
-        ))
-    })?;
-    snapshot
+fn project_for_item(snapshot: &PmShowResult, item: &PmItem, team_id: &str) -> OpsResult<PmProject> {
+    if item.team_id != team_id {
+        return Err(OpsError::Message(format!(
+            "task {} belongs to Linear Team {}, expected repository Team {}; \
+             run `lf pm sync --plan` and repair repository ownership",
+            item.identifier, item.team_id, team_id
+        )));
+    }
+    let project = snapshot
         .projects
         .iter()
-        .find(|project| project.slug == slug)
+        .find(|project| project.id == item.project_id)
         .cloned()
         .ok_or_else(|| {
             OpsError::Message(format!(
-                "task {} names unknown Project {slug:?} in wave/{}",
-                item.identifier, snapshot.wave
+                "task {} names unknown Project {} in wave/{}",
+                item.identifier, item.project_id, snapshot.wave
             ))
-        })
+        })?;
+    validate_project_ownership(snapshot, &project, team_id)?;
+    if item.project != project.slug {
+        return Err(OpsError::Message(format!(
+            "task {} carries stale Project slug {:?}, expected {:?}; run `lf pm sync --wave {}`",
+            item.identifier, item.project, project.slug, snapshot.wave
+        )));
+    }
+    Ok(project)
+}
+
+fn validate_project_ownership(
+    snapshot: &PmShowResult,
+    project: &PmProject,
+    team_id: &str,
+) -> OpsResult<()> {
+    crate::pm::validate_project_ownership(
+        &snapshot.wave,
+        &snapshot.initiative,
+        Some(team_id),
+        project,
+    )
+    .map_err(|error| OpsError::Message(error.to_string()))
 }

--- a/rust/loopflow/src/pm/linear.rs
+++ b/rust/loopflow/src/pm/linear.rs
@@ -17,7 +17,7 @@ const LINEAR_BASE_URL: &str = "https://api.linear.app/graphql";
 const LIST_ITEMS_PAGE_SIZE: u32 = 50;
 const LIST_PROJECTS_PAGE_SIZE: u32 = 50;
 const COMPLETED_STATE_TYPE: &str = "completed";
-const DEFAULT_LOOPFLOW_TEAM_NAME: &str = "Loopflow";
+const REPOSITORY_CLAIM_PREFIX: &str = "<!-- loopflow-repository:";
 
 const LIST_TEAMS_QUERY: &str = r#"query ListTeams {
   teams {
@@ -25,12 +25,21 @@ const LIST_TEAMS_QUERY: &str = r#"query ListTeams {
       id
       name
       key
+      description
     }
   }
 }"#;
 
-const CREATE_TEAM_MUTATION: &str = r#"mutation CreateTeam($name: String!, $key: String!) {
-  teamCreate(input: { name: $name, key: $key }) {
+const CREATE_TEAM_MUTATION: &str = r#"mutation CreateTeam($name: String!, $key: String!, $description: String!) {
+  teamCreate(input: { name: $name, key: $key, description: $description }) {
+    team {
+      id
+    }
+  }
+}"#;
+
+const UPDATE_TEAM_DESCRIPTION_MUTATION: &str = r#"mutation UpdateTeamDescription($id: String!, $description: String!) {
+  teamUpdate(id: $id, input: { description: $description }) {
     team {
       id
     }
@@ -111,10 +120,18 @@ const UPDATE_PROJECT_MUTATION: &str = r#"mutation UpdateProject($id: String!, $n
 }"#;
 
 // Sets the Project's teams to exactly `[$teamId]` — a replacement, not an add —
-// so a Project stranded on the shared team lands on the wave's team. Projects
+// so a Project stranded on legacy Teams lands on the repository Team. Projects
 // keep their id/slug across a team move (only issues renumber).
 const MOVE_PROJECT_TO_TEAM_MUTATION: &str = r#"mutation MoveProjectToTeam($id: String!, $teamId: String!) {
   projectUpdate(id: $id, input: { teamIds: [$teamId] }) {
+    project {
+      id
+    }
+  }
+}"#;
+
+const SET_PROJECT_TEAMS_MUTATION: &str = r#"mutation SetProjectTeams($id: String!, $teamIds: [String!]!) {
+  projectUpdate(id: $id, input: { teamIds: $teamIds }) {
     project {
       id
     }
@@ -152,12 +169,53 @@ const LIST_ITEMS_QUERY: &str = r#"query ListProjectIssues($projectId: String!, $
         state {
           type
         }
+        project {
+          id
+          name
+        }
+        team {
+          id
+        }
       }
       pageInfo {
         hasNextPage
         endCursor
       }
     }
+  }
+}"#;
+
+const ISSUE_OWNERSHIP_QUERY: &str = r#"query IssueOwnership($id: String!) {
+  issue(id: $id) {
+    id
+    identifier
+    url
+    title
+    description
+    prioritySortOrder
+    sortOrder
+    assignee { id }
+    state { type }
+    team { id }
+    project {
+      id
+      name
+      description
+      content
+      initiatives(first: 50) { nodes { id } }
+      teams(first: 50) { nodes { id } }
+    }
+  }
+}"#;
+
+const PROJECT_OWNERSHIP_QUERY: &str = r#"query ProjectOwnership($id: String!) {
+  project(id: $id) {
+    id
+    name
+    description
+    content
+    initiatives(first: 50) { nodes { id } }
+    teams(first: 50) { nodes { id } }
   }
 }"#;
 
@@ -237,11 +295,10 @@ const VIEWER_QUERY: &str = r#"query Viewer {
   }
 }"#;
 
-// Register the webhook that streams issue/comment changes to a Loopflow receiver.
-// `allPublicTeams: true` covers every team the token can see; the caller owns the
-// signing secret (from Doppler) and the public URL.
-const CREATE_WEBHOOK_MUTATION: &str = r#"mutation CreateWebhook($url: String!, $secret: String!, $resourceTypes: [String!]!) {
-  webhookCreate(input: { url: $url, secret: $secret, resourceTypes: $resourceTypes, allPublicTeams: true }) {
+// Register the webhook that streams issue/comment changes for this repository's
+// one Team. The caller owns the signing secret and public URL.
+const CREATE_WEBHOOK_MUTATION: &str = r#"mutation CreateWebhook($url: String!, $secret: String!, $resourceTypes: [String!]!, $teamId: String!) {
+  webhookCreate(input: { url: $url, secret: $secret, resourceTypes: $resourceTypes, teamId: $teamId }) {
     webhook {
       id
     }
@@ -360,13 +417,18 @@ impl LinearClient {
         }
     }
 
-    /// Adopt or create the team a wave should own, keyed by `key`. Returns the
-    /// stable team id. Diagnoses conflicts instead of guessing:
+    /// Adopt or create the team a repository should own, keyed by `key`.
+    /// Diagnoses conflicts and claims the Team with the canonical Git origin:
     /// - the requested key already belongs to a team with the same name → adopt;
     /// - the requested key belongs to a *different*-named team → refuse;
     /// - the name exists under a different key → refuse (name the existing key);
     /// - neither exists → create.
-    pub async fn ensure_team(&self, name: &str, key: &str) -> PmResult<TeamBinding> {
+    pub async fn ensure_team(
+        &self,
+        name: &str,
+        key: &str,
+        repository: &str,
+    ) -> PmResult<TeamBinding> {
         let requested_key = key.trim().to_ascii_uppercase();
         if requested_key.is_empty() {
             return Err(PmError::Message(
@@ -382,11 +444,7 @@ impl LinearClient {
             .find(|team| team.key.eq_ignore_ascii_case(&requested_key))
         {
             if team.name.eq_ignore_ascii_case(name) {
-                return Ok(TeamBinding {
-                    id: team.id.clone(),
-                    key: team.key.clone(),
-                    created: false,
-                });
+                return self.claim_team(team, repository).await;
             }
             return Err(PmError::Message(format!(
                 "Linear team key {requested_key:?} already belongs to team {:?} (id {}). \
@@ -399,6 +457,9 @@ impl LinearClient {
             .iter()
             .find(|team| team.name.eq_ignore_ascii_case(name))
         {
+            if team.key.eq_ignore_ascii_case(&requested_key) {
+                return self.claim_team(team, repository).await;
+            }
             return Err(PmError::Message(format!(
                 "a Linear team named {name:?} already exists with key {:?} (id {}). \
                  Pass --team-key {} to adopt it, or rename the team.",
@@ -406,44 +467,124 @@ impl LinearClient {
             )));
         }
 
-        let response: TeamCreateData = self
-            .graphql(
-                CREATE_TEAM_MUTATION,
-                json!({ "name": name, "key": requested_key }),
-            )
-            .await?;
-        Ok(TeamBinding {
-            id: response.team_create.team.id,
-            key: requested_key,
-            created: true,
-        })
-    }
-
-    async fn resolve_team_id(&self) -> PmResult<String> {
-        if let Some(team_id) = &self.team_id {
-            return Ok(team_id.clone());
-        }
-
-        let response: TeamsData = self.graphql(LIST_TEAMS_QUERY, json!({})).await?;
-        if let Some(team) = response
-            .teams
-            .nodes
-            .iter()
-            .find(|team| team.name.eq_ignore_ascii_case(DEFAULT_LOOPFLOW_TEAM_NAME))
-        {
-            return Ok(team.id.clone());
-        }
-
+        let description = repository_claim_marker(repository);
         let response: TeamCreateData = self
             .graphql(
                 CREATE_TEAM_MUTATION,
                 json!({
-                    "name": DEFAULT_LOOPFLOW_TEAM_NAME,
-                    "key": team_key_from_name(DEFAULT_LOOPFLOW_TEAM_NAME),
+                    "name": name,
+                    "key": requested_key,
+                    "description": description,
                 }),
             )
             .await?;
-        Ok(response.team_create.team.id)
+        let team_id = response.team_create.team.id;
+        let binding = self.validate_team_claim(&team_id, repository).await?;
+        Ok(TeamBinding {
+            created: true,
+            ..binding
+        })
+    }
+
+    async fn claim_team(&self, team: &TeamNode, repository: &str) -> PmResult<TeamBinding> {
+        match repository_claim(team.description.as_deref().unwrap_or_default())? {
+            Some(claimed) if claimed == repository => {}
+            Some(claimed) => {
+                return Err(PmError::Message(format!(
+                    "Linear team {} ({}, key {}) is claimed by repository {claimed}; \
+                     repository {repository} cannot use it",
+                    team.name, team.id, team.key
+                )))
+            }
+            None => {
+                let description = description_with_repository_claim(
+                    team.description.as_deref().unwrap_or_default(),
+                    repository,
+                );
+                let _: Value = self
+                    .graphql(
+                        UPDATE_TEAM_DESCRIPTION_MUTATION,
+                        json!({ "id": team.id, "description": description }),
+                    )
+                    .await?;
+            }
+        }
+        let mut binding = self.validate_team_claim(&team.id, repository).await?;
+        binding.created = false;
+        Ok(binding)
+    }
+
+    pub async fn claim_configured_team(
+        &self,
+        team_id: &str,
+        repository: &str,
+        expected_name: Option<&str>,
+        expected_key: Option<&str>,
+    ) -> PmResult<TeamBinding> {
+        let response: TeamsData = self.graphql(LIST_TEAMS_QUERY, json!({})).await?;
+        let team = response
+            .teams
+            .nodes
+            .into_iter()
+            .find(|team| team.id == team_id)
+            .ok_or_else(|| PmError::Message(format!("no Linear team with id {team_id}")))?;
+        if let Some(name) = expected_name.filter(|name| !team.name.eq_ignore_ascii_case(name)) {
+            return Err(PmError::Message(format!(
+                "repository {repository} is already bound to Linear Team {} ({}, key {}); \
+                 it cannot rebind through --team-name {name:?}. Run repository-wide `lf pm reteam` instead.",
+                team.name, team.id, team.key
+            )));
+        }
+        if let Some(key) = expected_key.filter(|key| !team.key.eq_ignore_ascii_case(key.trim())) {
+            return Err(PmError::Message(format!(
+                "repository {repository} is already bound to Linear Team {} ({}, key {}); \
+                 it cannot rebind through --team-key {key:?}. Run repository-wide `lf pm reteam` instead.",
+                team.name, team.id, team.key
+            )));
+        }
+        self.claim_team(&team, repository).await
+    }
+
+    /// Validate that a stable Team id is claimed by this repository.
+    pub async fn validate_team_claim(
+        &self,
+        team_id: &str,
+        repository: &str,
+    ) -> PmResult<TeamBinding> {
+        let response: TeamsData = self.graphql(LIST_TEAMS_QUERY, json!({})).await?;
+        let team = response
+            .teams
+            .nodes
+            .into_iter()
+            .find(|team| team.id == team_id)
+            .ok_or_else(|| PmError::Message(format!("no Linear team with id {team_id}")))?;
+        match repository_claim(team.description.as_deref().unwrap_or_default())? {
+            Some(claimed) if claimed == repository => Ok(TeamBinding {
+                id: team.id,
+                key: team.key,
+                created: false,
+            }),
+            Some(claimed) => Err(PmError::Message(format!(
+                "Linear team {} ({}, key {}) is claimed by repository {claimed}; \
+                 configured repository {repository} must choose another Team",
+                team.name, team.id, team.key
+            ))),
+            None => Err(PmError::Message(format!(
+                "Linear team {} ({}, key {}) has no Loopflow repository claim; \
+                 run `lf pm init --team-key {}` to claim it for {repository}",
+                team.name, team.id, team.key, team.key
+            ))),
+        }
+    }
+
+    fn require_team_id(&self) -> PmResult<String> {
+        self.team_id.clone().ok_or_else(|| {
+            PmError::Message(
+                "Linear write requires repository `pm.linear_team` in .lf/config.yaml; \
+                 run `lf pm init --wave <wave> --team-key <KEY>`"
+                    .to_string(),
+            )
+        })
     }
 
     async fn graphql<T>(&self, query: &str, variables: Value) -> PmResult<T>
@@ -590,16 +731,15 @@ impl LinearClient {
         &self,
         initiative_id: &str,
         name: &str,
-        summary: &str,
         content: &ProjectContent,
     ) -> PmResult<String> {
-        let team_id = self.resolve_team_id().await?;
+        let team_id = self.require_team_id()?;
         let response: ProjectCreateData = self
             .graphql(
                 CREATE_PROJECT_MUTATION,
                 json!({
                     "name": name,
-                    "description": linear_description(summary),
+                    "description": project_description(content),
                     "content": render_project_content(content),
                     "teamId": team_id,
                 }),
@@ -622,7 +762,6 @@ impl LinearClient {
         &self,
         project_id: &str,
         name: &str,
-        summary: &str,
         content: &ProjectContent,
     ) -> PmResult<()> {
         let _: Value = self
@@ -631,7 +770,7 @@ impl LinearClient {
                 json!({
                     "id": project_id,
                     "name": name,
-                    "description": linear_description(summary),
+                    "description": project_description(content),
                     "content": render_project_content(content),
                 }),
             )
@@ -680,13 +819,12 @@ impl LinearClient {
     }
 
     pub async fn list_items(&self, project_id: &str) -> PmResult<Vec<PmItem>> {
-        Ok(self
-            .list_issue_nodes(project_id)
+        self.list_issue_nodes(project_id)
             .await?
             .into_iter()
             .enumerate()
             .map(|(rank, issue)| issue.into_pm_item(rank as u32))
-            .collect())
+            .collect()
     }
 
     async fn list_issue_nodes(&self, project_id: &str) -> PmResult<Vec<IssueNode>> {
@@ -722,7 +860,7 @@ impl LinearClient {
     }
 
     pub async fn create_item(&self, project_id: &str, item: &PmItemCreate) -> PmResult<String> {
-        let team_id = self.resolve_team_id().await?;
+        let team_id = self.require_team_id()?;
         let state_id = self.unstarted_state_id(&team_id).await?;
         let response: IssueCreateData = self
             .graphql(
@@ -795,7 +933,7 @@ impl LinearClient {
 
     /// Reassign a Project to exactly one team. `teamIds` is a set replacement, so
     /// this pulls the Project off whatever team(s) it was on (e.g. the shared
-    /// team) and onto the wave's team. Unlike issues, a Project keeps its id and
+    /// teams) and onto the repository Team. Unlike issues, a Project keeps its id and
     /// slug across the move.
     pub async fn move_project_to_team(&self, project_id: &str, team_id: &str) -> PmResult<()> {
         let _: Value = self
@@ -810,17 +948,36 @@ impl LinearClient {
         Ok(())
     }
 
-    /// The key (Task prefix) of a team by its id, e.g. `PRD` for the product
-    /// team. Errors if no team carries that id.
-    pub async fn team_key(&self, team_id: &str) -> PmResult<String> {
-        let response: TeamsData = self.graphql(LIST_TEAMS_QUERY, json!({})).await?;
+    pub async fn set_project_teams(&self, project_id: &str, team_ids: &[String]) -> PmResult<()> {
+        let _: Value = self
+            .graphql(
+                SET_PROJECT_TEAMS_MUTATION,
+                json!({ "id": project_id, "teamIds": team_ids }),
+            )
+            .await?;
+        Ok(())
+    }
+
+    /// Resolve one Issue directly by UUID or identifier, including its owning
+    /// Project and Team. This is the online Task-to-Wave ownership edge.
+    pub async fn issue_ownership(&self, issue_id: &str) -> PmResult<(PmItem, PmProject)> {
+        let response: IssueOwnershipData = self
+            .graphql(ISSUE_OWNERSHIP_QUERY, json!({ "id": issue_id }))
+            .await?;
+        let issue = response.issue.ok_or_else(|| {
+            PmError::Message(format!("no Linear issue with id or identifier {issue_id}"))
+        })?;
+        issue.into_ownership()
+    }
+
+    pub async fn project_ownership(&self, project_id: &str) -> PmResult<PmProject> {
+        let response: ProjectOwnershipData = self
+            .graphql(PROJECT_OWNERSHIP_QUERY, json!({ "id": project_id }))
+            .await?;
         response
-            .teams
-            .nodes
-            .into_iter()
-            .find(|team| team.id == team_id)
-            .map(|team| team.key)
-            .ok_or_else(|| PmError::Message(format!("no Linear team with id {team_id}")))
+            .project
+            .map(ProjectNode::into_pm_project)
+            .ok_or_else(|| PmError::Message(format!("no Linear Project with id {project_id}")))
     }
 
     pub async fn complete_item(&self, item_id: &str) -> PmResult<()> {
@@ -984,6 +1141,7 @@ impl LinearClient {
     /// Register a webhook for `Issue` and `Comment` changes, signed with `secret`.
     /// Returns the created webhook id.
     pub async fn create_webhook(&self, url: &str, secret: &str) -> PmResult<String> {
+        let team_id = self.require_team_id()?;
         let response: WebhookCreateData = self
             .graphql(
                 CREATE_WEBHOOK_MUTATION,
@@ -991,6 +1149,7 @@ impl LinearClient {
                     "url": url,
                     "secret": secret,
                     "resourceTypes": ["Issue", "Comment"],
+                    "teamId": team_id,
                 }),
             )
             .await?;
@@ -1242,10 +1401,14 @@ struct IssueNode {
     assignee: Option<IdNode>,
     #[serde(default)]
     state: Option<WorkflowStateRef>,
+    #[serde(default)]
+    project: Option<ProjectRef>,
+    #[serde(default)]
+    team: Option<IdNode>,
 }
 
 impl IssueNode {
-    fn into_pm_item(self, rank: u32) -> PmItem {
+    fn into_pm_item(self, rank: u32) -> PmResult<PmItem> {
         let completed = self
             .state
             .as_ref()
@@ -1256,7 +1419,13 @@ impl IssueNode {
         } else {
             self.identifier
         };
-        PmItem {
+        let project = self
+            .project
+            .ok_or_else(|| PmError::Message(format!("Linear issue {identifier} has no Project")))?;
+        let team = self
+            .team
+            .ok_or_else(|| PmError::Message(format!("Linear issue {identifier} has no Team")))?;
+        Ok(PmItem {
             id: self.id,
             identifier,
             url: self.url,
@@ -1264,9 +1433,72 @@ impl IssueNode {
             description: self.description.unwrap_or_default(),
             rank,
             completed,
-            project: None,
+            project_id: project.id,
+            project: project_slug(&project.name),
+            team_id: team.id,
             assignee: self.assignee.map(|assignee| assignee.id),
+        })
+    }
+}
+
+#[derive(Deserialize)]
+struct ProjectRef {
+    id: String,
+    name: String,
+}
+
+#[derive(Deserialize)]
+struct IssueOwnershipData {
+    issue: Option<OwnedIssueNode>,
+}
+
+#[derive(Deserialize)]
+struct OwnedIssueNode {
+    id: String,
+    #[serde(default)]
+    identifier: String,
+    url: Option<String>,
+    #[serde(default)]
+    title: String,
+    #[serde(default)]
+    description: Option<String>,
+    #[serde(rename = "prioritySortOrder", default)]
+    priority_sort_order: f64,
+    #[serde(rename = "sortOrder", default)]
+    sort_order: f64,
+    #[serde(default)]
+    assignee: Option<IdNode>,
+    #[serde(default)]
+    state: Option<WorkflowStateRef>,
+    #[serde(default)]
+    team: Option<IdNode>,
+    #[serde(default)]
+    project: Option<ProjectNode>,
+}
+
+impl OwnedIssueNode {
+    fn into_ownership(self) -> PmResult<(PmItem, PmProject)> {
+        let project = self.project.ok_or_else(|| {
+            PmError::Message(format!("Linear issue {} has no Project", self.identifier))
+        })?;
+        let item = IssueNode {
+            id: self.id,
+            identifier: self.identifier,
+            url: self.url,
+            title: self.title,
+            description: self.description,
+            priority_sort_order: self.priority_sort_order,
+            sort_order: self.sort_order,
+            assignee: self.assignee,
+            state: self.state,
+            project: Some(ProjectRef {
+                id: project.id.clone(),
+                name: project.name.clone(),
+            }),
+            team: self.team,
         }
+        .into_pm_item(0)?;
+        Ok((item, project.into_pm_project()))
     }
 }
 
@@ -1333,6 +1565,8 @@ struct TeamNode {
     id: String,
     name: String,
     key: String,
+    #[serde(default)]
+    description: Option<String>,
 }
 
 #[derive(Deserialize)]
@@ -1377,9 +1611,14 @@ impl ProjectNode {
                 .into_iter()
                 .map(|initiative| initiative.id)
                 .collect(),
-            team_ids: Some(self.teams.nodes.into_iter().map(|team| team.id).collect()),
+            team_ids: self.teams.nodes.into_iter().map(|team| team.id).collect(),
         }
     }
+}
+
+#[derive(Deserialize)]
+struct ProjectOwnershipData {
+    project: Option<ProjectNode>,
 }
 
 #[derive(Default, Deserialize)]
@@ -1464,16 +1703,46 @@ async fn parse_graphql_response<T: DeserializeOwned>(response: reqwest::Response
         .map_err(|err| PmError::Message(format!("failed to decode Linear response: {err}")))
 }
 
-fn team_key_from_name(name: &str) -> String {
-    let key: String = name
-        .split_whitespace()
-        .filter_map(|word| word.chars().next())
-        .map(|ch| ch.to_ascii_uppercase())
-        .collect();
-    if key.is_empty() {
-        "LF".to_string()
+fn repository_claim_marker(repository: &str) -> String {
+    format!("{REPOSITORY_CLAIM_PREFIX} {repository} -->")
+}
+
+fn repository_claim(description: &str) -> PmResult<Option<String>> {
+    let mut claims = Vec::new();
+    for line in description.lines() {
+        if !line.contains(REPOSITORY_CLAIM_PREFIX) {
+            continue;
+        }
+        let trimmed = line.trim();
+        let Some(value) = trimmed
+            .strip_prefix(REPOSITORY_CLAIM_PREFIX)
+            .and_then(|value| value.strip_suffix("-->"))
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+        else {
+            return Err(PmError::Message(format!(
+                "Linear Team has a malformed Loopflow repository marker: {trimmed:?}"
+            )));
+        };
+        claims.push(value.to_string());
+    }
+    match claims.as_slice() {
+        [] => Ok(None),
+        [claim] => Ok(Some(claim.clone())),
+        _ => Err(PmError::Message(format!(
+            "Linear Team has multiple Loopflow repository markers: {}",
+            claims.join(", ")
+        ))),
+    }
+}
+
+fn description_with_repository_claim(description: &str, repository: &str) -> String {
+    let human = description.trim_end();
+    let marker = repository_claim_marker(repository);
+    if human.is_empty() {
+        marker
     } else {
-        key[..key.len().min(5)].to_string()
+        format!("{human}\n\n{marker}")
     }
 }
 
@@ -1485,6 +1754,16 @@ fn linear_description(description: &str) -> String {
 
     const MAX_DESCRIPTION_LEN: usize = 255;
     summary.chars().take(MAX_DESCRIPTION_LEN).collect()
+}
+
+fn project_description(content: &ProjectContent) -> String {
+    let summary = content
+        .definition
+        .split("\n\n")
+        .map(|paragraph| paragraph.split_whitespace().collect::<Vec<_>>().join(" "))
+        .find(|paragraph| !paragraph.is_empty())
+        .unwrap_or_default();
+    linear_description(&summary)
 }
 
 fn first_meaningful_paragraph(description: &str) -> String {
@@ -1567,7 +1846,11 @@ mod tests {
             json!({ "data": { "webhookCreate": { "webhook": { "id": "wh-1" } } } }),
         )])
         .await;
-        let client = LinearClient::with_base_url("linear-secret".to_string(), None, base_url);
+        let client = LinearClient::with_base_url(
+            "linear-secret".to_string(),
+            Some("team-loo".to_string()),
+            base_url,
+        );
 
         let id = client
             .create_webhook("https://loopflow.example/linear/webhook", "whsec")
@@ -1585,6 +1868,8 @@ mod tests {
             body["variables"]["resourceTypes"],
             json!(["Issue", "Comment"])
         );
+        assert_eq!(body["variables"]["teamId"], "team-loo");
+        assert!(!CREATE_WEBHOOK_MUTATION.contains("allPublicTeams"));
         // Webhook input ids are String!, never ID! (see the position-sensitive
         // Linear id trap).
         assert!(CREATE_WEBHOOK_MUTATION.contains("$url: String!"));
@@ -1691,21 +1976,27 @@ mod tests {
                             "nodes": [
                                 {
                                     "id": "issue-1",
+                                    "identifier": "LOO-1",
                                     "url": "https://linear.app/loopflow/issue/INF-1/first",
                                     "title": "First",
                                     "description": "one",
                                     "prioritySortOrder": 10.0,
                                     "sortOrder": 10.0,
                                     "assignee": { "id": "user-1" },
-                                    "state": { "type": "unstarted" }
+                                    "state": { "type": "unstarted" },
+                                    "project": { "id": "project-123", "name": "Scan" },
+                                    "team": { "id": "team-9" }
                                 },
                                 {
                                     "id": "issue-2",
+                                    "identifier": "LOO-2",
                                     "title": "Second",
                                     "description": "two",
                                     "prioritySortOrder": 0.0,
                                     "sortOrder": 0.0,
-                                    "state": { "type": "completed" }
+                                    "state": { "type": "completed" },
+                                    "project": { "id": "project-123", "name": "Scan" },
+                                    "team": { "id": "team-9" }
                                 }
                             ],
                             "pageInfo": {
@@ -1779,10 +2070,7 @@ mod tests {
             .expect("list projects");
 
         assert_eq!(projects.len(), 1);
-        assert_eq!(
-            projects[0].team_ids.as_deref(),
-            Some(["team-cadenza".to_string()].as_slice())
-        );
+        assert_eq!(projects[0].team_ids, ["team-cadenza".to_string()]);
         let request: Value =
             serde_json::from_str(&requests.lock().await[0].body).expect("query json");
         assert!(request["query"]
@@ -1814,7 +2102,6 @@ mod tests {
             .create_project(
                 "initiative-1",
                 "Wave Chat",
-                "Conversation stays in flow.",
                 &ProjectContent {
                     definition: "Conversation stays in flow.".to_string(),
                     flows: crate::pm::ProjectFlowPlan::empty(),
@@ -1857,7 +2144,6 @@ mod tests {
             .update_project(
                 "project-1",
                 "Wave Chat",
-                "Conversation stays in flow.",
                 &ProjectContent {
                     definition: "Conversation stays in flow.".to_string(),
                     flows: crate::pm::ProjectFlowPlan {
@@ -1965,26 +2251,11 @@ mod tests {
         let body: Value = serde_json::from_str(&requests[0].body).expect("move json");
         let query = body["query"].as_str().expect("query");
         assert!(query.contains("projectUpdate"));
-        // teamIds is a set replacement: exactly the wave's team, pulling the
-        // Project off the shared team.
+        // teamIds is a set replacement: exactly the repository Team, pulling
+        // the Project off legacy Wave Teams.
         assert!(query.contains("teamIds: [$teamId]"));
         assert_eq!(body["variables"]["id"], "project-1");
         assert_eq!(body["variables"]["teamId"], "team-cadenza");
-    }
-
-    #[tokio::test]
-    async fn team_key_resolves_the_prefix_for_a_team_id() {
-        let (base_url, _requests) = test_server::spawn(vec![json_response(
-            StatusCode::OK,
-            json!({ "data": { "teams": { "nodes": [
-                { "id": "team-w2", "name": "Wave 2", "key": "W2" },
-                { "id": "team-prd", "name": "Product", "key": "PRD" }
-            ] } } }),
-        )])
-        .await;
-        let client = LinearClient::with_base_url("linear-secret".to_string(), None, base_url);
-
-        assert_eq!(client.team_key("team-prd").await.expect("key"), "PRD");
     }
 
     #[tokio::test]
@@ -2212,18 +2483,19 @@ mod tests {
 
     #[tokio::test]
     async fn ensure_team_adopts_matching_key_without_creating() {
-        let (base_url, requests) = test_server::spawn(vec![json_response(
+        let claimed = "<!-- loopflow-repository: loopflowstudio/loopflow -->";
+        let teams = json_response(
             StatusCode::OK,
             json!({ "data": { "teams": { "nodes": [
-                { "id": "team-prd", "name": "Product", "key": "PRD" },
-                { "id": "team-inf", "name": "Infrastructure", "key": "INF" },
+                { "id": "team-prd", "name": "Product", "key": "PRD", "description": claimed },
+                { "id": "team-inf", "name": "Infrastructure", "key": "INF", "description": null },
             ] } } }),
-        )])
-        .await;
+        );
+        let (base_url, requests) = test_server::spawn(vec![teams.clone(), teams]).await;
         let client = LinearClient::with_base_url("linear-secret".to_string(), None, base_url);
 
         let binding = client
-            .ensure_team("Product", "PRD")
+            .ensure_team("Product", "PRD", "loopflowstudio/loopflow")
             .await
             .expect("adopt existing team");
 
@@ -2235,8 +2507,7 @@ mod tests {
                 created: false,
             }
         );
-        // Only the list query fired — no team was created.
-        assert_eq!(requests.lock().await.len(), 1);
+        assert_eq!(requests.lock().await.len(), 2);
     }
 
     #[tokio::test]
@@ -2250,12 +2521,19 @@ mod tests {
                 StatusCode::OK,
                 json!({ "data": { "teamCreate": { "team": { "id": "team-new" } } } }),
             ),
+            json_response(
+                StatusCode::OK,
+                json!({ "data": { "teams": { "nodes": [{
+                    "id": "team-new", "name": "Product", "key": "PRD",
+                    "description": "<!-- loopflow-repository: loopflowstudio/loopflow -->"
+                }] } } }),
+            ),
         ])
         .await;
         let client = LinearClient::with_base_url("linear-secret".to_string(), None, base_url);
 
         let binding = client
-            .ensure_team("Product", "prd")
+            .ensure_team("Product", "prd", "loopflowstudio/loopflow")
             .await
             .expect("create team");
 
@@ -2272,6 +2550,10 @@ mod tests {
             serde_json::from_str(&requests[1].body).expect("create body is json");
         assert_eq!(create_body["variables"]["key"], "PRD");
         assert_eq!(create_body["variables"]["name"], "Product");
+        assert_eq!(
+            create_body["variables"]["description"],
+            "<!-- loopflow-repository: loopflowstudio/loopflow -->"
+        );
     }
 
     #[tokio::test]
@@ -2286,7 +2568,7 @@ mod tests {
         let client = LinearClient::with_base_url("linear-secret".to_string(), None, base_url);
 
         let err = client
-            .ensure_team("Product", "PRD")
+            .ensure_team("Product", "PRD", "loopflowstudio/loopflow")
             .await
             .expect_err("conflicting key is refused");
         let message = err.to_string();
@@ -2306,16 +2588,136 @@ mod tests {
         let client = LinearClient::with_base_url("linear-secret".to_string(), None, base_url);
 
         let err = client
-            .ensure_team("Product", "PRD")
+            .ensure_team("Product", "PRD", "loopflowstudio/loopflow")
             .await
             .expect_err("name reused under a different key is refused");
         assert!(err.to_string().contains("PROD"), "{err}");
     }
 
     #[tokio::test]
+    async fn ensure_team_claims_unmarked_team_without_erasing_human_description() {
+        let (base_url, requests) = test_server::spawn(vec![
+            json_response(
+                StatusCode::OK,
+                json!({ "data": { "teams": { "nodes": [{
+                    "id": "team-loo", "name": "Loopflow", "key": "LOO",
+                    "description": "Human-owned team notes."
+                }] } } }),
+            ),
+            json_response(
+                StatusCode::OK,
+                json!({ "data": { "teamUpdate": { "team": { "id": "team-loo" } } } }),
+            ),
+            json_response(
+                StatusCode::OK,
+                json!({ "data": { "teams": { "nodes": [{
+                    "id": "team-loo", "name": "Loopflow", "key": "LOO",
+                    "description": "Human-owned team notes.\n\n<!-- loopflow-repository: loopflowstudio/loopflow -->"
+                }] } } }),
+            ),
+        ])
+        .await;
+        let client = LinearClient::with_base_url("linear-secret".to_string(), None, base_url);
+
+        let binding = client
+            .ensure_team("Loopflow", "LOO", "loopflowstudio/loopflow")
+            .await
+            .expect("claim unmarked Team");
+        assert_eq!(binding.id, "team-loo");
+
+        let requests = requests.lock().await;
+        let update: Value = serde_json::from_str(&requests[1].body).unwrap();
+        let description = update["variables"]["description"].as_str().unwrap();
+        assert!(description.starts_with("Human-owned team notes."));
+        assert!(description.contains("loopflowstudio/loopflow"));
+    }
+
+    #[tokio::test]
+    async fn ensure_team_refuses_a_foreign_repository_claim_before_mutation() {
+        let (base_url, requests) = test_server::spawn(vec![json_response(
+            StatusCode::OK,
+            json!({ "data": { "teams": { "nodes": [{
+                "id": "team-loo", "name": "Loopflow", "key": "LOO",
+                "description": "<!-- loopflow-repository: acme/other -->"
+            }] } } }),
+        )])
+        .await;
+        let client = LinearClient::with_base_url("linear-secret".to_string(), None, base_url);
+
+        let error = client
+            .ensure_team("Loopflow", "LOO", "loopflowstudio/loopflow")
+            .await
+            .unwrap_err();
+        assert!(error.to_string().contains("acme/other"));
+        assert!(error.to_string().contains("loopflowstudio/loopflow"));
+        assert_eq!(requests.lock().await.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn configured_team_rebind_is_refused_before_claiming_another_team() {
+        let (base_url, requests) = test_server::spawn(vec![json_response(
+            StatusCode::OK,
+            json!({ "data": { "teams": { "nodes": [{
+                "id": "team-loo", "name": "Loopflow", "key": "LOO",
+                "description": "Human-owned team notes."
+            }] } } }),
+        )])
+        .await;
+        let client = LinearClient::with_base_url("linear-secret".to_string(), None, base_url);
+
+        let error = client
+            .claim_configured_team("team-loo", "loopflowstudio/loopflow", None, Some("HOO"))
+            .await
+            .unwrap_err();
+
+        assert!(error.to_string().contains("already bound"));
+        assert!(error.to_string().contains("lf pm reteam"));
+        assert_eq!(requests.lock().await.len(), 1);
+    }
+
+    #[test]
+    fn repository_claim_rejects_ambiguous_markers() {
+        let description =
+            "<!-- loopflow-repository: acme/one -->\n<!-- loopflow-repository: acme/two -->";
+        assert!(repository_claim(description).is_err());
+    }
+
+    #[tokio::test]
+    async fn issue_ownership_resolves_project_and_team_by_stable_ids() {
+        let (base_url, _requests) = test_server::spawn(vec![json_response(
+            StatusCode::OK,
+            json!({ "data": { "issue": {
+                "id": "issue-uuid", "identifier": "LOO-42", "url": null,
+                "title": "Resolve ownership", "description": "",
+                "prioritySortOrder": 0.0, "sortOrder": 0.0,
+                "assignee": null, "state": { "type": "unstarted" },
+                "team": { "id": "team-loo" },
+                "project": {
+                    "id": "project-api", "name": "Product — Loopflow API",
+                    "description": "", "content": "## Definition\n\nOne model.\n\n## KRs\n",
+                    "initiatives": { "nodes": [{ "id": "initiative-product" }] },
+                    "teams": { "nodes": [{ "id": "team-loo" }] }
+                }
+            } } }),
+        )])
+        .await;
+        let client = LinearClient::with_base_url(
+            "linear-secret".to_string(),
+            Some("team-loo".to_string()),
+            base_url,
+        );
+
+        let (item, project) = client.issue_ownership("LOO-42").await.unwrap();
+        assert_eq!(item.project_id, "project-api");
+        assert_eq!(item.team_id, "team-loo");
+        assert_eq!(project.initiative_ids, ["initiative-product"]);
+        assert_eq!(project.team_ids, ["team-loo"]);
+    }
+
+    #[tokio::test]
     async fn complete_item_resolves_state_from_the_issue_team_not_the_wave_team() {
-        // The client is bound to the wave's team, but the issue lives in a
-        // *different* team (the ENG-*/W2-* split). The completed state must be
+        // The client is bound to the repository Team, but this fixture puts the
+        // issue in a different Team. The completed state must be
         // resolved from the issue's own team or Linear rejects the transition.
         let (base_url, requests) = test_server::spawn(vec![
             json_response(

--- a/rust/loopflow/src/pm/mod.rs
+++ b/rust/loopflow/src/pm/mod.rs
@@ -1,5 +1,6 @@
 pub mod linear;
 
+use std::collections::{BTreeMap, BTreeSet};
 use std::str::FromStr;
 use std::time::Duration;
 
@@ -25,17 +26,9 @@ impl PmProviderKind {
             Self::Linear => "linear_initiative",
         }
     }
-
-    /// GOAL.md frontmatter key binding a wave to its provider team — the team
-    /// whose key prefixes every Task identifier (`PRD-*`, `INF-*`, …).
-    pub fn team_key(self) -> &'static str {
-        match self {
-            Self::Linear => "linear_team",
-        }
-    }
 }
 
-/// The result of adopting or creating a provider team for a wave. The stable
+/// The result of adopting or creating a provider team for a repository. The stable
 /// `id` owns identity; `key` is mutable presentation (the Task prefix).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TeamBinding {
@@ -106,12 +99,9 @@ pub struct PmProject {
     pub flows: Option<ProjectFlowPlan>,
     pub krs: Vec<PmKr>,
     pub initiative_ids: Vec<String>,
-    /// Stable ids of the Linear teams this Project belongs to. `None` when the
-    /// read did not resolve teams (a snapshot written before the field existed);
-    /// `Some(vec)` is authoritative. Team ownership drives `doctor`/`reteam`
-    /// repair; a Project's team is otherwise invisible to the team-agnostic read
-    /// path. Optional so an older cached snapshot still decodes.
-    pub team_ids: Option<Vec<String>>,
+    /// Stable ids of the Linear teams this Project belongs to. A managed Project
+    /// must carry exactly the repository Team.
+    pub team_ids: Vec<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -133,9 +123,160 @@ pub struct PmItem {
     pub description: String,
     pub rank: u32,
     pub completed: bool,
-    pub project: Option<String>,
+    /// Stable owning Project id. Task-to-Wave resolution follows this edge.
+    pub project_id: String,
+    /// Canonical Project slug for display only.
+    pub project: String,
+    /// Stable owning repository Team id.
+    pub team_id: String,
     /// Provider user ID of the assignee, if any.
     pub assignee: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct PmSnapshot {
+    pub(crate) projects: Vec<PmProject>,
+    pub(crate) items: Vec<PmItem>,
+}
+
+/// Validates provider ownership across cached Wave snapshots presented together.
+#[derive(Debug, Default)]
+pub(crate) struct PmPortfolioValidator {
+    initiative_owners: BTreeMap<String, String>,
+    project_owners: BTreeMap<String, String>,
+    task_owners: BTreeMap<String, String>,
+}
+
+impl PmPortfolioValidator {
+    pub(crate) fn validate(
+        &mut self,
+        wave: &str,
+        initiative_id: &str,
+        expected_team_id: Option<&str>,
+        projects: &[PmProject],
+        items: &[PmItem],
+    ) -> PmResult<()> {
+        validate_snapshot_ownership(wave, initiative_id, expected_team_id, projects, items)?;
+
+        if let Some(owner) = self
+            .initiative_owners
+            .insert(initiative_id.to_string(), wave.to_string())
+        {
+            return Err(PmError::Message(format!(
+                "Linear Initiative {initiative_id} is bound by both wave/{owner} and wave/{wave} snapshots"
+            )));
+        }
+        for project in projects {
+            if let Some(owner) = self
+                .project_owners
+                .insert(project.id.clone(), wave.to_string())
+            {
+                return Err(PmError::Message(format!(
+                    "Linear Project {} belongs to both wave/{owner} and wave/{wave} snapshots",
+                    project.id
+                )));
+            }
+        }
+        for item in items {
+            if let Some(owner) = self.task_owners.insert(item.id.clone(), wave.to_string()) {
+                return Err(PmError::Message(format!(
+                    "Linear task {} belongs to both wave/{owner} and wave/{wave} snapshots",
+                    item.identifier
+                )));
+            }
+        }
+        Ok(())
+    }
+}
+
+fn validate_snapshot_ownership(
+    wave: &str,
+    initiative_id: &str,
+    expected_team_id: Option<&str>,
+    projects: &[PmProject],
+    items: &[PmItem],
+) -> PmResult<()> {
+    let mut projects_by_id = BTreeMap::new();
+    for project in projects {
+        if projects_by_id
+            .insert(project.id.as_str(), project)
+            .is_some()
+        {
+            return Err(PmError::Message(format!(
+                "Linear Project {} appears more than once in wave/{wave}",
+                project.id
+            )));
+        }
+        validate_project_ownership(wave, initiative_id, expected_team_id, project)?;
+    }
+
+    let mut issue_ids = BTreeSet::new();
+    for item in items {
+        if !issue_ids.insert(item.id.as_str()) {
+            return Err(PmError::Message(format!(
+                "Linear task {} appears more than once in wave/{wave}",
+                item.identifier
+            )));
+        }
+        let project = projects_by_id
+            .get(item.project_id.as_str())
+            .ok_or_else(|| {
+                PmError::Message(format!(
+                    "Linear task {} in wave/{wave} points to missing Project {}",
+                    item.identifier, item.project_id
+                ))
+            })?;
+        if item.project != project.slug {
+            return Err(PmError::Message(format!(
+                "Linear task {} in wave/{wave} names Project slug `{}`, but Project {} has slug `{}`",
+                item.identifier, item.project, project.id, project.slug
+            )));
+        }
+        if project.team_ids.as_slice() != [item.team_id.as_str()] {
+            return Err(PmError::Message(format!(
+                "Linear task {} in wave/{wave} belongs to Team {}, but Project {} belongs to Teams [{}]",
+                item.identifier,
+                item.team_id,
+                project.id,
+                project.team_ids.join(", ")
+            )));
+        }
+    }
+    Ok(())
+}
+
+pub(crate) fn validate_project_ownership(
+    wave: &str,
+    initiative_id: &str,
+    expected_team_id: Option<&str>,
+    project: &PmProject,
+) -> PmResult<()> {
+    if project.initiative_ids.as_slice() != [initiative_id] {
+        return Err(PmError::Message(format!(
+            "Linear Project `{}` ({}) in wave/{wave} belongs to Initiatives [{}]; expected exactly {initiative_id}",
+            project.name,
+            project.id,
+            project.initiative_ids.join(", ")
+        )));
+    }
+    let [team_id] = project.team_ids.as_slice() else {
+        return Err(PmError::Message(format!(
+            "Linear Project `{}` ({}) in wave/{wave} belongs to {} Teams [{}]; expected exactly one repository Team",
+            project.name,
+            project.id,
+            project.team_ids.len(),
+            project.team_ids.join(", ")
+        )));
+    };
+    if expected_team_id.is_some_and(|expected| expected != team_id) {
+        return Err(PmError::Message(format!(
+            "Linear Project `{}` ({}) in wave/{wave} belongs to Team {team_id}; expected repository Team {}",
+            project.name,
+            project.id,
+            expected_team_id.expect("checked as Some")
+        )));
+    }
+    Ok(())
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -521,7 +662,7 @@ mod tests {
                 "definition":"Incidents are resolved at every causal layer.",
                 "krs":[],
                 "initiative_ids":["initiative-1"],
-                "team_ids":null
+                "team_ids":["team-1"]
             }"#,
         )
         .expect("legacy project snapshot");

--- a/rust/loopflow/src/project/runner.rs
+++ b/rust/loopflow/src/project/runner.rs
@@ -888,7 +888,7 @@ async fn inspect_outcome(
         .snapshot
         .items
         .iter()
-        .filter(|item| item.project.as_deref() == Some(project.plan.slug.as_str()))
+        .filter(|item| item.project == project.plan.slug)
         .collect::<Vec<_>>();
     let mut task_states = Vec::with_capacity(tasks.len());
     for task in &tasks {

--- a/rust/loopflow/tests/dto_fixtures.rs
+++ b/rust/loopflow/tests/dto_fixtures.rs
@@ -1,0 +1,37 @@
+use loopflow::ops::pm::PmShowResult;
+
+const PM_SHOW: &str = include_str!("../../../tests/fixtures/dto/pm_show.json");
+
+#[test]
+fn pm_show_preserves_repository_team_and_project_ownership() {
+    let snapshot: PmShowResult = serde_json::from_str(PM_SHOW).unwrap();
+
+    assert_eq!(snapshot.wave, "survival/infrastructure");
+    assert_eq!(
+        snapshot.projects[0].initiative_ids,
+        ["initiative-infrastructure"]
+    );
+    assert_eq!(snapshot.projects[0].name, "Gmail");
+    assert_eq!(snapshot.projects[0].team_ids, ["team-loo"]);
+    assert_eq!(snapshot.items[0].identifier, "LOO-2");
+    assert_eq!(snapshot.items[0].project_id, "project-gmail");
+    assert_eq!(snapshot.items[0].team_id, "team-loo");
+
+    let round_trip = serde_json::to_string(&snapshot).unwrap();
+    assert_eq!(
+        serde_json::from_str::<PmShowResult>(&round_trip).unwrap(),
+        snapshot
+    );
+}
+
+#[test]
+fn pm_show_rejects_a_legacy_item_without_stable_ownership() {
+    let mut fixture: serde_json::Value = serde_json::from_str(PM_SHOW).unwrap();
+    fixture["items"][0]
+        .as_object_mut()
+        .unwrap()
+        .remove("project_id");
+
+    let error = serde_json::from_value::<PmShowResult>(fixture).unwrap_err();
+    assert!(error.to_string().contains("project_id"));
+}

--- a/rust/loopflow/tests/repository_team_matrix.rs
+++ b/rust/loopflow/tests/repository_team_matrix.rs
@@ -1,0 +1,476 @@
+//! PRD-43: one repository Team, stable Project ownership, and a fail-closed migration.
+
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+use loopflow::id::WaveId;
+use loopflow::ops::pm::{canonical_wave_title_path, list_local_waves};
+use loopflow::store::sqlite::SqliteStore;
+use loopflow::store::PmSnapshotRow;
+use loopflow::wave::Wave;
+
+fn git(repo: &Path, args: &[&str]) {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(repo)
+        .output()
+        .expect("run git");
+    assert!(
+        output.status.success(),
+        "git {} failed: {}",
+        args.join(" "),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn write_goal(repo: &Path, wave: &str, initiative: &str, legacy: bool) {
+    let directory = repo.join("wave").join(wave);
+    std::fs::create_dir_all(&directory).unwrap();
+    let legacy = if legacy {
+        "  provider: linear\n  linear_team: team-old\n"
+    } else {
+        ""
+    };
+    std::fs::write(
+        directory.join("GOAL.md"),
+        format!(
+            "---\npm:\n{legacy}  linear_initiative: {initiative}\n---\n\n## Objective\n\nTest {wave}.\n"
+        ),
+    )
+    .unwrap();
+}
+
+fn snapshot(
+    initiative: &str,
+    project_id: &str,
+    project_slug: &str,
+    project_name: &str,
+    issue_id: &str,
+    identifier: &str,
+    completed: bool,
+) -> String {
+    serde_json::json!({
+        "projects": [{
+            "id": project_id,
+            "slug": project_slug,
+            "name": project_name,
+            "summary": "Fixture project",
+            "definition": "A measured bet.",
+            "flows": { "first": null, "loop": null, "finally": null },
+            "krs": [{ "text": "Ownership is deterministic", "holds": true }],
+            "initiative_ids": [initiative],
+            "team_ids": ["team-loo"]
+        }],
+        "items": [{
+            "id": issue_id,
+            "identifier": identifier,
+            "url": null,
+            "name": format!("Task {identifier}"),
+            "description": "",
+            "rank": 0,
+            "completed": completed,
+            "project_id": project_id,
+            "project": project_slug,
+            "team_id": "team-loo",
+            "assignee": null
+        }]
+    })
+    .to_string()
+}
+
+fn put_snapshot(store: &SqliteStore, repo: &Path, wave: &str, initiative: &str, payload: String) {
+    store
+        .put_pm_snapshot(&PmSnapshotRow {
+            repo: std::fs::canonicalize(repo).unwrap().display().to_string(),
+            wave: wave.to_string(),
+            provider: "linear".to_string(),
+            initiative: initiative.to_string(),
+            synced_at: chrono::Utc::now().timestamp(),
+            payload,
+        })
+        .unwrap();
+}
+
+fn lf_command(home: &Path, repo: &Path, args: &[&str]) -> Command {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_lf"));
+    command
+        .args(args)
+        .current_dir(repo)
+        .env("LF_HOME", home)
+        .env("HOME", home)
+        .env_remove("LF_DB_PATH")
+        .env_remove("LF_WAVE_ID");
+    command
+}
+
+fn run_lf(home: &Path, repo: &Path, args: &[&str]) -> Output {
+    lf_command(home, repo, args).output().expect("run lf")
+}
+
+fn run_project_control(home: &Path, repo: &Path, project: &str) -> Output {
+    lf_command(home, repo, &["project", "run", project])
+        .env("LF_BIN", repo.join("missing-lf"))
+        .env_remove("LF_CONTROL_BIN")
+        .output()
+        .expect("run project control")
+}
+
+fn assert_success(output: &Output, command: &str) -> String {
+    assert!(
+        output.status.success(),
+        "{command} failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8_lossy(&output.stdout).into_owned()
+}
+
+fn seed_repository(repo: &Path) {
+    std::fs::create_dir_all(repo.join(".lf")).unwrap();
+    std::fs::write(
+        repo.join(".lf/config.yaml"),
+        "pm:\n  provider: linear\n  linear_team: team-loo\n",
+    )
+    .unwrap();
+    write_goal(repo, "survival", "initiative-survival", false);
+    write_goal(
+        repo,
+        "survival/infrastructure",
+        "initiative-infrastructure",
+        false,
+    );
+    git(repo, &["init", "-b", "main"]);
+    git(repo, &["config", "user.email", "matrix@loopflow.test"]);
+    git(repo, &["config", "user.name", "Repository Team Matrix"]);
+    git(
+        repo,
+        &[
+            "remote",
+            "add",
+            "origin",
+            "https://github.com/loopflowstudio/fixture.git",
+        ],
+    );
+    git(repo, &["add", "."]);
+    git(repo, &["commit", "-m", "seed repository team fixture"]);
+}
+
+#[test]
+fn repository_team_matrix() {
+    let fixture = tempfile::tempdir().unwrap();
+    let home = fixture.path().join("home");
+    let repo = fixture.path().join("fixture");
+    std::fs::create_dir_all(&home).unwrap();
+    std::fs::create_dir_all(&repo).unwrap();
+    seed_repository(&repo);
+
+    let database = home.join("loopflow.db");
+    let store = SqliteStore::new(&database).unwrap();
+    let survival = Wave::new(
+        WaveId::new(),
+        "survival".to_string(),
+        repo.display().to_string(),
+    );
+    let infrastructure = Wave::new(
+        WaveId::new(),
+        "survival/infrastructure".to_string(),
+        repo.display().to_string(),
+    )
+    .with_parent(survival.id().clone());
+    store.create_wave(&survival).unwrap();
+    store.create_wave(&infrastructure).unwrap();
+    put_snapshot(
+        &store,
+        &repo,
+        "survival",
+        "initiative-survival",
+        snapshot(
+            "initiative-survival",
+            "project-survival",
+            "a-real-task",
+            "A real task reaches done",
+            "issue-survival",
+            "LOO-1",
+            true,
+        ),
+    );
+    put_snapshot(
+        &store,
+        &repo,
+        "survival/infrastructure",
+        "initiative-infrastructure",
+        snapshot(
+            "initiative-infrastructure",
+            "project-gmail",
+            "gmail",
+            "Gmail",
+            "issue-gmail",
+            "LOO-2",
+            true,
+        ),
+    );
+    drop(store);
+
+    // Recursive discovery and durable ancestry make nested titles legible.
+    assert_eq!(
+        list_local_waves(&repo).unwrap(),
+        ["survival", "survival/infrastructure"]
+    );
+    let old_home = std::env::var_os("LF_HOME");
+    let old_db = std::env::var_os("LF_DB_PATH");
+    // SAFETY: this integration binary contains one test; no sibling thread can
+    // observe the temporary storage selection.
+    unsafe {
+        std::env::set_var("LF_HOME", &home);
+        std::env::remove_var("LF_DB_PATH");
+    }
+    assert_eq!(
+        canonical_wave_title_path(&repo, "survival/infrastructure").unwrap(),
+        "Survival / Infrastructure"
+    );
+    // SAFETY: restore the process environment before exercising subprocesses.
+    unsafe {
+        match old_home {
+            Some(value) => std::env::set_var("LF_HOME", value),
+            None => std::env::remove_var("LF_HOME"),
+        }
+        match old_db {
+            Some(value) => std::env::set_var("LF_DB_PATH", value),
+            None => std::env::remove_var("LF_DB_PATH"),
+        }
+    }
+
+    for (wave, issue) in [("survival", "LOO-1"), ("survival/infrastructure", "LOO-2")] {
+        let show = run_lf(
+            &home,
+            &repo,
+            &["pm", "show", "--wave", wave, "--no-sync", "--json"],
+        );
+        let stdout = assert_success(&show, "pm show");
+        assert!(stdout.contains(issue), "{wave} snapshot lost {issue}");
+
+        let run = run_lf(&home, &repo, &["task", "run", issue]);
+        let error = String::from_utf8_lossy(&run.stderr);
+        assert!(!run.status.success());
+        assert!(
+            error.contains("already complete"),
+            "unexpected task result: {error}"
+        );
+    }
+    let status = assert_success(&run_lf(&home, &repo, &["pm", "status"]), "pm status");
+    assert!(status.contains("survival"));
+    assert!(status.contains("survival/infrastructure"));
+    let roadmap = assert_success(&run_lf(&home, &repo, &["roadmap", "--json"]), "roadmap");
+    assert!(roadmap.contains("LOO-1"));
+    assert!(roadmap.contains("LOO-2"));
+
+    // Project controls resolve each stable Project id to its own Wave before
+    // the deliberately missing worker binary stops the fixture from launching.
+    let control_home = fixture.path().join("project-control-home");
+    std::fs::create_dir_all(&control_home).unwrap();
+    let control_store = SqliteStore::new(&control_home.join("loopflow.db")).unwrap();
+    let control_survival = Wave::new(
+        WaveId::new(),
+        "survival".to_string(),
+        repo.display().to_string(),
+    );
+    let control_infrastructure = Wave::new(
+        WaveId::new(),
+        "survival/infrastructure".to_string(),
+        repo.display().to_string(),
+    )
+    .with_parent(control_survival.id().clone());
+    control_store.create_wave(&control_survival).unwrap();
+    control_store.create_wave(&control_infrastructure).unwrap();
+    put_snapshot(
+        &control_store,
+        &repo,
+        "survival",
+        "initiative-survival",
+        snapshot(
+            "initiative-survival",
+            "project-survival",
+            "a-real-task",
+            "A real task reaches done",
+            "issue-survival",
+            "LOO-1",
+            true,
+        ),
+    );
+    put_snapshot(
+        &control_store,
+        &repo,
+        "survival/infrastructure",
+        "initiative-infrastructure",
+        snapshot(
+            "initiative-infrastructure",
+            "project-gmail",
+            "gmail",
+            "Gmail",
+            "issue-gmail",
+            "LOO-2",
+            true,
+        ),
+    );
+    drop(control_store);
+    for (project_id, wave_id) in [
+        ("project-survival", control_survival.id()),
+        ("project-gmail", control_infrastructure.id()),
+    ] {
+        let output = run_project_control(&control_home, &repo, project_id);
+        let error = String::from_utf8_lossy(&output.stderr);
+        assert!(!output.status.success());
+        assert!(
+            error.contains("cannot resolve current lf binary"),
+            "{error}"
+        );
+        let control_store = SqliteStore::new(&control_home.join("loopflow.db")).unwrap();
+        let project = control_store
+            .project_by_project(project_id)
+            .unwrap()
+            .expect("Project control reserved the resolved Project");
+        assert_eq!(&project.wave_id, wave_id);
+    }
+
+    // Reopening the store preserves the one Team and both stable associations.
+    let reopened = SqliteStore::new(&database).unwrap();
+    assert_eq!(reopened.list_waves(None).unwrap().len(), 2);
+
+    // A duplicated Project/Issue association fails before Work or worktree creation.
+    put_snapshot(
+        &reopened,
+        &repo,
+        "survival/infrastructure",
+        "initiative-infrastructure",
+        snapshot(
+            "initiative-infrastructure",
+            "project-survival",
+            "a-real-task",
+            "A real task reaches done",
+            "issue-survival",
+            "LOO-1",
+            false,
+        ),
+    );
+    drop(reopened);
+    let duplicate = run_lf(&home, &repo, &["task", "run", "LOO-1"]);
+    let error = String::from_utf8_lossy(&duplicate.stderr);
+    assert!(error.contains("belongs to both"), "{error}");
+    for args in [
+        &["pm", "status"][..],
+        &["status", "survival", "--json"][..],
+        &["roadmap", "--json"][..],
+        &["roadmap", "--wave", "survival", "--json"][..],
+        &["project", "run", "project-survival"][..],
+    ] {
+        let output = run_lf(&home, &repo, args);
+        let error = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            !output.status.success(),
+            "{} accepted ambiguous ownership",
+            args.join(" ")
+        );
+        assert!(
+            error.contains("belongs to both") || error.contains("belongs to 2"),
+            "{} returned an unrelated error: {error}",
+            args.join(" ")
+        );
+    }
+    assert!(!fixture
+        .path()
+        .join("fixture.a-real-task-reaches-done")
+        .exists());
+
+    // The capable PR leaves a legacy repository readable but blocks mutations
+    // with the PRD-44 handoff before any provider call.
+    let legacy_repo = fixture.path().join("legacy");
+    std::fs::create_dir_all(legacy_repo.join(".lf")).unwrap();
+    std::fs::write(
+        legacy_repo.join(".lf/config.yaml"),
+        "pm:\n  provider: linear\n  linear_team: team-loo\nlinear:\n  team: team-old\n",
+    )
+    .unwrap();
+    write_goal(&legacy_repo, "product", "initiative-product", true);
+    git(&legacy_repo, &["init", "-b", "main"]);
+    git(
+        &legacy_repo,
+        &["config", "user.email", "matrix@loopflow.test"],
+    );
+    git(
+        &legacy_repo,
+        &["config", "user.name", "Repository Team Matrix"],
+    );
+    git(
+        &legacy_repo,
+        &[
+            "remote",
+            "add",
+            "origin",
+            "https://github.com/loopflowstudio/legacy-fixture.git",
+        ],
+    );
+    git(&legacy_repo, &["add", "."]);
+    git(&legacy_repo, &["commit", "-m", "seed legacy fixture"]);
+    let legacy_store = SqliteStore::new(&home.join("loopflow.db")).unwrap();
+    legacy_store
+        .create_wave(&Wave::new(
+            WaveId::new(),
+            "product".to_string(),
+            legacy_repo.display().to_string(),
+        ))
+        .unwrap();
+    put_snapshot(
+        &legacy_store,
+        &legacy_repo,
+        "product",
+        "initiative-product",
+        snapshot(
+            "initiative-product",
+            "project-api",
+            "loopflow-api",
+            "Loopflow API",
+            "issue-legacy",
+            "OLD-1",
+            true,
+        ),
+    );
+    drop(legacy_store);
+    assert_success(
+        &run_lf(
+            &home,
+            &legacy_repo,
+            &["pm", "show", "--wave", "product", "--no-sync", "--json"],
+        ),
+        "legacy cached read",
+    );
+    let blocked = run_lf(
+        &home,
+        &legacy_repo,
+        &[
+            "pm",
+            "project",
+            "create",
+            "--wave",
+            "product",
+            "--title",
+            "Blocked",
+            "--definition",
+            "No side effects",
+            "--kr",
+            "Nothing changed",
+        ],
+    );
+    let error = String::from_utf8_lossy(&blocked.stderr);
+    assert!(!blocked.status.success());
+    assert!(error.contains("lf pm reteam --apply"), "{error}");
+    assert!(error.contains("PRD-44"), "{error}");
+
+    // PRD-43 must preserve Loopflow's checked-in legacy bindings verbatim.
+    let source = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..");
+    let config = std::fs::read_to_string(source.join(".lf/config.yaml")).unwrap();
+    assert!(config.contains("linear:\n  team:"));
+    assert!(!config.contains("linear_team:"));
+    let product = std::fs::read_to_string(source.join("wave/product/GOAL.md")).unwrap();
+    assert!(product.contains("linear_team:"));
+
+    println!("one Team team-loo: Survival — A real task reaches done; Survival / Infrastructure — Gmail; LOO-1 and LOO-2 resolve independently");
+}

--- a/rust/loopflow/tests/status_tests.rs
+++ b/rust/loopflow/tests/status_tests.rs
@@ -331,7 +331,9 @@ fn seed_stale_project_work(home: &Path) {
                 "description": "Keep focused reads useful through stale Work.",
                 "rank": 1,
                 "completed": false,
+                "project_id": "95159066-9098-4d0b-8903-01459dc7ec14",
                 "project": "auditability",
+                "team_id": "team-product",
                 "assignee": null
             }
         ]

--- a/rust/loopflow/tests/wave_resolution_matrix.rs
+++ b/rust/loopflow/tests/wave_resolution_matrix.rs
@@ -14,10 +14,8 @@
 use std::collections::HashSet;
 use std::io::Write;
 use std::os::unix::fs::PermissionsExt;
-use std::os::unix::process::CommandExt;
 use std::path::Path;
 use std::process::{Command, Stdio};
-use std::time::{Duration, Instant};
 
 use clap::{ArgAction, CommandFactory};
 use loopflow::id::WaveId;
@@ -54,10 +52,6 @@ struct Special {
     /// `NoContext` → exit 0 "dropped" (publish-to-no-subscriber). `chat post`
     /// drops silently instead of erroring.
     silent_drop: bool,
-    /// Blocks (server or subscriber); needs a kill timeout.
-    long_running: bool,
-    /// Needs `LF_LINEAR_WEBHOOK_SECRET` to reach wave resolution.
-    needs_secret: bool,
     /// Pipes this text to stdin (for commands whose `trailing_var_arg` would
     /// swallow `--wave` if text were on the command line).
     stdin: Option<&'static str>,
@@ -67,8 +61,6 @@ impl Special {
     const NONE: Self = Self {
         global_default: false,
         silent_drop: false,
-        long_running: false,
-        needs_secret: false,
         stdin: None,
     };
 }
@@ -206,14 +198,6 @@ const COMMANDS: &[Cmd] = &[
         special: Special::NONE,
     },
     Cmd {
-        id: "pm reteam",
-        path: &["pm", "reteam"],
-        base_args: &["pm", "reteam"],
-        wave_form: WaveForm::Flag,
-        kind: Kind::Mutation,
-        special: Special::NONE,
-    },
-    Cmd {
         id: "pm task create",
         path: &["pm", "task", "create"],
         base_args: &["pm", "task", "create", "--project", "test", "--title", "T"],
@@ -288,35 +272,6 @@ const COMMANDS: &[Cmd] = &[
         wave_form: WaveForm::Flag,
         kind: Kind::Mutation,
         special: Special::NONE,
-    },
-    Cmd {
-        id: "pm webhook serve",
-        path: &["pm", "webhook", "serve"],
-        base_args: &["pm", "webhook", "serve", "--addr", "127.0.0.1:0"],
-        wave_form: WaveForm::Flag,
-        kind: Kind::Mutation,
-        special: Special {
-            needs_secret: true,
-            long_running: true,
-            ..Special::NONE
-        },
-    },
-    Cmd {
-        id: "pm webhook register",
-        path: &["pm", "webhook", "register"],
-        base_args: &[
-            "pm",
-            "webhook",
-            "register",
-            "--url",
-            "https://example.com/wh",
-        ],
-        wave_form: WaveForm::Flag,
-        kind: Kind::Mutation,
-        special: Special {
-            needs_secret: true,
-            ..Special::NONE
-        },
     },
     Cmd {
         id: "cron add",
@@ -496,6 +451,10 @@ fn classify(output: &std::process::Output) -> Outcome {
 
 // ─── Helpers ────────────────────────────────────────────────────────────
 
+fn open_test_store(path: &Path) -> SqliteStore {
+    SqliteStore::new(path).expect("open store")
+}
+
 /// Seed a machine home with one registered wave ("product"), a PM snapshot,
 /// a wave directory with MEMORY.md, and a git repo on a clean `main` branch.
 fn seed(home: &Path, repo: &Path) -> Wave {
@@ -527,7 +486,7 @@ fn seed(home: &Path, repo: &Path) -> Wave {
         git(&["config", "user.name", "Matrix Test"]);
     }
 
-    let store = SqliteStore::new(&home.join("loopflow.db")).expect("open store");
+    let store = open_test_store(&home.join("loopflow.db"));
     let wave = Wave::new(
         WaveId::new(),
         "product".to_string(),
@@ -612,10 +571,6 @@ fn run_lf(home: &Path, repo: &Path, cmd: &Cmd, env: &Env) -> std::process::Outpu
     if let Some(id) = &env.wave_id {
         command.env("LF_WAVE_ID", id);
     }
-    if cmd.special.needs_secret {
-        command.env("LF_LINEAR_WEBHOOK_SECRET", "test");
-    }
-
     if let Some(stdin_text) = cmd.special.stdin {
         command
             .stdin(Stdio::piped())
@@ -635,32 +590,6 @@ fn run_lf(home: &Path, repo: &Path, cmd: &Cmd, env: &Env) -> std::process::Outpu
         let output = child.wait_with_output().expect("wait");
         let _ = handle.join();
         return output;
-    }
-
-    if cmd.special.long_running {
-        command
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .process_group(0);
-        let mut child = command.spawn().expect("spawn");
-        let deadline = Instant::now() + Duration::from_secs(3);
-        loop {
-            match child.try_wait() {
-                Ok(Some(_)) => return child.wait_with_output().expect("wait"),
-                Ok(None) if Instant::now() < deadline => {
-                    std::thread::sleep(Duration::from_millis(50));
-                }
-                _ => {
-                    // SAFETY: the child created its own process group above,
-                    // and its pid is therefore the group id. A negative pid
-                    // targets only that test-owned group and its descendants.
-                    unsafe {
-                        libc::kill(-(child.id() as i32), libc::SIGKILL);
-                    }
-                    return child.wait_with_output().expect("wait after kill");
-                }
-            }
-        }
     }
 
     command.output().expect("lf runs")
@@ -877,7 +806,7 @@ fn cache_mutations_target_the_resolved_wave() {
     git(&["add", "."]);
     git(&["commit", "-m", "init"]);
 
-    let store = SqliteStore::new(&home.join("loopflow.db")).expect("open store");
+    let store = open_test_store(&home.join("loopflow.db"));
     let alpha = Wave::new(
         WaveId::new(),
         "alpha".to_string(),

--- a/scripts/materialize_rust_tests.py
+++ b/scripts/materialize_rust_tests.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+"""Run Rust tests against CI's materialized draft-migration graph.
+
+The active checkout may contain committed, staged, unstaged, and untracked
+work. Mirror that exact tree into a disposable Git worktree, materialize draft
+migrations there, and run the requested command without dirtying the checkout.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import signal
+import subprocess
+import sys
+import tempfile
+from contextlib import contextmanager
+from pathlib import Path
+from types import FrameType
+from typing import Iterator
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+AMBIENT_WORK_AUTHORITY = (
+    "LF_RUN_CONTEXT",
+    "LF_RUN_LEASE",
+    "LF_WAVE_ID",
+    "LF_ACCOUNT_LEASE",
+)
+
+
+def _run_git(repo_root: Path, *arguments: str, **kwargs: object) -> subprocess.CompletedProcess:
+    return subprocess.run(["git", *arguments], cwd=repo_root, **kwargs)
+
+
+def _copy_untracked_files(repo_root: Path, worktree: Path) -> None:
+    listed = _run_git(
+        repo_root,
+        "ls-files",
+        "--others",
+        "--exclude-standard",
+        "-z",
+        check=True,
+        capture_output=True,
+    )
+    for raw_path in (path for path in listed.stdout.split(b"\0") if path):
+        relative = Path(os.fsdecode(raw_path))
+        source = repo_root / relative
+        destination = worktree / relative
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        if source.is_symlink():
+            destination.symlink_to(os.readlink(source))
+        else:
+            shutil.copy2(source, destination)
+
+
+def _remove_worktree(repo_root: Path, worktree: Path, temp_root: Path) -> None:
+    removed = _run_git(
+        repo_root,
+        "worktree",
+        "remove",
+        "--force",
+        str(worktree),
+        capture_output=True,
+        text=True,
+    )
+    if removed.returncode != 0:
+        shutil.rmtree(worktree, ignore_errors=True)
+        _run_git(repo_root, "worktree", "prune", check=True)
+    shutil.rmtree(temp_root, ignore_errors=True)
+
+    registered = _run_git(
+        repo_root,
+        "worktree",
+        "list",
+        "--porcelain",
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    if str(worktree) in registered.stdout:
+        raise RuntimeError(f"failed to remove disposable worktree {worktree}")
+
+
+@contextmanager
+def _exact_tree_worktree(repo_root: Path) -> Iterator[Path]:
+    temp_root = Path(tempfile.mkdtemp(prefix="loopflow-materialized-"))
+    worktree = temp_root / "worktree"
+    try:
+        _run_git(
+            repo_root,
+            "worktree",
+            "add",
+            "--detach",
+            str(worktree),
+            "HEAD",
+            check=True,
+        )
+
+        patch = _run_git(
+            repo_root,
+            "diff",
+            "--binary",
+            "HEAD",
+            check=True,
+            capture_output=True,
+        ).stdout
+        if patch:
+            subprocess.run(
+                ["git", "apply", "--binary", "--whitespace=nowarn", "-"],
+                cwd=worktree,
+                input=patch,
+                check=True,
+            )
+        _copy_untracked_files(repo_root, worktree)
+        yield worktree
+    finally:
+        _remove_worktree(repo_root, worktree, temp_root)
+
+
+def _workspace_version(worktree: Path) -> str:
+    in_workspace_package = False
+    for line in (worktree / "Cargo.toml").read_text().splitlines():
+        stripped = line.strip()
+        if stripped == "[workspace.package]":
+            in_workspace_package = True
+            continue
+        if stripped.startswith("["):
+            in_workspace_package = False
+        if not in_workspace_package or not stripped.startswith("version"):
+            continue
+        key, separator, value = stripped.partition("=")
+        if separator and key.strip() == "version":
+            return value.strip().strip('"')
+    raise ValueError("Cargo.toml has no [workspace.package] version")
+
+
+def _terminate(signum: int, _frame: FrameType | None) -> None:
+    raise SystemExit(128 + signum)
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("command", nargs=argparse.REMAINDER)
+    args = parser.parse_args(argv)
+    if args.command[:1] == ["--"]:
+        args.command = args.command[1:]
+    if not args.command:
+        parser.error("provide a command after --")
+    return args
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    previous_sigterm = signal.signal(signal.SIGTERM, _terminate)
+    try:
+        with _exact_tree_worktree(REPO_ROOT) as worktree:
+            version = _workspace_version(worktree)
+            materialized = subprocess.run(
+                [
+                    sys.executable,
+                    "scripts/canonicalize_migrations.py",
+                    version,
+                    "--materialize-for-tests",
+                ],
+                cwd=worktree,
+            )
+            if materialized.returncode != 0:
+                return materialized.returncode
+
+            environment = os.environ.copy()
+            for name in AMBIENT_WORK_AUTHORITY:
+                environment.pop(name, None)
+            environment.setdefault("CARGO_TARGET_DIR", str(REPO_ROOT / "target"))
+            return subprocess.run(args.command, cwd=worktree, env=environment).returncode
+    except (OSError, RuntimeError, ValueError, subprocess.CalledProcessError) as exc:
+        print(f"materialized Rust test setup failed: {exc}", file=sys.stderr)
+        return 1
+    finally:
+        signal.signal(signal.SIGTERM, previous_sigterm)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test.py
+++ b/scripts/test.py
@@ -193,7 +193,18 @@ def _rust_commands(_changed: list[str]) -> list[Command]:
             REPO_ROOT,
             "clippy",
         ),
-        Command(test_argv, REPO_ROOT, "rust"),
+        Command(
+            [
+                "uv",
+                "run",
+                "python",
+                "scripts/materialize_rust_tests.py",
+                "--",
+                *test_argv,
+            ],
+            REPO_ROOT,
+            "rust",
+        ),
     ]
 
 

--- a/swift/Loopflow/Services/RegistryQuery.swift
+++ b/swift/Loopflow/Services/RegistryQuery.swift
@@ -269,9 +269,10 @@ private struct PmShowSnapshot: Decodable {
     let project: String?
     let syncedAt: Int64
     let projects: [PmProjectSnapshot]
+    let items: [PmItemSnapshot]
 
     enum CodingKeys: String, CodingKey {
-        case wave, provider, initiative, project, projects
+        case wave, provider, initiative, project, projects, items
         case syncedAt = "synced_at"
     }
 }
@@ -285,15 +286,32 @@ private struct PmProjectSnapshot: Decodable {
     let flows: ProjectFlowPlanSnapshot
     let krs: [PmKrSnapshot]
     let initiativeIds: [String]
-    // Stable ids of the Linear teams the Project belongs to. Optional: a snapshot
-    // written before the field existed decodes to nil. Mirrors Rust
-    // `PmProject.team_ids`.
-    let teamIds: [String]?
+    let teamIds: [String]
 
     enum CodingKeys: String, CodingKey {
         case id, slug, name, summary, definition, flows, krs
         case initiativeIds = "initiative_ids"
         case teamIds = "team_ids"
+    }
+}
+
+private struct PmItemSnapshot: Decodable {
+    let id: String
+    let identifier: String
+    let url: String?
+    let name: String
+    let description: String
+    let rank: Int
+    let completed: Bool
+    let projectId: String
+    let project: String
+    let teamId: String
+    let assignee: String?
+
+    enum CodingKeys: String, CodingKey {
+        case id, identifier, url, name, description, rank, completed, project, assignee
+        case projectId = "project_id"
+        case teamId = "team_id"
     }
 }
 

--- a/swift/LoopflowTests/DTOFixtureTests.swift
+++ b/swift/LoopflowTests/DTOFixtureTests.swift
@@ -7,6 +7,25 @@ import Testing
 /// the Mac app.
 @Suite("DTO Fixtures")
 struct DTOFixtureTests {
+    @Test("PM snapshot fixture preserves repository Team and Project ownership")
+    func pmShowFixturePreservesOwnership() async throws {
+        let data = try loadFixtureData("pm_show.json")
+        let json = String(decoding: data, as: UTF8.self)
+        let query = RegistryQuery { args, _ in
+            #expect(args == ["pm", "show", "--wave", "survival/infrastructure", "--json", "--no-sync"])
+            return json
+        }
+
+        let plan = try await query.plan(
+            wave: "survival/infrastructure",
+            objective: "Keep mail flowing.",
+            cwd: "/fixture"
+        )
+        #expect(plan.projects.map(\.id) == ["gmail"])
+        #expect(plan.projects[0].title == "Gmail")
+        #expect(plan.projects[0].krs[0].proof == .holds)
+    }
+
     @Test("Turn spend fixture preserves additive identity and absent measurements")
     func turnSpendFixtureRoundTrips() throws {
         let data = try loadFixtureData("turn_spend.json")

--- a/swift/LoopflowTests/RegistryQueryTests.swift
+++ b/swift/LoopflowTests/RegistryQueryTests.swift
@@ -367,8 +367,8 @@ struct RegistryQueryTests {
     func planDecodesProjects() async throws {
         let json = """
         {"wave":"goals","provider":"linear","initiative":"init-1","project":null,"synced_at":1,"projects":[
-          {"id":"project-1","slug":"runtime","name":"Runtime","summary":"Run reliably.","definition":"Run reliably.","flows":{"first":null,"loop":null,"finally":null},"krs":[{"text":"Survives restart","holds":true}],"initiative_ids":["init-1"]}
-        ],"items":[]}
+          {"id":"project-1","slug":"runtime","name":"Runtime","summary":"Run reliably.","definition":"Run reliably.","flows":{"first":null,"loop":null,"finally":null},"krs":[{"text":"Survives restart","holds":true}],"initiative_ids":["init-1"],"team_ids":["team-loo"]}
+        ],"items":[{"id":"issue-1","identifier":"LOO-1","url":null,"name":"Wire runtime","description":"","rank":1,"completed":false,"project_id":"project-1","project":"runtime","team_id":"team-loo","assignee":null}]}
         """
         let query = RegistryQuery { args, cwd in
             #expect(args == ["pm", "show", "--wave", "goals", "--json", "--no-sync"])

--- a/tests/fixtures/dto/README.md
+++ b/tests/fixtures/dto/README.md
@@ -30,3 +30,9 @@ reimplementing prompt transformations in Swift.
 Turn, AgentInvocation, trace, and exec; the second row proves a cache-only measurement
 survives while absent token and cost fields remain explicit nulls. Rust and
 Swift both round-trip it.
+
+`pm_show.json` pins the repository-owned Linear hierarchy read by `lf pm show`
+and the app: a Project carries exactly one Wave Initiative and the repository
+Team; its Task carries the stable Project and Team ids used for ownership.
+The shared `LOO-*` identifier and canonical Project name remain presentation;
+the provider's Wave-qualified title is normalized before this wire boundary.

--- a/tests/fixtures/dto/pm_show.json
+++ b/tests/fixtures/dto/pm_show.json
@@ -1,0 +1,48 @@
+{
+  "wave": "survival/infrastructure",
+  "provider": "linear",
+  "initiative": "initiative-infrastructure",
+  "project": null,
+  "synced_at": 1784592000,
+  "projects": [
+    {
+      "id": "project-gmail",
+      "slug": "gmail",
+      "name": "Gmail",
+      "summary": "Keep mail flowing.",
+      "definition": "Keep mail flowing.",
+      "flows": {
+        "first": null,
+        "loop": "task_pursue",
+        "finally": null
+      },
+      "krs": [
+        {
+          "text": "Mail processing survives restart",
+          "holds": true
+        }
+      ],
+      "initiative_ids": [
+        "initiative-infrastructure"
+      ],
+      "team_ids": [
+        "team-loo"
+      ]
+    }
+  ],
+  "items": [
+    {
+      "id": "issue-gmail",
+      "identifier": "LOO-2",
+      "url": "https://linear.app/loopflow/issue/LOO-2/gmail",
+      "name": "Route incoming mail",
+      "description": "Resolve through the owning Project.",
+      "rank": 1,
+      "completed": false,
+      "project_id": "project-gmail",
+      "project": "gmail",
+      "team_id": "team-loo",
+      "assignee": null
+    }
+  ]
+}

--- a/wave/product/MEMORY.md
+++ b/wave/product/MEMORY.md
@@ -94,6 +94,27 @@ they mean the Mac surface.
   tolerate failure — drop the PM section rather than block. The scheduled
   `lf pm sync` cron keeps the snapshot warm for cross-machine readers.
 - **task = one Linear issue** under a Project. Linear is the only roadmap.
+- **Linear Team ownership moves to repository scope in PRD-43 (capability branch,
+  2026-07-20).** Repo-only `.lf/config.yaml` owns `pm.provider` plus the stable
+  `pm.linear_team`; each `GOAL.md` retains only its Initiative. A managed Team's
+  description carries one canonical Git-origin claim marker, validated before
+  every networked mutation. This is a cross-machine collision detector, not a
+  distributed lock (Linear exposes no compare-and-swap update).
+- **PM ownership follows stable provider edges.** Required snapshot fields are
+  Project `initiative_ids` + `team_ids` and Task `project_id` + `team_id`.
+  Reads and mutations resolve Issue → exactly one Project → exactly one
+  Initiative → exactly one local Wave; shared Issue prefixes and
+  ancestry-qualified Project titles are presentation only. Rust and Swift pin
+  this in the shared `pm_show.json` fixture; legacy payloads invalidate rather
+  than silently default.
+- **Repository-wide `lf pm reteam` is the only migration path.** It preflights
+  every linked Wave before provider writes, expands Project Team sets, moves all
+  open and completed Issues by UUID, reconciles durable identifiers, narrows
+  Projects, verifies/refills every snapshot, then removes legacy sentinels and
+  commits. Any Wave-level Team/provider or repo `linear.team` sentinel blocks
+  normal PM/Work mutations while cache-only reads and diagnostics remain.
+  PRD-43 deliberately preserves Loopflow's checked-in/live legacy bindings;
+  PRD-44 must run the consequential LOO migration from merged main.
 - The seven live bets (Linear Projects under the product Initiative): loopflow-api,
   wave-chat, mac-surface-ux, ios-surface-ux, distributed-computing,
   product-performance, auditability. The old Concerto project set


### PR DESCRIPTION
## Try it!

```bash
uv run python scripts/materialize_rust_tests.py -- \
  cargo test -p loopflow --test repository_team_matrix -- --nocapture
```

The fixture creates root `survival` and child `infrastructure` on one `LOO`
Team, displays `Survival — A real task reaches done` and
`Survival / Infrastructure — Gmail`, and resolves two `LOO-*` Tasks to their
own Waves through status, roadmap, Task run, and Project controls. It also
rejects duplicate Project ownership before creating a worktree. The test uses a
fixture repository and provider; it does not touch live Linear.

Exercise the migration, claim, wire, and existing-resolution boundaries:

```bash
uv run python scripts/materialize_rust_tests.py -- cargo test -p loopflow repository_team -- --nocapture
uv run python scripts/materialize_rust_tests.py -- cargo test -p loopflow --test wave_resolution_matrix
uv run python scripts/materialize_rust_tests.py -- cargo test -p loopflow --test dto_fixtures
swift test --package-path swift --filter DTOFixtureTests
```

## Intent

Size Linear at one Team per repository instead of one Team per Wave. A
repository owns one Team and issue-key namespace; each Wave owns one Initiative;
each Project belongs to exactly one Wave; each Task resolves through its Project
and Initiative rather than a Team prefix. Nested Waves stay cheap while every
planning and execution surface reads the same ownership model.

## Assumptions

- A canonical Git origin is available wherever a repository claims a Team.
- A Loopflow-managed Project belongs to exactly one Initiative and the one
  repository Team.
- Linear Team descriptions can carry a preserved managed claim marker, but not
  an atomic lock; every networked mutation therefore revalidates the claim.
- PM snapshots are rebuildable cache. Missing stable ownership fields are a
  sync error, not a compatibility mode.
- Loopflow's checked-in legacy Team fields intentionally keep this repository
  migration-required until PRD-44 runs the live migration from merged main.

## Key decisions

- `.lf/config.yaml pm.linear_team` is the sole local Team binding; Waves retain
  only `pm.linear_initiative`.
- Task ownership is Issue UUID → Project UUID → exactly one Initiative → local
  Wave. Issue prefixes and Project titles are presentation only.
- Visible Project titles include the canonical Wave ancestry. Promotion records
  ancestry before child PM initialization so the first title is correct.
- `lf pm reteam` migrates and verifies the entire repository as one resumable
  operation, cleaning legacy sentinels only after provider and snapshot proof.
- Webhooks scope to the repository Team, and Rust/Swift DTOs require the same
  stable Project and Team identifiers.

## Not included

PRD-43 does not claim Loopflow's live `LOO` Team, move real Projects or Issues,
or remove the checked-in legacy Wave bindings. PRD-44 owns that provider/config
migration and the configured continuity demo. This PR also does not add Wave
sub-Initiatives, multiple PM workspaces/providers, or Home runtime topology.

## Learning

Draft-backed tests must use the same materialized migration graph as Rust CI;
they must not `ALTER` draft-owned columns themselves. The first hosted run
caught PRD-43 fixtures adding `promoted_at` after CI had already materialized
that draft. Those fixture-local schema writes are now deleted, while
`.github/workflows/ci.yml` and `rust/loopflow/src/store/MIGRATIONS.md` own the
materialization contract.

The changed-aware Rust phase now enforces that invariant too. It mirrors the
exact committed, staged, unstaged, and untracked tree into a disposable Git
worktree, materializes drafts there, runs Cargo against the shared target
directory, and removes the worktree on success or failure. A focused regression
test proves dirty-tree visibility, exit propagation, and cleanup without
changing the active checkout. The wrapper stays within the declared Python 3.8
floor; its regression proof parses the source with Python 3.8 grammar and
rejects a `tomllib` import. It also strips ambient Run, Wave, and account
authority before launching Cargo so agent-run local tests reproduce unowned CI.
