### PR TITLE
mac: show live agent activity above the control room

### DIFF
--- a/rust/loopflow/src/lf/commands/top.rs
+++ b/rust/loopflow/src/lf/commands/top.rs
@@ -1234,6 +1234,34 @@ fn kernel_state_label(state: &str) -> &'static str {
 mod tests {
     use super::*;
 
+    #[test]
+    fn activity_fixture_round_trips_process_and_output_evidence() {
+        let fixture = include_str!("../../../../../tests/fixtures/dto/activity_snapshot.json");
+        let snapshot = serde_json::from_str::<ActivitySnapshot>(fixture).unwrap();
+
+        assert_eq!(snapshot.aggregate.measured_output_tokens, 48_200);
+        assert_eq!(snapshot.aggregate.output_tokens_per_second_fast, 4.0);
+        assert_eq!(
+            snapshot
+                .nodes
+                .iter()
+                .filter(|node| node.kind == ActivityNodeKind::ProviderLaunch)
+                .map(|node| node.state)
+                .collect::<Vec<_>>(),
+            vec![ActivityState::Working, ActivityState::Stalled]
+        );
+        assert_eq!(
+            snapshot.provider_processes[0].claim,
+            ProviderClaim::Orphaned
+        );
+
+        let encoded = serde_json::to_string(&snapshot).unwrap();
+        assert_eq!(
+            serde_json::from_str::<ActivitySnapshot>(&encoded).unwrap(),
+            snapshot
+        );
+    }
+
     fn run_event(
         trace: &str,
         exec: &str,

--- a/swift/Loopflow/Models/ActivitySnapshot.swift
+++ b/swift/Loopflow/Models/ActivitySnapshot.swift
@@ -1,0 +1,96 @@
+import Foundation
+
+public enum ActivityNodeKind: String, Codable, Sendable, Hashable {
+    case exec
+    case providerLaunch = "provider_launch"
+}
+
+public enum ActivityState: String, Codable, Sendable, Hashable {
+    case working
+    case waiting
+    case stalled
+}
+
+public struct OutputActivity: Codable, Sendable, Hashable {
+    public let measuredOutputTokens: UInt64
+    public let outputTokensFast: UInt64
+    public let outputTokensSlow: UInt64
+    public let outputTokensPerSecondFast: Double
+    public let outputTokensPerSecondSlow: Double
+    public let measuredTurns: UInt64
+    public let unmeasuredTurns: UInt64
+
+    enum CodingKeys: String, CodingKey {
+        case measuredOutputTokens = "measured_output_tokens"
+        case outputTokensFast = "output_tokens_fast"
+        case outputTokensSlow = "output_tokens_slow"
+        case outputTokensPerSecondFast = "output_tokens_per_second_fast"
+        case outputTokensPerSecondSlow = "output_tokens_per_second_slow"
+        case measuredTurns = "measured_turns"
+        case unmeasuredTurns = "unmeasured_turns"
+    }
+}
+
+public struct ActivityNode: Codable, Sendable, Hashable, Identifiable {
+    public let id: String
+    public let parentId: String?
+    public let kind: ActivityNodeKind
+    public let label: String
+    public let pid: UInt32?
+    public let startedAt: Int64
+    public let lastProgressAt: Int64?
+    public let state: ActivityState
+    public let direct: OutputActivity
+    public let cumulative: OutputActivity
+
+    enum CodingKeys: String, CodingKey {
+        case id, kind, label, pid, state, direct, cumulative
+        case parentId = "parent_id"
+        case startedAt = "started_at"
+        case lastProgressAt = "last_progress_at"
+    }
+}
+
+public enum ProviderClaim: String, Codable, Sendable, Hashable {
+    case orphaned
+    case unclaimed
+}
+
+public struct ProviderProcess: Codable, Sendable, Hashable, Identifiable {
+    public let pid: UInt32
+    public let ppid: UInt32
+    public let processGroup: UInt32
+    public let startedAt: Int64
+    public let kernelState: String
+    public let provider: String
+    public let command: String
+    public let claim: ProviderClaim
+
+    public var id: UInt32 { pid }
+
+    enum CodingKeys: String, CodingKey {
+        case pid, ppid, provider, command, claim
+        case processGroup = "process_group"
+        case startedAt = "started_at"
+        case kernelState = "kernel_state"
+    }
+}
+
+public struct ActivitySnapshot: Codable, Sendable, Hashable {
+    public let schemaVersion: UInt32
+    public let observedAt: Int64
+    public let fastWindowSeconds: Int64
+    public let slowWindowSeconds: Int64
+    public let aggregate: OutputActivity
+    public let nodes: [ActivityNode]
+    public let providerProcesses: [ProviderProcess]
+
+    enum CodingKeys: String, CodingKey {
+        case aggregate, nodes
+        case schemaVersion = "schema_version"
+        case observedAt = "observed_at"
+        case fastWindowSeconds = "fast_window_seconds"
+        case slowWindowSeconds = "slow_window_seconds"
+        case providerProcesses = "provider_processes"
+    }
+}

--- a/swift/Loopflow/Services/RegistryQuery.swift
+++ b/swift/Loopflow/Services/RegistryQuery.swift
@@ -6,7 +6,7 @@
 // — are QUERIES against the shared SQLite ledger, served by the daemonless `lf`
 // CLI. Live motion is a per-wave SSE stream (`WaveChatConnection`), never this.
 //
-// This runs `lf ls/status/roadmap/runs --json` as a subprocess and decodes the wire
+// This runs `lf ls/status/roadmap/ps/runs --json` as a subprocess and decodes the wire
 // snapshots (mirrors of the Rust types in `lf/commands/waves.rs` and
 // `lf/commands/runs.rs`) into the app models the stores hold. The subprocess
 // runner is injected: on macOS it resolves and execs a local `lf`. There is no
@@ -86,6 +86,12 @@ public struct RegistryQuery: Sendable {
         args.append("--json")
         let stdout = try await run(args, nil)
         return try Self.decode(RoadmapSnapshot.self, from: stdout)
+    }
+
+    /// Live Loopflow process trees and provider-measured output activity.
+    public func activity() async throws -> ActivitySnapshot {
+        let stdout = try await run(["ps", "--json"], nil)
+        return try Self.decode(ActivitySnapshot.self, from: stdout)
     }
 
     /// Latest durable Wave turns from the local journal. This read does not

--- a/swift/LoopflowMac/ControlRoomFixture.swift
+++ b/swift/LoopflowMac/ControlRoomFixture.swift
@@ -15,26 +15,35 @@ enum ControlRoomFixture {
                 model.applyFixture(
                     roadmap: .available(snapshot),
                     waves: .available([]),
+                    activity: .available(try emptyActivity()),
                     repos: [],
                     fixed: true
                 )
             case .mockWaves:
                 let fixture = try loadRoadmap(sourceFile: sourceFile)
                 let reading: ControlRoomReading<RoadmapSnapshot>
+                let activity: ControlRoomReading<ActivitySnapshot>
                 switch MockWaveFixture.detailState {
                 case .selected:
                     reading = .available(fixture.roadmap)
+                    activity = .available(try loadActivity(sourceFile: sourceFile))
                 case .loading:
                     reading = .loading
+                    activity = .loading
                 case .error:
                     reading = .unavailable(
                         lastGood: nil,
                         reason: "the local registry is unreachable"
                     )
+                    activity = .unavailable(
+                        lastGood: nil,
+                        reason: "live process evidence is unavailable"
+                    )
                 }
                 model.applyFixture(
                     roadmap: reading,
                     waves: .available(fixture.waves),
+                    activity: activity,
                     repos: fixture.repos,
                     fixed: true
                 )
@@ -52,6 +61,7 @@ enum ControlRoomFixture {
                     reason: "Control-room fixture unavailable: \(error.localizedDescription)"
                 ),
                 waves: .unavailable(lastGood: nil, reason: error.localizedDescription),
+                activity: .unavailable(lastGood: nil, reason: error.localizedDescription),
                 repos: [],
                 fixed: true
             )
@@ -61,7 +71,7 @@ enum ControlRoomFixture {
     private static func loadRoadmap(
         sourceFile: String
     ) throws -> (roadmap: RoadmapSnapshot, waves: [Wave], repos: [PortfolioRepo]) {
-        let url = try roadmapFixtureURL(sourceFile: sourceFile)
+        let url = try fixtureURL(named: "roadmap_snapshot.json", sourceFile: sourceFile)
         let data = try Data(contentsOf: url)
         let roadmap = try JSONDecoder().decode(RoadmapSnapshot.self, from: data)
         let waves = roadmap.waves.map { snapshot in
@@ -85,7 +95,17 @@ enum ControlRoomFixture {
         return (roadmap, waves, repos)
     }
 
-    private static func roadmapFixtureURL(sourceFile: String) throws -> URL {
+    private static func loadActivity(sourceFile: String) throws -> ActivitySnapshot {
+        let url = try fixtureURL(named: "activity_snapshot.json", sourceFile: sourceFile)
+        return try JSONDecoder().decode(ActivitySnapshot.self, from: Data(contentsOf: url))
+    }
+
+    private static func emptyActivity() throws -> ActivitySnapshot {
+        let json = #"{"schema_version":1,"observed_at":1784606400,"fast_window_seconds":300,"slow_window_seconds":1800,"aggregate":{"measured_output_tokens":0,"output_tokens_fast":0,"output_tokens_slow":0,"output_tokens_per_second_fast":0.0,"output_tokens_per_second_slow":0.0,"measured_turns":0,"unmeasured_turns":0},"nodes":[],"provider_processes":[]}"#
+        return try JSONDecoder().decode(ActivitySnapshot.self, from: Data(json.utf8))
+    }
+
+    private static func fixtureURL(named name: String, sourceFile: String) throws -> URL {
         let fileManager = FileManager.default
         var roots = [URL(fileURLWithPath: fileManager.currentDirectoryPath, isDirectory: true)]
         if let executableURL = Bundle.main.executableURL {
@@ -100,7 +120,8 @@ enum ControlRoomFixture {
             var directory = root.standardizedFileURL
             while visited.insert(directory.path).inserted {
                 let candidate = directory
-                    .appendingPathComponent("tests/fixtures/dto/roadmap_snapshot.json")
+                    .appendingPathComponent("tests/fixtures/dto")
+                    .appendingPathComponent(name)
                 if fileManager.fileExists(atPath: candidate.path) {
                     return candidate
                 }
@@ -112,7 +133,7 @@ enum ControlRoomFixture {
 
         throw CocoaError(
             .fileNoSuchFile,
-            userInfo: [NSFilePathErrorKey: "tests/fixtures/dto/roadmap_snapshot.json"]
+            userInfo: [NSFilePathErrorKey: "tests/fixtures/dto/\(name)"]
         )
     }
 }

--- a/swift/LoopflowMac/ControlRoomModel.swift
+++ b/swift/LoopflowMac/ControlRoomModel.swift
@@ -42,6 +42,33 @@ enum ControlRoomReading<Value> {
     }
 }
 
+struct ControlRoomActivitySummary: Equatable {
+    let activeAgents: Int
+    let working: Int
+    let waiting: Int
+    let stalled: Int
+    let orphaned: Int
+    let unclaimed: Int
+    let outputTokensPerSecond5m: Double
+    let measuredOutputTokens: UInt64
+}
+
+extension ActivitySnapshot {
+    var controlRoomSummary: ControlRoomActivitySummary {
+        let providers = nodes.filter { $0.kind == .providerLaunch }
+        return ControlRoomActivitySummary(
+            activeAgents: providers.count + providerProcesses.count,
+            working: providers.count { $0.state == .working },
+            waiting: providers.count { $0.state == .waiting },
+            stalled: providers.count { $0.state == .stalled },
+            orphaned: providerProcesses.count { $0.claim == .orphaned },
+            unclaimed: providerProcesses.count { $0.claim == .unclaimed },
+            outputTokensPerSecond5m: aggregate.outputTokensPerSecondFast,
+            measuredOutputTokens: aggregate.measuredOutputTokens
+        )
+    }
+}
+
 @MainActor
 @Observable
 final class ControlRoomModel {
@@ -49,6 +76,7 @@ final class ControlRoomModel {
     var selection: ControlRoomSelection?
     private(set) var roadmap: ControlRoomReading<RoadmapSnapshot> = .loading
     private(set) var waves: ControlRoomReading<[Wave]> = .loading
+    private(set) var activity: ControlRoomReading<ActivitySnapshot> = .loading
     private(set) var repos: [PortfolioRepo] = []
     private(set) var authoredWavesByRepo: [String: [String]] = [:]
     private(set) var isRefreshing = false
@@ -121,13 +149,17 @@ final class ControlRoomModel {
 
         let previousRoadmap = roadmap.value
         let previousWaves = waves.value
+        let previousActivity = activity.value
         if previousRoadmap == nil { roadmap = .loading }
         if previousWaves == nil { waves = .loading }
+        if previousActivity == nil { activity = .loading }
 
         async let roadmapResult = readRoadmap()
         async let wavesResult = readWaves()
+        async let activityResult = readActivity()
         roadmap = reading(from: await roadmapResult, lastGood: previousRoadmap)
         waves = reading(from: await wavesResult, lastGood: previousWaves)
+        activity = reading(from: await activityResult, lastGood: previousActivity)
         selectRequestedWaveIfNeeded()
         clearSelectionIfOutsideScope()
     }
@@ -206,11 +238,13 @@ final class ControlRoomModel {
     func applyFixture(
         roadmap: ControlRoomReading<RoadmapSnapshot>,
         waves: ControlRoomReading<[Wave]>,
+        activity: ControlRoomReading<ActivitySnapshot>,
         repos: [PortfolioRepo],
         fixed: Bool = false
     ) {
         self.roadmap = roadmap
         self.waves = waves
+        self.activity = activity
         self.repos = repos
         authoredWavesByRepo = [:]
         usesFixedFixture = fixed
@@ -247,6 +281,14 @@ final class ControlRoomModel {
     private func readWaves() async -> Result<[Wave], Error> {
         do {
             return .success(try await query.allWaves())
+        } catch {
+            return .failure(error)
+        }
+    }
+
+    private func readActivity() async -> Result<ActivitySnapshot, Error> {
+        do {
+            return .success(try await query.activity())
         } catch {
             return .failure(error)
         }

--- a/swift/LoopflowMac/Views/ControlRoomActivityStrip.swift
+++ b/swift/LoopflowMac/Views/ControlRoomActivityStrip.swift
@@ -1,0 +1,163 @@
+import Foundation
+import Loopflow
+import SwiftUI
+
+struct ControlRoomActivityStrip: View {
+    @Bindable var model: ControlRoomModel
+    @Environment(\.palette) private var palette
+
+    var body: some View {
+        Group {
+            if let snapshot = model.activity.value {
+                available(snapshot)
+            } else if let reason = model.activity.errorMessage {
+                unavailable(reason)
+            } else {
+                loading
+            }
+        }
+        .frame(maxWidth: .infinity, minHeight: 58, alignment: .leading)
+        .background(palette.surface)
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("Live Loopflow activity")
+        .accessibilityIdentifier("control-room-activity")
+    }
+
+    private func available(_ snapshot: ActivitySnapshot) -> some View {
+        let summary = snapshot.controlRoomSummary
+        return HStack(spacing: Spacing.xl) {
+            VStack(alignment: .leading, spacing: Spacing.xxs) {
+                Text("LIVE ACTIVITY")
+                    .font(Typography.caption(9).weight(.bold))
+                    .tracking(1.2)
+                    .foregroundStyle(palette.textSecondary)
+                Text("Observed \(observedTime(snapshot))")
+                    .font(Typography.caption(10))
+                    .foregroundStyle(palette.textSecondary)
+                    .accessibilityLabel("Evidence observed \(observedTime(snapshot))")
+            }
+
+            metric("Agents", value: summary.activeAgents.formatted())
+            metric("Motion", value: motion(summary))
+            metric(
+                "5m output",
+                value: "\(formatRate(summary.outputTokensPerSecond5m)) tok/s"
+            )
+            metric("Measured", value: "\(compactTokens(summary.measuredOutputTokens)) tokens")
+
+            Spacer(minLength: 0)
+
+            if summary.orphaned > 0 {
+                evidenceBadge(
+                    "\(summary.orphaned) orphaned",
+                    systemImage: "exclamationmark.triangle.fill",
+                    color: .statusError
+                )
+            }
+            if summary.unclaimed > 0 {
+                evidenceBadge(
+                    "\(summary.unclaimed) unclaimed",
+                    systemImage: "questionmark.diamond.fill",
+                    color: .statusWarning
+                )
+            }
+            if let reason = model.activity.errorMessage {
+                evidenceBadge(
+                    "Refresh failed",
+                    systemImage: "arrow.clockwise.circle.fill",
+                    color: .statusWarning
+                )
+                .help(reason)
+                .accessibilityHint(reason)
+            }
+        }
+        .padding(.horizontal, Spacing.lg)
+        .padding(.vertical, Spacing.sm)
+    }
+
+    private var loading: some View {
+        HStack(spacing: Spacing.sm) {
+            ProgressView()
+                .controlSize(.small)
+            Text("Reading live activity…")
+                .font(Typography.body(11))
+                .foregroundStyle(palette.textSecondary)
+        }
+        .padding(.horizontal, Spacing.lg)
+        .accessibilityIdentifier("control-room-activity-loading")
+    }
+
+    private func unavailable(_ reason: String) -> some View {
+        HStack(spacing: Spacing.sm) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .foregroundStyle(Color.statusWarning)
+            VStack(alignment: .leading, spacing: Spacing.xxs) {
+                Text("Live activity unavailable")
+                    .font(Typography.body(11).weight(.semibold))
+                    .foregroundStyle(palette.text)
+                Text(reason)
+                    .font(Typography.caption(10))
+                    .foregroundStyle(palette.textSecondary)
+                    .lineLimit(1)
+            }
+        }
+        .padding(.horizontal, Spacing.lg)
+        .accessibilityIdentifier("control-room-activity-unavailable")
+    }
+
+    private func metric(_ label: String, value: String) -> some View {
+        VStack(alignment: .leading, spacing: Spacing.xxs) {
+            Text(label.uppercased())
+                .font(Typography.caption(8).weight(.bold))
+                .tracking(0.8)
+                .foregroundStyle(palette.textSecondary)
+            Text(value)
+                .font(Typography.code(11).weight(.medium))
+                .foregroundStyle(palette.text)
+                .lineLimit(1)
+        }
+        .accessibilityElement(children: .combine)
+    }
+
+    private func evidenceBadge(
+        _ label: String,
+        systemImage: String,
+        color: Color
+    ) -> some View {
+        Label(label, systemImage: systemImage)
+            .font(Typography.caption(9).weight(.semibold))
+            .foregroundStyle(color)
+            .lineLimit(1)
+            .padding(.horizontal, Spacing.sm)
+            .padding(.vertical, Spacing.xs)
+            .background(color.opacity(0.1))
+            .clipShape(Capsule())
+    }
+
+    private func motion(_ summary: ControlRoomActivitySummary) -> String {
+        "\(summary.working) working · \(summary.waiting) waiting · \(summary.stalled) stalled"
+    }
+
+    private func formatRate(_ rate: Double) -> String {
+        if rate >= 10 { return String(format: "%.0f", rate) }
+        return String(format: "%.1f", rate)
+    }
+
+    private func observedTime(_ snapshot: ActivitySnapshot) -> String {
+        Date(timeIntervalSince1970: TimeInterval(snapshot.observedAt))
+            .formatted(date: .omitted, time: .shortened)
+    }
+
+    private func compactTokens(_ tokens: UInt64) -> String {
+        switch tokens {
+        case 1_000_000...:
+            String(format: "%.1fM", Double(tokens) / 1_000_000)
+        case 10_000...:
+            "\(tokens / 1_000)k"
+        case 1_000...:
+            String(format: "%.1fk", Double(tokens) / 1_000)
+        default:
+            tokens.formatted()
+        }
+    }
+}

--- a/swift/LoopflowMac/Views/ControlRoomView.swift
+++ b/swift/LoopflowMac/Views/ControlRoomView.swift
@@ -22,16 +22,20 @@ struct ControlRoomView: View {
 
     var body: some View {
         @Bindable var model = model
-        HSplitView {
-            ControlRoomSidebar(model: model)
-                .frame(minWidth: 205, idealWidth: 245, maxWidth: 290)
+        VStack(spacing: 0) {
+            ControlRoomActivityStrip(model: model)
+            Divider()
+            HSplitView {
+                ControlRoomSidebar(model: model)
+                    .frame(minWidth: 205, idealWidth: 245, maxWidth: 290)
 
-            RoadmapView(model: model, selection: $model.selection)
-                .frame(minWidth: 390, idealWidth: 650, maxWidth: .infinity)
-                .accessibilityIdentifier("control-room-work")
+                RoadmapView(model: model, selection: $model.selection)
+                    .frame(minWidth: 390, idealWidth: 650, maxWidth: .infinity)
+                    .accessibilityIdentifier("control-room-work")
 
-            ControlRoomInspector(model: model)
-                .frame(minWidth: 245, idealWidth: 310, maxWidth: 390)
+                ControlRoomInspector(model: model)
+                    .frame(minWidth: 245, idealWidth: 310, maxWidth: 390)
+            }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(palette.background)

--- a/swift/LoopflowTests/ControlRoomModelTests.swift
+++ b/swift/LoopflowTests/ControlRoomModelTests.swift
@@ -49,6 +49,7 @@ struct ControlRoomModelTests {
         model.applyFixture(
             roadmap: .available(fixture.roadmap),
             waves: .available(fixture.waves),
+            activity: .available(fixture.activity),
             repos: []
         )
 
@@ -58,12 +59,31 @@ struct ControlRoomModelTests {
         #expect(model.roadmap.errorMessage == "registry unavailable")
         #expect(model.waves.value == fixture.waves)
         #expect(model.waves.errorMessage == "registry unavailable")
+        #expect(model.activity.value == fixture.activity)
+        #expect(model.activity.errorMessage == "registry unavailable")
+    }
+
+    @Test("Activity summary counts providers once and preserves orphan evidence")
+    func activitySummaryPreservesOrthogonalEvidence() throws {
+        let fixture = try ControlRoomTestFixture.load()
+
+        let summary = fixture.activity.controlRoomSummary
+
+        #expect(summary.activeAgents == 3)
+        #expect(summary.working == 1)
+        #expect(summary.waiting == 0)
+        #expect(summary.stalled == 1)
+        #expect(summary.orphaned == 1)
+        #expect(summary.unclaimed == 0)
+        #expect(summary.outputTokensPerSecond5m == 4.0)
+        #expect(summary.measuredOutputTokens == 48_200)
     }
 }
 
 private struct ControlRoomTestFixture {
     let roadmap: RoadmapSnapshot
     let waves: [Wave]
+    let activity: ActivitySnapshot
     let query: RegistryQuery
 
     static func load(sourceFile: String = #filePath) throws -> ControlRoomTestFixture {
@@ -74,6 +94,9 @@ private struct ControlRoomTestFixture {
             .appendingPathComponent("tests/fixtures/dto/roadmap_snapshot.json")
         let roadmapData = try Data(contentsOf: url)
         let roadmap = try JSONDecoder().decode(RoadmapSnapshot.self, from: roadmapData)
+        let activityURL = url.deletingLastPathComponent().appendingPathComponent("activity_snapshot.json")
+        let activityData = try Data(contentsOf: activityURL)
+        let activity = try JSONDecoder().decode(ActivitySnapshot.self, from: activityData)
         let object = try #require(JSONSerialization.jsonObject(with: roadmapData) as? [String: Any])
         let roadmapWaves = try #require(object["waves"] as? [[String: Any]])
         let waveObjects = try roadmapWaves.map { try #require($0["wave"] as? [String: Any]) }
@@ -93,14 +116,21 @@ private struct ControlRoomTestFixture {
         }
         let roadmapJSON = try #require(String(data: roadmapData, encoding: .utf8))
         let wavesJSON = try #require(String(data: waveData, encoding: .utf8))
+        let activityJSON = try #require(String(data: activityData, encoding: .utf8))
         let query = RegistryQuery { args, _ in
             switch args.first {
             case "roadmap": roadmapJSON
             case "ls": wavesJSON
+            case "ps": activityJSON
             default: throw RegistryQueryError("unexpected command \(args.joined(separator: " "))")
             }
         }
-        return ControlRoomTestFixture(roadmap: roadmap, waves: waves, query: query)
+        return ControlRoomTestFixture(
+            roadmap: roadmap,
+            waves: waves,
+            activity: activity,
+            query: query
+        )
     }
 }
 #endif

--- a/swift/LoopflowTests/DTOFixtureTests.swift
+++ b/swift/LoopflowTests/DTOFixtureTests.swift
@@ -47,6 +47,24 @@ struct DTOFixtureTests {
         #expect(decoded == turns)
     }
 
+    @Test("Activity fixture preserves process state and exact output evidence")
+    func activityFixtureRoundTrips() throws {
+        let data = try loadFixtureData("activity_snapshot.json")
+        let snapshot = try JSONDecoder().decode(ActivitySnapshot.self, from: data)
+
+        #expect(snapshot.schemaVersion == 1)
+        #expect(snapshot.fastWindowSeconds == 300)
+        #expect(snapshot.aggregate.measuredOutputTokens == 48_200)
+        #expect(snapshot.aggregate.outputTokensPerSecondFast == 4.0)
+        #expect(snapshot.nodes.filter { $0.kind == .providerLaunch }.map(\.state)
+            == [.working, .stalled])
+        #expect(snapshot.providerProcesses[0].claim == .orphaned)
+
+        let encoded = try JSONEncoder().encode(snapshot)
+        let decoded = try JSONDecoder().decode(ActivitySnapshot.self, from: encoded)
+        #expect(decoded == snapshot)
+    }
+
     @Test("Context Lab fixture preserves missing coverage and trace identity")
     func contextLabFixturePreservesResearchTruth() throws {
         let data = try loadFixtureData("context_lab_snapshot.json")

--- a/swift/LoopflowTests/RegistryQueryTests.swift
+++ b/swift/LoopflowTests/RegistryQueryTests.swift
@@ -265,6 +265,22 @@ struct RegistryQueryTests {
         #expect(runs[1].task == nil)
     }
 
+    @Test("lf ps decodes the shared live activity snapshot")
+    func activityDecodes() async throws {
+        let fixture = try String(contentsOf: activityFixtureURL(), encoding: .utf8)
+        let query = RegistryQuery { args, cwd in
+            #expect(args == ["ps", "--json"])
+            #expect(cwd == nil)
+            return fixture
+        }
+
+        let snapshot = try await query.activity()
+
+        #expect(snapshot.nodes.count == 3)
+        #expect(snapshot.aggregate.outputTokensPerSecondFast == 4.0)
+        #expect(snapshot.providerProcesses[0].claim == .orphaned)
+    }
+
     @Test("lf usage --json decodes one additive Turn row")
     func spendDecodes() async throws {
         let json = """
@@ -416,6 +432,14 @@ private func contextLabFixtureURL(sourceFile: String = #filePath) -> URL {
         .deletingLastPathComponent()
         .deletingLastPathComponent()
         .appendingPathComponent("tests/fixtures/dto/context_lab_snapshot.json")
+}
+
+private func activityFixtureURL(sourceFile: String = #filePath) -> URL {
+    URL(fileURLWithPath: sourceFile)
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+        .appendingPathComponent("tests/fixtures/dto/activity_snapshot.json")
 }
 
 private actor CallCounter {

--- a/swift/README.md
+++ b/swift/README.md
@@ -9,9 +9,12 @@
 
 Loopflow opens on the control room: repository and Wave scope on the left,
 machine-wide Now/Roadmap work in the center, and selected Work evidence on the
-right. Selecting a Wave, Project, or Task preserves the surrounding live view.
-The control room reads `lf roadmap --json` and `lf ls --json` once per refresh;
-repository scope filters those shared snapshots locally.
+right. The strip above them shows active agents, attributed motion,
+five-minute output, measured tokens, and orphaned or unclaimed providers from
+`lf ps --json`. Selecting a Wave, Project, or Task preserves the surrounding
+live view. The control room reads `lf roadmap --json`, `lf ls --json`, and
+`lf ps --json` once per refresh; repository scope filters the Work snapshots
+locally while activity remains machine-wide.
 
 Loading, empty, stale-last-good, and unavailable reads stay distinct. A failed
 refresh keeps the last useful Work visible with its failure reason rather than
@@ -65,7 +68,7 @@ and observation spans.
   Lifecycle mutations remain `lf task run/resume/interrupt`; routed questions
   are answered through the explicit `lf work asks/answer` CLI.
 - **Registry queries** own durable reads. `RegistryQuery` runs
-  `lf ls/status/roadmap/runs/usage/doctor/tokens/context/trace --json`; the app
+  `lf ls/status/roadmap/ps/runs/usage/doctor/tokens/context/trace --json`; the app
   does not maintain a second roadmap or lifecycle database. Unavailable per-Wave
   evidence renders its reason, and refresh failures leave the last successful
   roadmap or selected Wave detail visible.
@@ -76,6 +79,7 @@ and observation spans.
 ## Code map
 
 - `LoopflowMac/Views/ControlRoomView.swift` — primary scope, live Work, and selected detail
+- `LoopflowMac/Views/ControlRoomActivityStrip.swift` — machine-wide agent motion and output
 - `LoopflowMac/ControlRoomModel.swift` — shared readings, stable selection, and local scope
 - `LoopflowMac/Views/WavesView.swift` — previous Wave workspace during migration
 - `LoopflowMac/Views/RoadmapView.swift` — all-Wave roadmap and lifecycle controls

--- a/tests/fixtures/dto/README.md
+++ b/tests/fixtures/dto/README.md
@@ -31,6 +31,11 @@ Turn, AgentInvocation, trace, and exec; the second row proves a cache-only measu
 survives while absent token and cost fields remain explicit nulls. Rust and
 Swift both round-trip it.
 
+`activity_snapshot.json` pins `lf ps --json`: attributed Exec and provider
+nodes retain working/stalled state and exact token rates, while a registered
+orphan stays separate from the counted call tree. Rust and Swift both
+round-trip it; the control room derives no process state of its own.
+
 `pm_show.json` pins the repository-owned Linear hierarchy read by `lf pm show`
 and the app: a Project carries exactly one Wave Initiative and the repository
 Team; its Task carries the stable Project and Team ids used for ownership.

--- a/tests/fixtures/dto/activity_snapshot.json
+++ b/tests/fixtures/dto/activity_snapshot.json
@@ -1,0 +1,113 @@
+{
+  "schema_version": 1,
+  "observed_at": 1784606400,
+  "fast_window_seconds": 300,
+  "slow_window_seconds": 1800,
+  "aggregate": {
+    "measured_output_tokens": 48200,
+    "output_tokens_fast": 1200,
+    "output_tokens_slow": 2400,
+    "output_tokens_per_second_fast": 4.0,
+    "output_tokens_per_second_slow": 1.3333333333333333,
+    "measured_turns": 18,
+    "unmeasured_turns": 1
+  },
+  "nodes": [
+    {
+      "id": "exec:exec-control-room",
+      "parent_id": null,
+      "kind": "exec",
+      "label": "lf task pursue",
+      "pid": 4100,
+      "started_at": 1784602800,
+      "last_progress_at": 1784606380,
+      "state": "working",
+      "direct": {
+        "measured_output_tokens": 0,
+        "output_tokens_fast": 0,
+        "output_tokens_slow": 0,
+        "output_tokens_per_second_fast": 0.0,
+        "output_tokens_per_second_slow": 0.0,
+        "measured_turns": 0,
+        "unmeasured_turns": 0
+      },
+      "cumulative": {
+        "measured_output_tokens": 48200,
+        "output_tokens_fast": 1200,
+        "output_tokens_slow": 2400,
+        "output_tokens_per_second_fast": 4.0,
+        "output_tokens_per_second_slow": 1.3333333333333333,
+        "measured_turns": 18,
+        "unmeasured_turns": 1
+      }
+    },
+    {
+      "id": "launch:invocation-working",
+      "parent_id": "exec:exec-control-room",
+      "kind": "provider_launch",
+      "label": "codex 4101",
+      "pid": 4101,
+      "started_at": 1784602805,
+      "last_progress_at": 1784606380,
+      "state": "working",
+      "direct": {
+        "measured_output_tokens": 41000,
+        "output_tokens_fast": 1200,
+        "output_tokens_slow": 1200,
+        "output_tokens_per_second_fast": 4.0,
+        "output_tokens_per_second_slow": 0.6666666666666666,
+        "measured_turns": 15,
+        "unmeasured_turns": 0
+      },
+      "cumulative": {
+        "measured_output_tokens": 41000,
+        "output_tokens_fast": 1200,
+        "output_tokens_slow": 1200,
+        "output_tokens_per_second_fast": 4.0,
+        "output_tokens_per_second_slow": 0.6666666666666666,
+        "measured_turns": 15,
+        "unmeasured_turns": 0
+      }
+    },
+    {
+      "id": "launch:invocation-stalled",
+      "parent_id": "exec:exec-control-room",
+      "kind": "provider_launch",
+      "label": "claude 4201",
+      "pid": 4201,
+      "started_at": 1784599200,
+      "last_progress_at": 1784603400,
+      "state": "stalled",
+      "direct": {
+        "measured_output_tokens": 7200,
+        "output_tokens_fast": 0,
+        "output_tokens_slow": 1200,
+        "output_tokens_per_second_fast": 0.0,
+        "output_tokens_per_second_slow": 0.6666666666666666,
+        "measured_turns": 3,
+        "unmeasured_turns": 1
+      },
+      "cumulative": {
+        "measured_output_tokens": 7200,
+        "output_tokens_fast": 0,
+        "output_tokens_slow": 1200,
+        "output_tokens_per_second_fast": 0.0,
+        "output_tokens_per_second_slow": 0.6666666666666666,
+        "measured_turns": 3,
+        "unmeasured_turns": 1
+      }
+    }
+  ],
+  "provider_processes": [
+    {
+      "pid": 4301,
+      "ppid": 1,
+      "process_group": 4301,
+      "started_at": 1784595600,
+      "kernel_state": "S",
+      "provider": "opencode",
+      "command": "opencode serve",
+      "claim": "orphaned"
+    }
+  ]
+}


### PR DESCRIPTION
## Try it!

```bash
lf ps
cd swift && ./dev run
```

Compare the CLI snapshot with the strip above the primary control room. Active agents, working/waiting/stalled motion, five-minute output, measured tokens, and orphaned or unclaimed providers come from the same Rust-owned evidence.

## Intent

Make the non-chat control room answer “what is running and producing?” at a glance. This is the first fleet-health-spine slice: it brings existing live process evidence into the primary workspace without claiming a synthetic health state.

## Key decisions

- Mirror the existing Rust DTO in Swift and pin it with one shared fixture.
- Count attributed provider launches once; parent Exec nodes never inflate agent or motion counts.
- Keep current-Home activity machine-wide while repository scope filters planned Work.
- Preserve last-good activity and explicit failure evidence when refresh fails.

## Not included

Desired residency, listener/resident health, remote Homes, budgets, human gates, per-call drill-down, and the future closeable Chat sidebar remain later control-room slices.

## Evidence

`uv run python scripts/test.py --reuse-passing` passed Rust format, clippy, 1,718 Rust tests, 200 Swift tests, the Swift boundary check, the Mac app build, and eight distinct control-room renders across four states and two widths.