### PR TITLE
lf pr land: complete final tasks over merged prs

### DIFF
--- a/docs/lf.md
+++ b/docs/lf.md
@@ -675,6 +675,11 @@ the operator. `--match-head-commit` fences the arming command; Loopflow revokes
 Auto before its own later head mutation. Concurrent Loopflow finalization and
 push commands in one worktree are refused rather than interleaved.
 
+If a Task reaches `finally` after its work already merged and rotation left a
+provably empty unpublished successor, `lf pr land -c` completes over the merged
+PR without creating another one. Earlier lifecycle phases still refuse the
+empty range.
+
 Submit and land clear `scratch/`, preserve a recovery ref, collapse the
 authored range to one tree-identical commit, replay that commit onto the pinned
 target, verify it, and push once. Ordinary `lf rebase` keeps commit history.

--- a/rust/loopflow/src/engine/builtins/ops/skill/pr-land.md
+++ b/rust/loopflow/src/engine/builtins/ops/skill/pr-land.md
@@ -91,6 +91,9 @@ If `lf pr land` fails due to rebase conflicts, launch a sub-agent to run the
 ## Notes
 
 - If the PR already has a good title and body, run `lf pr land` without `--title`/`--body` to keep existing content.
+- In a Task's `finally` phase, `-c` completes directly over already-merged work
+  when lifecycle rotation left a provably empty unpublished successor. It does
+  not create an empty PR; earlier phases keep the ordinary empty-range refusal.
 
 ## Adaptation
 

--- a/rust/loopflow/src/engine/git.rs
+++ b/rust/loopflow/src/engine/git.rs
@@ -398,10 +398,21 @@ pub fn get_default_branch(repo: &Path) -> Result<String, GitError> {
 
 /// Return true if working tree is clean.
 pub fn is_clean(repo: &Path) -> Result<bool, GitError> {
-    let output = run_git(repo, &["status", "--porcelain"])?;
+    is_clean_for_pathspec(repo, &[])
+}
+
+/// Return true when only gate artifacts under `scratch/` are dirty.
+pub fn is_materially_clean(repo: &Path) -> Result<bool, GitError> {
+    is_clean_for_pathspec(repo, &[".", ":(exclude)scratch", ":(exclude)scratch/**"])
+}
+
+fn is_clean_for_pathspec(repo: &Path, pathspec: &[&str]) -> Result<bool, GitError> {
+    let mut args = vec!["status", "--porcelain"];
+    args.extend_from_slice(pathspec);
+    let output = run_git(repo, &args)?;
     if !output.status.success() {
         return Err(GitError::CommandFailed {
-            command: "git status --porcelain".to_string(),
+            command: format!("git {}", args.join(" ")),
             stderr: String::from_utf8_lossy(&output.stderr).to_string(),
         });
     }
@@ -1455,6 +1466,7 @@ mod tests {
         let repo = init_repo();
         commit_file(repo.path(), "README.md", "tracked");
         let initial = material_worktree_state(repo.path()).expect("initial state");
+        assert!(is_materially_clean(repo.path()).expect("initially clean"));
 
         fs::create_dir(repo.path().join("scratch")).expect("create scratch");
         fs::write(repo.path().join("scratch/review.md"), "gate evidence")
@@ -1463,12 +1475,14 @@ mod tests {
             material_worktree_state(repo.path()).expect("scratch-only state"),
             initial
         );
+        assert!(is_materially_clean(repo.path()).expect("scratch-only clean"));
 
         fs::write(repo.path().join("src.txt"), "material repair").expect("write repair");
         assert_ne!(
             material_worktree_state(repo.path()).expect("material state"),
             initial
         );
+        assert!(!is_materially_clean(repo.path()).expect("materially dirty"));
     }
 
     #[test]

--- a/rust/loopflow/src/ops/land.rs
+++ b/rust/loopflow/src/ops/land.rs
@@ -48,8 +48,9 @@ enum Integration {
 /// Run every land skill: commit, rebase onto main, clear scratch, mark the PR
 /// ready, and finalize per `finalize`. `land` arms auto-merge; `submit` assigns
 /// the PR for a human to merge. Neither rotates the worktree — the wave home is
-/// permanent. Returns the resulting PR (`None` for a local merge) so callers can
-/// record it against the run.
+/// permanent. Returns the resulting PR, or `None` for a local merge or direct
+/// Task completion over an already-merged PR, so callers can record it against
+/// the run.
 fn prepare_pr(
     repo: &Path,
     options: &LandOptions,
@@ -70,6 +71,22 @@ fn prepare_pr(
     }
     let (repo_root, main_repo) = resolve_repos(repo, options.worktree.as_deref())?;
     crate::ops::pr::reject_control_plane_pr(&repo_root)?;
+    if options.complete && (!options.strict || is_clean(&repo_root)?) {
+        if let Some(issue) = crate::ops::task::find_discardable_final_task(&repo_root)? {
+            // The final flow reviewed work that already landed, and rotation left
+            // one unpublished branch at its recorded base. Reuse the Task completion
+            // gate instead of manufacturing an empty GitHub PR. Pre-final Tasks do
+            // not match the query and continue through the ordinary range refusal.
+            clear_scratch(&repo_root, progress)?;
+            crate::ops::task::task_complete(
+                &issue,
+                "Final Task flow approved completion after its prior pull request merged"
+                    .to_string(),
+            )?;
+            progress.status("Completed Task over its merged pull request.");
+            return Ok(None);
+        }
+    }
     if !options.local && !crate::ops::pr::gh_available() {
         return Err(OpsError::Message("gh CLI not found".to_string()));
     }

--- a/rust/loopflow/src/ops/task.rs
+++ b/rust/loopflow/src/ops/task.rs
@@ -13,8 +13,8 @@ use crate::durable::{
 use crate::engine::config::{load_config_or_default, parse_agent};
 use crate::engine::git::{
     checkout, checkout_new_branch_from, cherry_pick_range, current_branch, delete_local_branch,
-    fetch, get_default_branch, is_ancestor, is_clean, merge_base, push_with_upstream, ref_exists,
-    rev_parse, stash_including_untracked, stash_pop,
+    fetch, get_default_branch, is_ancestor, is_clean, is_materially_clean, merge_base,
+    push_with_upstream, ref_exists, rev_parse, stash_including_untracked, stash_pop,
 };
 use crate::engine::naming::sanitize_for_branch;
 use crate::engine::process::{tmux_session_exists, tmux_session_slug};
@@ -3633,6 +3633,29 @@ pub fn task_status(issue: &str) -> OpsResult<Task> {
         reconcile_process_liveness(&store, &mut task).await?;
         reconcile_task_completion(&store, &mut task, None).await?;
         Ok(task)
+    })
+}
+
+/// Find a final Task whose only active PR is the empty artifact of rotating
+/// past already-merged work. Scratch is gate evidence, not another PR slice.
+pub(crate) fn find_discardable_final_task(repo: &Path) -> OpsResult<Option<String>> {
+    let repo = repo.to_path_buf();
+    block_on_task(async move {
+        let TaskAuthority::Authority { store, task, .. } = resolve_task_authority(&repo).await?
+        else {
+            return Ok(None);
+        };
+        if task.lifecycle_phase != crate::task::TaskLifecyclePhase::Finally {
+            return Ok(None);
+        }
+        let materially_clean = is_materially_clean(&task.worktree)
+            .map_err(|error| task_error(format!("failed to inspect Task worktree: {error}")))?;
+        if !materially_clean {
+            return Ok(None);
+        }
+        let gate = task_completion_gate(&store, &task).await?;
+        Ok((gate.satisfied && gate.discardable_successor.is_some())
+            .then(|| task.plan.identifier.clone()))
     })
 }
 

--- a/rust/loopflow/tests/pr_tests.rs
+++ b/rust/loopflow/tests/pr_tests.rs
@@ -7,10 +7,12 @@ use std::process::Command;
 use loopflow::durable::WorkStatus;
 use loopflow::ops::task::{pr_next, task_complete, task_resume, task_snapshot, task_status};
 use loopflow::ops::{
-    commit_workflow, create_or_update_pr, current_pr, present_pr_review, CommitOptions,
-    NullProgress, OpsError, PrOptions,
+    commit_workflow, create_or_update_pr, current_pr, land, present_pr_review, CommitOptions,
+    LandOptions, NullProgress, OpsError, PrOptions,
 };
-use loopflow::task::{AfterMerge, GithubPr, PrMergeMode, PrMergeRequest, PrPhase, PrPublication};
+use loopflow::task::{
+    AfterMerge, GithubPr, PrMergeMode, PrMergeRequest, PrPhase, PrPublication, TaskGateProposal,
+};
 use loopflow_test_support::TestRepo;
 use support::{
     counting_open_script, presentation_attempts, register_active_task, register_task,
@@ -75,6 +77,27 @@ if [ "$1" = "api" ]; then
 fi
 exit 0
 "#
+}
+
+fn gh_merged_pr_logging_script(log_path: &str) -> String {
+    format!(
+        r#"#!/bin/sh
+echo "$@" >> "{log_path}"
+if [ "$1" = "--version" ]; then
+  exit 0
+fi
+if [ "$1" = "api" ]; then
+  head=$(git rev-parse HEAD)
+  printf '{{"merged":true,"state":"closed","draft":false,"merge_commit_sha":"merge-912","number":912,"html_url":"https://example.com/pr/912","head":{{"sha":"%s"}}}}\n' "$head"
+  exit 0
+fi
+if [ "$1 $2" = "pr list" ]; then
+  echo '[]'
+  exit 0
+fi
+exit 0
+"#
+    )
 }
 
 fn gh_changed_head_script(log_path: &str) -> String {
@@ -454,6 +477,140 @@ fn merged_continue_task_rotates_to_a_working_pr_without_review_state() {
         runtime.block_on(task.store.work_status(&work)).unwrap(),
         WorkStatus::Done
     ));
+}
+
+#[test]
+fn completing_land_discards_an_empty_successor_only_in_finally() {
+    let home = tempfile::TempDir::new().expect("temp home");
+    let log_path = home.path().join("gh.log");
+    let script = gh_merged_pr_logging_script(log_path.to_string_lossy().as_ref());
+    let _env = EnvGuard::with_lf_home(&[("gh", script.as_str())], home.path());
+    let repo = TestRepo::new();
+    fs::create_dir_all(repo.path().join("scratch")).expect("create scratch");
+    fs::write(repo.path().join("scratch/.gitkeep"), "").expect("write gitkeep");
+    repo.stage_all();
+    repo.commit("track scratch");
+    push_branch(&repo, "main");
+    let base = repo.head_sha();
+    let branch = "jack/task-pr-proof";
+    repo.create_branch(branch);
+    point_origin_at_github(&repo);
+    let task = register_task(home.path(), repo.path(), branch, &base);
+    let mut pr = task.pr.clone();
+    pr.publication = Some(PrPublication {
+        requested_at: time::OffsetDateTime::now_utc(),
+        github: Some(GithubPr {
+            number: 912,
+            url: "https://example.com/pr/912".to_string(),
+            head_sha: None,
+        }),
+        merge: None,
+    });
+    let runtime = tokio::runtime::Runtime::new().expect("task runtime");
+    runtime
+        .block_on(task.store.update_task_pr(&pr))
+        .expect("mark PR as published");
+    task_status("INF-123").expect("reconcile merged Task PR");
+
+    let restore = Command::new("git")
+        .current_dir(repo.path())
+        .args([
+            "remote",
+            "set-url",
+            "origin",
+            repo.bare_path().to_str().expect("bare origin path"),
+        ])
+        .status()
+        .expect("restore local origin");
+    assert!(restore.success());
+    let successor = pr_next(repo.path(), None).expect("rotate merged continuation");
+    assert_eq!(successor.phase(), PrPhase::Working);
+
+    let options = LandOptions {
+        strict: false,
+        local: false,
+        create_pr: true,
+        complete: true,
+        next_slug: None,
+        worktree: None,
+        commit_message: None,
+        pr_title: None,
+        pr_body: None,
+        agent: None,
+    };
+    let pre_final = land(repo.path(), &options, &NullProgress)
+        .expect_err("an empty pre-final successor must not complete");
+    assert!(pre_final.to_string().contains("PR range is empty"));
+
+    let work = runtime
+        .block_on(
+            task.store
+                .work_for_child(&loopflow::child::ChildRef::Task(task.task.id.clone())),
+        )
+        .expect("resolve Task Work");
+    assert!(!matches!(
+        runtime.block_on(task.store.work_status(&work)).unwrap(),
+        WorkStatus::Done
+    ));
+    let mut final_task = runtime
+        .block_on(task.store.get_task(&task.task.id))
+        .expect("read Task")
+        .expect("Task exists");
+    final_task
+        .enter_finally(TaskGateProposal {
+            done: false,
+            reason: "review the already-merged slice".to_string(),
+        })
+        .expect("enter finally");
+    let conn =
+        rusqlite::Connection::open(home.path().join("loopflow.db")).expect("open Task registry");
+    conn.execute(
+        "UPDATE tasks SET lifecycle_phase='gate', phase_epoch=?2, gate_cycle=?3, \
+         gate_proposal_json=?4 WHERE id=?1",
+        rusqlite::params![
+            final_task.id.as_str(),
+            final_task.phase_epoch,
+            final_task.gate_cycle,
+            serde_json::to_string(&final_task.gate_proposal).expect("serialize gate proposal")
+        ],
+    )
+    .expect("persist finally phase");
+    fs::create_dir_all(repo.path().join("scratch")).expect("recreate scratch after rotation");
+    fs::write(repo.path().join("scratch/review.md"), "final gate evidence")
+        .expect("write final evidence");
+    let calls_before = fs::read_to_string(&log_path).expect("read setup calls");
+
+    let result = land(repo.path(), &options, &NullProgress).expect("complete final Task");
+
+    assert!(result.is_none(), "no empty GitHub PR should be created");
+    let calls_after = fs::read_to_string(&log_path).expect("read final calls");
+    let final_calls = calls_after
+        .strip_prefix(&calls_before)
+        .expect("setup calls remain a prefix");
+    for mutation in ["pr create", "pr edit", "pr ready", "pr merge"] {
+        assert!(
+            !final_calls.contains(mutation),
+            "direct completion must not mutate GitHub: {final_calls}"
+        );
+    }
+    assert_eq!(
+        runtime.block_on(task.store.work_status(&work)).unwrap(),
+        WorkStatus::Done
+    );
+    let completed = runtime
+        .block_on(task.store.get_task(&task.task.id))
+        .expect("read completed Task")
+        .expect("completed Task exists");
+    assert!(completed
+        .gate_proposal
+        .as_ref()
+        .is_some_and(|gate| gate.done));
+    let prs = runtime
+        .block_on(task.store.task_prs(&task.task.id))
+        .expect("read completed PR chain");
+    assert_eq!(prs.len(), 1, "the empty successor is removed atomically");
+    assert_eq!(prs[0].phase(), PrPhase::Merged);
+    assert!(!repo.path().join("scratch/review.md").exists());
 }
 
 #[test]


### PR DESCRIPTION
## Usage

```bash
lf pr land -c
```

When a Task reaches `finally` after its work has already merged and rotation left a provably empty unpublished successor, this now completes the Task directly instead of attempting to create an empty PR.

## Summary

This fixes final-gate completion for work that merged before the Task lifecycle finished. `lf pr land -c` now recognizes the narrowly proven empty-successor state, clears gate artifacts, and completes against the existing merged PR without mutating GitHub. Earlier lifecycle phases and successors with material changes retain the normal empty-range refusal.

## Changes

- Added a material-cleanliness check that treats `scratch/` as gate evidence
- Reused the Task completion gate to validate and discard the empty successor
- Covered direct completion, pre-final refusal, scratch cleanup, and the absence of GitHub PR mutations
- Documented the final-phase completion behavior