### PR TITLE
Task status: record controller completion atomically

### DIFF
--- a/rust/loopflow/src/ops/task.rs
+++ b/rust/loopflow/src/ops/task.rs
@@ -3657,34 +3657,11 @@ pub fn task_complete(issue: &str, summary: String) -> OpsResult<Task> {
         .await
         .map_err(|error| task_error(format!("failed to complete Task: {error}")))?;
         if lease.is_none() {
-            let (_run, completion_lease) = store
-                .reserve_run(&work, crate::durable::RunTrigger::User)
-                .await
-                .map_err(|error| {
-                    task_error(format!("failed to reserve completion Run: {error}"))
-                })?;
-            let basis = store
-                .current_epoch(&work)
-                .await
-                .map_err(|error| task_error(error.to_string()))?
-                .current_basis;
-            store
-                .done(&completion_lease, &basis)
-                .await
-                .map_err(|error| task_error(format!("failed to complete Work: {error}")))?;
             reconcile_pm_writeback(&store, &mut task, None).await;
             store
                 .update_task(&task)
                 .await
                 .map_err(|error| task_error(error.to_string()))?;
-            append_task_event_with_authority(
-                &store,
-                &task.id,
-                &TaskEventKind::Completed { summary },
-                None,
-            )
-            .await
-            .map_err(|error| task_error(error.to_string()))?;
         }
         Ok(task)
     })
@@ -4009,14 +3986,14 @@ async fn advance_completion_after_gate(
         .work_for_child(&ChildRef::Task(task.id.clone()))
         .await
         .map_err(|error| task_error(error.to_string()))?;
-    if matches!(
-        store
-            .work_status(&work)
-            .await
-            .map_err(|error| task_error(error.to_string()))?,
-        WorkStatus::Done | WorkStatus::Abandoned
-    ) {
-        return Ok(false);
+    match store
+        .work_status(&work)
+        .await
+        .map_err(|error| task_error(error.to_string()))?
+    {
+        WorkStatus::Done | WorkStatus::Abandoned => return Ok(false),
+        WorkStatus::Running { .. } if lease.is_none() => return Ok(false),
+        WorkStatus::Ready | WorkStatus::Waiting { .. } | WorkStatus::Running { .. } => {}
     }
     let Some(pr) = merged_completing_pr(store, task).await? else {
         return Ok(false);
@@ -4044,26 +4021,9 @@ async fn advance_completion_after_gate(
         .await
         .map_err(|error| task_error(error.to_string()))?;
     if lease.is_none() {
-        let (_run, completion_lease) = store
-            .reserve_run(&work, crate::durable::RunTrigger::User)
-            .await
-            .map_err(|error| task_error(format!("failed to reserve completion Run: {error}")))?;
-        let basis = store
-            .current_epoch(&work)
-            .await
-            .map_err(|error| task_error(error.to_string()))?
-            .current_basis;
-        store
-            .done(&completion_lease, &basis)
-            .await
-            .map_err(|error| task_error(format!("failed to complete Work: {error}")))?;
         reconcile_pm_writeback(store, task, url.as_deref()).await;
         store
             .update_task(task)
-            .await
-            .map_err(|error| task_error(error.to_string()))?;
-        store
-            .append_task_event(&task.id, &TaskEventKind::Completed { summary })
             .await
             .map_err(|error| task_error(error.to_string()))?;
     }

--- a/rust/loopflow/src/store/mod.rs
+++ b/rust/loopflow/src/store/mod.rs
@@ -1986,7 +1986,12 @@ mod tests {
         store.create_wave(&wave).await.unwrap();
         let project = make_project(&wave);
         store.create_project(&project).await.unwrap();
-        let task = make_task(&wave, &project);
+        let mut task = make_task(&wave, &project);
+        task.enter_finally(crate::task::TaskGateProposal {
+            done: true,
+            reason: "empty Task is complete".to_string(),
+        })
+        .unwrap();
         let pr = make_task_pr(&task);
         store.create_task(&task, &pr).await.unwrap();
 

--- a/rust/loopflow/src/store/sqlite/children.rs
+++ b/rust/loopflow/src/store/sqlite/children.rs
@@ -97,7 +97,7 @@ impl SqliteStore {
         let parameters = task_params(task);
         transaction
             .execute(
-                TASK_REOPEN_UPDATE,
+                TASK_LIFECYCLE_UPDATE,
                 rusqlite::params_from_iter(parameters.iter().map(|value| value.as_ref())),
             )
             .map_err(|error| StoreError::InvalidData(format!("update reopened Task: {error}")))?;
@@ -286,7 +286,7 @@ impl SqliteStore {
             None => {
                 let parameters = task_control_params(task);
                 transaction.execute(
-                    TASK_UPDATE,
+                    TASK_LIFECYCLE_UPDATE,
                     rusqlite::params_from_iter(parameters.iter().map(|value| value.as_ref())),
                 )?
             }
@@ -299,6 +299,9 @@ impl SqliteStore {
                 )));
             }
             return Err(StoreError::NotFound);
+        }
+        if run_lease.is_none() {
+            complete_task_work_in(&transaction, task)?;
         }
         transaction.commit()?;
         Ok(())
@@ -544,12 +547,13 @@ impl SqliteStore {
         settle_task_pr_on(&transaction, pr)?;
         let parameters = task_control_params(task);
         if transaction.execute(
-            TASK_UPDATE,
+            TASK_LIFECYCLE_UPDATE,
             rusqlite::params_from_iter(parameters.iter().map(|value| value.as_ref())),
         )? == 0
         {
             return Err(StoreError::NotFound);
         }
+        complete_task_work_in(&transaction, task)?;
         transaction.commit()?;
         Ok(())
     }
@@ -1319,6 +1323,72 @@ fn validate_task(task: &Task) -> StoreResult<()> {
         .map_err(|error| StoreError::InvalidData(error.to_string()))
 }
 
+// A controller-proven Task completion is its own authority boundary. It must
+// not fabricate a Run merely to reuse the agent-owned `done` transition.
+fn complete_task_work_in(conn: &Connection, task: &Task) -> StoreResult<()> {
+    let proposal = task
+        .gate_proposal
+        .as_ref()
+        .filter(|proposal| proposal.done)
+        .ok_or_else(|| {
+            StoreError::InvalidData("completed Task requires a done gate proposal".to_string())
+        })?;
+    let (epoch_id, state) = conn.query_row(
+        "SELECT id, state FROM epochs
+         WHERE task_id=?1 ORDER BY number DESC LIMIT 1",
+        [task.id.as_str()],
+        |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?)),
+    )?;
+    match state.as_str() {
+        "done" => return Ok(()),
+        "open" => {}
+        "abandoned" => {
+            return Err(StoreError::InvalidData(format!(
+                "Task {} Work is abandoned and cannot be completed",
+                task.id
+            )))
+        }
+        other => {
+            return Err(StoreError::InvalidData(format!(
+                "Task {} Work has invalid Epoch state {other:?}",
+                task.id
+            )))
+        }
+    }
+    let active_run: Option<String> = conn
+        .query_row(
+            "SELECT id FROM runs WHERE epoch_id=?1 AND state!='ended' LIMIT 1",
+            [epoch_id.as_str()],
+            |row| row.get(0),
+        )
+        .optional()?;
+    if let Some(run_id) = active_run {
+        return Err(StoreError::InvalidData(format!(
+            "Task {} Work cannot complete while Run {run_id} is active",
+            task.id
+        )));
+    }
+    if conn.execute(
+        "UPDATE epochs SET state='done', terminal_at=?2
+         WHERE id=?1 AND state='open'",
+        params![epoch_id, now_unix()],
+    )? != 1
+    {
+        return Err(StoreError::InvalidData(format!(
+            "Task {} Work changed while completion was being recorded",
+            task.id
+        )));
+    }
+    insert_task_event_in(
+        conn,
+        task,
+        &TaskEventKind::Completed {
+            summary: proposal.reason.clone(),
+        },
+    )?;
+    Ok(())
+}
+
 fn resolve_current_task(key: &str, mut tasks: Vec<Task>) -> StoreResult<Option<Task>> {
     if tasks.len() > 1 {
         return Err(StoreError::InvalidData(format!(
@@ -1516,7 +1586,7 @@ const TASK_UPDATE: &str = "UPDATE tasks SET
     iterate_flow=?16, kickoff_flow=?19, gate_flow=?20,
     created_at=?25, updated_at=?26
     WHERE id=?1";
-const TASK_REOPEN_UPDATE: &str = "UPDATE tasks SET
+const TASK_LIFECYCLE_UPDATE: &str = "UPDATE tasks SET
     project_id=?2, external_issue_id=?3, issue_identifier=?4,
     issue_title=?5, issue_description=?6, pm_snapshot_synced_at=?7,
     pm_writeback_json=?8, worktree=?9, workspace_slug=?10, agent=?11, provider=?12,

--- a/rust/loopflow/tests/pr_tests.rs
+++ b/rust/loopflow/tests/pr_tests.rs
@@ -12,7 +12,10 @@ use loopflow::ops::{
 };
 use loopflow::task::{AfterMerge, GithubPr, PrMergeMode, PrMergeRequest, PrPhase, PrPublication};
 use loopflow_test_support::TestRepo;
-use support::{counting_open_script, presentation_attempts, register_task, EnvGuard};
+use support::{
+    counting_open_script, presentation_attempts, register_active_task, register_task,
+    register_unrun_task, EnvGuard,
+};
 
 fn write_gh_script(pr_list: &str, pr_diff: Option<&str>) -> String {
     let diff = pr_diff.unwrap_or("");
@@ -674,6 +677,158 @@ fn observed_merge_completes_a_pr_marked_to_complete_the_task() {
         .expect("read completing PR");
     assert_eq!(prs.len(), 1);
     assert_eq!(prs[0].phase(), PrPhase::Merged);
+}
+
+#[test]
+fn repeated_status_of_merged_task_without_a_boundary_records_completion_once() {
+    let home = tempfile::TempDir::new().expect("temp home");
+    let _env = EnvGuard::with_lf_home(&[("gh", gh_merged_pr_script())], home.path());
+    let repo = TestRepo::new();
+    let base = repo.head_sha();
+    let branch = "jack/task-pr-proof";
+    repo.create_branch(branch);
+    point_origin_at_github(&repo);
+    let task = register_unrun_task(home.path(), repo.path(), branch, &base);
+    let head = repo.head_sha();
+    let now = time::OffsetDateTime::now_utc();
+    let mut pr = task.pr.clone();
+    pr.publication = Some(PrPublication {
+        requested_at: now,
+        github: Some(GithubPr {
+            number: 912,
+            url: "https://example.com/pr/912".to_string(),
+            head_sha: Some(head.clone()),
+        }),
+        merge: Some(PrMergeRequest {
+            mode: PrMergeMode::User,
+            requested_at: now,
+            head_sha: head,
+            after_merge: AfterMerge::CompleteTask,
+            next_slug: None,
+        }),
+    });
+    let runtime = tokio::runtime::Runtime::new().expect("task runtime");
+    runtime
+        .block_on(task.store.update_task_pr(&pr))
+        .expect("mark PR as completing");
+
+    let first = task_status("INF-123").expect("first completed status");
+    let first_snapshot = task_snapshot(&first).expect("first completed snapshot");
+    assert_eq!(first_snapshot.status, WorkStatus::Done);
+    let first_events = runtime
+        .block_on(task.store.task_events_after(&task.task.id, 0))
+        .expect("read first Task events");
+    let conn =
+        rusqlite::Connection::open(home.path().join("loopflow.db")).expect("open test registry");
+    let first_epoch: (String, String, i64, i64) = conn
+        .query_row(
+            "SELECT id, state, current_rev, terminal_at FROM epochs
+             WHERE task_id=?1 ORDER BY number DESC LIMIT 1",
+            [task.task.id.as_str()],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+        )
+        .expect("read completed Epoch");
+    let second = task_status("INF-123").expect("repeated completed status");
+    let second_snapshot = task_snapshot(&second).expect("repeated completed snapshot");
+    let second_epoch: (String, String, i64, i64) = conn
+        .query_row(
+            "SELECT id, state, current_rev, terminal_at FROM epochs
+             WHERE task_id=?1 ORDER BY number DESC LIMIT 1",
+            [task.task.id.as_str()],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+        )
+        .expect("reread completed Epoch");
+    let second_events = runtime
+        .block_on(task.store.task_events_after(&task.task.id, 0))
+        .expect("reread Task events");
+
+    assert_eq!(second_snapshot.status, WorkStatus::Done);
+    assert_eq!(
+        second_epoch, first_epoch,
+        "terminal Work must not be mutated"
+    );
+    assert_eq!(
+        second_events, first_events,
+        "completion must be recorded once"
+    );
+    let run_count: i64 = conn
+        .query_row(
+            "SELECT count(*) FROM runs WHERE epoch_id=?1",
+            [first_epoch.0.as_str()],
+            |row| row.get(0),
+        )
+        .expect("count completion Runs");
+    assert_eq!(run_count, 0, "status must not reserve a completion Run");
+    let completion_count = second_events
+        .iter()
+        .filter(|event| matches!(event.kind, loopflow::task::TaskEventKind::Completed { .. }))
+        .count();
+    assert_eq!(completion_count, 1);
+}
+
+#[test]
+fn status_does_not_duplicate_an_active_run_while_completion_is_pending() {
+    let home = tempfile::TempDir::new().expect("temp home");
+    let _env = EnvGuard::with_lf_home(&[("gh", gh_merged_pr_script())], home.path());
+    let repo = TestRepo::new();
+    let base = repo.head_sha();
+    let branch = "jack/task-pr-proof";
+    repo.create_branch(branch);
+    point_origin_at_github(&repo);
+    let task = register_active_task(home.path(), repo.path(), branch, &base);
+    let head = repo.head_sha();
+    let now = time::OffsetDateTime::now_utc();
+    let mut pr = task.pr.clone();
+    pr.publication = Some(PrPublication {
+        requested_at: now,
+        github: Some(GithubPr {
+            number: 912,
+            url: "https://example.com/pr/912".to_string(),
+            head_sha: Some(head.clone()),
+        }),
+        merge: Some(PrMergeRequest {
+            mode: PrMergeMode::User,
+            requested_at: now,
+            head_sha: head,
+            after_merge: AfterMerge::CompleteTask,
+            next_slug: None,
+        }),
+    });
+    let runtime = tokio::runtime::Runtime::new().expect("task runtime");
+    runtime
+        .block_on(task.store.update_task_pr(&pr))
+        .expect("mark PR as completing");
+    let conn =
+        rusqlite::Connection::open(home.path().join("loopflow.db")).expect("open test registry");
+    let count_runs = || {
+        conn.query_row(
+            "SELECT count(*) FROM runs r
+             JOIN epochs e ON e.id=r.epoch_id WHERE e.task_id=?1",
+            [task.task.id.as_str()],
+            |row| row.get::<_, i64>(0),
+        )
+        .expect("count Task Runs")
+    };
+    let runs_before = count_runs();
+
+    let first = task_status("INF-123").expect("status with active Run");
+    let second = task_status("INF-123").expect("repeated status with active Run");
+
+    assert!(matches!(
+        task_snapshot(&first).expect("first active snapshot").status,
+        WorkStatus::Running { .. }
+    ));
+    assert!(matches!(
+        task_snapshot(&second)
+            .expect("repeated active snapshot")
+            .status,
+        WorkStatus::Running { .. }
+    ));
+    assert_eq!(
+        count_runs(),
+        runs_before,
+        "status must not reserve another Run"
+    );
 }
 
 #[test]

--- a/rust/loopflow/tests/support/mod.rs
+++ b/rust/loopflow/tests/support/mod.rs
@@ -229,7 +229,17 @@ pub fn register_task(
     branch: &str,
     base_commit: &str,
 ) -> RegisteredTask {
-    register_task_with_process(home, worktree, branch, base_commit, false)
+    register_task_with_process(home, worktree, branch, base_commit, true, false)
+}
+
+#[allow(dead_code)] // Shared helper compiled into integration tests without this incident shape.
+pub fn register_unrun_task(
+    home: &Path,
+    worktree: &Path,
+    branch: &str,
+    base_commit: &str,
+) -> RegisteredTask {
+    register_task_with_process(home, worktree, branch, base_commit, false, false)
 }
 
 #[allow(dead_code)] // Shared helper compiled into integration tests that do not need Task state.
@@ -239,7 +249,7 @@ pub fn register_active_task(
     branch: &str,
     base_commit: &str,
 ) -> RegisteredTask {
-    register_task_with_process(home, worktree, branch, base_commit, true)
+    register_task_with_process(home, worktree, branch, base_commit, true, true)
 }
 
 fn register_task_with_process(
@@ -247,6 +257,7 @@ fn register_task_with_process(
     worktree: &Path,
     branch: &str,
     base_commit: &str,
+    completed_boundary: bool,
     active: bool,
 ) -> RegisteredTask {
     let runtime = tokio::runtime::Runtime::new().expect("task test runtime");
@@ -341,6 +352,9 @@ fn register_task_with_process(
             .work_for_child(&loopflow::child::ChildRef::Task(task.id.clone()))
             .await
             .expect("resolve test Task Work");
+        if !completed_boundary {
+            return;
+        }
         let (_, lease) = store
             .reserve_run(&work, loopflow::durable::RunTrigger::User)
             .await

--- a/wave/infrastructure/MEMORY.md
+++ b/wave/infrastructure/MEMORY.md
@@ -44,6 +44,12 @@ Renamed from `systems` in the 2026-07-08 wave/project/task restructure. Steers L
   deleted. Authored input is a durable Work Steer. Best-effort process nudges may
   reduce latency, but the server follow-up must make Home-owned Ready scanning
   the correctness path so a stopped Project cannot miss child Feedback.
+- **Controller evidence is not an agent Run** (learned 2026-07-20). When a
+  merged PR or another controller fact completes a Task, persist the Task
+  lifecycle, Work Epoch, and completion event in one transaction. Never mint a
+  synthetic Run to reuse a Run-owned terminal transition. Prove this boundary
+  with a zero-agent-boundary fixture and repeated reads that count Runs and
+  completion events.
 - **Durable Ask is the only blocking human-input primitive** (decided
   2026-07-21). Interactive Task phases are advisory: the runner makes one launch
   attempt and advances independently of launcher success, UI lifetime, or


### PR DESCRIPTION
## Try it!

Read the incident Task twice:

```bash
lf task status ENG-123 --json
lf task status ENG-123 --json
```

Both reads return `status: done` and `recommended: no_action`. The second read
does not add a Run, duplicate the completion event, or change the terminal Work
Epoch.

The isolated regression is
`repeated_status_of_merged_task_without_a_boundary_records_completion_once`.
It begins with zero agent boundaries, observes a merged completing PR, and
asserts two stable Done snapshots, one completion event, and zero Runs.

## Intent

Restore completed-Task status after ENG-123 exposed two alternating failures:
duplicate completion-Run reservation violated `runs.epoch_id`, while a newly
reserved synthetic Run could not complete Work because it had no successful
agent boundary. Controller-proven completion is now one idempotent store
transaction instead of an imitation agent turn.

## Assumptions

- A merged PR marked `CompleteTask`, or an explicit controller completion after
  its gates hold, is sufficient controller evidence to complete Task Work.
- A genuine active Run retains authority; passive reconciliation waits rather
  than creating another Run.
- PM writeback is an external retryable side effect and does not belong inside
  the SQLite transaction.

## Key decisions

- Persist final Task lifecycle fields, the terminal Work Epoch, and the
  completion event atomically with PR settlement.
- Keep agent-owned completion on the existing Run lease and successful-boundary
  path.
- Make terminal completion idempotent by returning immediately when the current
  Epoch is already Done.
- Prove both incident edges: no prior agent boundary and a still-active real
  Run.

## Not included

- No generic controller-completion API for Project or Wave Work.
- No schema or CLI shape change.
- No explicit cleanup of historical synthetic Runs; ENG-123 already converged
  to one durable completion event, and repeated reads are stable.

## Evidence

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- 21/21 materialized-schema `pr_tests`
- 1,706/1,706 materialized-schema Rust tests passed; 2 skipped
- Two real installed `lf task status ENG-123 --json` reads returned stable Done
