### PR TITLE
mac: make the control room the primary workspace

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,14 +126,14 @@ jobs:
         run: swift test --package-path swift -Xswiftc -gnone
       - name: Check Swift multiplatform boundaries
         run: uv run python scripts/check_swift_multiplatform_boundaries.py
-      - name: Prove the Wave surface renders its five states distinctly
+      - name: Prove the control room renders its four states distinctly
         # Unlike the hosted XCUITest (which needs Automation permission and so
         # lives behind the `--ui-host` gate), this launches the built app
         # directly and renders each state's window through SnapshotService
         # (cacheDisplay, no Screen Recording or Automation permission needed),
-        # then asserts the five states at two widths are pairwise distinct. It
-        # is the CI-runnable half of the W2-178 distinctness proof — a
-        # regression like the DETAIL_STATE forwarding gap fails this step.
+        # then asserts the four states at two widths are pairwise distinct. It
+        # is the CI-runnable half of the control-room state proof — fixture
+        # lookup and state-forwarding regressions fail this step.
         run: |
           swift build --package-path swift --product LoopflowMac
           scripts/prove_wave_surface_states.sh

--- a/scripts/generate_screenshots.py
+++ b/scripts/generate_screenshots.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Capture deterministic Wave-surface evidence from fixtures.
+"""Capture deterministic control-room evidence from fixtures.
 
     uv run python scripts/generate_screenshots.py
 
@@ -41,7 +41,7 @@ DELAY = 2
 
 @dataclass(frozen=True)
 class WaveProofShot:
-    """One fixture-rendered Wave-surface state at one width."""
+    """One fixture-rendered control-room state at one width."""
 
     name: str
     mode: str

--- a/scripts/prove_wave_surface_states.sh
+++ b/scripts/prove_wave_surface_states.sh
@@ -1,17 +1,13 @@
 #!/usr/bin/env bash
-# Prove the stable Wave surface (W2-178) renders the five Proof states —
-# selected, loading, error, empty, and future-child indentation — DISTINCTLY,
-# at both a narrow and a wide desktop width, on a host without UI-automation
-# permission.
+# Prove the primary control room renders its four fixture states — populated,
+# loading, unavailable, and empty — DISTINCTLY at both a narrow and a wide
+# desktop width, on a host without UI-automation permission.
 #
-# The permissioned XCUITest (LoopflowUITests/WaveSurfaceStateTests) asserts each
-# state's unique affordance and row hittability; it runs on the maintained UI
-# host. This script is the run-here complement: it launches the built app in
-# each state, has the app render its own key window to a PNG (SnapshotService,
-# no Screen Recording permission), and asserts the states produce pairwise
-# distinct images. Together they catch a regression like PR #972's — where the
-# detail-state env never reached the app, so loading and error rendered as
-# selected (identical images here, failed affordance assertions there).
+# The permissioned XCUITest asserts each state's unique affordance and region
+# reachability; it runs on the maintained UI host. This script is the run-here
+# complement: it launches the built app in each state, has the app render its
+# own key window to a PNG (SnapshotService, no Screen Recording permission),
+# and asserts the states produce pairwise distinct images.
 #
 # Usage: scripts/prove_wave_surface_states.sh
 set -euo pipefail
@@ -28,11 +24,10 @@ trap 'rm -rf "$OUT"' EXIT
 
 # state|mode|detail_state|select_branch
 STATES=(
-  "selected|mock-waves||"
+  "populated|mock-waves||"
   "loading|mock-waves|loading|"
-  "error|mock-waves|error|"
+  "unavailable|mock-waves|error|"
   "empty|empty-workspaces||"
-  "child|mock-waves||cadenza"
 )
 WIDTHS=(900 1440)
 
@@ -54,7 +49,7 @@ capture() {
   wait "$pid" 2>/dev/null || true
 }
 
-echo "Capturing 5 states × 2 widths through the app's own renderer…"
+echo "Capturing 4 states × 2 widths through the app's own renderer…"
 declare -a HASHES=()
 declare -a LABELS=()
 fail=0
@@ -90,7 +85,7 @@ for ((i = 0; i < n; i++)); do
 done
 
 if [ "$fail" -ne 0 ]; then
-  echo "FAIL — the Wave surface did not render all states distinctly."
+  echo "FAIL — the control room did not render all states distinctly."
   exit 1
 fi
-echo "PASS — all ${n} captures (5 states × 2 widths) are distinct and non-empty."
+echo "PASS — all ${n} captures (4 states × 2 widths) are distinct and non-empty."

--- a/scripts/screenshots.yaml
+++ b/scripts/screenshots.yaml
@@ -13,7 +13,7 @@ website:
     delay: 8
     output: website/static/context-lab.png
 
-  - name: wave-surface
+  - name: control-room
     view: wave
     wave: product
     width: 1440
@@ -31,43 +31,34 @@ website:
 
 # Stable Wave-surface proof, rendered offline from fixtures at both widths.
 wave-proof:
-  - name: wave-surface-selected-narrow
+  - name: control-room-selected-narrow
     mode: mock-waves
     width: 900
-  - name: wave-surface-selected-wide
+  - name: control-room-selected-wide
     mode: mock-waves
     width: 1440
 
-  - name: wave-surface-child-narrow
-    mode: mock-waves
-    wave: cadenza
-    width: 900
-  - name: wave-surface-child-wide
-    mode: mock-waves
-    wave: cadenza
-    width: 1440
-
-  - name: wave-surface-loading-narrow
+  - name: control-room-loading-narrow
     mode: mock-waves
     detail_state: loading
     width: 900
-  - name: wave-surface-loading-wide
+  - name: control-room-loading-wide
     mode: mock-waves
     detail_state: loading
     width: 1440
 
-  - name: wave-surface-error-narrow
+  - name: control-room-error-narrow
     mode: mock-waves
     detail_state: error
     width: 900
-  - name: wave-surface-error-wide
+  - name: control-room-error-wide
     mode: mock-waves
     detail_state: error
     width: 1440
 
-  - name: wave-surface-empty-narrow
+  - name: control-room-empty-narrow
     mode: empty-workspaces
     width: 900
-  - name: wave-surface-empty-wide
+  - name: control-room-empty-wide
     mode: empty-workspaces
     width: 1440

--- a/scripts/test.py
+++ b/scripts/test.py
@@ -72,6 +72,8 @@ PHASE_BUDGETS: dict[str, int] = {
     "website": 900,
     "swift": 1200,
     "swift-boundaries": 120,
+    "swift-build": 900,
+    "swift-surface": 900,
     "xcodegen": 180,
     "xcodebuild": 1200,
     "e2e-smoke": 600,
@@ -248,6 +250,16 @@ def _swift_commands(_changed: list[str]) -> list[Command]:
             REPO_ROOT,
             "swift-boundaries",
         ),
+        Command(
+            ["swift", "build", "--package-path", "swift", "--product", "LoopflowMac"],
+            REPO_ROOT,
+            "swift-build",
+        ),
+        Command(
+            ["scripts/prove_wave_surface_states.sh"],
+            REPO_ROOT,
+            "swift-surface",
+        ),
     ]
 
 
@@ -409,8 +421,10 @@ SUITES: list[Suite] = [
     Suite(
         name="swift",
         slow=False,
-        trigger_desc="swift/",
-        match=lambda c: _touches(c, "swift/"),
+        trigger_desc="swift/ or the headless surface proof",
+        match=lambda c: (
+            _touches(c, "swift/") or _touches_exact(c, "scripts/prove_wave_surface_states.sh")
+        ),
         build=_swift_commands,
     ),
     Suite(

--- a/swift/LoopflowMac/ControlRoomFixture.swift
+++ b/swift/LoopflowMac/ControlRoomFixture.swift
@@ -1,0 +1,118 @@
+import Foundation
+import Loopflow
+
+@MainActor
+enum ControlRoomFixture {
+    static func applyIfRequested(to model: ControlRoomModel, sourceFile: String = #filePath) {
+        guard let mode = AppTestMode.current(), mode != .live else { return }
+        do {
+            switch mode {
+            case .emptyWorkspaces:
+                let snapshot = try JSONDecoder().decode(
+                    RoadmapSnapshot.self,
+                    from: Data(#"{"generated_at":"2026-07-20T00:00:00Z","waves":[]}"#.utf8)
+                )
+                model.applyFixture(
+                    roadmap: .available(snapshot),
+                    waves: .available([]),
+                    repos: [],
+                    fixed: true
+                )
+            case .mockWaves:
+                let fixture = try loadRoadmap(sourceFile: sourceFile)
+                let reading: ControlRoomReading<RoadmapSnapshot>
+                switch MockWaveFixture.detailState {
+                case .selected:
+                    reading = .available(fixture.roadmap)
+                case .loading:
+                    reading = .loading
+                case .error:
+                    reading = .unavailable(
+                        lastGood: nil,
+                        reason: "the local registry is unreachable"
+                    )
+                }
+                model.applyFixture(
+                    roadmap: reading,
+                    waves: .available(fixture.waves),
+                    repos: fixture.repos,
+                    fixed: true
+                )
+                let requested = AppTestMode.selectBranch ?? fixture.roadmap.waves.first?.wave.name
+                if let wave = fixture.roadmap.waves.first(where: { $0.wave.name == requested }) {
+                    model.select(.wave(waveId: wave.wave.id))
+                }
+            case .live:
+                break
+            }
+        } catch {
+            model.applyFixture(
+                roadmap: .unavailable(
+                    lastGood: nil,
+                    reason: "Control-room fixture unavailable: \(error.localizedDescription)"
+                ),
+                waves: .unavailable(lastGood: nil, reason: error.localizedDescription),
+                repos: [],
+                fixed: true
+            )
+        }
+    }
+
+    private static func loadRoadmap(
+        sourceFile: String
+    ) throws -> (roadmap: RoadmapSnapshot, waves: [Wave], repos: [PortfolioRepo]) {
+        let url = try roadmapFixtureURL(sourceFile: sourceFile)
+        let data = try Data(contentsOf: url)
+        let roadmap = try JSONDecoder().decode(RoadmapSnapshot.self, from: data)
+        let waves = roadmap.waves.map { snapshot in
+            Wave(
+                id: snapshot.wave.id,
+                name: snapshot.wave.name,
+                repo: snapshot.wave.repo,
+                status: snapshot.wave.status,
+                live: snapshot.wave.live,
+                activeTasks: snapshot.wave.activeTasks,
+                activeProjects: snapshot.wave.activeProjects,
+                parentWaveId: snapshot.wave.parentWaveId
+            )
+        }
+        var seen = Set<String>()
+        let repos = roadmap.waves.compactMap { roadmap -> PortfolioRepo? in
+            let path = WaveOrigin.resolve(roadmap.wave.repo).normalizedFilePath
+            guard seen.insert(path).inserted else { return nil }
+            return PortfolioRepo(path: path, lastOpened: .distantPast)
+        }
+        return (roadmap, waves, repos)
+    }
+
+    private static func roadmapFixtureURL(sourceFile: String) throws -> URL {
+        let fileManager = FileManager.default
+        var roots = [URL(fileURLWithPath: fileManager.currentDirectoryPath, isDirectory: true)]
+        if let executableURL = Bundle.main.executableURL {
+            roots.append(executableURL.deletingLastPathComponent())
+        }
+        if sourceFile.hasPrefix("/") {
+            roots.append(URL(fileURLWithPath: sourceFile).deletingLastPathComponent())
+        }
+
+        var visited = Set<String>()
+        for root in roots {
+            var directory = root.standardizedFileURL
+            while visited.insert(directory.path).inserted {
+                let candidate = directory
+                    .appendingPathComponent("tests/fixtures/dto/roadmap_snapshot.json")
+                if fileManager.fileExists(atPath: candidate.path) {
+                    return candidate
+                }
+                let parent = directory.deletingLastPathComponent()
+                guard parent.path != directory.path else { break }
+                directory = parent
+            }
+        }
+
+        throw CocoaError(
+            .fileNoSuchFile,
+            userInfo: [NSFilePathErrorKey: "tests/fixtures/dto/roadmap_snapshot.json"]
+        )
+    }
+}

--- a/swift/LoopflowMac/ControlRoomModel.swift
+++ b/swift/LoopflowMac/ControlRoomModel.swift
@@ -1,0 +1,266 @@
+import Foundation
+import Loopflow
+import Observation
+
+enum ControlRoomSelection: Equatable, Hashable {
+    case wave(waveId: String)
+    case project(waveId: String, projectId: String)
+    case task(waveId: String, taskId: String)
+
+    var waveId: String {
+        switch self {
+        case .wave(let waveId), .project(let waveId, _), .task(let waveId, _):
+            waveId
+        }
+    }
+}
+
+enum ControlRoomReading<Value> {
+    case loading
+    case available(Value)
+    case unavailable(lastGood: Value?, reason: String)
+
+    var value: Value? {
+        switch self {
+        case .loading:
+            nil
+        case .available(let value):
+            value
+        case .unavailable(let lastGood, _):
+            lastGood
+        }
+    }
+
+    var errorMessage: String? {
+        guard case .unavailable(_, let reason) = self else { return nil }
+        return reason
+    }
+
+    var isLoading: Bool {
+        if case .loading = self { return true }
+        return false
+    }
+}
+
+@MainActor
+@Observable
+final class ControlRoomModel {
+    var repoPath: String?
+    var selection: ControlRoomSelection?
+    private(set) var roadmap: ControlRoomReading<RoadmapSnapshot> = .loading
+    private(set) var waves: ControlRoomReading<[Wave]> = .loading
+    private(set) var repos: [PortfolioRepo] = []
+    private(set) var authoredWavesByRepo: [String: [String]] = [:]
+    private(set) var isRefreshing = false
+
+    private let query: RegistryQuery
+    private var usesFixedFixture = false
+
+    init(query: RegistryQuery, repoPath: String? = nil) {
+        self.query = query
+        self.repoPath = repoPath
+    }
+
+    var visibleRoadmaps: [WaveRoadmap] {
+        filterByRepo(roadmap.value?.waves ?? [], repo: { $0.wave.repo })
+    }
+
+    var visibleWaves: [WaveViewModel] {
+        let registered = filterByRepo(waves.value ?? [], repo: { $0.repo })
+        let registeredNames = Set(registered.map { waveIdentity(repo: $0.repo, name: $0.name) })
+        var result = registered.map { wave in
+            let objective = roadmap.value?.waves.first(where: { $0.wave.id == wave.id })?.wave.goal ?? ""
+            let plan = objective.isEmpty ? nil : WavePlan(objective: objective)
+            return WaveViewModel(api: wave, plan: plan)
+        }
+
+        for repo in visibleRepos {
+            for name in authoredWavesByRepo[repo.path] ?? [] {
+                let identity = waveIdentity(repo: repo.path, name: name)
+                guard !registeredNames.contains(identity) else { continue }
+                result.append(WaveViewModel(
+                    api: Wave(
+                        id: identity,
+                        name: name,
+                        repo: repo.path,
+                        status: .ready
+                    ),
+                    isRegistered: false
+                ))
+            }
+        }
+        return result.sorted {
+            $0.displayName.localizedCaseInsensitiveCompare($1.displayName) == .orderedAscending
+        }
+    }
+
+    var visibleRepos: [PortfolioRepo] {
+        guard let repoPath else { return allRepos }
+        let target = WaveOrigin.resolve(repoPath).normalizedFilePath
+        return allRepos.filter { WaveOrigin.resolve($0.path).normalizedFilePath == target }
+    }
+
+    var allRepos: [PortfolioRepo] {
+        var result = repos
+        var seen = Set(result.map { WaveOrigin.resolve($0.path).normalizedFilePath })
+        for wave in waves.value ?? [] {
+            let path = WaveOrigin.resolve(wave.repo).normalizedFilePath
+            guard seen.insert(path).inserted else { continue }
+            result.append(PortfolioRepo(path: path, lastOpened: .distantPast))
+        }
+        return result.sorted {
+            $0.displayName.localizedCaseInsensitiveCompare($1.displayName) == .orderedAscending
+        }
+    }
+
+    func refresh() async {
+        guard !usesFixedFixture else { return }
+        guard !isRefreshing else { return }
+        isRefreshing = true
+        defer { isRefreshing = false }
+
+        let previousRoadmap = roadmap.value
+        let previousWaves = waves.value
+        if previousRoadmap == nil { roadmap = .loading }
+        if previousWaves == nil { waves = .loading }
+
+        async let roadmapResult = readRoadmap()
+        async let wavesResult = readWaves()
+        roadmap = reading(from: await roadmapResult, lastGood: previousRoadmap)
+        waves = reading(from: await wavesResult, lastGood: previousWaves)
+        selectRequestedWaveIfNeeded()
+        clearSelectionIfOutsideScope()
+    }
+
+    func refreshPortfolio(
+        initialRepoPath: String?,
+        persistedRepos: [PortfolioRepo] = []
+    ) async {
+        guard !usesFixedFixture else { return }
+        let discovered = await PortfolioDiscovery.repos(
+            initialRepoPath: initialRepoPath,
+            persistedRepos: persistedRepos
+        )
+        repos = discovered
+        authoredWavesByRepo = await PortfolioDiscovery.authoredWaves(in: discovered)
+        if repoPath == nil, let initialRepoPath {
+            repoPath = PortfolioDiscovery.resolveLaunchRepo(initialRepoPath).path
+        }
+        clearSelectionIfOutsideScope()
+    }
+
+    func setRepoPath(_ path: String?) {
+        repoPath = path
+        clearSelectionIfOutsideScope()
+    }
+
+    func select(_ selection: ControlRoomSelection?) {
+        self.selection = selection
+        clearSelectionIfOutsideScope()
+    }
+
+    func wave(id: String) -> WaveRoadmap? {
+        roadmap.value?.waves.first { $0.wave.id == id }
+    }
+
+    func rosterWave(id: String) -> WaveViewModel? {
+        visibleWaves.first { $0.id == id }
+    }
+
+    func project(waveId: String, projectId: String) -> RoadmapProject? {
+        wave(id: waveId)?.projects.items.first { $0.id == projectId }
+    }
+
+    func task(waveId: String, taskId: String) -> (project: RoadmapProject, task: RoadmapTask)? {
+        guard let projects = wave(id: waveId)?.projects.items else { return nil }
+        for project in projects {
+            if let task = project.tasks.first(where: { $0.id == taskId }) {
+                return (project, task)
+            }
+        }
+        return nil
+    }
+
+    func clearSelectionIfOutsideScope() {
+        guard let selection else { return }
+        let visibleIds = Set(visibleWaves.map(\.id) + visibleRoadmaps.map { $0.wave.id })
+        guard visibleIds.contains(selection.waveId) else {
+            self.selection = nil
+            return
+        }
+
+        switch selection {
+        case .wave:
+            break
+        case .project(let waveId, let projectId):
+            if project(waveId: waveId, projectId: projectId) == nil {
+                self.selection = .wave(waveId: waveId)
+            }
+        case .task(let waveId, let taskId):
+            if task(waveId: waveId, taskId: taskId) == nil {
+                self.selection = .wave(waveId: waveId)
+            }
+        }
+    }
+
+    func applyFixture(
+        roadmap: ControlRoomReading<RoadmapSnapshot>,
+        waves: ControlRoomReading<[Wave]>,
+        repos: [PortfolioRepo],
+        fixed: Bool = false
+    ) {
+        self.roadmap = roadmap
+        self.waves = waves
+        self.repos = repos
+        authoredWavesByRepo = [:]
+        usesFixedFixture = fixed
+        clearSelectionIfOutsideScope()
+    }
+
+    private func filterByRepo<Value>(
+        _ values: [Value],
+        repo: (Value) -> String
+    ) -> [Value] {
+        guard let repoPath else { return values }
+        let target = WaveOrigin.resolve(repoPath).normalizedFilePath
+        return values.filter { WaveOrigin.resolve(repo($0)).normalizedFilePath == target }
+    }
+
+    private func waveIdentity(repo: String, name: String) -> String {
+        "\(WaveOrigin.resolve(repo).normalizedFilePath)#\(name)"
+    }
+
+    private func selectRequestedWaveIfNeeded() {
+        guard selection == nil, let requested = AppTestMode.selectBranch else { return }
+        guard let wave = visibleRoadmaps.first(where: { $0.wave.name == requested }) else { return }
+        selection = .wave(waveId: wave.wave.id)
+    }
+
+    private func readRoadmap() async -> Result<RoadmapSnapshot, Error> {
+        do {
+            return .success(try await query.roadmap())
+        } catch {
+            return .failure(error)
+        }
+    }
+
+    private func readWaves() async -> Result<[Wave], Error> {
+        do {
+            return .success(try await query.allWaves())
+        } catch {
+            return .failure(error)
+        }
+    }
+
+    private func reading<Value>(
+        from result: Result<Value, Error>,
+        lastGood: Value?
+    ) -> ControlRoomReading<Value> {
+        switch result {
+        case .success(let value):
+            .available(value)
+        case .failure(let error):
+            .unavailable(lastGood: lastGood, reason: error.localizedDescription)
+        }
+    }
+}

--- a/swift/LoopflowMac/LoopflowApp.swift
+++ b/swift/LoopflowMac/LoopflowApp.swift
@@ -56,7 +56,7 @@ struct LoopflowApp: App {
         let launchRepoURL = LaunchArguments.repoURL()
 
         WindowGroup {
-            WavesView(
+            ControlRoomView(
                 portfolioService: portfolioService,
                 initialRepoPath: launchRepoURL?.path
             )
@@ -71,7 +71,7 @@ struct LoopflowApp: App {
             }
         }
         .windowStyle(.automatic)
-        .defaultSize(width: 1080, height: 760)
+        .defaultSize(width: 1280, height: 800)
         .commands {
             CommandGroup(after: .appSettings) {
                 Picker("Appearance", selection: Binding(

--- a/swift/LoopflowMac/PortfolioDiscovery.swift
+++ b/swift/LoopflowMac/PortfolioDiscovery.swift
@@ -1,0 +1,95 @@
+import Foundation
+
+struct PortfolioLaunchRepo: Sendable {
+    let path: String
+    let mainPath: String
+    let displayName: String
+}
+
+enum PortfolioDiscovery {
+    nonisolated static func resolveLaunchRepo(_ initialPath: String) -> PortfolioLaunchRepo {
+        let scanner = RepoScanner()
+        let dev = ProcessInfo.processInfo.environment["LOOPFLOW_DEV_WAVE_REPO"]
+        let devOverride = dev?.isEmpty == false ? dev : nil
+        let readURL = URL(fileURLWithPath: devOverride ?? initialPath)
+        let mainURL = scanner.resolveMainWorktree(readURL)
+        let readPath = devOverride != nil ? readURL.normalizedFilePath : mainURL.normalizedFilePath
+        return PortfolioLaunchRepo(
+            path: readPath,
+            mainPath: mainURL.normalizedFilePath,
+            displayName: mainURL.lastPathComponent
+        )
+    }
+
+    static func repos(
+        initialRepoPath: String?,
+        persistedRepos: [PortfolioRepo] = []
+    ) async -> [PortfolioRepo] {
+        await Task.detached {
+            let scanner = RepoScanner()
+            var seen = Set<String>()
+            var result: [PortfolioRepo] = []
+            for url in scanner.scanDefaultRoot() {
+                let path = url.normalizedFilePath
+                guard seen.insert(path).inserted else { continue }
+                result.append(PortfolioRepo(path: path, lastOpened: Date()))
+            }
+            for repo in persistedRepos {
+                let path = repo.path.normalizedFilePath
+                guard seen.insert(path).inserted else { continue }
+                result.append(repo)
+            }
+            if let initialRepoPath {
+                let launch = resolveLaunchRepo(initialRepoPath)
+                if launch.path == launch.mainPath {
+                    if seen.insert(launch.path).inserted {
+                        result.append(PortfolioRepo(
+                            path: launch.path,
+                            lastOpened: Date(),
+                            displayNameOverride: launch.displayName
+                        ))
+                    }
+                } else {
+                    result.removeAll { $0.path == launch.mainPath || $0.path == launch.path }
+                    result.append(PortfolioRepo(
+                        path: launch.path,
+                        lastOpened: Date(),
+                        displayNameOverride: launch.displayName
+                    ))
+                }
+            }
+            return result
+        }.value
+    }
+
+    static func authoredWaves(in repos: [PortfolioRepo]) async -> [String: [String]] {
+        await Task.detached {
+            var result: [String: [String]] = [:]
+            for repo in repos {
+                result[repo.path] = authoredWaves(inRepo: repo.path)
+            }
+            return result
+        }.value
+    }
+
+    nonisolated static func authoredWaves(inRepo repoPath: String) -> [String] {
+        let waveDir = URL(fileURLWithPath: repoPath).appendingPathComponent("wave", isDirectory: true)
+        let fileManager = FileManager.default
+        guard let children = try? fileManager.contentsOfDirectory(
+            at: waveDir,
+            includingPropertiesForKeys: [.isDirectoryKey],
+            options: [.skipsHiddenFiles]
+        ) else {
+            return []
+        }
+        return children
+            .filter { url in
+                var isDirectory = ObjCBool(false)
+                let goal = url.appendingPathComponent("GOAL.md")
+                return fileManager.fileExists(atPath: goal.path, isDirectory: &isDirectory)
+                    && !isDirectory.boolValue
+            }
+            .map(\.lastPathComponent)
+            .sorted { $0.localizedCaseInsensitiveCompare($1) == .orderedAscending }
+    }
+}

--- a/swift/LoopflowMac/PortfolioRepo.swift
+++ b/swift/LoopflowMac/PortfolioRepo.swift
@@ -3,7 +3,7 @@
 import Loopflow
 import Foundation
 
-struct PortfolioRepo: Codable, Identifiable, Hashable {
+struct PortfolioRepo: Codable, Identifiable, Hashable, Sendable {
     let path: String
     var lastOpened: Date
 

--- a/swift/LoopflowMac/Views/ControlRoomView.swift
+++ b/swift/LoopflowMac/Views/ControlRoomView.swift
@@ -1,0 +1,446 @@
+import Loopflow
+import SwiftUI
+
+struct ControlRoomView: View {
+    let portfolioService: PortfolioService
+    let initialRepoPath: String?
+
+    @Environment(\.palette) private var palette
+    @State private var model: ControlRoomModel
+
+    init(
+        portfolioService: PortfolioService,
+        initialRepoPath: String? = nil,
+        query: RegistryQuery = RegistryQueryLocal.shared
+    ) {
+        self.portfolioService = portfolioService
+        self.initialRepoPath = initialRepoPath
+        let model = ControlRoomModel(query: query)
+        ControlRoomFixture.applyIfRequested(to: model)
+        _model = State(initialValue: model)
+    }
+
+    var body: some View {
+        @Bindable var model = model
+        HSplitView {
+            ControlRoomSidebar(model: model)
+                .frame(minWidth: 205, idealWidth: 245, maxWidth: 290)
+
+            RoadmapView(model: model, selection: $model.selection)
+                .frame(minWidth: 390, idealWidth: 650, maxWidth: .infinity)
+                .accessibilityIdentifier("control-room-work")
+
+            ControlRoomInspector(model: model)
+                .frame(minWidth: 245, idealWidth: 310, maxWidth: 390)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(palette.background)
+        .accessibilityIdentifier("control-room")
+        .task {
+            await model.refreshPortfolio(
+                initialRepoPath: initialRepoPath,
+                persistedRepos: portfolioService.repos
+            )
+        }
+        .onChange(of: portfolioService.repos.map(\.path)) { _, _ in
+            Task {
+                await model.refreshPortfolio(
+                    initialRepoPath: initialRepoPath,
+                    persistedRepos: portfolioService.repos
+                )
+            }
+        }
+    }
+}
+
+private struct ControlRoomSidebar: View {
+    @Bindable var model: ControlRoomModel
+
+    private var outlinedWaves: [(wave: WaveViewModel, indent: Int)] {
+        let waves = model.visibleWaves
+        let byId = Dictionary(waves.map { ($0.id, $0) }, uniquingKeysWith: { first, _ in first })
+        let roots = waves.filter { wave in
+            guard let parent = wave.parentWaveId else { return true }
+            return byId[parent] == nil
+        }
+        let children = Dictionary(
+            grouping: waves.filter { !roots.contains($0) },
+            by: { $0.parentWaveId ?? "" }
+        )
+        var result: [(WaveViewModel, Int)] = []
+        func append(_ wave: WaveViewModel, indent: Int) {
+            result.append((wave, indent))
+            for child in (children[wave.id] ?? []).sorted(by: Self.sortWaves) {
+                append(child, indent: indent + 1)
+            }
+        }
+        for root in roots.sorted(by: Self.sortWaves) {
+            append(root, indent: 0)
+        }
+        return result
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            header
+            if let error = model.waves.errorMessage {
+                rosterError(error)
+            }
+            if model.waves.isLoading {
+                ProgressView("Reading Waves…")
+                    .controlSize(.small)
+                    .foregroundStyle(.white.opacity(0.65))
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(Spacing.lg)
+                    .accessibilityIdentifier("control-room-roster-loading")
+            } else if outlinedWaves.isEmpty {
+                Text(model.repoPath == nil ? "No Waves found." : "No Waves in this repository.")
+                    .font(Typography.caption())
+                    .foregroundStyle(.white.opacity(0.58))
+                    .padding(Spacing.lg)
+                    .accessibilityIdentifier("control-room-roster-empty")
+            } else {
+                ScrollView {
+                    LazyVStack(alignment: .leading, spacing: Spacing.xs) {
+                        ForEach(outlinedWaves, id: \.wave.id) { entry in
+                            WaveRow(
+                                wave: entry.wave,
+                                isSelected: model.selection?.waveId == entry.wave.id,
+                                onSelect: {
+                                    model.select(.wave(waveId: entry.wave.id))
+                                },
+                                indentLevel: entry.indent
+                            )
+                        }
+                    }
+                    .padding(.horizontal, Spacing.sm)
+                    .padding(.top, Spacing.xs)
+                }
+                .accessibilityIdentifier("control-room-wave-list")
+            }
+            Spacer(minLength: 0)
+        }
+        .background(Color.loopflowBurgundy)
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("Portfolio scope")
+        .accessibilityIdentifier("control-room-sidebar")
+    }
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: Spacing.sm) {
+            Text("LOOPFLOW")
+                .font(Typography.caption(9).weight(.bold))
+                .tracking(1.8)
+                .foregroundStyle(.white.opacity(0.48))
+            Menu {
+                Button("All repositories") { model.setRepoPath(nil) }
+                if !model.allRepos.isEmpty { Divider() }
+                ForEach(model.allRepos) { repo in
+                    Button(repo.displayName) { model.setRepoPath(repo.path) }
+                }
+            } label: {
+                HStack(spacing: Spacing.xs) {
+                    Text(scopeTitle)
+                        .font(Typography.sectionTitle(18))
+                        .foregroundStyle(.white)
+                        .lineLimit(1)
+                    Image(systemName: "chevron.down")
+                        .font(.system(size: 9, weight: .semibold))
+                        .foregroundStyle(.white.opacity(0.55))
+                    Spacer(minLength: 0)
+                }
+                .contentShape(Rectangle())
+            }
+            .menuStyle(.borderlessButton)
+            .menuIndicator(.hidden)
+            .accessibilityIdentifier("control-room-repo-scope")
+        }
+        .padding(.horizontal, Spacing.lg)
+        .padding(.vertical, Spacing.md)
+    }
+
+    private var scopeTitle: String {
+        guard let repoPath = model.repoPath else { return "All repositories" }
+        return model.allRepos.first {
+            WaveOrigin.resolve($0.path).normalizedFilePath
+                == WaveOrigin.resolve(repoPath).normalizedFilePath
+        }?.displayName ?? URL(fileURLWithPath: repoPath).lastPathComponent
+    }
+
+    private func rosterError(_ message: String) -> some View {
+        Label(message, systemImage: "exclamationmark.triangle.fill")
+            .font(Typography.caption(10))
+            .foregroundStyle(.white.opacity(0.82))
+            .lineLimit(3)
+            .padding(.horizontal, Spacing.lg)
+            .padding(.vertical, Spacing.sm)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(Color.white.opacity(0.08))
+            .accessibilityIdentifier("control-room-roster-error")
+    }
+
+    private static func sortWaves(_ lhs: WaveViewModel, _ rhs: WaveViewModel) -> Bool {
+        lhs.displayName.localizedCaseInsensitiveCompare(rhs.displayName) == .orderedAscending
+    }
+}
+
+private struct ControlRoomInspector: View {
+    @Bindable var model: ControlRoomModel
+    @Environment(\.palette) private var palette
+
+    var body: some View {
+        VStack(spacing: 0) {
+            HStack {
+                VStack(alignment: .leading, spacing: Spacing.xxs) {
+                    Text("Selected Work")
+                        .font(Typography.sectionTitle(18))
+                        .foregroundStyle(palette.text)
+                    Text("Shared state and next move")
+                        .font(Typography.caption(10))
+                        .foregroundStyle(palette.textSecondary)
+                }
+                Spacer()
+                if model.selection != nil {
+                    Button {
+                        model.select(nil)
+                    } label: {
+                        Image(systemName: "xmark")
+                    }
+                    .buttonStyle(.borderless)
+                    .help("Clear selection")
+                    .accessibilityLabel("Clear selected Work")
+                }
+            }
+            .padding(.horizontal, Spacing.lg)
+            .padding(.vertical, Spacing.md)
+            Divider()
+            content
+        }
+        .background(palette.surface)
+        .accessibilityElement(children: .contain)
+        .accessibilityIdentifier("control-room-inspector")
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        if let selection = model.selection {
+            ScrollView {
+                VStack(alignment: .leading, spacing: Spacing.lg) {
+                    switch selection {
+                    case .wave(let waveId):
+                        waveDetail(waveId)
+                    case .project(let waveId, let projectId):
+                        projectDetail(waveId: waveId, projectId: projectId)
+                    case .task(let waveId, let taskId):
+                        taskDetail(waveId: waveId, taskId: taskId)
+                    }
+                }
+                .padding(Spacing.lg)
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+        } else {
+            ContentUnavailableView(
+                "Select Work",
+                systemImage: "scope",
+                description: Text("Choose a Wave, Project, or Task without leaving the live control room.")
+            )
+            .accessibilityIdentifier("control-room-no-selection")
+        }
+    }
+
+    @ViewBuilder
+    private func waveDetail(_ waveId: String) -> some View {
+        if let roadmap = model.wave(id: waveId) {
+            eyebrow("Wave")
+            title(roadmap.wave.name)
+            if !roadmap.wave.goal.isEmpty {
+                Text(roadmap.wave.goal)
+                    .font(Typography.body(12))
+                    .foregroundStyle(palette.text)
+                    .textSelection(.enabled)
+            }
+            facts([
+                ("State", roadmap.wave.status.label),
+                ("Home", roadmap.wave.home.route == "local" ? roadmap.wave.home.id : roadmap.wave.home.route),
+                ("Projects", String(roadmap.wave.activeProjects)),
+                ("Tasks", String(roadmap.wave.activeTasks)),
+            ])
+            if let reason = roadmap.projects.unavailableReason {
+                unavailable(reason)
+            }
+        } else if let wave = model.rosterWave(id: waveId) {
+            eyebrow("Authored Wave")
+            title(wave.displayName)
+            Text(wave.lens.reason)
+                .font(Typography.body(12))
+                .foregroundStyle(palette.textSecondary)
+        } else {
+            unavailable("This Wave is no longer in the selected scope.")
+        }
+    }
+
+    @ViewBuilder
+    private func projectDetail(waveId: String, projectId: String) -> some View {
+        if let project = model.project(waveId: waveId, projectId: projectId) {
+            eyebrow("Project · \(waveName(waveId))")
+            title(project.project.name)
+            if !project.project.definition.isEmpty {
+                Text(project.project.definition)
+                    .font(Typography.body(12))
+                    .foregroundStyle(palette.text)
+                    .textSelection(.enabled)
+            }
+            nextMove(owner: project.nextMove.owner.rawValue, reason: project.nextMove.reason)
+            VStack(alignment: .leading, spacing: Spacing.sm) {
+                Text("Key results")
+                    .font(Typography.caption(10).weight(.semibold))
+                    .foregroundStyle(palette.textSecondary)
+                    .textCase(.uppercase)
+                ForEach(project.project.krs) { kr in
+                    Label(kr.text, systemImage: kr.holds ? "checkmark.circle.fill" : "circle")
+                        .font(Typography.body(11))
+                        .foregroundStyle(kr.holds ? Color.statusSuccess : palette.text)
+                }
+            }
+        } else {
+            unavailable("This Project is absent from the latest roadmap evidence.")
+        }
+    }
+
+    @ViewBuilder
+    private func taskDetail(waveId: String, taskId: String) -> some View {
+        if let selected = model.task(waveId: waveId, taskId: taskId) {
+            let task = selected.task
+            eyebrow("Task · \(waveName(waveId)) · \(selected.project.project.name)")
+            Text(task.task.identifier)
+                .font(Typography.caption(10).weight(.bold))
+                .foregroundStyle(Color.loopflowBurgundy)
+            title(task.task.name)
+            if !task.task.description.isEmpty {
+                Text(task.task.description)
+                    .font(Typography.body(12))
+                    .foregroundStyle(palette.text)
+                    .textSelection(.enabled)
+            }
+            nextMove(owner: task.attention.nextOwner.rawValue, reason: task.attention.reason)
+            facts([
+                ("Plan", task.task.completed ? "complete" : "open"),
+                ("Work", task.runtime?.status.label ?? "not started"),
+                ("Process", processLabel(task)),
+                ("Section", sectionLabel(task.section)),
+            ])
+            if let action = roadmapTaskAction(task) {
+                VStack(alignment: .leading, spacing: Spacing.xxs) {
+                    Text("Legal action")
+                        .font(Typography.caption(10).weight(.semibold))
+                        .foregroundStyle(palette.textSecondary)
+                        .textCase(.uppercase)
+                    Text(action.label)
+                        .font(Typography.sectionTitle(15))
+                        .foregroundStyle(Color.loopflowBurgundy)
+                    Text(task.attention.actions.reason)
+                        .font(Typography.caption(10))
+                        .foregroundStyle(palette.textSecondary)
+                }
+            }
+            if let workspace = task.reference.workspace {
+                fact(label: "Worktree", value: workspace.worktree)
+            }
+            if let github = task.activePr?.publication?.github {
+                Link("Open PR #\(github.number)", destination: github.url)
+                    .font(Typography.body(11).weight(.semibold))
+            }
+        } else {
+            unavailable("This Task is absent from the latest roadmap evidence.")
+        }
+    }
+
+    private func eyebrow(_ value: String) -> some View {
+        Text(value.uppercased())
+            .font(Typography.caption(9).weight(.bold))
+            .tracking(1.2)
+            .foregroundStyle(palette.textSecondary)
+    }
+
+    private func title(_ value: String) -> some View {
+        Text(value)
+            .font(Typography.sectionTitle(23))
+            .foregroundStyle(palette.text)
+            .textSelection(.enabled)
+            .accessibilityIdentifier("control-room-selection-title")
+    }
+
+    private func nextMove(owner: String, reason: String) -> some View {
+        VStack(alignment: .leading, spacing: Spacing.xxs) {
+            Text("Next · \(owner)")
+                .font(Typography.caption(10).weight(.semibold))
+                .foregroundStyle(Color.loopflowBurgundy)
+                .textCase(.uppercase)
+            Text(reason)
+                .font(Typography.body(12))
+                .foregroundStyle(palette.text)
+                .textSelection(.enabled)
+        }
+        .padding(Spacing.md)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color.loopflowBurgundy.opacity(0.08))
+        .clipShape(RoundedRectangle(cornerRadius: CornerRadius.md))
+    }
+
+    private func facts(_ values: [(String, String)]) -> some View {
+        Grid(alignment: .leading, horizontalSpacing: Spacing.md, verticalSpacing: Spacing.sm) {
+            ForEach(Array(values.enumerated()), id: \.offset) { _, value in
+                GridRow {
+                    Text(value.0)
+                        .font(Typography.caption(10))
+                        .foregroundStyle(palette.textSecondary)
+                    Text(value.1)
+                        .font(Typography.caption(10).weight(.medium))
+                        .foregroundStyle(palette.text)
+                        .textSelection(.enabled)
+                }
+            }
+        }
+    }
+
+    private func fact(label: String, value: String) -> some View {
+        VStack(alignment: .leading, spacing: Spacing.xxs) {
+            Text(label.uppercased())
+                .font(Typography.caption(9).weight(.semibold))
+                .foregroundStyle(palette.textSecondary)
+            Text(value)
+                .font(Typography.caption(10))
+                .foregroundStyle(palette.text)
+                .textSelection(.enabled)
+        }
+    }
+
+    private func unavailable(_ reason: String) -> some View {
+        Label(reason, systemImage: "exclamationmark.triangle")
+            .font(Typography.body(11))
+            .foregroundStyle(Color.statusWarning)
+            .textSelection(.enabled)
+    }
+
+    private func waveName(_ waveId: String) -> String {
+        model.wave(id: waveId)?.wave.name ?? model.rosterWave(id: waveId)?.displayName ?? "Wave"
+    }
+
+    private func processLabel(_ task: RoadmapTask) -> String {
+        switch task.attention.process.state {
+        case .observed: task.attention.process.alive == true ? "alive" : "dead"
+        case .notExpected: "not expected"
+        case .notApplicable: "none"
+        case .unavailable: "unknown"
+        }
+    }
+
+    private func sectionLabel(_ section: RoadmapSection) -> String {
+        switch section {
+        case .now: "Now"
+        case .needsAttention: "Needs attention"
+        case .available: "Available"
+        case .later: "Later"
+        }
+    }
+}

--- a/swift/LoopflowMac/Views/RoadmapView.swift
+++ b/swift/LoopflowMac/Views/RoadmapView.swift
@@ -76,10 +76,9 @@ func roadmapTaskIsActionable(_ task: RoadmapTask) -> Bool {
     roadmapTaskAction(task) != nil || roadmapTaskCanInterrupt(task)
 }
 
-/// The default Wave Chat surface: one machine-wide `lf roadmap --json` read,
-/// rendered without re-querying each Wave or inventing another work model.
+/// The control room's shared Work surface: one machine-wide `lf roadmap --json`
+/// read, rendered without re-querying each Wave or inventing another work model.
 struct RoadmapView: View {
-    let repoPath: String?
     let onOpenWave: (WaveSnapshot) -> Void
 
     @Environment(\.palette) private var palette
@@ -87,14 +86,40 @@ struct RoadmapView: View {
     // WaveDetailPane) — the create-and-own lifecycle fires the publisher during
     // the first body pass and logs an AttributeGraph cycle at cold launch.
     @ObservedObject private var terminalStore = TaskTerminalStore.shared
+    @State private var model: ControlRoomModel
+    @Binding private var selection: ControlRoomSelection?
     @State private var lens: WorkLens = .now
-    @State private var snapshot: RoadmapSnapshot?
-    @State private var queryError: String?
     @State private var controlError: String?
     @State private var activeControlId: String?
     @State private var workspaceSelection: RoadmapTaskSelection?
     @State private var interruptSelection: RoadmapTaskSelection?
-    @State private var isRefreshing = false
+
+    init(
+        repoPath: String?,
+        onOpenWave: @escaping (WaveSnapshot) -> Void
+    ) {
+        _model = State(initialValue: ControlRoomModel(
+            query: RegistryQueryLocal.shared,
+            repoPath: repoPath
+        ))
+        _selection = .constant(nil)
+        self.onOpenWave = onOpenWave
+    }
+
+    init(
+        model: ControlRoomModel,
+        selection: Binding<ControlRoomSelection?>,
+        onOpenWave: @escaping (WaveSnapshot) -> Void = { _ in }
+    ) {
+        _model = State(initialValue: model)
+        _selection = selection
+        self.onOpenWave = onOpenWave
+    }
+
+    private var repoPath: String? { model.repoPath }
+    private var snapshot: RoadmapSnapshot? { model.roadmap.value }
+    private var queryError: String? { model.roadmap.errorMessage }
+    private var isRefreshing: Bool { model.isRefreshing }
 
     private var visibleWaves: [WaveRoadmap] {
         guard let repoPath else { return snapshot?.waves ?? [] }
@@ -201,17 +226,20 @@ struct RoadmapView: View {
         if snapshot == nil, queryError == nil {
             ProgressView("Reading roadmap…")
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .accessibilityIdentifier("control-room-work-loading")
         } else if snapshot == nil {
             ContentUnavailableView(
                 "Work unavailable",
                 systemImage: "exclamationmark.triangle",
                 description: Text("Couldn't read the latest work. Refresh to try again.")
             )
+            .accessibilityIdentifier("control-room-work-unavailable")
         } else if visibleWaves.isEmpty {
             ContentUnavailableView(
                 repoPath == nil ? "No Waves yet" : "No Waves in this repository",
                 systemImage: "map"
             )
+            .accessibilityIdentifier("control-room-work-empty")
         } else {
             switch lens {
             case .now: nowContent
@@ -238,7 +266,11 @@ struct RoadmapView: View {
                     ForEach(nowSectionsList) { section in
                         NowSectionView(
                             section: section,
+                            selection: selection,
                             activeControlId: activeControlId,
+                            onSelect: { row in
+                                selection = .task(waveId: row.wave.id, taskId: row.task.id)
+                            },
                             onTaskAction: { row, action in
                                 perform(action, on: RoadmapTaskSelection(wave: row.wave, task: row.task))
                             },
@@ -264,8 +296,13 @@ struct RoadmapView: View {
                 ForEach(visibleWaves, id: \.wave.id) { roadmap in
                     RoadmapWaveCard(
                         roadmap: roadmap,
+                        selection: selection,
                         activeControlId: activeControlId,
-                        onOpen: { openWave(roadmap.wave) },
+                        onSelect: { selected in selection = selected },
+                        onOpen: {
+                            selection = .wave(waveId: roadmap.wave.id)
+                            openWave(roadmap.wave)
+                        },
                         onError: { controlError = $0 },
                         onTaskAction: { task, action in
                             perform(action, on: RoadmapTaskSelection(wave: roadmap.wave, task: task))
@@ -306,15 +343,7 @@ struct RoadmapView: View {
 
     @MainActor
     private func refresh() async {
-        guard !isRefreshing else { return }
-        isRefreshing = true
-        defer { isRefreshing = false }
-        do {
-            snapshot = try await RegistryQueryLocal.shared.roadmap()
-            queryError = nil
-        } catch {
-            queryError = error.localizedDescription
-        }
+        await model.refresh()
     }
 
     /// Navigate to the Wave. Starting a stopped Wave remains the Home control's
@@ -500,7 +529,9 @@ private struct HomeControl: View {
 
 private struct RoadmapWaveCard: View {
     let roadmap: WaveRoadmap
+    let selection: ControlRoomSelection?
     let activeControlId: String?
+    let onSelect: (ControlRoomSelection) -> Void
     let onOpen: () -> Void
     let onError: (String) -> Void
     let onTaskAction: (RoadmapTask, RoadmapTaskAction) -> Void
@@ -531,6 +562,11 @@ private struct RoadmapWaveCard: View {
                             .lineLimit(2)
                     }
                 }
+                .contentShape(Rectangle())
+                .onTapGesture { onSelect(.wave(waveId: roadmap.wave.id)) }
+                .accessibilityAddTraits(
+                    selection == .wave(waveId: roadmap.wave.id) ? [.isSelected] : []
+                )
                 Spacer()
                 HomeControl(wave: roadmap.wave, onOpen: onOpen, onError: onError)
             }
@@ -549,8 +585,11 @@ private struct RoadmapWaveCard: View {
                 } else {
                     ForEach(projects) { project in
                         RoadmapProjectCard(
+                            waveId: roadmap.wave.id,
                             project: project,
+                            selection: selection,
                             activeControlId: activeControlId,
+                            onSelect: onSelect,
                             onTaskAction: onTaskAction,
                             onInterrupt: onInterrupt,
                             onOpenWorktree: onOpenWorktree
@@ -569,14 +608,22 @@ private struct RoadmapWaveCard: View {
         .clipShape(RoundedRectangle(cornerRadius: CornerRadius.lg))
         .overlay {
             RoundedRectangle(cornerRadius: CornerRadius.lg)
-                .stroke(palette.border, lineWidth: 1)
+                .stroke(
+                    selection == .wave(waveId: roadmap.wave.id)
+                        ? Color.loopflowBurgundy : palette.border,
+                    lineWidth: selection == .wave(waveId: roadmap.wave.id) ? 2 : 1
+                )
         }
+        .accessibilityIdentifier("control-room-wave-\(roadmap.wave.id)")
     }
 }
 
 private struct RoadmapProjectCard: View {
+    let waveId: String
     let project: RoadmapProject
+    let selection: ControlRoomSelection?
     let activeControlId: String?
+    let onSelect: (ControlRoomSelection) -> Void
     let onTaskAction: (RoadmapTask, RoadmapTaskAction) -> Void
     let onInterrupt: (RoadmapTask) -> Void
     let onOpenWorktree: (TaskWorkspaceSnapshot) -> Void
@@ -595,6 +642,10 @@ private struct RoadmapProjectCard: View {
                     .font(Typography.caption(10))
                     .foregroundStyle(palette.textSecondary)
             }
+            .contentShape(Rectangle())
+            .onTapGesture {
+                onSelect(.project(waveId: waveId, projectId: project.id))
+            }
             if !project.project.definition.isEmpty {
                 Text(project.project.definition)
                     .font(Typography.caption(11))
@@ -609,7 +660,11 @@ private struct RoadmapProjectCard: View {
                 ForEach(project.tasks) { task in
                     RoadmapTaskRow(
                         task: task,
+                        isSelected: selection == .task(waveId: waveId, taskId: task.id),
                         activeControlId: activeControlId,
+                        onSelect: {
+                            onSelect(.task(waveId: waveId, taskId: task.id))
+                        },
                         onAction: { action in onTaskAction(task, action) },
                         onInterrupt: { onInterrupt(task) },
                         onOpenWorktree: onOpenWorktree
@@ -618,8 +673,16 @@ private struct RoadmapProjectCard: View {
             }
         }
         .padding(Spacing.md)
-        .background(palette.surfaceMuted.opacity(0.6))
+        .background(
+            selection == .project(waveId: waveId, projectId: project.id)
+                ? Color.loopflowBurgundy.opacity(0.08)
+                : palette.surfaceMuted.opacity(0.6)
+        )
         .clipShape(RoundedRectangle(cornerRadius: CornerRadius.md))
+        .accessibilityAddTraits(
+            selection == .project(waveId: waveId, projectId: project.id) ? [.isSelected] : []
+        )
+        .accessibilityIdentifier("control-room-project-\(project.id)")
     }
 
     private func sectionBadge(_ section: RoadmapSection) -> some View {
@@ -635,7 +698,9 @@ private struct RoadmapProjectCard: View {
 
 private struct RoadmapTaskRow: View {
     let task: RoadmapTask
+    let isSelected: Bool
     let activeControlId: String?
+    let onSelect: () -> Void
     let onAction: (RoadmapTaskAction) -> Void
     let onInterrupt: () -> Void
     let onOpenWorktree: (TaskWorkspaceSnapshot) -> Void
@@ -686,8 +751,14 @@ private struct RoadmapTaskRow: View {
             }
         }
         .padding(Spacing.sm)
-        .background(palette.background.opacity(0.6))
+        .background(
+            isSelected ? Color.loopflowBurgundy.opacity(0.1) : palette.background.opacity(0.6)
+        )
         .clipShape(RoundedRectangle(cornerRadius: CornerRadius.sm))
+        .contentShape(Rectangle())
+        .onTapGesture { onSelect() }
+        .accessibilityAddTraits(isSelected ? [.isSelected] : [])
+        .accessibilityIdentifier("control-room-task-\(task.id)")
         .opacity(roadmapTaskIsActionable(task) ? 1 : 0.55)
     }
 }
@@ -794,7 +865,9 @@ private struct TaskActionCluster: View {
 
 private struct NowSectionView: View {
     let section: NowSection
+    let selection: ControlRoomSelection?
     let activeControlId: String?
+    let onSelect: (NowRow) -> Void
     let onTaskAction: (NowRow, RoadmapTaskAction) -> Void
     let onInterrupt: (NowRow) -> Void
     let onOpenWorktree: (TaskWorkspaceSnapshot) -> Void
@@ -819,13 +892,16 @@ private struct NowSectionView: View {
             ForEach(section.rows) { row in
                 NowRowView(
                     row: row,
+                    isSelected: selection == .task(waveId: row.wave.id, taskId: row.task.id),
                     activeControlId: activeControlId,
+                    onSelect: { onSelect(row) },
                     onAction: { action in onTaskAction(row, action) },
                     onInterrupt: { onInterrupt(row) },
                     onOpenWorktree: onOpenWorktree
                 )
             }
         }
+        .accessibilityIdentifier("control-room-now-\(section.group.rawValue)")
     }
 
     private func nowColor(_ group: NowGroup) -> Color {
@@ -842,7 +918,9 @@ private struct NowSectionView: View {
 
 private struct NowRowView: View {
     let row: NowRow
+    let isSelected: Bool
     let activeControlId: String?
+    let onSelect: () -> Void
     let onAction: (RoadmapTaskAction) -> Void
     let onInterrupt: () -> Void
     let onOpenWorktree: (TaskWorkspaceSnapshot) -> Void
@@ -889,12 +967,16 @@ private struct NowRowView: View {
             )
         }
         .padding(Spacing.sm)
-        .background(palette.surface)
+        .background(isSelected ? Color.loopflowBurgundy.opacity(0.1) : palette.surface)
         .clipShape(RoundedRectangle(cornerRadius: CornerRadius.sm))
         .overlay {
             RoundedRectangle(cornerRadius: CornerRadius.sm)
                 .stroke(palette.border, lineWidth: 1)
         }
+        .contentShape(Rectangle())
+        .onTapGesture { onSelect() }
+        .accessibilityAddTraits(isSelected ? [.isSelected] : [])
+        .accessibilityIdentifier("control-room-task-\(task.id)")
         .opacity(roadmapTaskIsActionable(task) ? 1 : 0.55)
     }
 }

--- a/swift/LoopflowMac/Views/WavesView.swift
+++ b/swift/LoopflowMac/Views/WavesView.swift
@@ -384,29 +384,12 @@ struct WavesView: View {
         guard let initialRepoPath, !didApplyInitialRepo else { return nil }
         if AppTestMode.shouldBypassRegistry { return nil }
         let readPath = await Task.detached {
-            Self.resolveLaunchRepo(initialRepoPath).path
+            PortfolioDiscovery.resolveLaunchRepo(initialRepoPath).path
         }.value
         if !portfolioService.repos.contains(where: { $0.path.normalizedFilePath == readPath }) {
             portfolioService.addRepo(URL(fileURLWithPath: readPath))
         }
         return readPath
-    }
-
-    /// Resolve the launch-provided repo into its (read path, main path, rail label).
-    /// Production reads the collapsed main worktree — the on-disk `wave/` dir is
-    /// quick-launch templates that live on main by design. The
-    /// `LOOPFLOW_DEV_WAVE_REPO` dev override (set by loopflow-dev on `run` /
-    /// `run-debug`) instead reads the launched checkout AS-IS, so a dev launch
-    /// enumerates its own worktree's waves. The rail label is always the collapsed
-    /// main-repo name, so the rail stays clean and worktree-free.
-    private nonisolated static func resolveLaunchRepo(_ initialPath: String) -> (path: String, mainPath: String, displayName: String) {
-        let scanner = RepoScanner()
-        let dev = ProcessInfo.processInfo.environment["LOOPFLOW_DEV_WAVE_REPO"]
-        let devOverride = (dev?.isEmpty == false) ? dev : nil
-        let readURL = URL(fileURLWithPath: devOverride ?? initialPath)
-        let mainURL = scanner.resolveMainWorktree(readURL)
-        let readPath = devOverride != nil ? readURL.normalizedFilePath : mainURL.normalizedFilePath
-        return (readPath, mainURL.normalizedFilePath, mainURL.lastPathComponent)
     }
 
     /// Source the rail directly from a `~/src` scan of main (non-worktree) repos,
@@ -421,42 +404,10 @@ struct WavesView: View {
             return
         }
 
-        let initialPath = initialRepoPath
-        repos = await Task.detached {
-            let scanner = RepoScanner()
-            var seen = Set<String>()
-            var result: [PortfolioRepo] = []
-            for url in scanner.scanDefaultRoot() {
-                let path = url.normalizedFilePath
-                guard seen.insert(path).inserted else { continue }
-                result.append(PortfolioRepo(path: path, lastOpened: Date()))
-            }
-            if let initialPath {
-                let launch = Self.resolveLaunchRepo(initialPath)
-                if launch.path == launch.mainPath {
-                    // Production (or a launched main repo): read main. Keep the
-                    // scanned row in place; add it only if the scan missed it.
-                    if seen.insert(launch.path).inserted {
-                        result.append(PortfolioRepo(
-                            path: launch.path,
-                            lastOpened: Date(),
-                            displayNameOverride: launch.displayName
-                        ))
-                    }
-                } else {
-                    // Dev override: the launched worktree stands in for its main
-                    // repo. Drop the scanned main row so the worktree is the sole
-                    // row (reads its own wave/ dir + registry), labeled with the main name.
-                    result.removeAll { $0.path == launch.mainPath || $0.path == launch.path }
-                    result.append(PortfolioRepo(
-                        path: launch.path,
-                        lastOpened: Date(),
-                        displayNameOverride: launch.displayName
-                    ))
-                }
-            }
-            return result
-        }.value
+        repos = await PortfolioDiscovery.repos(
+            initialRepoPath: initialRepoPath,
+            persistedRepos: portfolioService.repos
+        )
     }
 
     /// Enumerate each rail repo's authored waves — `<repo>/wave/<name>/GOAL.md`
@@ -464,35 +415,7 @@ struct WavesView: View {
     /// rows before they have a registry entry.
     private func refreshAuthoredWaves() async {
         if AppTestMode.shouldBypassRegistry { return }
-        let paths = repos.map(\.path)
-        authoredWavesByRepo = await Task.detached {
-            var result: [String: [String]] = [:]
-            for path in paths {
-                result[path] = Self.authoredWaves(inRepo: path)
-            }
-            return result
-        }.value
-    }
-
-    /// Wave names authored on disk at `<repo>/wave/<name>/GOAL.md`, sorted.
-    private nonisolated static func authoredWaves(inRepo repoPath: String) -> [String] {
-        let waveDir = URL(fileURLWithPath: repoPath).appendingPathComponent("wave", isDirectory: true)
-        let fm = FileManager.default
-        guard let children = try? fm.contentsOfDirectory(
-            at: waveDir,
-            includingPropertiesForKeys: [.isDirectoryKey],
-            options: [.skipsHiddenFiles]
-        ) else {
-            return []
-        }
-        return children
-            .filter { url in
-                var isDir: ObjCBool = false
-                let goal = url.appendingPathComponent("GOAL.md")
-                return fm.fileExists(atPath: goal.path, isDirectory: &isDir) && !isDir.boolValue
-            }
-            .map(\.lastPathComponent)
-            .sorted { $0.localizedCaseInsensitiveCompare($1) == .orderedAscending }
+        authoredWavesByRepo = await PortfolioDiscovery.authoredWaves(in: repos)
     }
 
     private func ensureRepoStates() {

--- a/swift/LoopflowTests/ControlRoomModelTests.swift
+++ b/swift/LoopflowTests/ControlRoomModelTests.swift
@@ -1,0 +1,106 @@
+#if os(macOS)
+import Foundation
+import Testing
+@testable import Loopflow
+@testable import LoopflowMac
+
+@Suite("Control room model")
+@MainActor
+struct ControlRoomModelTests {
+    @Test("Repository scope filters one shared snapshot and clears outside selection")
+    func repositoryScopeFiltersSharedSnapshot() async throws {
+        let fixture = try ControlRoomTestFixture.load()
+        let model = ControlRoomModel(query: fixture.query)
+
+        await model.refresh()
+        #expect(model.visibleRoadmaps.map(\.wave.name) == ["product", "context"])
+
+        model.select(.wave(waveId: "wave-1"))
+        model.setRepoPath("/src/context")
+
+        #expect(model.visibleRoadmaps.map(\.wave.name) == ["context"])
+        #expect(model.selection == nil)
+    }
+
+    @Test("Stable Work selection resolves against the latest snapshot")
+    func stableSelectionSurvivesRefresh() async throws {
+        let fixture = try ControlRoomTestFixture.load()
+        let model = ControlRoomModel(query: fixture.query)
+
+        await model.refresh()
+        model.select(.task(waveId: "wave-1", taskId: "issue-now"))
+        await model.refresh()
+
+        #expect(model.selection == .task(waveId: "wave-1", taskId: "issue-now"))
+        #expect(model.task(waveId: "wave-1", taskId: "issue-now")?.task.task.name
+            == "Make lf roadmap the machine-wide view")
+
+        model.select(.task(waveId: "wave-1", taskId: "missing"))
+        #expect(model.selection == .wave(waveId: "wave-1"))
+    }
+
+    @Test("Refresh failure preserves last-good Work and exposes the reason")
+    func refreshFailurePreservesLastGoodWork() async throws {
+        let fixture = try ControlRoomTestFixture.load()
+        let failing = RegistryQuery { _, _ in
+            throw RegistryQueryError("registry unavailable")
+        }
+        let model = ControlRoomModel(query: failing)
+        model.applyFixture(
+            roadmap: .available(fixture.roadmap),
+            waves: .available(fixture.waves),
+            repos: []
+        )
+
+        await model.refresh()
+
+        #expect(model.roadmap.value == fixture.roadmap)
+        #expect(model.roadmap.errorMessage == "registry unavailable")
+        #expect(model.waves.value == fixture.waves)
+        #expect(model.waves.errorMessage == "registry unavailable")
+    }
+}
+
+private struct ControlRoomTestFixture {
+    let roadmap: RoadmapSnapshot
+    let waves: [Wave]
+    let query: RegistryQuery
+
+    static func load(sourceFile: String = #filePath) throws -> ControlRoomTestFixture {
+        let url = URL(fileURLWithPath: sourceFile)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent("tests/fixtures/dto/roadmap_snapshot.json")
+        let roadmapData = try Data(contentsOf: url)
+        let roadmap = try JSONDecoder().decode(RoadmapSnapshot.self, from: roadmapData)
+        let object = try #require(JSONSerialization.jsonObject(with: roadmapData) as? [String: Any])
+        let roadmapWaves = try #require(object["waves"] as? [[String: Any]])
+        let waveObjects = try roadmapWaves.map { try #require($0["wave"] as? [String: Any]) }
+        let waveData = try JSONSerialization.data(withJSONObject: waveObjects)
+        let snapshots = try JSONDecoder().decode([WaveSnapshot].self, from: waveData)
+        let waves = snapshots.map { snapshot in
+            Wave(
+                id: snapshot.id,
+                name: snapshot.name,
+                repo: snapshot.repo,
+                status: snapshot.status,
+                live: snapshot.live,
+                activeTasks: snapshot.activeTasks,
+                activeProjects: snapshot.activeProjects,
+                parentWaveId: snapshot.parentWaveId
+            )
+        }
+        let roadmapJSON = try #require(String(data: roadmapData, encoding: .utf8))
+        let wavesJSON = try #require(String(data: waveData, encoding: .utf8))
+        let query = RegistryQuery { args, _ in
+            switch args.first {
+            case "roadmap": roadmapJSON
+            case "ls": wavesJSON
+            default: throw RegistryQueryError("unexpected command \(args.joined(separator: " "))")
+            }
+        }
+        return ControlRoomTestFixture(roadmap: roadmap, waves: waves, query: query)
+    }
+}
+#endif

--- a/swift/LoopflowUITests/WaveSurfaceStateTests.swift
+++ b/swift/LoopflowUITests/WaveSurfaceStateTests.swift
@@ -1,20 +1,8 @@
 import XCTest
 
-/// Executable proof that the stable Wave surface renders the five states the
-/// W2-178 Proof names — selected, loading, error, empty, and future-child
-/// indentation — *distinctly*, at both a narrow and a wide desktop size.
-///
-/// Each state is checked by a UNIQUE on-screen affordance, so the states can't
-/// collapse into one another undetected. This is the test that would have
-/// caught PR #972's forwarding gap: with `LOOPFLOW_UI_TEST_DETAIL_STATE` not
-/// reaching the app, `loading` and `error` rendered as `selected`, and the
-/// loading/error assertions below would fail.
-///
-/// Runs under the host-permissioned macOS UI-test gate (Automation access),
-/// the same gate the screenshot pipeline uses.
-final class WaveSurfaceStateTests: XCTestCase {
-    /// A genuinely narrow desktop (still wide enough to show the 300pt list and
-    /// the detail panes' minimums) and a wide one.
+/// Executable proof for the new primary control-room root. Fixture states use
+/// the same roadmap DTO file as Rust and Swift contract tests.
+final class ControlRoomStateTests: XCTestCase {
     private let widths: [Double] = [900, 1440]
 
     override func setUp() {
@@ -22,193 +10,104 @@ final class WaveSurfaceStateTests: XCTestCase {
     }
 
     @MainActor
-    func testSelectedStateShowsPopulatedHierarchy() {
+    func testPopulatedControlRoomKeepsScopeWorkAndSelectionVisible() {
         forEachWidth { app in
-            XCTAssertTrue(waitFor(app, id: "wave-objective-lead"),
-                          "selected must lead with the objective")
-            XCTAssertFalse(exists(app, id: "wave-detail-loading"),
-                           "selected must not show the loading affordance")
-            XCTAssertFalse(exists(app, id: "wave-live-status-footer"),
-                           "selected must not show the error footer")
-            assertStableNavigation(app)
-            assertHalLenses(app)
-            assertPrimaryInformationHierarchy(app)
-            assertEveryWaveRowHittable(app)
+            assertControlRoomRegions(app)
+            XCTAssertTrue(waitFor(app, id: "control-room-wave-list"))
+            XCTAssertTrue(waitFor(app, id: "control-room-now-readyForReview"))
+            XCTAssertTrue(waitFor(app, id: "control-room-now-working"))
+            XCTAssertFalse(exists(app, id: "wave-chat-transcript"),
+                           "cold launch must spend the primary window on live administration")
+
+            let task = app.descendants(matching: .any)["control-room-task-issue-now"]
+            XCTAssertTrue(task.waitForExistence(timeout: 8))
+            task.click()
+
+            let title = app.descendants(matching: .any)["control-room-selection-title"]
+            XCTAssertTrue(title.waitForExistence(timeout: 8))
+            XCTAssertEqual(title.label, "Make lf roadmap the machine-wide view")
+            assertControlRoomRegions(app)
         }
     }
 
     @MainActor
-    func testControlIsSecondaryAndOpensToWorkCensus() {
+    func testRoadmapProjectAndAvailableTaskSelectIntoInspector() {
         forEachWidth { app in
-            XCTAssertTrue(waitFor(app, id: "wave-chat-transcript"),
-                          "Chat must be the selected Wave's default surface")
-            XCTAssertFalse(exists(app, id: "control-surface"),
-                           "Control must stay behind an explicit interaction")
+            let roadmap = app.buttons["Roadmap"]
+            XCTAssertTrue(roadmap.waitForExistence(timeout: 8))
+            roadmap.click()
 
-            let button = app.descendants(matching: .any)["wave-control-button"]
-            XCTAssertTrue(button.waitForExistence(timeout: 8),
-                          "the secondary Control destination must be discoverable")
-            button.click()
+            let project = app.descendants(matching: .any)["control-room-project-project-1"]
+            XCTAssertTrue(project.waitForExistence(timeout: 8))
+            project.click()
+            XCTAssertEqual(
+                app.descendants(matching: .any)["control-room-selection-title"].label,
+                "Loopflow API"
+            )
 
-            XCTAssertTrue(waitFor(app, id: "control-surface"),
-                          "Control must open from the Wave header")
-            XCTAssertTrue(waitFor(app, id: "control-work-census"),
-                          "Control must open to the Work Census")
-            XCTAssertTrue(exists(app, id: "control-run-history-tab"),
-                          "Run History remains visible as later disclosure")
+            let task = app.descendants(matching: .any)["control-room-task-issue-available"]
+            XCTAssertTrue(task.waitForExistence(timeout: 8))
+            task.click()
+            XCTAssertEqual(
+                app.descendants(matching: .any)["control-room-selection-title"].label,
+                "Wave Chat consumes the roadmap snapshot"
+            )
+            assertControlRoomRegions(app)
         }
     }
 
     @MainActor
-    func testLoadingStateShowsLoadingAffordance() {
+    func testLoadingKeepsPortfolioScopeVisible() {
         forEachWidth(detailState: "loading") { app in
-            XCTAssertTrue(waitFor(app, id: "wave-detail-loading"),
-                          "loading must show the loading affordance, not the populated hierarchy")
-            XCTAssertFalse(exists(app, id: "wave-live-status-footer"),
-                           "loading is not the error state")
-            assertEveryWaveRowHittable(app)
+            XCTAssertTrue(waitFor(app, id: "control-room-work-loading"))
+            XCTAssertTrue(exists(app, id: "control-room-wave-list"))
+            XCTAssertFalse(exists(app, id: "control-room-work-unavailable"))
         }
     }
 
     @MainActor
-    func testErrorStatePreservesDetailUnderFooter() {
+    func testUnavailableIsNotRenderedAsEmpty() {
         forEachWidth(detailState: "error") { app in
-            XCTAssertTrue(waitFor(app, id: "wave-live-status-footer"),
-                          "error must show the quiet cached-plan footer")
-            XCTAssertTrue(exists(app, id: "wave-objective-lead"),
-                          "error preserves the last-good detail — the objective still leads")
-            XCTAssertFalse(exists(app, id: "wave-detail-loading"),
-                           "error is not the loading state")
-            assertEveryWaveRowHittable(app)
+            XCTAssertTrue(waitFor(app, id: "control-room-work-unavailable"))
+            XCTAssertTrue(exists(app, id: "control-room-wave-list"))
+            XCTAssertFalse(exists(app, id: "control-room-work-empty"))
         }
     }
 
     @MainActor
-    func testEmptyStateShowsCalmCreateSurface() {
+    func testEmptyFleetHasDistinctRosterAndWorkStates() {
         forEachWidth(mode: "empty-workspaces") { app in
-            XCTAssertTrue(waitFor(app, id: "wave-empty-create"),
-                          "empty must offer a calm create surface")
-            XCTAssertEqual(waveRows(app).count, 0, "empty has no Wave rows")
+            XCTAssertTrue(waitFor(app, id: "control-room-roster-empty"))
+            XCTAssertTrue(waitFor(app, id: "control-room-work-empty"))
+            XCTAssertTrue(exists(app, id: "control-room-no-selection"))
         }
     }
-
-    @MainActor
-    func testChildIndentationKeepsBothRowsSelectable() {
-        forEachWidth(selectBranch: "cadenza") { app in
-            let rows = waveRows(app)
-            XCTAssertTrue(rows.contains { $0.label.contains("infrastructure") },
-                          "the parent Wave stays in the list")
-            XCTAssertTrue(rows.contains { $0.label.contains("cadenza") },
-                          "the indented child Wave is present")
-            assertEveryWaveRowHittable(app)
-        }
-    }
-
-    // MARK: - Harness
 
     @MainActor
     private func forEachWidth(
         mode: String = "mock-waves",
         detailState: String? = nil,
-        selectBranch: String? = nil,
         _ assertions: (XCUIApplication) -> Void
     ) {
         for width in widths {
             var launch = WaveSurfaceLaunch()
             launch.mode = mode
             launch.detailState = detailState
-            launch.selectBranch = selectBranch
             launch.width = width
             let app = launch.makeApp()
             app.launch()
-            XCTAssertTrue(app.windows.element(boundBy: 0).waitForExistence(timeout: 10),
-                          "window must appear at width \(Int(width))")
+            XCTAssertTrue(app.windows.element(boundBy: 0).waitForExistence(timeout: 10))
             assertions(app)
             app.terminate()
         }
     }
 
     @MainActor
-    private func waveRows(_ app: XCUIApplication) -> [XCUIElement] {
-        // WaveRow combines its children into one element labeled "Wave: <name>. <reason>".
-        let predicate = NSPredicate(format: "label BEGINSWITH %@", "Wave: ")
-        return app.descendants(matching: .any).matching(predicate).allElementsBoundByIndex
-    }
-
-    @MainActor
-    private func assertEveryWaveRowHittable(_ app: XCUIApplication) {
-        let rows = waveRows(app)
-        XCTAssertFalse(rows.isEmpty, "expected at least one Wave row")
-        for row in rows {
-            XCTAssertTrue(row.isHittable,
-                          "every Wave stays selectable without clipping: \(row.label)")
-        }
-    }
-
-    @MainActor
-    private func assertStableNavigation(_ app: XCUIApplication) {
-        let dropdown = app.descendants(matching: .any)["repo-dropdown"]
-        let list = app.descendants(matching: .any)["repo-wave-list"]
-        XCTAssertTrue(dropdown.waitForExistence(timeout: 8),
-                      "repository scope must be one dropdown above the Wave list")
-        XCTAssertTrue(list.waitForExistence(timeout: 8),
-                      "the stable Wave list must remain the primary navigation")
-        XCTAssertLessThanOrEqual(dropdown.frame.maxY, list.frame.minY,
-                                 "the repository dropdown belongs above, not beside, the Wave list")
-
-        let names = waveRows(app).compactMap(Self.waveName)
-        XCTAssertEqual(names, ["feedback", "infrastructure", "cadenza", "intelligence"],
-                       "liveness must not regroup the stable outline")
-
-        let child = waveRows(app).first { Self.waveName($0) == "cadenza" }
-        XCTAssertTrue((child?.value as? String)?.contains("child wave") == true,
-                      "the child row must preserve its hierarchy affordance")
-    }
-
-    @MainActor
-    private func assertHalLenses(_ app: XCUIApplication) {
-        let expected = [
-            "infrastructure": "green lens",
-            "intelligence": "red lens",
-            "feedback": "black lens",
-            "cadenza": "green lens",
-        ]
-        let rows = waveRows(app)
-        for (name, lens) in expected {
-            guard let row = rows.first(where: { Self.waveName($0) == name }) else {
-                XCTFail("missing \(name) Wave row")
-                continue
-            }
-            XCTAssertTrue((row.value as? String)?.hasPrefix(lens) == true,
-                          "\(name) must expose its \(lens) attention signal")
-        }
-    }
-
-    @MainActor
-    private func assertPrimaryInformationHierarchy(_ app: XCUIApplication) {
-        XCTAssertTrue(exists(app, id: "wave-projects"),
-                      "Projects must follow the objective")
-        XCTAssertTrue(exists(app, id: "wave-project"),
-                      "the selected Wave must expose its Project")
-        XCTAssertTrue(exists(app, id: "project-open-tasks"),
-                      "a Project must foreground its open-task count")
-        XCTAssertTrue(exists(app, id: "project-key-result"),
-                      "a Project must foreground its KR list")
-        XCTAssertTrue(exists(app, id: "wave-task"),
-                      "Task rows must stay progressively disclosed under Projects")
-        XCTAssertTrue(exists(app, id: "wave-chat-transcript"),
-                      "Chat must remain present beside the plan")
-        XCTAssertTrue(exists(app, id: "wave-control-button"),
-                      "Control must be reachable without replacing Chat")
-    }
-
-    @MainActor
-    private static func waveName(_ row: XCUIElement) -> String? {
-        let prefix = "Wave: "
-        guard row.label.hasPrefix(prefix),
-              let end = row.label.dropFirst(prefix.count).firstIndex(of: ".")
-        else { return nil }
-        return String(row.label.dropFirst(prefix.count)[..<end])
+    private func assertControlRoomRegions(_ app: XCUIApplication) {
+        XCTAssertTrue(waitFor(app, id: "control-room"))
+        XCTAssertTrue(waitFor(app, id: "control-room-sidebar"))
+        XCTAssertTrue(waitFor(app, id: "control-room-work"))
+        XCTAssertTrue(waitFor(app, id: "control-room-inspector"))
     }
 
     @MainActor

--- a/swift/README.md
+++ b/swift/README.md
@@ -7,17 +7,21 @@
 ./dev xcode        # regenerate and open the Xcode project
 ```
 
-Loopflow opens on a repository rail, a Wave list, and the machine-wide roadmap.
-The roadmap reads `lf roadmap --json` once, showing every Wave's durable
-Projects and Tasks even when its process is stopped. Select **All Repos** for
-the whole machine or a repository to filter that same snapshot locally.
+Loopflow opens on the control room: repository and Wave scope on the left,
+machine-wide Now/Roadmap work in the center, and selected Work evidence on the
+right. Selecting a Wave, Project, or Task preserves the surrounding live view.
+The control room reads `lf roadmap --json` and `lf ls --json` once per refresh;
+repository scope filters those shared snapshots locally.
 
-Create a Wave with the `+` button. The app writes `GOAL.md` and `MEMORY.md`
-in the repository's main checkout. **Open chat** attaches to a live Wave;
-**Start & open** launches a stopped Wave through `lf wave` and opens its
-conversation while it connects. Wave Chat paints the bounded local journal
-tail before SSE, keeps it visible through reconnects, and rolls equivalent
-operational failures into one disclosed notice.
+Loading, empty, stale-last-good, and unavailable reads stay distinct. A failed
+refresh keeps the last useful Work visible with its failure reason rather than
+painting a healthy empty fleet.
+
+The previous Wave workspace remains available in repository and Portfolio
+windows while its proven inspectors and Chat surface move into the new root.
+Wave Chat paints the bounded local journal tail before SSE, keeps it visible
+through reconnects, and rolls equivalent operational failures into one
+disclosed notice. Cold launch does not start a chat transcript read.
 Commands, tools, file edits, and loop bookkeeping stay in the journal;
 decisions, deliveries, and human-level failures remain visible. The detail pane
 reads Projects, Tasks, decisions, PR delivery, and attention from
@@ -71,7 +75,9 @@ and observation spans.
 
 ## Code map
 
-- `LoopflowMac/Views/WavesView.swift` — repository rail and Wave selection
+- `LoopflowMac/Views/ControlRoomView.swift` — primary scope, live Work, and selected detail
+- `LoopflowMac/ControlRoomModel.swift` — shared readings, stable selection, and local scope
+- `LoopflowMac/Views/WavesView.swift` — previous Wave workspace during migration
 - `LoopflowMac/Views/RoadmapView.swift` — all-Wave roadmap and lifecycle controls
 - `LoopflowMac/Views/WaveDetailPane.swift` — Wave Chat plus Project/Task work
 - `LoopflowMac/Views/TaskWorkspaceView.swift` — Task diff, file, Ghostty, and Warp surface


### PR DESCRIPTION
## Usage

```bash
./swift/dev run
swift build --package-path swift --product LoopflowMac
scripts/prove_wave_surface_states.sh
```

## Summary

Makes the macOS control room the primary app window. The new three-pane workspace keeps repository and Wave scope, machine-wide Now/Roadmap work, and selected Wave, Project, or Task evidence visible together, preserving live context while navigating without starting Wave Chat on cold launch.

## Changes

- Added a shared control-room model that reads roadmap and Wave state once per refresh, filters by repository locally, and keeps stable selections across updates
- Preserved last-good evidence when refreshes fail while rendering loading, unavailable, empty, and populated states distinctly
- Extracted portfolio discovery so the control room and previous Wave workspace share repository and authored-Wave behavior
- Added deterministic fixtures, model and UI coverage, and a headless narrow/wide rendering proof wired into the Swift test suite and CI