### PR TITLE
task runner: scope gate proposals to finally epochs

### DIFF
--- a/rust/loopflow/src/task/runner.rs
+++ b/rust/loopflow/src/task/runner.rs
@@ -1309,7 +1309,15 @@ fn resume_task_phase(task: &Task) -> Result<Playhead> {
 
 fn sync_task_state(task: &mut Task, latest: &Task) {
     task.pm_writeback = latest.pm_writeback.clone();
-    task.gate_proposal = latest.gate_proposal.clone();
+    if task.lifecycle_phase == TaskLifecyclePhase::Finally && task.phase_epoch == latest.phase_epoch
+    {
+        task.gate_proposal = latest.gate_proposal.clone();
+    } else if task.lifecycle_phase != TaskLifecyclePhase::Finally {
+        // A gate proposal belongs to one Finally epoch. Copying a newer
+        // proposal into a pre-final body forms an invalid Task before the store's
+        // phase-epoch fence can discard that stale body's write.
+        task.gate_proposal = None;
+    }
 }
 
 fn task_state_fingerprint(task: &Task) -> Result<String> {
@@ -1974,7 +1982,8 @@ fn progress_summary(text: &str) -> String {
 #[cfg(test)]
 mod planning_tests {
     use super::{
-        complete_interactive_step, finish_task_flow_turn, interactive_step_prompt, task_seed,
+        complete_interactive_step, finish_task_flow_turn, interactive_step_prompt, sync_task_state,
+        task_seed,
     };
     use crate::chat::types::{ConversationEvent, Lifecycle};
     use crate::durable::{
@@ -1986,8 +1995,8 @@ mod planning_tests {
     use crate::project::{Project, ProjectId};
     use crate::store::{open_store, StorageConfig};
     use crate::task::{
-        Observation, PmWritebackState, Task, TaskId, TaskLifecyclePhase, TaskLifecyclePlan, TaskPr,
-        TaskPrId,
+        Observation, PmWritebackState, Task, TaskGateProposal, TaskId, TaskLifecyclePhase,
+        TaskLifecyclePlan, TaskPr, TaskPrId,
     };
     use crate::wave::playhead::{BodyProvenance, Playhead, QueuedInvocation};
     use crate::wave::Wave;
@@ -2049,6 +2058,68 @@ mod planning_tests {
         assert!(prompt.contains("lf invocation handback invocation_demo"));
         assert!(prompt.contains("do not execute the command from this read-only surface"));
         assert!(!prompt.contains("leaves this step waiting"));
+    }
+
+    #[test]
+    fn task_state_sync_keeps_gate_proposals_scoped_to_finally_epoch() {
+        let now = time::OffsetDateTime::now_utc();
+        let first = Task {
+            id: TaskId::new(),
+            plan: TaskPlan {
+                id: LinearIssueId::new("incident-issue").unwrap(),
+                identifier: "ENG-125".to_string(),
+                title: "Incident".to_string(),
+                description: String::new(),
+                pm_snapshot_synced_at: 1,
+            },
+            pm_writeback: PmWritebackState::Current,
+            wave_id: crate::id::WaveId::new(),
+            project_id: ProjectId::new(),
+            worktree: "/tmp/incident".into(),
+            workspace_slug: "incident".to_string(),
+            lifecycle: TaskLifecyclePlan::standard("incident", "ship-5whys", "ship"),
+            lifecycle_phase: TaskLifecyclePhase::First,
+            phase_epoch: 1,
+            phase_cursor: 0,
+            phase_iteration: 0,
+            gate_cycle: 0,
+            gate_proposal: None,
+            agent: "codex".to_string(),
+            provider: "codex".to_string(),
+            provider_session_id: None,
+            abandon_intent: None,
+            created_at: now,
+            updated_at: now,
+            observation: Observation::NotRequired,
+        };
+        let mut finally = first.clone();
+        finally.enter_loop().unwrap();
+        finally
+            .enter_finally(TaskGateProposal {
+                done: true,
+                reason: "pull request merged".to_string(),
+            })
+            .unwrap();
+
+        let mut first_body = first.clone();
+        sync_task_state(&mut first_body, &finally);
+        assert!(first_body.gate_proposal.is_none());
+        first_body.validate().unwrap();
+
+        let mut loop_body = first;
+        loop_body.enter_loop().unwrap();
+        sync_task_state(&mut loop_body, &finally);
+        assert!(loop_body.gate_proposal.is_none());
+        loop_body.validate().unwrap();
+
+        let mut finally_body = finally.clone();
+        finally.gate_proposal = Some(TaskGateProposal {
+            done: false,
+            reason: "another prevention remains".to_string(),
+        });
+        sync_task_state(&mut finally_body, &finally);
+        assert_eq!(finally_body.gate_proposal, finally.gate_proposal);
+        finally_body.validate().unwrap();
     }
 
     #[test]

--- a/wave/infrastructure/MEMORY.md
+++ b/wave/infrastructure/MEMORY.md
@@ -51,6 +51,14 @@ Renamed from `systems` in the 2026-07-08 wave/project/task restructure. Steers L
   synthetic Run to reuse a Run-owned terminal transition. Prove this boundary
   with a zero-agent-boundary fixture and repeated reads that count Runs and
   completion events.
+- **Phase-owned state needs the same freshness boundary in memory and storage**
+  (learned 2026-07-20). Passive reconciliation may advance a durable Task to
+  finally while its active Run still holds a pre-final snapshot. Refresh a gate
+  proposal only within the same finally epoch; first/loop snapshots keep no
+  proposal and the store's `phase_epoch` fence preserves newer durable truth.
+  Validation runs before SQL, so a persistence fence cannot repair a torn local
+  refresh. Terminal Work remains authoritative over stale resumable failure
+  observations.
 - **Durable Ask is the only blocking human-input primitive** (decided
   2026-07-21). Interactive Task phases are advisory: the runner makes one launch
   attempt and advances independently of launcher success, UI lifetime, or


### PR DESCRIPTION
## Usage

```bash
cargo test -p loopflow --lib task_state_sync_keeps_gate_proposals_scoped_to_finally_epoch
cargo test -p loopflow --test pr_tests repeated_status_of_merged_task_without_a_boundary_records_completion_once
```

## Summary

Keeps Task gate proposals attached to the `finally` phase epoch that owns them. Passive PR reconciliation can advance durable state while an active Run still holds a pre-final snapshot; previously, state sync could copy the newer proposal into that stale body and fail validation before the epoch-fenced write rejected it. The runner now preserves a coherent local Task while newer durable state remains authoritative.

## Changes

- Refresh gate proposals only when local and durable Tasks share the same `finally` epoch
- Clear proposals from `first` and `loop` snapshots during state sync
- Add regression coverage across the inherited `incident -> ship-5whys -> ship` lifecycle
- Record the cross-authority freshness rule and incident analysis