### PR TITLE
wave chat: expose one active conversation backing

### DIFF
--- a/docs/waves.md
+++ b/docs/waves.md
@@ -96,7 +96,17 @@ craft — is covered in [Authoring → Goals](authoring.md#goals).
 
 ### Discord chat
 
-Bind one existing guild text channel to one Wave:
+Wave Chat is local by default. Omitting `chat` (or explicitly choosing
+`provider: local`) keeps messages in the Wave journal and exposes the local
+composer in Loopflow:
+
+```yaml
+chat:
+  provider: local
+```
+
+Bind one existing guild text channel to replace the local backing for future
+messages:
 
 ```yaml
 # wave/product/GOAL.md
@@ -116,13 +126,29 @@ doppler run -- lf wave product
 ```
 
 The bot needs only **View Channel**, **Read Message History**, and **Send
-Messages**, with Message Content enabled in the Discord developer portal. The
-first start attaches at the channel's current head; later starts resume from
-the journaled cursor. Discord remains the shared company transcript. Loopflow
-retains source-linked Wave inputs, answering turns, and send receipts as Run
-evidence. `home_id` is the binding's durable owner (`lf home id`). Another Home
-fails before contacting Discord, while an OS-held lease prevents another
+Messages**, with Message Content enabled in the Discord developer portal. A
+backing change takes effect when the listener restarts and starts one durable
+conversation epoch. Earlier local epochs stay selectable and read-only.
+
+Discord is the transcript authority while its epoch is active. Loopflow reads
+bounded history from Discord on demand and stores no duplicate presentation
+transcript. `lf chat "text"` returns an Open-in-Discord action as a rejection
+instead of appending a hidden local message. Agent speech appears only after
+Discord returns its provider message id. Every API message names its epoch and
+exact local journal event or Discord message source.
+
+Loopflow retains source-linked inputs until the resident consumes them,
+execution turns, deterministic send intents, cursors, and provider receipts as
+Run evidence. `home_id` is the binding's durable owner (`lf home id`). Another
+Home fails before contacting Discord, while an OS-held lease prevents another
 checkout on the owner Home from consuming the same channel.
+
+Read the active epoch or an earlier one explicitly:
+
+```bash
+lf chat --history --json --wave product
+lf chat --history --json --wave product --epoch chat-epoch-42
+```
 
 ### Memory
 

--- a/rust/loopflow/src/bin/lf.rs
+++ b/rust/loopflow/src/bin/lf.rs
@@ -1479,9 +1479,19 @@ fn main() -> anyhow::Result<()> {
                 history,
                 json,
                 limit,
+                epoch,
                 target,
             }) => loopflow::lf::commands::chat::run(
-                text, *follow, *steer, *history, *json, *limit, target,
+                text,
+                loopflow::lf::commands::chat::ChatOptions {
+                    follow: *follow,
+                    steer: *steer,
+                    history: *history,
+                    json: *json,
+                    limit: *limit,
+                    epoch: epoch.as_deref(),
+                },
+                target,
             ),
             Some(Commands::Install { .. }) => {
                 unreachable!("install dispatches before home routing")

--- a/rust/loopflow/src/engine/wave_config.rs
+++ b/rust/loopflow/src/engine/wave_config.rs
@@ -48,6 +48,7 @@ pub struct WavePmConfig {
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(tag = "provider", rename_all = "snake_case")]
 pub enum WaveChatConfig {
+    Local,
     Discord {
         #[serde(deserialize_with = "deserialize_home_id")]
         home_id: HomeId,
@@ -389,6 +390,18 @@ mod tests {
         assert!(matches!(
             try_read_wave_config(temp.path(), "scan"),
             Err(WaveConfigError::Parse { .. })
+        ));
+
+        fs::write(
+            dir.join("GOAL.md"),
+            "---\nchat:\n  provider: local\n---\nDrive the work.\n",
+        )
+        .expect("write local chat");
+        assert!(matches!(
+            try_read_wave_config(temp.path(), "scan")
+                .expect("local config")
+                .and_then(|config| config.chat),
+            Some(WaveChatConfig::Local)
         ));
 
         fs::write(

--- a/rust/loopflow/src/lf/commands/chat.rs
+++ b/rust/loopflow/src/lf/commands/chat.rs
@@ -28,10 +28,6 @@ use std::io::BufRead;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-use anyhow::{anyhow, bail, Result};
-use serde::{Deserialize, Serialize};
-
-use crate::chat::turns::ChatTurn;
 use crate::engine::wave_context::{
     read_endpoint_pointer, resolve_managed_wave_name, wave_origin, WaveResolveError,
 };
@@ -39,52 +35,46 @@ use crate::lf::commands::thread;
 use crate::lf::commands::util::{find_repo_root, message_text};
 use crate::lf::WaveTargetArgs;
 use crate::store::{open_existing_store, SharedStore};
+use crate::wave::chat::{
+    ChatAction, ChatBacking, ChatHistorySnapshot, ChatHistoryState, ChatMessageSource,
+    PostMessageErrorResponse, WaveChatMessage,
+};
 use crate::wave::journal::{
     fold_thread, journal_path, read_events_with_state, MessageOp, ReadOnlyJournalState,
 };
 use crate::wave::server::HUMAN_THREAD_REPLAY_LIMIT;
 use crate::wave::Wave;
+use anyhow::{anyhow, bail, Result};
 
-/// Evidence state for a bounded read of the durable Wave thread.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum ChatHistoryState {
-    Available,
-    Missing,
-    Partial,
-    Unavailable,
+#[derive(Debug, Clone, Copy)]
+pub struct ChatOptions<'a> {
+    pub follow: bool,
+    pub steer: bool,
+    pub history: bool,
+    pub json: bool,
+    pub limit: Option<usize>,
+    pub epoch: Option<&'a str>,
 }
 
-/// Stable `lf chat --history --json` response, mirrored by Swift.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-pub struct ChatHistorySnapshot {
-    pub state: ChatHistoryState,
-    pub detail: Option<String>,
-    pub turns: Vec<ChatTurn>,
-    pub truncated: bool,
-}
-
-pub fn run(
-    text_args: &[String],
-    follow: bool,
-    steer: bool,
-    history: bool,
-    json: bool,
-    limit: Option<usize>,
-    target: &WaveTargetArgs,
-) -> Result<()> {
+pub fn run(text_args: &[String], options: ChatOptions<'_>, target: &WaveTargetArgs) -> Result<()> {
     let rt = tokio::runtime::Runtime::new()?;
     rt.block_on(async {
         let context = CliContext::detect().await;
-        if history {
-            if !json {
+        if options.history {
+            if !options.json {
                 bail!("--history currently requires --json");
             }
-            history_with_context(&context, target, limit.unwrap_or(HUMAN_THREAD_REPLAY_LIMIT)).await
-        } else if follow {
-            follow_with_context(&context, steer, target).await
+            history_with_context(
+                &context,
+                target,
+                options.limit.unwrap_or(HUMAN_THREAD_REPLAY_LIMIT),
+                options.epoch,
+            )
+            .await
+        } else if options.follow {
+            follow_with_context(&context, options.steer, target).await
         } else {
-            run_with_context(&context, text_args, steer, target).await
+            run_with_context(&context, text_args, options.steer, target).await
         }
     })
 }
@@ -94,6 +84,7 @@ async fn history_with_context(
     context: &CliContext,
     target: &WaveTargetArgs,
     limit: usize,
+    epoch: Option<&str>,
 ) -> Result<()> {
     if limit == 0 {
         bail!("--limit must be at least 1");
@@ -108,18 +99,35 @@ async fn history_with_context(
     else {
         bail!("no wave here — name one with `lf chat --history --json -w <wave>`");
     };
+    if let Some(endpoint) = resolved.endpoint.as_deref() {
+        let mut path = format!("/conversation?limit={limit}");
+        if let Some(epoch) = epoch {
+            path.push_str("&epoch=");
+            path.push_str(epoch);
+        }
+        let value = get_json(endpoint, &path).await?;
+        let snapshot: ChatHistorySnapshot = serde_json::from_value(value)
+            .map_err(|error| anyhow!("bad Wave Chat history response: {error}"))?;
+        println!("{}", serde_json::to_string(&snapshot)?);
+        return Ok(());
+    }
     let repo_root = resolved.repo_root.ok_or_else(|| {
         anyhow!(
             "wave '{}' has no local origin repository for durable history",
             resolved.name
         )
     })?;
-    let snapshot = history_snapshot(&repo_root, &resolved.name, limit);
+    let snapshot = history_snapshot(&repo_root, &resolved.name, limit, epoch);
     println!("{}", serde_json::to_string(&snapshot)?);
     Ok(())
 }
 
-fn history_snapshot(repo_root: &Path, wave: &str, limit: usize) -> ChatHistorySnapshot {
+fn history_snapshot(
+    repo_root: &Path,
+    wave: &str,
+    limit: usize,
+    selected_epoch_id: Option<&str>,
+) -> ChatHistorySnapshot {
     let read = read_events_with_state(&journal_path(repo_root, wave));
     let state = match read.state {
         ReadOnlyJournalState::Available => ChatHistoryState::Available,
@@ -129,13 +137,65 @@ fn history_snapshot(repo_root: &Path, wave: &str, limit: usize) -> ChatHistorySn
     };
     let mut fold = fold_thread(&read.events);
     fold.turns.append(&mut fold.open);
-    let truncated = fold.turns.len() > limit;
-    let keep_from = fold.turns.len().saturating_sub(limit);
-    let turns = fold.turns.split_off(keep_from);
+    let epochs = fold.conversation_epochs.clone();
+    let active_epoch = epochs.last().cloned();
+    let selected_epoch = match selected_epoch_id {
+        Some(id) => epochs.iter().find(|epoch| epoch.id == id).cloned(),
+        None => active_epoch.clone(),
+    };
+    let mut messages = selected_epoch
+        .as_ref()
+        .filter(|epoch| matches!(epoch.backing, ChatBacking::Local))
+        .map(|epoch| {
+            let imported_turns = fold.conversation_epoch_turns.get(&epoch.id).cloned();
+            let end_seq = epochs
+                .iter()
+                .find(|candidate| candidate.number == epoch.number + 1)
+                .map(|candidate| candidate.journal_seq)
+                .unwrap_or(u64::MAX);
+            fold.turns
+                .into_iter()
+                .filter_map(|turn| {
+                    let journal_seq = turn.id.strip_prefix("turn-")?.parse::<u64>().ok()?;
+                    let belongs = imported_turns.as_ref().map_or_else(
+                        || journal_seq > epoch.journal_seq && journal_seq < end_seq,
+                        |turn_ids| turn_ids.contains(&turn.id),
+                    );
+                    belongs.then(|| WaveChatMessage {
+                        epoch_id: epoch.id.clone(),
+                        source: ChatMessageSource::Local { journal_seq },
+                        turn,
+                    })
+                })
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+    let truncated = messages.len() > limit;
+    let keep_from = messages.len().saturating_sub(limit);
+    messages = messages.split_off(keep_from);
+    let (state, detail) =
+        if let Some(missing_epoch) = selected_epoch_id.filter(|_| selected_epoch.is_none()) {
+            (
+                ChatHistoryState::Unavailable,
+                Some(format!("Unknown Wave Chat epoch '{missing_epoch}'.")),
+            )
+        } else if selected_epoch
+            .as_ref()
+            .is_some_and(|epoch| matches!(epoch.backing, ChatBacking::Discord { .. }))
+        {
+            (
+                ChatHistoryState::Unavailable,
+                Some("Discord history requires the active Wave listener.".to_string()),
+            )
+        } else {
+            (state, read.detail)
+        };
     ChatHistorySnapshot {
+        epochs,
+        selected_epoch_id: selected_epoch.map(|epoch| epoch.id),
         state,
-        detail: read.detail,
-        turns,
+        detail,
+        messages,
         truncated,
     }
 }
@@ -492,6 +552,15 @@ pub(crate) async fn post_json(
     let status = response.status();
     let text = response.text().await.unwrap_or_default();
     if !status.is_success() {
+        if let Ok(rejection) = serde_json::from_str::<PostMessageErrorResponse>(&text) {
+            if let ChatBacking::Discord {
+                open: ChatAction::OpenDiscord { label, url },
+                ..
+            } = rejection.epoch.backing
+            {
+                bail!("{label}: {url}");
+            }
+        }
         bail!("wave server rejected the request ({status}): {text}");
     }
     Ok(serde_json::from_str(&text).unwrap_or(serde_json::Value::Null))
@@ -534,22 +603,104 @@ mod tests {
                 .expect("append message");
         }
 
-        let snapshot = history_snapshot(tmp.path(), "ship", 12);
+        let snapshot = history_snapshot(tmp.path(), "ship", 12, None);
         assert_eq!(snapshot.state, ChatHistoryState::Available);
-        assert_eq!(snapshot.turns.len(), 12);
+        assert_eq!(snapshot.messages.len(), 12);
         assert!(snapshot.truncated);
-        assert_eq!(snapshot.turns.first().unwrap().text, "message 3");
-        assert_eq!(snapshot.turns.last().unwrap().text, "message 14");
+        assert_eq!(snapshot.messages.first().unwrap().turn.text, "message 3");
+        assert_eq!(snapshot.messages.last().unwrap().turn.text, "message 14");
     }
 
     #[test]
     fn durable_history_distinguishes_missing_evidence_from_an_empty_thread() {
         let tmp = tempfile::tempdir().expect("tempdir");
-        let snapshot = history_snapshot(tmp.path(), "ship", 12);
+        let snapshot = history_snapshot(tmp.path(), "ship", 12, None);
         assert_eq!(snapshot.state, ChatHistoryState::Missing);
-        assert!(snapshot.turns.is_empty());
+        assert!(snapshot.messages.is_empty());
         assert!(!snapshot.truncated);
         assert!(snapshot.detail.is_some());
+    }
+
+    #[test]
+    fn serverless_history_keeps_the_imported_local_epoch() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let path = journal_path(tmp.path(), "ship");
+        let (mut journal, _) = crate::wave::journal::Journal::open(&path).expect("legacy journal");
+        journal.append(|_| EventKind::UserMessage {
+            id: crate::wave::journal::MessageId("legacy-message".into()),
+            op: MessageOp::Message,
+            text: "read me after migration".into(),
+        });
+        drop(journal);
+        drop(
+            crate::wave::runtime::WaveRuntime::open("ship".into(), tmp.path().to_path_buf())
+                .expect("migrate journal"),
+        );
+
+        let snapshot = history_snapshot(tmp.path(), "ship", 12, Some("chat-epoch-legacy-1"));
+        assert_eq!(snapshot.state, ChatHistoryState::Available);
+        assert_eq!(snapshot.messages.len(), 1);
+        assert_eq!(snapshot.messages[0].turn.text, "read me after migration");
+        assert!(matches!(
+            snapshot.messages[0].source,
+            ChatMessageSource::Local { .. }
+        ));
+    }
+
+    #[test]
+    fn serverless_history_keeps_discord_epoch_without_shadow_transcript() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let local =
+            crate::wave::runtime::WaveRuntime::open("ship".into(), tmp.path().to_path_buf())
+                .expect("open local epoch");
+        local
+            .try_deliver_authored(MessageOp::Message, "local history".into())
+            .expect("write local message");
+        drop(local);
+
+        let binding = crate::wave::journal::DiscordChatBinding {
+            guild_id: "guild".into(),
+            channel_id: "channel".into(),
+        };
+        let discord = crate::wave::runtime::WaveRuntime::open_with_backing(
+            "ship".into(),
+            tmp.path().to_path_buf(),
+            ChatBacking::discord(&binding),
+        )
+        .expect("open Discord epoch");
+        let discord_epoch = discord.active_conversation_epoch();
+        drop(discord);
+
+        let local_again =
+            crate::wave::runtime::WaveRuntime::open("ship".into(), tmp.path().to_path_buf())
+                .expect("open next local epoch");
+        assert_eq!(local_again.active_conversation_epoch().number, 3);
+        drop(local_again);
+
+        let snapshot = history_snapshot(tmp.path(), "ship", 12, Some(&discord_epoch.id));
+        assert_eq!(snapshot.state, ChatHistoryState::Unavailable);
+        assert_eq!(snapshot.epochs.len(), 3);
+        assert_eq!(
+            snapshot.selected_epoch_id.as_deref(),
+            Some(discord_epoch.id.as_str())
+        );
+        let selected = snapshot
+            .epochs
+            .iter()
+            .find(|epoch| epoch.id == discord_epoch.id)
+            .expect("selected Discord epoch");
+        assert_eq!(selected.id, discord_epoch.id);
+        assert_eq!(selected.backing, discord_epoch.backing);
+        assert!(selected.ended_at.is_some());
+        assert!(matches!(
+            snapshot.epochs.last().map(|epoch| &epoch.backing),
+            Some(&ChatBacking::Local)
+        ));
+        assert!(snapshot.messages.is_empty());
+        assert_eq!(
+            snapshot.detail.as_deref(),
+            Some("Discord history requires the active Wave listener.")
+        );
     }
 
     #[test]
@@ -561,12 +712,44 @@ mod tests {
         let snapshot: ChatHistorySnapshot =
             serde_json::from_str(fixture).expect("decode chat history fixture");
         assert_eq!(snapshot.state, ChatHistoryState::Partial);
-        assert_eq!(snapshot.turns.len(), 1);
+        assert_eq!(snapshot.messages.len(), 1);
         assert!(snapshot.truncated);
         let encoded = serde_json::to_string(&snapshot).expect("encode chat history fixture");
         let decoded: ChatHistorySnapshot =
             serde_json::from_str(&encoded).expect("re-decode chat history fixture");
         assert_eq!(decoded, snapshot);
+    }
+
+    #[tokio::test]
+    async fn discord_chat_cli_surfaces_the_open_action() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind");
+        let address = listener.local_addr().expect("address");
+        let rejection: PostMessageErrorResponse = serde_json::from_str(include_str!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../tests/fixtures/dto/post_message_error_response.json"
+        )))
+        .expect("decode rejection fixture");
+        let app = axum::Router::new().route(
+            "/messages",
+            axum::routing::post(move || {
+                let rejection = rejection.clone();
+                async move { (reqwest::StatusCode::CONFLICT, axum::Json(rejection)) }
+            }),
+        );
+        let server = tokio::spawn(async move {
+            axum::serve(listener, app).await.ok();
+        });
+
+        let error = post_message(&address.to_string(), "shadow", false)
+            .await
+            .expect_err("Discord mode rejects CLI compose");
+        assert_eq!(
+            error.to_string(),
+            "Open in Discord: https://discord.com/channels/guild-1/channel-1"
+        );
+        server.abort();
     }
 
     #[test]
@@ -816,13 +999,13 @@ mod tests {
             &origin, "goals",
         ))
         .expect("journal");
-        assert!(matches!(
-            &events[0].kind,
+        assert!(events.iter().any(|event| matches!(
+            &event.kind,
             EventKind::UserMessage {
                 op: MessageOp::Message,
                 ..
             }
-        ));
+        )));
     }
 
     #[tokio::test]

--- a/rust/loopflow/src/lf/commands/thread.rs
+++ b/rust/loopflow/src/lf/commands/thread.rs
@@ -28,6 +28,7 @@ use crate::chat::turns::{
 use crate::chat::types::{ConversationItem, Lifecycle};
 use crate::lf::commands::chat::{resolve_target, CliContext};
 use crate::lf::WaveTargetArgs;
+use crate::wave::chat::{ChatBacking, ChatMessageSource, ConversationEpoch, WaveChatMessage};
 use crate::wave::journal::ellipsize;
 use crate::wave::subscription::{stream_events, Frame};
 
@@ -116,12 +117,11 @@ struct TurnProgress {
 #[derive(Debug)]
 struct Renderer {
     turns: HashMap<String, TurnProgress>,
-    /// Open turns reconstructed from `turn`/`turn-delta` frames, keyed by id.
-    /// A whole `turn` frame (re)baselines an entry; each `turn-delta` absorbs
-    /// one increment into it through the same rule the listener folds with, so
-    /// the reconstruction matches the served turn without the whole turn
-    /// crossing the wire per token.
-    open: HashMap<String, ChatTurn>,
+    /// Open source-bearing messages reconstructed from `message` and
+    /// `message-delta` frames, keyed by turn id. The opening message owns
+    /// provenance; deltas carry only the incremental turn item.
+    open: HashMap<String, WaveChatMessage>,
+    epoch: Option<ConversationEpoch>,
 }
 
 impl Renderer {
@@ -129,6 +129,7 @@ impl Renderer {
         Self {
             turns: HashMap::new(),
             open: HashMap::new(),
+            epoch: None,
         }
     }
 
@@ -144,33 +145,48 @@ impl Renderer {
             // A state transition is loop bookkeeping; the conversation shows
             // motion through the turns themselves.
             "state" => Vec::new(),
-            "turn" => {
-                let Ok(turn) = serde_json::from_str::<ChatTurn>(&frame.data) else {
+            "epoch" => {
+                let Ok(epoch) = serde_json::from_str::<ConversationEpoch>(&frame.data) else {
                     return vec![format!(
-                        "(unparseable turn frame: {})",
+                        "(unparseable epoch frame: {})",
                         ellipsize(&frame.data, 80)
                     )];
                 };
-                // Re-baseline the reconstruction: the whole turn is authoritative.
-                self.open.insert(turn.id.clone(), turn.clone());
-                self.turn_lines(&turn)
+                if self.epoch.as_ref().map(|current| &current.id) == Some(&epoch.id) {
+                    return Vec::new();
+                }
+                self.open.clear();
+                self.epoch = Some(epoch.clone());
+                vec![format!(
+                    "chat · epoch {} · {}",
+                    epoch.number,
+                    backing_name(&epoch.backing)
+                )]
             }
-            "turn-delta" => {
+            "message" => {
+                let Ok(message) = serde_json::from_str::<WaveChatMessage>(&frame.data) else {
+                    return vec![format!(
+                        "(unparseable message frame: {})",
+                        ellipsize(&frame.data, 80)
+                    )];
+                };
+                self.open.insert(message.turn.id.clone(), message.clone());
+                prefix_source(self.turn_lines(&message.turn), &message.source)
+            }
+            "message-delta" => {
                 let Ok(delta) = serde_json::from_str::<TurnDelta>(&frame.data) else {
                     return vec![format!(
-                        "(unparseable turn-delta frame: {})",
+                        "(unparseable message-delta frame: {})",
                         ellipsize(&frame.data, 80)
                     )];
                 };
-                // Grow the reconstructed open turn, then render as if a whole
-                // turn arrived. No open turn for this id means we missed its
-                // opening (a gap the server heals with `resync`); nothing to show.
-                let Some(turn) = self.open.get_mut(&delta.turn_id) else {
+                let Some(message) = self.open.get_mut(&delta.turn_id) else {
                     return Vec::new();
                 };
-                turn.absorb_item(delta.item);
-                let turn = turn.clone();
-                self.turn_lines(&turn)
+                message.turn.absorb_item(delta.item);
+                let turn = message.turn.clone();
+                let source = message.source.clone();
+                prefix_source(self.turn_lines(&turn), &source)
             }
             // The live turn stream lagged; our open-turn reconstructions may
             // have a gap. Drop them so the reconnect's whole-turn replay
@@ -255,6 +271,24 @@ impl Renderer {
     }
 }
 
+fn backing_name(backing: &ChatBacking) -> &'static str {
+    match backing {
+        ChatBacking::Local => "local",
+        ChatBacking::Discord { .. } => "discord",
+    }
+}
+
+fn prefix_source(lines: Vec<String>, source: &ChatMessageSource) -> Vec<String> {
+    let prefix = match source {
+        ChatMessageSource::Local { journal_seq } => format!("local event {journal_seq}"),
+        ChatMessageSource::Discord { .. } => "discord".to_string(),
+    };
+    lines
+        .into_iter()
+        .map(|line| format!("{prefix} · {line}"))
+        .collect()
+}
+
 fn child_activity_line(activity: &ChildControlActivity) -> Option<String> {
     match activity.kind {
         ChildActivityKind::StateChanged => return None,
@@ -289,25 +323,31 @@ mod tests {
         out
     }
 
-    fn turn_json(id: &str, role: &str, text: &str, status: &str, items: &str) -> String {
-        format!(
+    fn message_json(id: &str, role: &str, text: &str, status: &str, items: &str) -> String {
+        let turn = format!(
             "{{\"id\":\"{id}\",\"role\":\"{role}\",\"text\":\"{text}\",\"status\":\"{status}\",\
              \"items\":{items},\"created_at\":\"2026-07-04T00:00:00Z\",\"from\":null}}"
+        );
+        format!(
+            "{{\"epoch_id\":\"chat-epoch-1\",\"source\":{{\"kind\":\"local\",\"journal_seq\":2}},\"turn\":{turn}}}"
         )
     }
 
-    fn activity_turn_json(id: &str, kind: &str, title: &str, summary: &str) -> String {
-        format!(
+    fn activity_message_json(id: &str, kind: &str, title: &str, summary: &str) -> String {
+        let turn = format!(
             "{{\"id\":\"{id}\",\"role\":\"user\",\"text\":\"\",\"status\":\"completed\",\
              \"items\":[],\"created_at\":\"2026-07-04T00:00:00Z\",\"from\":\"task\",\
              \"activity\":{{\"id\":\"activity-{id}\",\"subject\":\"task\",\"subject_id\":\"W2-132\",\
              \"work_id\":\"ts_1\",\"kind\":\"{kind}\",\"title\":\"{title}\",\"summary\":\"{summary}\",\
              \"directive_version\":null,\"command_id\":null,\"effect\":null,\"source\":null,\
              \"decision_id\":null,\"options\":[]}}}}"
+        );
+        format!(
+            "{{\"epoch_id\":\"chat-epoch-1\",\"source\":{{\"kind\":\"local\",\"journal_seq\":2}},\"turn\":{turn}}}"
         )
     }
 
-    fn turn_delta_json(turn_id: &str, item: &str) -> String {
+    fn message_delta_json(turn_id: &str, item: &str) -> String {
         format!("{{\"turn_id\":\"{turn_id}\",\"item\":{item}}}")
     }
 
@@ -321,6 +361,60 @@ mod tests {
         )
     }
 
+    #[test]
+    fn source_bearing_messages_print_their_epoch_and_authority() {
+        let mut renderer = Renderer::new();
+        let epoch = ConversationEpoch {
+            id: "chat-epoch-1".into(),
+            number: 1,
+            backing: ChatBacking::Local,
+            journal_seq: 1,
+            started_at: "2026-07-04T00:00:00Z".into(),
+            ended_at: None,
+        };
+        assert_eq!(
+            renderer.lines_for(&Frame {
+                event: "epoch".into(),
+                data: serde_json::to_string(&epoch).expect("epoch JSON"),
+            }),
+            vec!["chat · epoch 1 · local"]
+        );
+
+        let local = WaveChatMessage {
+            epoch_id: epoch.id.clone(),
+            source: ChatMessageSource::Local { journal_seq: 7 },
+            turn: ChatTurn::user("turn-7".into(), "hello".into()),
+        };
+        assert_eq!(
+            renderer.lines_for(&Frame {
+                event: "message".into(),
+                data: serde_json::to_string(&local).expect("local message JSON"),
+            }),
+            vec!["local event 7 · you › hello"]
+        );
+
+        let mut assistant = ChatTurn::user("discord-9".into(), "shipped".into());
+        assistant.role = ChatRole::Assistant;
+        let discord = WaveChatMessage {
+            epoch_id: "chat-epoch-2".into(),
+            source: ChatMessageSource::Discord {
+                guild_id: "guild".into(),
+                channel_id: "channel".into(),
+                message_id: "9".into(),
+                author_id: "bot".into(),
+                url: "https://discord.com/channels/guild/channel/9".into(),
+            },
+            turn: assistant,
+        };
+        assert_eq!(
+            renderer.lines_for(&Frame {
+                event: "message".into(),
+                data: serde_json::to_string(&discord).expect("Discord message JSON"),
+            }),
+            vec!["discord · wave › shipped"]
+        );
+    }
+
     /// The GUI curates `commentary` narration behind a disclosure; the live
     /// follow has no such surface, so it prints the narration as the wave
     /// speaking — the same reading it had before the fold kept it out of `text`.
@@ -331,37 +425,37 @@ mod tests {
 
         assert!(renderer
             .lines_for(&Frame {
-                event: "turn".into(),
-                data: turn_json("turn-10", "assistant", "", "running", "[]"),
+                event: "message".into(),
+                data: message_json("turn-10", "assistant", "", "running", "[]"),
             })
             .is_empty());
 
         // A commentary increment reads as conversation, once.
         assert_eq!(
             renderer.lines_for(&Frame {
-                event: "turn-delta".into(),
-                data: turn_delta_json(
+                event: "message-delta".into(),
+                data: message_delta_json(
                     "turn-10",
                     &commentary_message_item("m-0", "Auditing the plan first."),
                 ),
             }),
-            vec!["wave › Auditing the plan first."]
+            vec!["local event 2 · wave › Auditing the plan first."]
         );
 
         // The conclusion streams as prose after it.
         assert_eq!(
             renderer.lines_for(&Frame {
-                event: "turn-delta".into(),
-                data: turn_delta_json("turn-10", &stream_message_item("text-0", "Done.")),
+                event: "message-delta".into(),
+                data: message_delta_json("turn-10", &stream_message_item("text-0", "Done.")),
             }),
-            vec!["wave › Done."]
+            vec!["local event 2 · wave › Done."]
         );
 
         // A re-baselining whole-turn frame reprints nothing already shown.
         assert!(renderer
             .lines_for(&Frame {
-                event: "turn".into(),
-                data: turn_json(
+                event: "message".into(),
+                data: message_json(
                     "turn-10",
                     "assistant",
                     "Done.",
@@ -375,39 +469,38 @@ mod tests {
             .is_empty());
     }
 
-    /// The wire the server actually sends now: a whole `turn` frame opens the
-    /// turn, then `turn-delta` increments grow it — and the reader renders the
-    /// wave's speech from the deltas without a whole turn per token. A `resync`
-    /// drops the reconstruction so the reconnect's whole-turn replay resumes it.
+    /// The human wire: a source-bearing `message` opens the turn, then plain
+    /// `message-delta` increments grow it. A `resync` drops the reconstruction
+    /// so the reconnect's source-bearing replay resumes it.
     #[test]
-    fn turn_delta_frames_render_growth_and_resync_drops_reconstruction() {
+    fn message_delta_frames_render_growth_and_resync_drops_reconstruction() {
         let mut renderer = Renderer::new();
 
         // The turn opens as a whole (empty, running) frame — no prose yet.
         assert!(renderer
             .lines_for(&Frame {
-                event: "turn".into(),
-                data: turn_json("turn-1", "assistant", "", "running", "[]"),
+                event: "message".into(),
+                data: message_json("turn-1", "assistant", "", "running", "[]"),
             })
             .is_empty());
 
         // Prose increments render as the wave speaking; nothing else on the wire.
         assert_eq!(
             renderer.lines_for(&Frame {
-                event: "turn-delta".into(),
-                data: turn_delta_json(
+                event: "message-delta".into(),
+                data: message_delta_json(
                     "turn-1",
                     &stream_message_item("text-0", "I fixed the parser.")
                 ),
             }),
-            vec!["wave › I fixed the parser."]
+            vec!["local event 2 · wave › I fixed the parser."]
         );
 
         // A tool increment stays out of the conversation, exactly like a whole turn.
         assert!(renderer
             .lines_for(&Frame {
-                event: "turn-delta".into(),
-                data: turn_delta_json(
+                event: "message-delta".into(),
+                data: message_delta_json(
                     "turn-1",
                     "{\"type\":\"tool\",\"id\":\"t-1\",\"name\":\"Bash\",\"status\":\"completed\",\"input\":null,\"output\":null}",
                 ),
@@ -425,8 +518,8 @@ mod tests {
         assert!(
             renderer
                 .lines_for(&Frame {
-                    event: "turn-delta".into(),
-                    data: turn_delta_json("turn-1", &stream_message_item("text-1", "more")),
+                    event: "message-delta".into(),
+                    data: message_delta_json("turn-1", &stream_message_item("text-1", "more")),
                 })
                 .is_empty(),
             "no reconstruction survives a resync; the whole-turn replay rebuilds it"
@@ -435,7 +528,7 @@ mod tests {
 
     #[test]
     fn sse_parser_splits_frames_on_blank_lines() {
-        let out = frames("event: state\ndata: idle\n\nevent: turn\ndata: {\"id\":1}\n\n");
+        let out = frames("event: state\ndata: idle\n\nevent: message\ndata: {\"id\":1}\n\n");
         assert_eq!(
             out,
             vec![
@@ -444,7 +537,7 @@ mod tests {
                     data: "idle".into()
                 },
                 Frame {
-                    event: "turn".into(),
+                    event: "message".into(),
                     data: "{\"id\":1}".into()
                 },
             ]
@@ -462,7 +555,7 @@ mod tests {
             }]
         );
         // An unterminated frame stays pending.
-        assert!(frames("event: turn\ndata: {\"id\":1}\n").is_empty());
+        assert!(frames("event: message\ndata: {\"id\":1}\n").is_empty());
     }
 
     /// The failure case this task exists to fix, in one transcript: a
@@ -507,8 +600,8 @@ mod tests {
         // The human asks for the work.
         feed(
             &mut renderer,
-            "turn",
-            turn_json(
+            "message",
+            message_json(
                 "turn-1",
                 "user",
                 "make wave chat human-first",
@@ -529,13 +622,13 @@ mod tests {
         );
         feed(
             &mut renderer,
-            "turn",
-            turn_json("turn-2", "assistant", "", "running", "[]"),
+            "message",
+            message_json("turn-2", "assistant", "", "running", "[]"),
         );
         feed(
             &mut renderer,
-            "turn",
-            turn_json(
+            "message",
+            message_json(
                 "turn-2",
                 "assistant",
                 "The transcript renders every tool call as a card. I'll keep them out of the conversation.",
@@ -556,8 +649,8 @@ mod tests {
         );
         feed(
             &mut renderer,
-            "turn",
-            turn_json(
+            "message",
+            message_json(
                 "turn-3",
                 "assistant",
                 "Projection landed. One test caught a stale signature; fixed and green.",
@@ -569,9 +662,9 @@ mod tests {
         assert_eq!(
             out,
             vec![
-                "you › make wave chat human-first",
-                "wave › The transcript renders every tool call as a card. I'll keep them out of the conversation.",
-                "wave › Projection landed. One test caught a stale signature; fixed and green.",
+                "local event 2 · you › make wave chat human-first",
+                "local event 2 · wave › The transcript renders every tool call as a card. I'll keep them out of the conversation.",
+                "local event 2 · wave › Projection landed. One test caught a stale signature; fixed and green.",
             ],
             "the conversation is prose; backend evidence remains in the journal"
         );
@@ -587,18 +680,18 @@ mod tests {
             }),
             Vec::<String>::new()
         );
-        let user = turn_json("turn-1", "user", "how goes it?", "completed", "[]");
+        let user = message_json("turn-1", "user", "how goes it?", "completed", "[]");
         assert_eq!(
             renderer.lines_for(&Frame {
-                event: "turn".into(),
+                event: "message".into(),
                 data: user.clone()
             }),
-            vec!["you › how goes it?"]
+            vec!["local event 2 · you › how goes it?"]
         );
         // Replay of the same user turn (reconnect) prints nothing.
         assert!(renderer
             .lines_for(&Frame {
-                event: "turn".into(),
+                event: "message".into(),
                 data: user
             })
             .is_empty());
@@ -607,7 +700,7 @@ mod tests {
     #[test]
     fn conversation_shows_child_outcomes_but_not_lifecycle_churn() {
         let mut renderer = Renderer::new();
-        let state = activity_turn_json(
+        let state = activity_message_json(
             "turn-1",
             "state_changed",
             "Task is running",
@@ -615,12 +708,12 @@ mod tests {
         );
         assert!(renderer
             .lines_for(&Frame {
-                event: "turn".into(),
+                event: "message".into(),
                 data: state,
             })
             .is_empty());
 
-        let opened = activity_turn_json(
+        let opened = activity_message_json(
             "turn-2",
             "pr_opened",
             "Opened PR #877",
@@ -628,10 +721,10 @@ mod tests {
         );
         assert_eq!(
             renderer.lines_for(&Frame {
-                event: "turn".into(),
+                event: "message".into(),
                 data: opened,
             }),
-            vec!["task W2-132 › Opened PR #877 — https://github.com/loopflowstudio/loopflow/pull/877"]
+            vec!["local event 2 · task W2-132 › Opened PR #877 — https://github.com/loopflowstudio/loopflow/pull/877"]
         );
     }
 
@@ -639,40 +732,40 @@ mod tests {
     fn conversation_prints_only_the_growth_of_a_repeating_turn_id() {
         let mut renderer = Renderer::new();
         let running =
-            |text: &str, items: &str| turn_json("turn-2", "assistant", text, "running", items);
+            |text: &str, items: &str| message_json("turn-2", "assistant", text, "running", items);
         let tool = "[{\"type\":\"tool\",\"id\":\"t0\",\"name\":\"Bash\",\"status\":\"completed\",\
               \"input\":null,\"output\":null}]";
 
         let lines = renderer.lines_for(&Frame {
-            event: "turn".into(),
+            event: "message".into(),
             data: running("", "[]"),
         });
         assert!(lines.is_empty());
 
         let lines = renderer.lines_for(&Frame {
-            event: "turn".into(),
+            event: "message".into(),
             data: running("thinking", "[]"),
         });
-        assert_eq!(lines, vec!["wave › thinking"]);
+        assert_eq!(lines, vec!["local event 2 · wave › thinking"]);
 
         // Same text re-sent with a successful item: backend machinery stays
         // quiet.
         let lines = renderer.lines_for(&Frame {
-            event: "turn".into(),
+            event: "message".into(),
             data: running("thinking", tool),
         });
         assert!(lines.is_empty());
 
         // The terminal frame closes the turn; replays of it are quiet.
-        let terminal = turn_json("turn-2", "assistant", "thinking", "completed", tool);
+        let terminal = message_json("turn-2", "assistant", "thinking", "completed", tool);
         let lines = renderer.lines_for(&Frame {
-            event: "turn".into(),
+            event: "message".into(),
             data: terminal.clone(),
         });
         assert!(lines.is_empty());
         assert!(renderer
             .lines_for(&Frame {
-                event: "turn".into(),
+                event: "message".into(),
                 data: terminal
             })
             .is_empty());
@@ -730,7 +823,7 @@ mod tests {
                 .lock()
                 .unwrap()
                 .iter()
-                .filter(|f| f.event == "turn")
+                .filter(|f| f.event == "message")
                 .count()
                 == 12
             {
@@ -749,7 +842,7 @@ mod tests {
                 .lock()
                 .unwrap()
                 .iter()
-                .any(|f| f.event == "turn" && f.data.contains("live after subscribe"))
+                .any(|f| f.event == "message" && f.data.contains("live after subscribe"))
             {
                 break;
             }
@@ -758,29 +851,31 @@ mod tests {
         task.abort();
 
         let frames = seen.lock().unwrap().clone();
-        assert_eq!(frames[0].event, "state", "replay opens with the state");
+        assert_eq!(frames[0].event, "epoch", "replay names its authority first");
+        assert_eq!(frames[1].event, "backing-health");
+        assert_eq!(frames[2].event, "state");
         assert!(
             frames
                 .iter()
-                .any(|f| f.event == "turn" && f.data.contains("replayed")),
-            "replayed turn arrives: {frames:?}"
+                .any(|f| f.event == "message" && f.data.contains("replayed")),
+            "replayed source-bearing message arrives: {frames:?}"
         );
         assert!(
             frames
                 .iter()
-                .all(|f| f.event != "turn" || !f.data.contains("old 0")),
-            "the default bounded replay omits older turns: {frames:?}"
+                .all(|f| f.event != "message" || !f.data.contains("old 0")),
+            "the default bounded replay omits older messages: {frames:?}"
         );
         assert_eq!(
-            frames.iter().filter(|f| f.event == "turn").count(),
+            frames.iter().filter(|f| f.event == "message").count(),
             13,
-            "human subscriptions replay 12 turns, then stream the live turn"
+            "human subscriptions replay 12 messages, then stream the live message"
         );
         assert!(
             frames
                 .iter()
-                .any(|f| f.event == "turn" && f.data.contains("live after subscribe")),
-            "live turn arrives: {frames:?}"
+                .any(|f| f.event == "message" && f.data.contains("live after subscribe")),
+            "live source-bearing message arrives: {frames:?}"
         );
     }
 }

--- a/rust/loopflow/src/lf/mod.rs
+++ b/rust/loopflow/src/lf/mod.rs
@@ -542,6 +542,9 @@ pub enum Commands {
         /// Maximum durable turns to return (default: 12).
         #[arg(long, requires = "history")]
         limit: Option<usize>,
+        /// Select one immutable conversation epoch.
+        #[arg(long, requires = "history")]
+        epoch: Option<String>,
         #[command(flatten)]
         target: WaveTargetArgs,
     },
@@ -2902,6 +2905,8 @@ mod tests {
             "--json",
             "--limit",
             "20",
+            "--epoch",
+            "chat-epoch-2",
             "--wave",
             "goals",
         ])
@@ -2910,6 +2915,7 @@ mod tests {
             history,
             json,
             limit,
+            epoch,
             target,
             ..
         }) = cli.command
@@ -2919,9 +2925,11 @@ mod tests {
         assert!(history);
         assert!(json);
         assert_eq!(limit, Some(20));
+        assert_eq!(epoch.as_deref(), Some("chat-epoch-2"));
         assert_eq!(target.wave.as_deref(), Some("goals"));
 
         assert!(Cli::try_parse_from(["lf", "chat", "--json", "--wave", "goals"]).is_err());
+        assert!(Cli::try_parse_from(["lf", "chat", "--epoch", "chat-epoch-2"]).is_err());
         assert!(Cli::try_parse_from([
             "lf",
             "chat",

--- a/rust/loopflow/src/wave/README.md
+++ b/rust/loopflow/src/wave/README.md
@@ -40,8 +40,10 @@ The journal rebuilds the thread, playhead, and loop state after restart. The
 endpoint and resident token exist only while the listener owns that boot and
 are removed on shutdown.
 
-An optional Discord channel binding is also listener-owned. The listener
-preflights the binding before reserving a Run or opening the journal, then polls
+Wave Chat is local when `GOAL.md` has no `chat` block. A Discord channel binding
+replaces that backing on the next listener start. Each change appends one
+conversation epoch; reopening the same backing resumes its epoch. The listener
+preflights Discord before reserving a Run or opening the journal, then polls
 after the committed cursor, journals external inputs before advancing it, and
 journals deterministic send intents before posting. The resident receives only
 source-tagged authored input and never inherits `LF_DISCORD_TOKEN`. Binding
@@ -55,15 +57,17 @@ listener per Wave; `--force` explicitly takes over a live endpoint.
 
 ## Thread
 
-`lf chat` writes to the durable human thread. `--steer` injects into a compatible
-active provider turn and otherwise queues the message for the next pass.
-`lf chat --follow` replays the latest 12 turns and follows new turns. The
-conversation shows human and Wave prose plus human-level failures; commands and
-tools stay in the journal, which retains the complete thread.
-`lf chat --history --json -w <wave>` folds the latest saved turns directly from
-that journal, so a stopped listener does not make the conversation disappear.
-The response distinguishes missing, partial, and unavailable evidence from a
-valid empty thread.
+`lf chat` writes only when the active epoch is local. `--steer` injects into a
+compatible active provider turn and otherwise queues the message for the next
+pass. A Discord epoch rejects authored text with a typed Open-in-Discord action;
+it never writes a parallel local turn. A bare interrupt remains available.
+
+`lf chat --follow` replays the latest 12 source-bearing messages and follows new
+ones, printing epoch boundaries and local/Discord provenance. Local history
+folds from the journal even while stopped. Discord history is projected from
+the provider through the active listener without copying transcript pages into
+the journal. `lf chat --history --json -w <wave> --epoch <id>` reads one earlier
+epoch without stitching it into the active conversation.
 
 ## Listener HTTP surface
 
@@ -72,10 +76,10 @@ do not require the resident token:
 
 | Method and path | What it does |
 | --- | --- |
-| `GET /health` | Reports listener and resident state. |
-| `GET /conversation` | Returns the durable thread; `?limit=N` tails it. |
-| `GET /events` | Replays the latest 12 human-thread turns, then streams turn, turn-delta, state, and playhead events over SSE; `?limit=N` overrides the replay tail. |
-| `POST /messages` | Sends `message`, `steer`, or `interrupt`. |
+| `GET /health` | Reports listener/resident state plus the active chat epoch and backing health. |
+| `GET /conversation` | Returns one source-bearing epoch; `?limit=N` tails it and `?epoch=<id>` selects history. |
+| `GET /events` | Emits epoch and backing health, replays source-bearing messages, then streams message, local-only message-delta, state, and playhead events. |
+| `POST /messages` | Sends locally, or returns `409` with Open in Discord when Discord is active. |
 | `GET /playhead` | Returns the durable pass cursor. |
 | `POST /stop` | Gracefully stops the listener and resident. |
 

--- a/rust/loopflow/src/wave/chat.rs
+++ b/rust/loopflow/src/wave/chat.rs
@@ -1,0 +1,145 @@
+//! Public Wave Chat identity and provenance.
+//!
+//! A Wave has exactly one active conversation backing. The backing lives on
+//! an append-only epoch so clients never need to infer destination from
+//! configuration or from individual messages.
+
+use serde::{Deserialize, Serialize};
+
+use crate::chat::turns::ChatTurn;
+use crate::wave::journal::DiscordChatBinding;
+
+/// A product action attached to chat state or a rejected write.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum ChatAction {
+    OpenDiscord { label: String, url: String },
+}
+
+impl ChatAction {
+    fn open_discord(binding: &DiscordChatBinding) -> Self {
+        Self::OpenDiscord {
+            label: "Open in Discord".to_string(),
+            url: binding.channel_url(),
+        }
+    }
+}
+
+/// The closed set of authorities that may own a Wave conversation.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum ChatBacking {
+    Local,
+    Discord {
+        guild_id: String,
+        channel_id: String,
+        open: ChatAction,
+    },
+}
+
+impl ChatBacking {
+    pub fn discord(binding: &DiscordChatBinding) -> Self {
+        Self::Discord {
+            guild_id: binding.guild_id.clone(),
+            channel_id: binding.channel_id.clone(),
+            open: ChatAction::open_discord(binding),
+        }
+    }
+
+    pub fn discord_binding(&self) -> Option<DiscordChatBinding> {
+        match self {
+            Self::Local => None,
+            Self::Discord {
+                guild_id,
+                channel_id,
+                ..
+            } => Some(DiscordChatBinding {
+                guild_id: guild_id.clone(),
+                channel_id: channel_id.clone(),
+            }),
+        }
+    }
+}
+
+/// One immutable interval during which a single backing owns Wave Chat.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ConversationEpoch {
+    pub id: String,
+    pub number: u64,
+    pub backing: ChatBacking,
+    /// Journal boundary establishing this epoch. Provider projections also
+    /// use its timestamp; the sequence keeps local history slices exact.
+    pub journal_seq: u64,
+    pub started_at: String,
+    pub ended_at: Option<String>,
+}
+
+/// Durable identity of the authority that committed one rendered message.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum ChatMessageSource {
+    Local {
+        journal_seq: u64,
+    },
+    Discord {
+        guild_id: String,
+        channel_id: String,
+        message_id: String,
+        author_id: String,
+        url: String,
+    },
+}
+
+/// Product chat unit: a turn-shaped message with explicit epoch and source.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct WaveChatMessage {
+    pub epoch_id: String,
+    pub source: ChatMessageSource,
+    pub turn: ChatTurn,
+}
+
+/// Availability of the active backing, separate from loop state.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "state", rename_all = "snake_case")]
+pub enum ChatBackingHealth {
+    Ready,
+    Retrying { detail: String },
+    Blocked { detail: String },
+}
+
+/// Whether the selected epoch's authority could be read for this snapshot.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ChatHistoryState {
+    Available,
+    Missing,
+    Partial,
+    Unavailable,
+}
+
+/// Stable Wave Chat history envelope consumed by CLI and app surfaces.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ChatHistorySnapshot {
+    pub epochs: Vec<ConversationEpoch>,
+    pub selected_epoch_id: Option<String>,
+    pub state: ChatHistoryState,
+    pub detail: Option<String>,
+    pub messages: Vec<WaveChatMessage>,
+    pub truncated: bool,
+}
+
+/// Successful `POST /messages` response.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct PostMessageResponse {
+    pub message: Option<WaveChatMessage>,
+    pub state: String,
+    pub epoch: ConversationEpoch,
+}
+
+/// Rejected `POST /messages` response. The active epoch owns any honest
+/// alternative write action; the rejection does not duplicate it.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PostMessageErrorResponse {
+    pub error: String,
+    pub epoch: ConversationEpoch,
+}

--- a/rust/loopflow/src/wave/discord.rs
+++ b/rust/loopflow/src/wave/discord.rs
@@ -5,7 +5,7 @@
 //! delivery receipts through [`WaveRuntime`]. It never owns an inbox or writes
 //! the journal directly.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::fs::{File, OpenOptions};
 use std::path::Path;
 use std::time::Duration;
@@ -18,8 +18,11 @@ use secrecy::{ExposeSecret, SecretString};
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
+use tokio::sync::watch;
 
+use crate::chat::turns::{ChatRole, ChatTurn};
 use crate::durable::HomeId;
+use crate::wave::chat::{ChatBackingHealth, ChatMessageSource, ConversationEpoch, WaveChatMessage};
 use crate::wave::journal::{DiscordChatBinding, DiscordMessageSource};
 use crate::wave::runtime::WaveRuntime;
 
@@ -241,7 +244,17 @@ pub struct DiscordAdapter {
     binding: DiscordChatBinding,
     bot_user_id: String,
     initial_head: Option<String>,
+    health: watch::Sender<ChatBackingHealth>,
     _lease: Option<DiscordBindingLease>,
+}
+
+/// Cloneable, read-only provider projection used by product API reads.
+#[derive(Debug, Clone)]
+pub(crate) struct DiscordProjection {
+    client: DiscordClient,
+    binding: DiscordChatBinding,
+    bot_user_id: String,
+    health: watch::Receiver<ChatBackingHealth>,
 }
 
 impl DiscordAdapter {
@@ -297,13 +310,24 @@ impl DiscordAdapter {
                 binding.channel_id
             ))
             .await?;
+        let (health, _) = watch::channel(ChatBackingHealth::Ready);
         Ok(Self {
             client,
             binding,
             bot_user_id: bot.id,
             initial_head: channel.last_message_id,
+            health,
             _lease: None,
         })
+    }
+
+    pub fn projection(&self) -> DiscordProjection {
+        DiscordProjection {
+            client: self.client.clone(),
+            binding: self.binding.clone(),
+            bot_user_id: self.bot_user_id.clone(),
+            health: self.health.subscribe(),
+        }
     }
 
     pub fn attach(&self, runtime: &WaveRuntime) -> Result<()> {
@@ -320,17 +344,26 @@ impl DiscordAdapter {
     pub async fn run(self, runtime: std::sync::Arc<WaveRuntime>) {
         loop {
             match self.sync_once(&runtime).await {
-                Ok(()) => tokio::time::sleep(POLL_CADENCE).await,
+                Ok(()) => {
+                    self.health.send_replace(ChatBackingHealth::Ready);
+                    tokio::time::sleep(POLL_CADENCE).await;
+                }
                 Err(error)
                     if error
                         .downcast_ref::<DiscordError>()
                         .is_some_and(DiscordError::retryable) =>
                 {
                     tracing::warn!(%error, "Discord chat sync failed; retrying");
+                    self.health.send_replace(ChatBackingHealth::Retrying {
+                        detail: error.to_string(),
+                    });
                     tokio::time::sleep(ERROR_BACKOFF).await;
                 }
                 Err(error) => {
                     tracing::error!(%error, "Discord chat sync stopped; restart after correcting the binding or local journal");
+                    self.health.send_replace(ChatBackingHealth::Blocked {
+                        detail: error.to_string(),
+                    });
                     return;
                 }
             }
@@ -399,13 +432,18 @@ impl DiscordAdapter {
     }
 
     fn accept_message(&self, runtime: &WaveRuntime, message: Message) -> Result<()> {
+        if !message_in_epoch(&message, &runtime.active_conversation_epoch())
+            .context("validate Discord input epoch")?
+        {
+            return Ok(());
+        }
         if message.author.id == self.bot_user_id {
             self.reconcile_echo(runtime, &message)?;
             return Ok(());
         }
         if message.author.bot == Some(true)
             || message.webhook_id.is_some()
-            || message.kind != 0
+            || !matches!(message.kind, 0 | 19)
             || message.content.trim().is_empty()
         {
             return Ok(());
@@ -462,15 +500,10 @@ impl DiscordAdapter {
 
     async fn deliver_pending(&self, runtime: &WaveRuntime) -> Result<()> {
         for delivery in runtime.discord_snapshot().deliveries {
-            let reply_to = delivery.reply_to().ok_or_else(|| {
-                anyhow!(
-                    "Discord delivery {} has no authored source",
-                    delivery.delivery_id
-                )
-            })?;
-            if reply_to.binding != self.binding {
+            if delivery.binding != self.binding {
                 continue;
             }
+            let reply_to = delivery.reply_to();
             for part in &delivery.parts {
                 if delivery.confirmed.contains_key(&part.part_id) {
                     continue;
@@ -484,10 +517,10 @@ impl DiscordAdapter {
                             nonce: &part.nonce,
                             enforce_nonce: true,
                             allowed_mentions: AllowedMentions { parse: Vec::new() },
-                            message_reference: MessageReference {
-                                message_id: &reply_to.message_id,
+                            message_reference: reply_to.map(|source| MessageReference {
+                                message_id: &source.message_id,
                                 fail_if_not_exists: false,
-                            },
+                            }),
                         },
                     )
                     .await?;
@@ -498,6 +531,144 @@ impl DiscordAdapter {
         }
         Ok(())
     }
+}
+
+impl DiscordProjection {
+    pub fn health(&self) -> ChatBackingHealth {
+        self.health.borrow().clone()
+    }
+
+    pub async fn history(
+        &self,
+        runtime: &WaveRuntime,
+        epoch: &ConversationEpoch,
+        limit: Option<usize>,
+    ) -> Result<Vec<WaveChatMessage>> {
+        if epoch.backing.discord_binding().as_ref() != Some(&self.binding) {
+            return Err(anyhow!(
+                "chat epoch {} is not backed by Discord channel {}/{}",
+                epoch.id,
+                self.binding.guild_id,
+                self.binding.channel_id
+            ));
+        }
+        let requested = limit.unwrap_or(12);
+        if requested == 0 {
+            return Ok(Vec::new());
+        }
+        let confirmed = runtime
+            .discord_snapshot()
+            .deliveries
+            .into_iter()
+            .filter(|delivery| delivery.binding == self.binding)
+            .flat_map(|delivery| delivery.confirmed.into_values())
+            .collect::<HashSet<_>>();
+        // Discord pages may contain system or unrelated bot messages. Read at
+        // least one full provider page so those records cannot starve a small
+        // product history request.
+        let messages = self.latest_messages(requested.max(100)).await?;
+        let mut projected = messages
+            .into_iter()
+            .filter(|message| message_in_epoch(message, epoch).unwrap_or(false))
+            .filter_map(|message| {
+                if message.webhook_id.is_some()
+                    || !matches!(message.kind, 0 | 19)
+                    || message.content.trim().is_empty()
+                {
+                    return None;
+                }
+                let role = if message.author.id == self.bot_user_id {
+                    if !confirmed.contains(&message.id) {
+                        return None;
+                    }
+                    ChatRole::Assistant
+                } else {
+                    if message.author.bot == Some(true) {
+                        return None;
+                    }
+                    ChatRole::User
+                };
+                let created_at = snowflake_timestamp(&message.id)
+                    .and_then(|timestamp| {
+                        timestamp
+                            .format(&time::format_description::well_known::Rfc3339)
+                            .map_err(anyhow::Error::from)
+                    })
+                    .ok()?;
+                let mut turn = ChatTurn::user(format!("discord-{}", message.id), message.content);
+                turn.role = role;
+                turn.created_at = created_at;
+                Some(WaveChatMessage {
+                    epoch_id: epoch.id.clone(),
+                    source: ChatMessageSource::Discord {
+                        guild_id: self.binding.guild_id.clone(),
+                        channel_id: self.binding.channel_id.clone(),
+                        message_id: message.id.clone(),
+                        author_id: message.author.id,
+                        url: self.binding.message_url(&message.id),
+                    },
+                    turn,
+                })
+            })
+            .collect::<Vec<_>>();
+        if projected.len() > requested {
+            projected.drain(..projected.len() - requested);
+        }
+        Ok(projected)
+    }
+
+    async fn latest_messages(&self, limit: usize) -> Result<Vec<Message>> {
+        let mut messages = Vec::new();
+        let mut before: Option<String> = None;
+        while messages.len() < limit {
+            let page_limit = (limit - messages.len()).min(100);
+            let before_query = before
+                .as_deref()
+                .map(|id| format!("&before={id}"))
+                .unwrap_or_default();
+            let page: Vec<Message> = self
+                .client
+                .get(&format!(
+                    "/channels/{}/messages?limit={page_limit}{before_query}",
+                    self.binding.channel_id
+                ))
+                .await?;
+            if page.is_empty() {
+                break;
+            }
+            before = page.last().map(|message| message.id.clone());
+            let page_len = page.len();
+            messages.extend(page);
+            if page_len < page_limit {
+                break;
+            }
+        }
+        messages.reverse();
+        Ok(messages)
+    }
+}
+
+fn message_in_epoch(message: &Message, epoch: &ConversationEpoch) -> Result<bool> {
+    let timestamp = snowflake_timestamp(&message.id)?;
+    let started_at = time::OffsetDateTime::parse(
+        &epoch.started_at,
+        &time::format_description::well_known::Rfc3339,
+    )?;
+    let ended_at = epoch
+        .ended_at
+        .as_deref()
+        .map(|value| {
+            time::OffsetDateTime::parse(value, &time::format_description::well_known::Rfc3339)
+        })
+        .transpose()?;
+    Ok(timestamp >= started_at && ended_at.is_none_or(|ended_at| timestamp < ended_at))
+}
+
+fn snowflake_timestamp(value: &str) -> Result<time::OffsetDateTime> {
+    const DISCORD_EPOCH_MILLIS: i128 = 1_420_070_400_000;
+    let snowflake = parse_snowflake(value)?;
+    let millis = i128::from(snowflake >> 22) + DISCORD_EPOCH_MILLIS;
+    time::OffsetDateTime::from_unix_timestamp_nanos(millis * 1_000_000).map_err(anyhow::Error::from)
 }
 
 fn require_permissions(
@@ -670,7 +841,8 @@ struct CreateMessage<'a> {
     nonce: &'a str,
     enforce_nonce: bool,
     allowed_mentions: AllowedMentions,
-    message_reference: MessageReference<'a>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    message_reference: Option<MessageReference<'a>>,
 }
 
 #[derive(Debug, Serialize)]
@@ -697,6 +869,7 @@ mod tests {
     use serde_json::json;
 
     use crate::chat::types::Lifecycle;
+    use crate::wave::chat::ChatBacking;
     use crate::wave::wire::ResidentDelta;
 
     #[derive(Debug)]
@@ -707,6 +880,7 @@ mod tests {
         messages: Vec<Message>,
         posts: usize,
         lose_next_post_response: bool,
+        channel_status: Option<u16>,
     }
 
     impl Fixture {
@@ -778,6 +952,12 @@ mod tests {
             }
             ("GET", "/channels/channel") => {
                 let fixture = fixture.lock().expect("fixture");
+                if let Some(status) = fixture.channel_status {
+                    return json_response(
+                        StatusCode::from_u16(status).expect("fixture status"),
+                        json!({"message": "fixture channel failure"}),
+                    );
+                }
                 json_response(
                     StatusCode::OK,
                     json!({
@@ -881,7 +1061,15 @@ mod tests {
             messages,
             posts: 0,
             lose_next_post_response: false,
+            channel_status: None,
         }))
+    }
+
+    fn snowflake_at_offset(seconds: i64, increment: u64) -> u64 {
+        const DISCORD_EPOCH_MILLIS: i128 = 1_420_070_400_000;
+        let timestamp = time::OffsetDateTime::now_utc() + time::Duration::seconds(seconds);
+        let millis = timestamp.unix_timestamp_nanos() / 1_000_000;
+        (((millis - DISCORD_EPOCH_MILLIS) as u64) << 22) | increment
     }
 
     #[test]
@@ -926,8 +1114,8 @@ mod tests {
     #[tokio::test]
     async fn discord_chat_starts_at_head_catches_up_in_order_and_reconciles_a_lost_send() {
         let fixture = fixture(vec![
-            Fixture::human_message(99),
-            Fixture::human_message(100),
+            Fixture::human_message(snowflake_at_offset(-1, 99)),
+            Fixture::human_message(snowflake_at_offset(-1, 100)),
         ]);
         let (base_url, server) = fixture_server(fixture.clone()).await;
         let client = DiscordClient::from_token(Some("fixture-token".into()), &base_url)
@@ -936,7 +1124,12 @@ mod tests {
             .await
             .expect("preflight");
         let temp = tempfile::tempdir().expect("tempdir");
-        let runtime = WaveRuntime::open("ship".into(), temp.path().to_path_buf()).expect("runtime");
+        let runtime = WaveRuntime::open_with_backing(
+            "ship".into(),
+            temp.path().to_path_buf(),
+            crate::wave::chat::ChatBacking::discord(&binding()),
+        )
+        .expect("runtime");
         adapter.attach(&runtime).expect("attach at head");
         adapter.sync_once(&runtime).await.expect("initial sync");
         assert!(
@@ -944,16 +1137,21 @@ mod tests {
             "history was not imported"
         );
 
+        let catch_up_ids: Vec<_> = (101..=205)
+            .map(|increment| snowflake_at_offset(1, increment))
+            .collect();
+        let first_id = catch_up_ids.first().expect("first catch-up id").to_string();
+        let newest_id = catch_up_ids.last().expect("newest catch-up id").to_string();
         fixture
             .lock()
             .expect("fixture")
             .messages
-            .extend((101..=205).map(Fixture::human_message));
+            .extend(catch_up_ids.into_iter().map(Fixture::human_message));
         adapter.sync_once(&runtime).await.expect("paged catch-up");
         let pending = runtime.pending_messages();
         assert_eq!(pending.len(), 105);
-        assert!(pending[0].text.ends_with("message 101"));
-        assert!(pending[104].text.ends_with("message 205"));
+        assert!(pending[0].text.ends_with(&format!("message {first_id}")));
+        assert!(pending[104].text.ends_with(&format!("message {newest_id}")));
         adapter.sync_once(&runtime).await.expect("duplicate fetch");
         assert_eq!(runtime.pending_messages().len(), 105);
 
@@ -971,7 +1169,7 @@ mod tests {
             runtime.discord_snapshot().deliveries[0]
                 .reply_to()
                 .map(|source| source.message_id.as_str()),
-            Some("205"),
+            Some(newest_id.as_str()),
             "the ordered source list makes the newest claim the reply target"
         );
         fixture.lock().expect("fixture").lose_next_post_response = true;
@@ -987,8 +1185,12 @@ mod tests {
         let adapter = DiscordAdapter::preflight_with_client(client, binding())
             .await
             .expect("restart preflight");
-        let runtime =
-            WaveRuntime::open("ship".into(), temp.path().to_path_buf()).expect("restart runtime");
+        let runtime = WaveRuntime::open_with_backing(
+            "ship".into(),
+            temp.path().to_path_buf(),
+            crate::wave::chat::ChatBacking::discord(&binding()),
+        )
+        .expect("restart runtime");
         adapter.attach(&runtime).expect("reattach after restart");
         adapter
             .sync_once(&runtime)
@@ -1003,6 +1205,306 @@ mod tests {
         assert!(
             runtime.pending_messages().is_empty(),
             "self echo is not input"
+        );
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn discord_projection_reads_normal_and_reply_messages_without_copying_history() {
+        let fixture = fixture(Vec::new());
+        let (base_url, server) = fixture_server(fixture.clone()).await;
+        let client = DiscordClient::from_token(Some("fixture-token".into()), &base_url)
+            .expect("fixture client");
+        let adapter = DiscordAdapter::preflight_with_client(client, binding())
+            .await
+            .expect("preflight");
+        let projection = adapter.projection();
+        let temp = tempfile::tempdir().expect("tempdir");
+        let runtime = WaveRuntime::open_with_backing(
+            "ship".into(),
+            temp.path().to_path_buf(),
+            crate::wave::chat::ChatBacking::discord(&binding()),
+        )
+        .expect("runtime");
+        adapter.attach(&runtime).expect("attach");
+
+        let normal_id = snowflake_at_offset(1, 1);
+        let reply_id = snowflake_at_offset(2, 2);
+        let unrelated_bot_id = snowflake_at_offset(3, 3);
+        let mut reply = Fixture::human_message(reply_id);
+        reply.kind = 19;
+        fixture.lock().expect("fixture").messages.extend([
+            Fixture::human_message(normal_id),
+            reply,
+            Message {
+                id: unrelated_bot_id.to_string(),
+                author: User {
+                    id: "another-bot".into(),
+                    bot: Some(true),
+                },
+                content: "not this Wave".into(),
+                kind: 0,
+                webhook_id: None,
+                message_reference: None,
+            },
+        ]);
+
+        adapter
+            .sync_once(&runtime)
+            .await
+            .expect("ingest provider head");
+        assert_eq!(
+            runtime.pending_messages().len(),
+            2,
+            "normal and reply messages both reach the resident inbox"
+        );
+        adapter
+            .sync_once(&runtime)
+            .await
+            .expect("repeat sync stays idempotent");
+        assert_eq!(
+            runtime.pending_messages().len(),
+            2,
+            "provider messages reach the resident exactly once"
+        );
+        let journal_before = crate::wave::journal::read_events(
+            &crate::wave::journal::journal_path(temp.path(), "ship"),
+        );
+        let epoch = runtime.active_conversation_epoch();
+        let messages = projection
+            .history(&runtime, &epoch, Some(12))
+            .await
+            .expect("project provider history");
+        let journal_after = crate::wave::journal::read_events(&crate::wave::journal::journal_path(
+            temp.path(),
+            "ship",
+        ));
+
+        assert_eq!(
+            journal_before, journal_after,
+            "history reads append nothing"
+        );
+        assert_eq!(messages.len(), 2, "unrelated bot speech stays out");
+        assert_eq!(messages[0].turn.id, format!("discord-{normal_id}"));
+        assert_eq!(messages[1].turn.id, format!("discord-{reply_id}"));
+        assert!(messages
+            .iter()
+            .all(|message| matches!(message.source, ChatMessageSource::Discord { .. })));
+
+        let answers = runtime
+            .pending_messages()
+            .into_iter()
+            .map(|message| message.id.0)
+            .collect();
+        runtime.apply_resident_delta(ResidentDelta::TurnOpened { answers });
+        runtime.apply_resident_delta(ResidentDelta::TurnText {
+            text: "provider-committed answer".into(),
+        });
+        runtime.apply_resident_delta(ResidentDelta::TurnFinished {
+            status: Lifecycle::Completed,
+            cost_usd: None,
+            reason: None,
+        });
+        assert_eq!(
+            projection
+                .history(&runtime, &epoch, Some(12))
+                .await
+                .expect("history before provider receipt")
+                .len(),
+            2,
+            "the internal assistant turn is not a chat preview"
+        );
+        adapter
+            .deliver_pending(&runtime)
+            .await
+            .expect("provider accepts answer");
+        let committed = projection
+            .history(&runtime, &epoch, Some(12))
+            .await
+            .expect("history after provider receipt");
+        assert_eq!(committed.len(), 3);
+        assert_eq!(
+            committed.last().expect("assistant message").turn.role,
+            ChatRole::Assistant
+        );
+        assert_eq!(
+            committed.last().expect("assistant message").turn.text,
+            "provider-committed answer"
+        );
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn discord_input_starts_at_the_durable_epoch_boundary() {
+        let fixture = fixture(Vec::new());
+        let (base_url, server) = fixture_server(fixture.clone()).await;
+        let client = DiscordClient::from_token(Some("fixture-token".into()), &base_url)
+            .expect("fixture client");
+        let adapter = DiscordAdapter::preflight_with_client(client, binding())
+            .await
+            .expect("preflight");
+        let projection = adapter.projection();
+        let temp = tempfile::tempdir().expect("tempdir");
+        let runtime = WaveRuntime::open_with_backing(
+            "ship".into(),
+            temp.path().to_path_buf(),
+            ChatBacking::discord(&binding()),
+        )
+        .expect("runtime");
+        adapter.attach(&runtime).expect("attach");
+
+        let before_epoch = snowflake_at_offset(-1, 1);
+        fixture
+            .lock()
+            .expect("fixture")
+            .messages
+            .push(Fixture::human_message(before_epoch));
+        adapter
+            .sync_once(&runtime)
+            .await
+            .expect("advance past pre-epoch input");
+        assert!(
+            runtime.pending_messages().is_empty(),
+            "a provider message before the durable epoch is not resident input"
+        );
+        assert!(
+            projection
+                .history(&runtime, &runtime.active_conversation_epoch(), Some(12))
+                .await
+                .expect("project history")
+                .is_empty(),
+            "the inbox and provider projection share one epoch boundary"
+        );
+
+        let inside_epoch = snowflake_at_offset(1, 2);
+        fixture
+            .lock()
+            .expect("fixture")
+            .messages
+            .push(Fixture::human_message(inside_epoch));
+        adapter
+            .sync_once(&runtime)
+            .await
+            .expect("ingest active-epoch input");
+        assert_eq!(runtime.pending_messages().len(), 1);
+        let messages = projection
+            .history(&runtime, &runtime.active_conversation_epoch(), Some(12))
+            .await
+            .expect("project active history");
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].turn.id, format!("discord-{inside_epoch}"));
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn discord_adapter_publishes_retrying_and_blocked_health() {
+        async fn wait_for(
+            projection: &DiscordProjection,
+            expected: fn(&ChatBackingHealth) -> bool,
+        ) {
+            for _ in 0..100 {
+                if expected(&projection.health()) {
+                    return;
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+            }
+            panic!("Discord health did not reach the expected state");
+        }
+
+        let retry_fixture = fixture(Vec::new());
+        let (base_url, retry_server) = fixture_server(retry_fixture.clone()).await;
+        let client = DiscordClient::from_token(Some("fixture-token".into()), &base_url)
+            .expect("fixture client");
+        let adapter = DiscordAdapter::preflight_with_client(client, binding())
+            .await
+            .expect("preflight");
+        let projection = adapter.projection();
+        let retry_temp = tempfile::tempdir().expect("tempdir");
+        let runtime = WaveRuntime::open_with_backing(
+            "ship".into(),
+            retry_temp.path().to_path_buf(),
+            ChatBacking::discord(&binding()),
+        )
+        .expect("runtime");
+        adapter.attach(&runtime).expect("attach");
+        retry_fixture.lock().expect("fixture").channel_status = Some(500);
+        let retry_task = tokio::spawn(adapter.run(runtime));
+        wait_for(&projection, |health| {
+            matches!(health, ChatBackingHealth::Retrying { .. })
+        })
+        .await;
+        retry_task.abort();
+        retry_server.abort();
+
+        let blocked_fixture = fixture(Vec::new());
+        let (base_url, blocked_server) = fixture_server(blocked_fixture.clone()).await;
+        let client = DiscordClient::from_token(Some("fixture-token".into()), &base_url)
+            .expect("fixture client");
+        let adapter = DiscordAdapter::preflight_with_client(client, binding())
+            .await
+            .expect("preflight");
+        let projection = adapter.projection();
+        let blocked_temp = tempfile::tempdir().expect("tempdir");
+        let runtime = WaveRuntime::open_with_backing(
+            "ship".into(),
+            blocked_temp.path().to_path_buf(),
+            ChatBacking::discord(&binding()),
+        )
+        .expect("runtime");
+        adapter.attach(&runtime).expect("attach");
+        blocked_fixture.lock().expect("fixture").channel_status = Some(403);
+        adapter.run(runtime).await;
+        wait_for(&projection, |health| {
+            matches!(health, ChatBackingHealth::Blocked { .. })
+        })
+        .await;
+        assert!(matches!(
+            projection.health(),
+            ChatBackingHealth::Blocked { .. }
+        ));
+        blocked_server.abort();
+    }
+
+    #[tokio::test]
+    async fn discord_adapter_never_sends_another_epochs_delivery() {
+        let fixture = fixture(Vec::new());
+        let (base_url, server) = fixture_server(fixture.clone()).await;
+        let client = DiscordClient::from_token(Some("fixture-token".into()), &base_url)
+            .expect("fixture client");
+        let adapter = DiscordAdapter::preflight_with_client(client, binding())
+            .await
+            .expect("preflight");
+        let other_binding = DiscordChatBinding {
+            guild_id: "other-guild".into(),
+            channel_id: "other-channel".into(),
+        };
+        let temp = tempfile::tempdir().expect("tempdir");
+        let runtime = WaveRuntime::open_with_backing(
+            "ship".into(),
+            temp.path().to_path_buf(),
+            ChatBacking::discord(&other_binding),
+        )
+        .expect("runtime");
+        runtime.apply_resident_delta(ResidentDelta::TurnOpened {
+            answers: Vec::new(),
+        });
+        runtime.apply_resident_delta(ResidentDelta::TurnText {
+            text: "belongs to the earlier channel".into(),
+        });
+        runtime.apply_resident_delta(ResidentDelta::TurnFinished {
+            status: Lifecycle::Completed,
+            cost_usd: None,
+            reason: None,
+        });
+
+        adapter
+            .deliver_pending(&runtime)
+            .await
+            .expect("foreign delivery is ignored");
+        assert_eq!(fixture.lock().expect("fixture").posts, 0);
+        assert_eq!(
+            runtime.discord_snapshot().deliveries[0].binding,
+            other_binding
         );
         server.abort();
     }

--- a/rust/loopflow/src/wave/journal.rs
+++ b/rust/loopflow/src/wave/journal.rs
@@ -32,6 +32,7 @@ use crate::chat::turns::{ChatRole, ChatTurn};
 use crate::chat::types::{ConversationItem, Lifecycle};
 use crate::project::ProjectObservation;
 use crate::task::TaskObservation;
+use crate::wave::chat::{ChatBacking, ConversationEpoch};
 use crate::wave::playhead::{BodyProvenance, Playhead, PlayheadEvent};
 use crate::wave::state::LoopState;
 use crate::wave::PromotionWake;
@@ -140,12 +141,34 @@ pub struct DiscordChatBinding {
     pub channel_id: String,
 }
 
+impl DiscordChatBinding {
+    pub fn channel_url(&self) -> String {
+        format!(
+            "https://discord.com/channels/{}/{}",
+            self.guild_id, self.channel_id
+        )
+    }
+
+    pub fn message_url(&self, message_id: &str) -> String {
+        format!("{}/{}", self.channel_url(), message_id)
+    }
+}
+
 /// Provider identity retained with one imported human message.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct DiscordMessageSource {
     pub binding: DiscordChatBinding,
     pub message_id: String,
     pub author_id: String,
+}
+
+/// One legacy epoch imported atomically when an old journal first adopts the
+/// explicit backing model. `turn_ids` keeps local projection exact even when
+/// the old journal alternated between local and Discord speech.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ConversationEpochImport {
+    pub epoch: ConversationEpoch,
+    pub turn_ids: Vec<String>,
 }
 
 impl DiscordMessageSource {
@@ -170,6 +193,7 @@ pub struct DiscordMessagePart {
 pub struct DiscordDelivery {
     pub delivery_id: String,
     pub turn_id: String,
+    pub binding: DiscordChatBinding,
     pub sources: Vec<DiscordMessageSource>,
     pub parts: Vec<DiscordMessagePart>,
     pub confirmed: HashMap<String, String>,
@@ -217,6 +241,14 @@ impl Event {
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum EventKind {
     // -- conversation --
+    ConversationEpochsImported {
+        epochs: Vec<ConversationEpochImport>,
+    },
+    ConversationEpochStarted {
+        epoch_id: String,
+        number: u64,
+        backing: ChatBacking,
+    },
     UserMessage {
         id: MessageId,
         op: MessageOp,
@@ -239,6 +271,10 @@ pub enum EventKind {
     DiscordChatSendPlanned {
         delivery_id: String,
         turn_id: String,
+        /// Added after the first sourced-reply format. Old events derive it
+        /// from `sources`; every new event writes it explicitly.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        binding: Option<DiscordChatBinding>,
         sources: Vec<DiscordMessageSource>,
         parts: Vec<DiscordMessagePart>,
     },
@@ -496,6 +532,12 @@ impl Narrator {
     /// console.
     fn render(&mut self, kind: &EventKind) -> Narration {
         match kind {
+            EventKind::ConversationEpochsImported { epochs } => {
+                info(format!("{} legacy chat epoch(s) imported", epochs.len()))
+            }
+            EventKind::ConversationEpochStarted {
+                number, backing, ..
+            } => info(format!("chat epoch {number} started · {backing:?}")),
             EventKind::UserMessage { id, op, text } => {
                 let op_tag = match op {
                     MessageOp::Message => "",
@@ -975,6 +1017,12 @@ pub struct ThreadFold {
     /// User turns and finalized assistant turns, in commit order (user turns
     /// at their `UserMessage` event; assistant turns at their `TurnFinished`).
     pub turns: Vec<ChatTurn>,
+    /// Immutable conversation authority intervals, oldest first.
+    pub conversation_epochs: Vec<ConversationEpoch>,
+    /// Exact turn membership for imported legacy epochs.
+    pub conversation_epoch_turns: HashMap<String, Vec<String>>,
+    /// Provider backing for legacy turns with confirmed Discord provenance.
+    pub discord_turn_bindings: HashMap<String, DiscordChatBinding>,
     /// Turns started but never finished — the crash tail. The boot janitor
     /// finalizes these as `Failed`.
     pub open: Vec<ChatTurn>,
@@ -1062,6 +1110,9 @@ pub fn restore_pending(
 /// items land in `ChatTurn.items`.
 pub fn fold_thread(events: &[Event]) -> ThreadFold {
     let mut turns: Vec<ChatTurn> = Vec::new();
+    let mut conversation_epochs: Vec<ConversationEpoch> = Vec::new();
+    let mut conversation_epoch_turns: HashMap<String, Vec<String>> = HashMap::new();
+    let mut discord_turn_bindings: HashMap<String, DiscordChatBinding> = HashMap::new();
     // In-order list, not a map: the crash tail keeps its start order.
     let mut open: Vec<ChatTurn> = Vec::new();
     let mut state = LoopState::Idle;
@@ -1081,6 +1132,34 @@ pub fn fold_thread(events: &[Event]) -> ThreadFold {
 
     for event in events {
         match &event.kind {
+            EventKind::ConversationEpochsImported { epochs } => {
+                for imported in epochs {
+                    if let Some(active) = conversation_epochs.last_mut() {
+                        active.ended_at = Some(imported.epoch.started_at.clone());
+                    }
+                    conversation_epoch_turns
+                        .insert(imported.epoch.id.clone(), imported.turn_ids.clone());
+                    conversation_epochs.push(imported.epoch.clone());
+                }
+            }
+            EventKind::ConversationEpochStarted {
+                epoch_id,
+                number,
+                backing,
+            } => {
+                let at = event.at_rfc3339();
+                if let Some(active) = conversation_epochs.last_mut() {
+                    active.ended_at = Some(at.clone());
+                }
+                conversation_epochs.push(ConversationEpoch {
+                    id: epoch_id.clone(),
+                    number: *number,
+                    backing: backing.clone(),
+                    journal_seq: event.seq,
+                    started_at: at,
+                    ended_at: None,
+                });
+            }
             EventKind::UserMessage { id, op, text } => {
                 let mut turn = ChatTurn::user(format!("turn-{}", event.seq), text.clone());
                 turn.created_at = event.at_rfc3339();
@@ -1108,9 +1187,11 @@ pub fn fold_thread(events: &[Event]) -> ThreadFold {
                 });
             }
             EventKind::DiscordUserMessage { id, text, source } => {
-                let mut turn = ChatTurn::user(format!("turn-{}", event.seq), text.clone());
+                let turn_id = format!("turn-{}", event.seq);
+                let mut turn = ChatTurn::user(turn_id.clone(), text.clone());
                 turn.created_at = event.at_rfc3339();
                 turns.push(turn);
+                discord_turn_bindings.insert(turn_id, source.binding.clone());
                 let message = PendingMessage {
                     id: id.clone(),
                     op: MessageOp::Message,
@@ -1135,18 +1216,27 @@ pub fn fold_thread(events: &[Event]) -> ThreadFold {
             EventKind::DiscordChatSendPlanned {
                 delivery_id,
                 turn_id,
+                binding,
                 sources,
                 parts,
             } => {
-                discord_deliveries
-                    .entry(delivery_id.clone())
-                    .or_insert_with(|| DiscordDelivery {
-                        delivery_id: delivery_id.clone(),
-                        turn_id: turn_id.clone(),
-                        sources: sources.clone(),
-                        parts: parts.clone(),
-                        confirmed: HashMap::new(),
-                    });
+                let destination = binding
+                    .clone()
+                    .or_else(|| sources.first().map(|source| source.binding.clone()));
+                if let Some(binding) = destination {
+                    discord_deliveries
+                        .entry(delivery_id.clone())
+                        .or_insert_with(|| DiscordDelivery {
+                            delivery_id: delivery_id.clone(),
+                            turn_id: turn_id.clone(),
+                            binding,
+                            sources: sources.clone(),
+                            parts: parts.clone(),
+                            confirmed: HashMap::new(),
+                        });
+                } else {
+                    tracing::warn!(%delivery_id, "Discord delivery has no destination; ignoring it");
+                }
             }
             EventKind::DiscordChatSendConfirmed {
                 delivery_id,
@@ -1309,8 +1399,17 @@ pub fn fold_thread(events: &[Event]) -> ThreadFold {
         .flatten()
         .collect();
 
+    for delivery in discord_deliveries.values() {
+        if !delivery.confirmed.is_empty() {
+            discord_turn_bindings.insert(delivery.turn_id.clone(), delivery.binding.clone());
+        }
+    }
+
     ThreadFold {
         turns,
+        conversation_epochs,
+        conversation_epoch_turns,
+        discord_turn_bindings,
         open,
         state,
         playhead,
@@ -1401,6 +1500,17 @@ mod tests {
         DiscordChatBinding {
             guild_id: "guild".into(),
             channel_id: "channel".into(),
+        }
+    }
+
+    fn local_epoch() -> ConversationEpoch {
+        ConversationEpoch {
+            id: "chat-epoch-legacy-1".into(),
+            number: 1,
+            backing: ChatBacking::Local,
+            journal_seq: 0,
+            started_at: "2026-07-04T00:00:00Z".into(),
+            ended_at: None,
         }
     }
 
@@ -1503,6 +1613,17 @@ mod tests {
     fn event_round_trips_every_kind() {
         let kinds = vec![
             user_message(1, "hi"),
+            EventKind::ConversationEpochsImported {
+                epochs: vec![ConversationEpochImport {
+                    epoch: local_epoch(),
+                    turn_ids: vec!["turn-1".into()],
+                }],
+            },
+            EventKind::ConversationEpochStarted {
+                epoch_id: "chat-epoch-2".into(),
+                number: 2,
+                backing: ChatBacking::Local,
+            },
             EventKind::DiscordChatAttached {
                 binding: discord_binding(),
                 bot_user_id: "bot".into(),
@@ -1520,6 +1641,7 @@ mod tests {
             EventKind::DiscordChatSendPlanned {
                 delivery_id: "delivery-1".into(),
                 turn_id: "turn-3".into(),
+                binding: None,
                 sources: vec![discord_source()],
                 parts: discord_parts(),
             },
@@ -1595,6 +1717,28 @@ mod tests {
         }
     }
 
+    #[test]
+    fn historical_sourced_delivery_derives_its_destination() {
+        let event = Event {
+            v: FORMAT_VERSION,
+            seq: 1,
+            at: OffsetDateTime::now_utc(),
+            kind: EventKind::DiscordChatSendPlanned {
+                delivery_id: "delivery-1".into(),
+                turn_id: "turn-1".into(),
+                binding: None,
+                sources: vec![discord_source()],
+                parts: discord_parts(),
+            },
+        };
+
+        let delivery = fold_thread(&[event])
+            .discord_deliveries
+            .remove("delivery-1")
+            .expect("historical delivery");
+        assert_eq!(delivery.binding, discord_binding());
+    }
+
     /// New appends carry the post-rename kind names on disk — a run completion
     /// serializes as `run_completed`, never the retired `worker_finished`.
     #[test]
@@ -1622,6 +1766,17 @@ mod tests {
     fn narration_renders_every_event_kind() {
         let kinds = vec![
             user_message(1, "hi"),
+            EventKind::ConversationEpochsImported {
+                epochs: vec![ConversationEpochImport {
+                    epoch: local_epoch(),
+                    turn_ids: vec!["turn-1".into()],
+                }],
+            },
+            EventKind::ConversationEpochStarted {
+                epoch_id: "chat-epoch-2".into(),
+                number: 2,
+                backing: ChatBacking::Local,
+            },
             EventKind::DiscordChatAttached {
                 binding: discord_binding(),
                 bot_user_id: "bot".into(),
@@ -1639,6 +1794,7 @@ mod tests {
             EventKind::DiscordChatSendPlanned {
                 delivery_id: "delivery-1".into(),
                 turn_id: "turn-3".into(),
+                binding: Some(discord_binding()),
                 sources: vec![discord_source()],
                 parts: discord_parts(),
             },

--- a/rust/loopflow/src/wave/mod.rs
+++ b/rust/loopflow/src/wave/mod.rs
@@ -47,6 +47,7 @@
 //! exists on the machine, child observations wait durably; the listener remains
 //! functional and acquires the registry when it appears.
 
+pub mod chat;
 pub(crate) mod discord;
 pub mod journal;
 pub(crate) mod memory;
@@ -76,6 +77,7 @@ use crate::engine::wave_config::{try_read_wave_config, WaveChatConfig};
 use crate::engine::worktrees::main_repo_root;
 use crate::ops::util::normalize_wave_name;
 use crate::store::{open_existing_store, SharedStore};
+use crate::wave::chat::ChatBacking;
 use crate::wave::runtime::WaveRuntime;
 
 /// The hidden subcommand a listener spawns for its own resident body. Named
@@ -318,7 +320,7 @@ pub(crate) async fn run_listener(
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
     let addr = listener.local_addr()?;
 
-    let discord_adapter =
+    let (chat_backing, discord_adapter) =
         match try_read_wave_config(&repo_root, &wave)?.and_then(|config| config.chat) {
             Some(WaveChatConfig::Discord {
                 home_id,
@@ -333,9 +335,12 @@ pub(crate) async fn run_listener(
                     guild_id,
                     channel_id,
                 };
-                Some(discord::DiscordAdapter::preflight(binding, &home_id, &local_home.id).await?)
+                let backing = ChatBacking::discord(&binding);
+                let adapter =
+                    discord::DiscordAdapter::preflight(binding, &home_id, &local_home.id).await?;
+                (backing, Some(adapter))
             }
-            None => None,
+            Some(WaveChatConfig::Local) | None => (ChatBacking::Local, None),
         };
 
     let registered = registry_config
@@ -380,7 +385,7 @@ pub(crate) async fn run_listener(
 
     // Refusals are behind us: NOW open the journal for writing and mark the
     // boot. The store-polling observer starts once the runtime exists.
-    let runtime = WaveRuntime::open(wave.clone(), repo_root.clone())?;
+    let runtime = WaveRuntime::open_with_backing(wave.clone(), repo_root.clone(), chat_backing)?;
     if let Some(adapter) = discord_adapter.as_ref() {
         adapter.attach(&runtime)?;
     }
@@ -398,6 +403,9 @@ pub(crate) async fn run_listener(
     });
     let observer = Arc::new(registry::ObserverSlot::new(runtime.clone(), observer));
     let observer_task = tokio::spawn(Arc::clone(&observer).run(registry::POLL_CADENCE));
+    let discord_projection = discord_adapter
+        .as_ref()
+        .map(discord::DiscordAdapter::projection);
     let discord_task = discord_adapter.map(|adapter| tokio::spawn(adapter.run(runtime.clone())));
 
     // The resident door: a per-boot token, published beside the endpoint
@@ -475,12 +483,13 @@ pub(crate) async fn run_listener(
             _ = shutdown_request.wait() => {}
         }
     };
-    let app = server::router_with_observer(
+    let app = server::router_with_chat_projection(
         runtime.clone(),
         door.clone(),
         observer,
         Some(supervisor_handle),
         shutdown_door,
+        discord_projection,
     );
     let result = axum::serve(listener, app)
         .with_graceful_shutdown(graceful_shutdown)
@@ -530,6 +539,7 @@ mod tests {
 
     use crate::chat::turns::{ChatRole, ChatTurn, TurnDelta};
     use crate::chat::types::Lifecycle;
+    use crate::wave::chat::{ChatHistorySnapshot, PostMessageResponse, WaveChatMessage};
     use crate::wave::journal::MessageOp;
     use crate::wave::server::ResidentDoor;
     use crate::wave::wire::{ResidentDelta, RESIDENT_TOKEN_HEADER};
@@ -661,16 +671,16 @@ mod tests {
         narrate(&runtime, "second");
         narrate(&runtime, "third");
 
-        let body: serde_json::Value = reqwest::get(format!("{base}/conversation?limit=2"))
+        let body: ChatHistorySnapshot = reqwest::get(format!("{base}/conversation?limit=2"))
             .await
             .unwrap()
             .json()
             .await
             .unwrap();
-        let turns = body["turns"].as_array().unwrap();
+        let turns: Vec<_> = body.messages.iter().map(|message| &message.turn).collect();
         assert_eq!(turns.len(), 2);
-        assert_eq!(turns[0]["text"], "second");
-        assert_eq!(turns[1]["text"], "third");
+        assert_eq!(turns[0].text, "second");
+        assert_eq!(turns[1].text, "third");
 
         // A limit past the thread length serves the whole thread; no limit
         // does too.
@@ -678,8 +688,8 @@ mod tests {
             format!("{base}/conversation?limit=99"),
             format!("{base}/conversation"),
         ] {
-            let body: serde_json::Value = reqwest::get(url).await.unwrap().json().await.unwrap();
-            assert_eq!(body["turns"].as_array().unwrap().len(), 3);
+            let body: ChatHistorySnapshot = reqwest::get(url).await.unwrap().json().await.unwrap();
+            assert_eq!(body.messages.len(), 3);
         }
 
         // The open turn counts as the newest turn in the tail.
@@ -689,16 +699,16 @@ mod tests {
         runtime.apply_resident_delta(ResidentDelta::TurnText {
             text: "in progress".into(),
         });
-        let body: serde_json::Value = reqwest::get(format!("{base}/conversation?limit=1"))
+        let body: ChatHistorySnapshot = reqwest::get(format!("{base}/conversation?limit=1"))
             .await
             .unwrap()
             .json()
             .await
             .unwrap();
-        let turns = body["turns"].as_array().unwrap();
+        let turns: Vec<_> = body.messages.iter().map(|message| &message.turn).collect();
         assert_eq!(turns.len(), 1);
-        assert_eq!(turns[0]["status"], "running");
-        assert_eq!(turns[0]["text"], "in progress");
+        assert_eq!(turns[0].status, Lifecycle::Running);
+        assert_eq!(turns[0].text, "in progress");
     }
 
     #[tokio::test]
@@ -706,7 +716,7 @@ mod tests {
         let (base, runtime, _tmp) = boot().await;
 
         let client = reqwest::Client::new();
-        let body: serde_json::Value = client
+        let body: PostMessageResponse = client
             .post(format!("{base}/messages"))
             .json(&serde_json::json!({ "op": "message", "text": "how's it going?" }))
             .send()
@@ -715,10 +725,10 @@ mod tests {
             .json()
             .await
             .unwrap();
-        let posted: ChatTurn = serde_json::from_value(body["turn"].clone()).unwrap();
+        let posted = body.message.expect("posted message").turn;
         assert_eq!(posted.role, ChatRole::User);
         assert_eq!(posted.text, "how's it going?");
-        assert_eq!(body["state"], "idle");
+        assert_eq!(body.state, "idle");
 
         // The message is in the thread; the resident answers it at its next
         // turn (loop scheduling is covered in loop/wave.rs tests).
@@ -804,7 +814,7 @@ mod tests {
     async fn bare_interrupt_while_idle_is_a_noop_success_with_state() {
         let (base, runtime, _tmp) = boot().await;
         let client = reqwest::Client::new();
-        let body: serde_json::Value = client
+        let body: PostMessageResponse = client
             .post(format!("{base}/messages"))
             .json(&serde_json::json!({ "op": "interrupt", "text": "" }))
             .send()
@@ -813,8 +823,8 @@ mod tests {
             .json()
             .await
             .unwrap();
-        assert!(body["turn"].is_null(), "nothing said, nothing appended");
-        assert_eq!(body["state"], "idle");
+        assert!(body.message.is_none(), "nothing said, nothing appended");
+        assert_eq!(body.state, "idle");
         assert!(runtime.thread_snapshot().is_empty());
     }
 
@@ -978,7 +988,10 @@ mod tests {
                 Ok(Err(_)) => break,
             }
         }
-        assert!(acc.contains("event: turn"), "SSE frames are named `turn`");
+        assert!(
+            acc.contains("event: message"),
+            "human SSE frames are named `message`"
+        );
         assert!(
             acc.contains("replayed turn"),
             "replays the thread on connect"
@@ -1046,8 +1059,8 @@ mod tests {
         );
     }
 
-    /// Raw-TCP SSE client that decodes the chunked body and parses every
-    /// `data:` line into a [`ChatTurn`], in arrival order.
+    /// Raw-TCP SSE client that decodes the chunked body and folds source-bearing
+    /// message frames into their [`ChatTurn`] values in arrival order.
     struct SseClient {
         stream: tokio::net::TcpStream,
         raw: Vec<u8>,
@@ -1075,7 +1088,7 @@ mod tests {
             let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
             let mut buf = [0u8; 4096];
             loop {
-                let frames = parse_turn_frames(&dechunk(&self.raw));
+                let frames = parse_message_frames(&dechunk(&self.raw));
                 if pred(&frames) {
                     return frames;
                 }
@@ -1133,10 +1146,11 @@ mod tests {
         out
     }
 
-    /// Reconstruct the thread the way a real client does: a `turn` frame
-    /// replaces the turn of its id, a `turn-delta` frame absorbs one increment
-    /// into it. Returns the turns in first-seen order, each at its latest state.
-    fn parse_turn_frames(sse_body: &str) -> Vec<ChatTurn> {
+    /// Reconstruct the thread the way a real client does: a `message` frame
+    /// replaces the source-bearing message's turn, and a `message-delta` frame
+    /// absorbs one increment into it. Returns turns in first-seen order at their
+    /// latest state.
+    fn parse_message_frames(sse_body: &str) -> Vec<ChatTurn> {
         let mut order: Vec<String> = Vec::new();
         let mut by_id: std::collections::HashMap<String, ChatTurn> =
             std::collections::HashMap::new();
@@ -1147,15 +1161,16 @@ mod tests {
             } else if let Some(data) = line.strip_prefix("data:") {
                 let data = data.trim();
                 match event.as_str() {
-                    "turn" => {
-                        if let Ok(turn) = serde_json::from_str::<ChatTurn>(data) {
+                    "message" => {
+                        if let Ok(message) = serde_json::from_str::<WaveChatMessage>(data) {
+                            let turn = message.turn;
                             if !by_id.contains_key(&turn.id) {
                                 order.push(turn.id.clone());
                             }
                             by_id.insert(turn.id.clone(), turn);
                         }
                     }
-                    "turn-delta" => {
+                    "message-delta" => {
                         if let Ok(delta) = serde_json::from_str::<TurnDelta>(data) {
                             if let Some(turn) = by_id.get_mut(&delta.turn_id) {
                                 turn.absorb_item(delta.item);
@@ -1283,16 +1298,16 @@ mod tests {
             text: "half a thought".into(),
         });
 
-        let body: serde_json::Value = reqwest::get(format!("{base}/conversation"))
+        let body: ChatHistorySnapshot = reqwest::get(format!("{base}/conversation"))
             .await
             .unwrap()
             .json()
             .await
             .unwrap();
-        let turns = body["turns"].as_array().unwrap();
+        let turns: Vec<_> = body.messages.iter().map(|message| &message.turn).collect();
         assert_eq!(turns.len(), 1);
-        assert_eq!(turns[0]["status"], "running");
-        assert_eq!(turns[0]["text"], "half a thought");
+        assert_eq!(turns[0].status, Lifecycle::Running);
+        assert_eq!(turns[0].text, "half a thought");
 
         // After finalization the same id is served exactly once, terminal.
         runtime.apply_resident_delta(ResidentDelta::TurnFinished {
@@ -1300,15 +1315,15 @@ mod tests {
             cost_usd: None,
             reason: None,
         });
-        let body: serde_json::Value = reqwest::get(format!("{base}/conversation"))
+        let body: ChatHistorySnapshot = reqwest::get(format!("{base}/conversation"))
             .await
             .unwrap()
             .json()
             .await
             .unwrap();
-        let turns = body["turns"].as_array().unwrap();
+        let turns: Vec<_> = body.messages.iter().map(|message| &message.turn).collect();
         assert_eq!(turns.len(), 1);
-        assert_eq!(turns[0]["status"], "completed");
+        assert_eq!(turns[0].status, Lifecycle::Completed);
     }
 
     #[tokio::test]
@@ -1342,16 +1357,20 @@ mod tests {
         });
         let base = format!("http://{addr}");
 
-        let body: serde_json::Value = reqwest::get(format!("{base}/conversation"))
+        let body: ChatHistorySnapshot = reqwest::get(format!("{base}/conversation"))
             .await
             .unwrap()
             .json()
             .await
             .unwrap();
-        let turns = body["turns"].as_array().unwrap();
+        let turns: Vec<_> = body.messages.iter().map(|message| &message.turn).collect();
         assert_eq!(turns.len(), 1);
-        assert_eq!(turns[0]["status"], "failed", "janitor closed the turn");
-        assert_eq!(turns[0]["text"], "half a thought");
+        assert_eq!(
+            turns[0].status,
+            Lifecycle::Failed,
+            "janitor closed the turn"
+        );
+        assert_eq!(turns[0].text, "half a thought");
 
         // SSE replay agrees: the turn arrives failed, never running.
         let mut client = SseClient::connect(&base).await;
@@ -1392,7 +1411,7 @@ mod tests {
         let (base, runtime, tmp) = boot_family().await;
         let client = reqwest::Client::new();
 
-        let body: serde_json::Value = client
+        let body: PostMessageResponse = client
             .post(format!("{base}/messages"))
             .json(&serde_json::json!({ "op": "message", "text": "landed the parser" }))
             .send()
@@ -1401,7 +1420,10 @@ mod tests {
             .json()
             .await
             .unwrap();
-        assert_eq!(body["turn"]["text"], "landed the parser");
+        assert_eq!(
+            body.message.expect("posted message").turn.text,
+            "landed the parser"
+        );
 
         let thread = runtime.thread_snapshot();
         assert_eq!(thread.len(), 1);

--- a/rust/loopflow/src/wave/runtime.rs
+++ b/rust/loopflow/src/wave/runtime.rs
@@ -35,13 +35,14 @@ use crate::chat::types::{ConversationItem, Lifecycle};
 use crate::engine::wave_config::read_wave_config;
 use crate::project::ProjectObservation;
 use crate::task::TaskObservation;
+use crate::wave::chat::{ChatBacking, ChatMessageSource, ConversationEpoch, WaveChatMessage};
 #[cfg(test)]
 use crate::wave::journal::JournalAppendStage;
 use crate::wave::journal::{
     fold_thread, journal_path, project_observation_message, promotion_wake_message,
-    restore_pending, task_observation_message, DiscordAttachment, DiscordChatBinding,
-    DiscordDelivery, DiscordMessagePart, DiscordMessageSource, EventKind, Journal,
-    JournalAppendError, MessageId, MessageOp, PendingMessage, Usage,
+    restore_pending, task_observation_message, ConversationEpochImport, DiscordAttachment,
+    DiscordChatBinding, DiscordDelivery, DiscordMessagePart, DiscordMessageSource, EventKind,
+    Journal, JournalAppendError, MessageId, MessageOp, PendingMessage, Usage,
 };
 use crate::wave::playhead::{
     now_rfc3339, BodyProvenance, Playhead, PlayheadEvent, PlayheadView, QueuedInvocation,
@@ -166,6 +167,7 @@ pub enum InboxItem {
 /// after it (see [`WaveRuntime::subscribe_with_snapshot`]).
 #[derive(Debug)]
 pub struct Subscription {
+    pub epoch: ConversationEpoch,
     pub turns: Vec<ChatTurn>,
     /// Live turn frames ride as [`TurnBroadcast`] (whole or delta), each an
     /// `Arc`: the broadcast clones once per subscriber, so N subscribers share
@@ -214,6 +216,8 @@ struct OpenTurn {
 struct Inner {
     journal: Journal,
     thread: Vec<ChatTurn>,
+    conversation_epochs: Vec<ConversationEpoch>,
+    conversation_epoch_turns: HashMap<String, Vec<String>>,
     /// The turn currently in progress, or `None` between turns. Everything
     /// that is only meaningful while a turn runs lives inside it, so closing a
     /// turn is one `take()` rather than four fields reset in step.
@@ -269,6 +273,16 @@ pub struct WaveRuntime {
     resident_expected: AtomicBool,
 }
 
+/// A human-authored chat write either commits to the active local epoch or is
+/// rejected because its active authority is Discord.
+#[derive(Debug, thiserror::Error)]
+pub enum ChatWriteError {
+    #[error("this Wave chat is backed by Discord")]
+    OpenDiscord,
+    #[error(transparent)]
+    Journal(#[from] JournalAppendError),
+}
+
 impl WaveRuntime {
     /// Open the runtime against the wave's journal, replaying it: the thread
     /// cache is rebuilt from the log and turn ids continue from its seq.
@@ -282,6 +296,22 @@ impl WaveRuntime {
     /// # Errors
     /// Journal I/O failure or an unreadable (future-versioned) journal.
     pub fn open(name: String, repo_root: PathBuf) -> anyhow::Result<Arc<Self>> {
+        Self::open_with_backing(name, repo_root, ChatBacking::Local)
+    }
+
+    /// Open the runtime with one boot-atomic conversation authority.
+    ///
+    /// A backing change starts a new append-only epoch. Reopening with the
+    /// same backing resumes the existing epoch instead of inventing a restart
+    /// boundary.
+    ///
+    /// # Errors
+    /// Journal I/O failure or an unreadable (future-versioned) journal.
+    pub fn open_with_backing(
+        name: String,
+        repo_root: PathBuf,
+        backing: ChatBacking,
+    ) -> anyhow::Result<Arc<Self>> {
         let (mut journal, events) = Journal::open(&journal_path(&repo_root, &name))?;
         let mut fold = fold_thread(&events);
 
@@ -346,11 +376,25 @@ impl WaveRuntime {
             LoopState::Idle
         };
 
+        initialize_conversation_epoch(
+            &mut journal,
+            &mut fold.conversation_epochs,
+            &mut fold.conversation_epoch_turns,
+            &fold.turns,
+            &fold.discord_turn_bindings,
+            backing.clone(),
+        );
+
         let planned_turns = fold
             .discord_deliveries
             .values()
             .map(|delivery| delivery.turn_id.clone())
             .collect::<std::collections::HashSet<_>>();
+        let active_epoch = fold
+            .conversation_epochs
+            .last()
+            .cloned()
+            .expect("conversation epoch initialized before delivery recovery");
         for (turn_id, claims) in &fold.completed_claims {
             if planned_turns.contains(turn_id) {
                 continue;
@@ -358,12 +402,20 @@ impl WaveRuntime {
             let Some(turn) = fold.turns.iter().find(|turn| &turn.id == turn_id) else {
                 continue;
             };
-            let Some(delivery) = build_discord_delivery(turn, claims, &fold.messages) else {
+            if turn_journal_seq(turn).is_none_or(|seq| seq <= active_epoch.journal_seq) {
+                continue;
+            }
+            let Some(binding) = active_epoch.backing.discord_binding() else {
+                continue;
+            };
+            let Some(delivery) = build_discord_delivery(turn, claims, &fold.messages, &binding)
+            else {
                 continue;
             };
             journal.append(|_| EventKind::DiscordChatSendPlanned {
                 delivery_id: delivery.delivery_id.clone(),
                 turn_id: delivery.turn_id.clone(),
+                binding: Some(delivery.binding.clone()),
                 sources: delivery.sources.clone(),
                 parts: delivery.parts.clone(),
             });
@@ -381,6 +433,8 @@ impl WaveRuntime {
             inner: Mutex::new(Inner {
                 journal,
                 thread: fold.turns,
+                conversation_epochs: fold.conversation_epochs,
+                conversation_epoch_turns: fold.conversation_epoch_turns,
                 open: None,
                 drop_deltas_until_opened: false,
                 state,
@@ -408,6 +462,78 @@ impl WaveRuntime {
 
     pub fn repo_root(&self) -> &std::path::Path {
         &self.repo_root
+    }
+
+    pub fn active_conversation_epoch(&self) -> ConversationEpoch {
+        self.inner()
+            .conversation_epochs
+            .last()
+            .cloned()
+            .expect("an open runtime always has an active conversation epoch")
+    }
+
+    pub fn conversation_epochs(&self) -> Vec<ConversationEpoch> {
+        self.inner().conversation_epochs.clone()
+    }
+
+    pub fn is_imported_conversation_epoch(&self, epoch_id: &str) -> bool {
+        self.inner().conversation_epoch_turns.contains_key(epoch_id)
+    }
+
+    pub fn chat_messages(
+        &self,
+        epoch_id: Option<&str>,
+        limit: Option<usize>,
+    ) -> Vec<WaveChatMessage> {
+        let inner = self.inner();
+        let selected = match epoch_id {
+            Some(id) => inner
+                .conversation_epochs
+                .iter()
+                .find(|epoch| epoch.id == id),
+            None => inner.conversation_epochs.last(),
+        };
+        let Some(epoch) = selected else {
+            return Vec::new();
+        };
+        if !matches!(epoch.backing, ChatBacking::Local) {
+            return Vec::new();
+        }
+        let imported_turns = inner.conversation_epoch_turns.get(&epoch.id);
+        let end_seq = inner
+            .conversation_epochs
+            .iter()
+            .find(|candidate| candidate.number == epoch.number + 1)
+            .map(|candidate| candidate.journal_seq)
+            .unwrap_or(u64::MAX);
+        let turns = snapshot_tail_locked(&inner, None)
+            .into_iter()
+            .filter_map(|turn| {
+                let journal_seq = turn_journal_seq(&turn)?;
+                let belongs = imported_turns.map_or_else(
+                    || journal_seq > epoch.journal_seq && journal_seq < end_seq,
+                    |turn_ids| turn_ids.contains(&turn.id),
+                );
+                belongs.then(|| WaveChatMessage {
+                    epoch_id: epoch.id.clone(),
+                    source: ChatMessageSource::Local { journal_seq },
+                    turn,
+                })
+            })
+            .collect::<Vec<_>>();
+        tail_chat_messages(turns, limit)
+    }
+
+    pub fn committed_local_message(&self, turn: ChatTurn) -> WaveChatMessage {
+        let epoch = self.active_conversation_epoch();
+        debug_assert!(matches!(epoch.backing, ChatBacking::Local));
+        let journal_seq = turn_journal_seq(&turn)
+            .expect("a runtime-committed ChatTurn id carries its journal sequence");
+        WaveChatMessage {
+            epoch_id: epoch.id,
+            source: ChatMessageSource::Local { journal_seq },
+            turn,
+        }
     }
 
     pub fn discord_snapshot(&self) -> DiscordSnapshot {
@@ -470,6 +596,13 @@ impl WaveRuntime {
         source: DiscordMessageSource,
     ) -> Result<bool, JournalAppendError> {
         let mut inner = self.inner();
+        let active_binding = inner
+            .conversation_epochs
+            .last()
+            .and_then(|epoch| epoch.backing.discord_binding());
+        if active_binding.as_ref() != Some(&source.binding) {
+            return Ok(false);
+        }
         if inner.messages.values().any(|known| {
             known.source.as_ref().is_some_and(|known| {
                 known.binding == source.binding && known.message_id == source.message_id
@@ -818,6 +951,11 @@ impl WaveRuntime {
     pub fn subscribe_with_snapshot(&self, limit: Option<usize>) -> Subscription {
         let inner = self.inner();
         Subscription {
+            epoch: inner
+                .conversation_epochs
+                .last()
+                .cloned()
+                .expect("an open runtime always has an active conversation epoch"),
             turns: snapshot_tail_locked(&inner, limit),
             turn_rx: self.turn_tx.subscribe(),
             state: inner.state.clone(),
@@ -986,6 +1124,32 @@ impl WaveRuntime {
             return Ok(None);
         }
         self.try_deliver_message(text, op).map(Some)
+    }
+
+    /// Deliver through the product write door, governed by the active epoch.
+    /// A bare interrupt is a Wave control and remains available in either
+    /// backing; authored text never falls through to a local shadow thread.
+    ///
+    /// # Errors
+    /// Discord-backed authored text is rejected; the active epoch owns its
+    /// Open-in-Discord action. Local journal append failures leave every
+    /// projection untouched.
+    pub fn try_deliver_authored(
+        &self,
+        op: MessageOp,
+        text: String,
+    ) -> Result<Option<ChatTurn>, ChatWriteError> {
+        if op == MessageOp::Interrupt && text.trim().is_empty() {
+            self.deliver_interrupt();
+            return Ok(None);
+        }
+        if matches!(
+            self.active_conversation_epoch().backing,
+            ChatBacking::Discord { .. }
+        ) {
+            return Err(ChatWriteError::OpenDiscord);
+        }
+        self.try_deliver(op, text).map_err(ChatWriteError::from)
     }
 
     fn try_deliver_message(
@@ -1417,7 +1581,14 @@ impl WaveRuntime {
         turn: &ChatTurn,
         claims: &[MessageId],
     ) {
-        let Some(delivery) = build_discord_delivery(turn, claims, &inner.messages) else {
+        let Some(binding) = inner
+            .conversation_epochs
+            .last()
+            .and_then(|epoch| epoch.backing.discord_binding())
+        else {
+            return;
+        };
+        let Some(delivery) = build_discord_delivery(turn, claims, &inner.messages, &binding) else {
             return;
         };
         if inner.discord_deliveries.contains_key(&delivery.delivery_id) {
@@ -1426,6 +1597,7 @@ impl WaveRuntime {
         inner.journal.append(|_| EventKind::DiscordChatSendPlanned {
             delivery_id: delivery.delivery_id.clone(),
             turn_id: delivery.turn_id.clone(),
+            binding: Some(delivery.binding.clone()),
             sources: delivery.sources.clone(),
             parts: delivery.parts.clone(),
         });
@@ -1506,6 +1678,100 @@ fn body_has_harness(body: &BodyProvenance) -> bool {
         .is_some_and(|harness| !harness.trim().is_empty())
 }
 
+fn initialize_conversation_epoch(
+    journal: &mut Journal,
+    epochs: &mut Vec<ConversationEpoch>,
+    epoch_turns: &mut HashMap<String, Vec<String>>,
+    turns: &[ChatTurn],
+    discord_turn_bindings: &HashMap<String, DiscordChatBinding>,
+    backing: ChatBacking,
+) {
+    let migrating_legacy = epochs.is_empty() && !turns.is_empty();
+    if migrating_legacy {
+        let imported = legacy_conversation_epochs(turns, discord_turn_bindings);
+        journal.append(|_| EventKind::ConversationEpochsImported {
+            epochs: imported.clone(),
+        });
+        for item in imported {
+            epoch_turns.insert(item.epoch.id.clone(), item.turn_ids);
+            epochs.push(item.epoch);
+        }
+    }
+    if !migrating_legacy
+        && epochs.last().is_some_and(|epoch| {
+            epoch.backing == backing && !epoch.id.starts_with("chat-epoch-legacy-")
+        })
+    {
+        return;
+    }
+    let number = epochs.last().map_or(1, |epoch| epoch.number + 1);
+    let event = journal.append(|seq| EventKind::ConversationEpochStarted {
+        epoch_id: format!("chat-epoch-{seq}"),
+        number,
+        backing: backing.clone(),
+    });
+    let at = event.at_rfc3339();
+    if let Some(previous) = epochs.last_mut() {
+        previous.ended_at = Some(at.clone());
+    }
+    epochs.push(ConversationEpoch {
+        id: format!("chat-epoch-{}", event.seq),
+        number,
+        backing,
+        journal_seq: event.seq,
+        started_at: at,
+        ended_at: None,
+    });
+}
+
+fn legacy_conversation_epochs(
+    turns: &[ChatTurn],
+    discord_turn_bindings: &HashMap<String, DiscordChatBinding>,
+) -> Vec<ConversationEpochImport> {
+    let mut imported: Vec<ConversationEpochImport> = Vec::new();
+    for turn in turns {
+        let backing = discord_turn_bindings
+            .get(&turn.id)
+            .map(ChatBacking::discord)
+            .unwrap_or(ChatBacking::Local);
+        if let Some(active) = imported
+            .last_mut()
+            .filter(|active| active.epoch.backing == backing)
+        {
+            active.turn_ids.push(turn.id.clone());
+            continue;
+        }
+        let number = imported.len() as u64 + 1;
+        if let Some(previous) = imported.last_mut() {
+            previous.epoch.ended_at = Some(turn.created_at.clone());
+        }
+        imported.push(ConversationEpochImport {
+            epoch: ConversationEpoch {
+                id: format!("chat-epoch-legacy-{number}"),
+                number,
+                backing,
+                journal_seq: turn_journal_seq(turn).unwrap_or(1).saturating_sub(1),
+                started_at: turn.created_at.clone(),
+                ended_at: None,
+            },
+            turn_ids: vec![turn.id.clone()],
+        });
+    }
+    imported
+}
+
+fn turn_journal_seq(turn: &ChatTurn) -> Option<u64> {
+    turn.id.strip_prefix("turn-")?.parse().ok()
+}
+
+fn tail_chat_messages(
+    messages: Vec<WaveChatMessage>,
+    limit: Option<usize>,
+) -> Vec<WaveChatMessage> {
+    let take = limit.unwrap_or(messages.len()).min(messages.len());
+    messages[messages.len() - take..].to_vec()
+}
+
 /// Validate a wire `answers` declaration against the pending fold: known ids
 /// are claimed (removed from pending) and returned in wire order; unknown or
 /// already-consumed ids are dropped with a warning — the journal never names
@@ -1546,22 +1812,20 @@ fn build_discord_delivery(
     turn: &ChatTurn,
     claims: &[MessageId],
     messages: &HashMap<MessageId, PendingMessage>,
+    binding: &DiscordChatBinding,
 ) -> Option<DiscordDelivery> {
-    if claims.is_empty() || turn.text.trim().is_empty() {
+    if turn.text.trim().is_empty() {
         return None;
     }
     let sources = claims
         .iter()
-        .map(|claim| {
+        .filter_map(|claim| {
             messages
                 .get(claim)
                 .and_then(|message| message.source.clone())
         })
-        .collect::<Option<Vec<_>>>()?;
-    let binding = &sources.first()?.binding;
-    if sources.iter().any(|source| &source.binding != binding) {
-        return None;
-    }
+        .filter(|source| &source.binding == binding)
+        .collect::<Vec<_>>();
     let mut hasher = Sha256::new();
     hasher.update(binding.guild_id.as_bytes());
     hasher.update(binding.channel_id.as_bytes());
@@ -1580,6 +1844,7 @@ fn build_discord_delivery(
     Some(DiscordDelivery {
         delivery_id,
         turn_id: turn.id.clone(),
+        binding: binding.clone(),
         sources,
         parts,
         confirmed: HashMap::new(),
@@ -1645,6 +1910,15 @@ mod tests {
 
     fn open_runtime(repo: &Path) -> Arc<WaveRuntime> {
         WaveRuntime::open("ship".into(), repo.to_path_buf()).expect("open runtime")
+    }
+
+    fn open_discord_runtime(repo: &Path, binding: &DiscordChatBinding) -> Arc<WaveRuntime> {
+        WaveRuntime::open_with_backing(
+            "ship".into(),
+            repo.to_path_buf(),
+            ChatBacking::discord(binding),
+        )
+        .expect("open Discord runtime")
     }
 
     // -- Wire delta builders (the resident door's vocabulary) --
@@ -1863,7 +2137,6 @@ mod tests {
         rt.apply_resident_delta(d_finished(Lifecycle::Completed));
         assert!(rt.pending_messages().is_empty());
         drop(rt);
-
         let reopened = open_runtime(tmp.path());
         assert!(reopened.pending_messages().is_empty());
         assert!(
@@ -2678,7 +2951,7 @@ mod tests {
             message_id: "101".into(),
             author_id: "human".into(),
         };
-        let rt = open_runtime(tmp.path());
+        let rt = open_discord_runtime(tmp.path(), &binding);
         rt.try_attach_discord(binding.clone(), "bot".into(), Some("100".into()))
             .expect("attach at current head");
         assert!(rt
@@ -2697,7 +2970,8 @@ mod tests {
             "input commit does not advance the fetch cursor"
         );
 
-        let reopened = open_runtime(tmp.path());
+        drop(rt);
+        let reopened = open_discord_runtime(tmp.path(), &binding);
         assert!(!reopened
             .try_deliver_discord("hello".into(), source)
             .expect("refetched input"));
@@ -2708,8 +2982,9 @@ mod tests {
         reopened
             .try_advance_discord_cursor(&binding, "101".into())
             .expect("commit cursor");
+        drop(reopened);
         assert_eq!(
-            open_runtime(tmp.path())
+            open_discord_runtime(tmp.path(), &binding)
                 .discord_snapshot()
                 .attachment
                 .expect("attached")
@@ -2722,17 +2997,17 @@ mod tests {
     #[test]
     fn discord_chat_answer_is_planned_in_chunks_before_receipts() {
         let tmp = tempfile::tempdir().expect("tempdir");
-        let rt = open_runtime(tmp.path());
         let binding = DiscordChatBinding {
             guild_id: "guild".into(),
             channel_id: "channel".into(),
         };
+        let rt = open_discord_runtime(tmp.path(), &binding);
         rt.try_attach_discord(binding.clone(), "bot".into(), None)
             .expect("attach");
         rt.try_deliver_discord(
             "question".into(),
             DiscordMessageSource {
-                binding,
+                binding: binding.clone(),
                 message_id: "101".into(),
                 author_id: "human".into(),
             },
@@ -2760,50 +3035,224 @@ mod tests {
             "provider-1".into(),
         )
         .expect("confirm first part");
-        let reopened = open_runtime(tmp.path());
+        drop(rt);
+        let reopened = open_discord_runtime(tmp.path(), &binding);
         let resumed = &reopened.discord_snapshot().deliveries[0];
         assert_eq!(resumed.confirmed.len(), 1);
         assert_eq!(resumed.parts.len(), 2);
     }
 
     #[test]
-    fn discord_chat_never_sends_a_turn_that_claims_local_input() {
+    fn discord_epoch_routes_autonomous_agent_speech_as_a_top_level_message() {
         let tmp = tempfile::tempdir().expect("tempdir");
-        let rt = open_runtime(tmp.path());
         let binding = DiscordChatBinding {
             guild_id: "guild".into(),
             channel_id: "channel".into(),
         };
+        let rt = open_discord_runtime(tmp.path(), &binding);
         rt.try_attach_discord(binding.clone(), "bot".into(), None)
             .expect("attach");
-        rt.try_deliver_discord(
-            "question from Discord".into(),
-            DiscordMessageSource {
-                binding,
+
+        rt.apply_resident_delta(d_opened(&[]));
+        rt.apply_resident_delta(d_text("autonomous update"));
+        rt.apply_resident_delta(d_finished(Lifecycle::Completed));
+
+        let delivery = rt
+            .discord_snapshot()
+            .deliveries
+            .into_iter()
+            .next()
+            .expect("active Discord epoch chooses delivery");
+        assert_eq!(delivery.binding, binding);
+        assert!(
+            delivery.sources.is_empty(),
+            "no reply target means top-level"
+        );
+        assert_eq!(delivery.parts[0].content, "autonomous update");
+    }
+
+    #[test]
+    fn discord_epoch_delivers_speech_that_claims_a_typed_task_observation() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let binding = DiscordChatBinding {
+            guild_id: "guild".into(),
+            channel_id: "channel".into(),
+        };
+        let rt = open_discord_runtime(tmp.path(), &binding);
+        let observation = crate::task::TaskObservation {
+            task_id: crate::task::TaskId::from_raw("task_example"),
+            issue_identifier: "INF-123".into(),
+            event_id: 7,
+            event: crate::task::TaskEventKind::Progress {
+                summary: "Task needs parent attention".into(),
+            },
+        };
+        assert!(rt.deliver_task_observation(observation.clone()));
+
+        rt.apply_resident_delta(d_opened(&[&observation.inbox_id()]));
+        rt.apply_resident_delta(d_text("I handled the child update."));
+        rt.apply_resident_delta(d_finished(Lifecycle::Completed));
+
+        let delivery = rt
+            .discord_snapshot()
+            .deliveries
+            .into_iter()
+            .next()
+            .expect("typed input cannot suppress active-backing speech");
+        assert_eq!(delivery.binding, binding);
+        assert!(
+            delivery.sources.is_empty(),
+            "typed input is not a reply target"
+        );
+        assert_eq!(delivery.parts[0].content, "I handled the child update.");
+    }
+
+    #[test]
+    fn wave_chat_backing_switch_rejects_parallel_local_compose() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let binding = DiscordChatBinding {
+            guild_id: "guild".into(),
+            channel_id: "channel".into(),
+        };
+        let local = open_runtime(tmp.path());
+        let local_epoch = local.active_conversation_epoch();
+        assert_eq!(local_epoch.number, 1);
+        assert_eq!(local_epoch.backing, ChatBacking::Local);
+        local
+            .try_deliver_authored(MessageOp::Message, "local question".into())
+            .expect("local write")
+            .expect("local turn");
+        let local_messages = local.chat_messages(None, None);
+        assert_eq!(local_messages.len(), 1);
+        assert!(matches!(
+            local_messages[0].source,
+            ChatMessageSource::Local { .. }
+        ));
+        drop(local);
+
+        let discord = open_discord_runtime(tmp.path(), &binding);
+        let discord_epoch = discord.active_conversation_epoch();
+        assert_eq!(discord_epoch.number, 2);
+        assert_eq!(discord_epoch.backing, ChatBacking::discord(&binding));
+        let epochs = discord.conversation_epochs();
+        assert_eq!(epochs.len(), 2);
+        assert!(epochs[0].ended_at.is_some());
+        assert_eq!(
+            discord.chat_messages(Some(&local_epoch.id), None),
+            local_messages,
+            "the earlier local epoch remains byte-identical"
+        );
+
+        let before = crate::wave::journal::read_events(&journal_path(tmp.path(), "ship"));
+        let before_pending = discord.pending_messages();
+        let error = discord
+            .try_deliver_authored(MessageOp::Message, "shadow message".into())
+            .expect_err("Discord mode rejects Loopflow compose");
+        assert!(matches!(error, ChatWriteError::OpenDiscord));
+        let after = crate::wave::journal::read_events(&journal_path(tmp.path(), "ship"));
+        assert_eq!(before, after, "rejection appends no local journal event");
+        assert_eq!(before_pending, discord.pending_messages());
+        assert!(discord.chat_messages(None, None).is_empty());
+
+        discord
+            .try_deliver_authored(MessageOp::Interrupt, String::new())
+            .expect("bare interrupt remains available");
+        drop(discord);
+        let reopened = open_discord_runtime(tmp.path(), &binding);
+        assert_eq!(
+            reopened.active_conversation_epoch().id,
+            discord_epoch.id,
+            "a restart with the same backing resumes the epoch"
+        );
+        drop(reopened);
+
+        let local_again = open_runtime(tmp.path());
+        assert_eq!(local_again.active_conversation_epoch().number, 3);
+        assert_eq!(
+            local_again.active_conversation_epoch().backing,
+            ChatBacking::Local
+        );
+        assert_eq!(local_again.conversation_epochs().len(), 3);
+    }
+
+    #[test]
+    fn legacy_local_epoch_survives_the_migration_restart() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let path = journal_path(tmp.path(), "ship");
+        let (mut journal, _) = Journal::open(&path).expect("legacy journal");
+        journal.append(|_| EventKind::UserMessage {
+            id: MessageId("legacy-message".into()),
+            op: MessageOp::Message,
+            text: "before epochs".into(),
+        });
+        drop(journal);
+
+        let migrated = open_runtime(tmp.path());
+        let epochs = migrated.conversation_epochs();
+        assert_eq!(epochs.len(), 2);
+        assert_eq!(epochs[0].id, "chat-epoch-legacy-1");
+        assert_eq!(epochs[0].backing, ChatBacking::Local);
+        let legacy_messages = migrated.chat_messages(Some(&epochs[0].id), None);
+        assert_eq!(legacy_messages.len(), 1);
+        assert_eq!(legacy_messages[0].turn.text, "before epochs");
+        drop(migrated);
+
+        let reopened = open_runtime(tmp.path());
+        assert_eq!(reopened.conversation_epochs(), epochs);
+        assert_eq!(
+            reopened.chat_messages(Some("chat-epoch-legacy-1"), None),
+            legacy_messages
+        );
+    }
+
+    #[test]
+    fn legacy_mixed_chat_imports_truthful_backing_epochs_atomically() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let path = journal_path(tmp.path(), "ship");
+        let binding = DiscordChatBinding {
+            guild_id: "guild".into(),
+            channel_id: "channel".into(),
+        };
+        let (mut journal, _) = Journal::open(&path).expect("legacy journal");
+        journal.append(|_| EventKind::UserMessage {
+            id: MessageId("local-message".into()),
+            op: MessageOp::Message,
+            text: "local history".into(),
+        });
+        journal.append(|_| EventKind::DiscordUserMessage {
+            id: MessageId("discord-message".into()),
+            text: "provider history".into(),
+            source: DiscordMessageSource {
+                binding: binding.clone(),
                 message_id: "101".into(),
                 author_id: "human".into(),
             },
-        )
-        .expect("deliver Discord input");
-        let local = rt
-            .deliver(MessageOp::Message, "local correction".into())
-            .expect("deliver local input");
-        let pending = rt.pending_messages();
-        let discord_id = pending
-            .iter()
-            .find(|message| message.source.is_some())
-            .expect("Discord input remains pending")
-            .id
-            .0
-            .clone();
+        });
+        drop(journal);
 
-        rt.apply_resident_delta(d_opened(&[&discord_id, &msg_id(&local)]));
-        rt.apply_resident_delta(d_text("one combined answer"));
-        rt.apply_resident_delta(d_finished(Lifecycle::Completed));
-
-        assert!(
-            rt.discord_snapshot().deliveries.is_empty(),
-            "a turn that incorporated local input must stay inside Loopflow"
+        let migrated = open_runtime(tmp.path());
+        let epochs = migrated.conversation_epochs();
+        assert_eq!(epochs.len(), 3);
+        assert_eq!(epochs[0].backing, ChatBacking::Local);
+        assert_eq!(epochs[1].backing, ChatBacking::discord(&binding));
+        assert_eq!(epochs[2].backing, ChatBacking::Local);
+        assert_eq!(
+            migrated.chat_messages(Some(&epochs[0].id), None)[0]
+                .turn
+                .text,
+            "local history"
         );
+        assert!(
+            migrated.chat_messages(Some(&epochs[1].id), None).is_empty(),
+            "Discord history remains provider-projected, never mislabeled local"
+        );
+        let imported = crate::wave::journal::read_events(&path)
+            .into_iter()
+            .filter(|event| matches!(event.kind, EventKind::ConversationEpochsImported { .. }))
+            .count();
+        assert_eq!(imported, 1, "the entire legacy catalog is one append");
+        drop(migrated);
+
+        assert_eq!(open_runtime(tmp.path()).conversation_epochs(), epochs);
     }
 }

--- a/rust/loopflow/src/wave/server.rs
+++ b/rust/loopflow/src/wave/server.rs
@@ -76,6 +76,7 @@
 //!
 //! `Turn` is [`crate::chat::turns::ChatTurn`].
 
+use std::collections::{HashSet, VecDeque};
 use std::convert::Infallible;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
@@ -83,6 +84,7 @@ use std::sync::{Arc, Mutex};
 use axum::extract::{DefaultBodyLimit, Query, State};
 use axum::http::{HeaderMap, StatusCode};
 use axum::response::sse::{Event, KeepAlive, Sse};
+use axum::response::IntoResponse;
 use axum::routing::{get, post};
 use axum::{Json, Router};
 use futures_util::stream::{self, Stream, StreamExt};
@@ -95,10 +97,17 @@ use tokio_stream::wrappers::errors::BroadcastStreamRecvError;
 use tokio_stream::wrappers::BroadcastStream;
 
 use crate::chat::turns::ChatTurn;
+use crate::wave::chat::{
+    ChatBacking, ChatBackingHealth, ChatHistorySnapshot, ChatHistoryState, ChatMessageSource,
+    ConversationEpoch, PostMessageErrorResponse, PostMessageResponse, WaveChatMessage,
+};
+use crate::wave::discord::DiscordProjection;
 use crate::wave::journal::{MessageOp, PendingMessage};
 use crate::wave::playhead::PlayheadView;
 use crate::wave::registry::{process_alive, ObserverSlot, StoreObserver};
-use crate::wave::runtime::{InboxItem, TurnBroadcast, TurnDeltaFrame, TurnFrame, WaveRuntime};
+use crate::wave::runtime::{
+    ChatWriteError, InboxItem, TurnBroadcast, TurnDeltaFrame, TurnFrame, WaveRuntime,
+};
 use crate::wave::state::LoopState;
 use crate::wave::supervisor::SupervisorHandle;
 use crate::wave::wire::{
@@ -228,11 +237,8 @@ struct HealthBody {
     /// refuses to start turns while set, though it keeps serving and queueing.
     paused: bool,
     uptime_seconds: i64,
-}
-
-#[derive(Debug, Serialize)]
-struct ConversationBody {
-    turns: Vec<ChatTurn>,
+    active_epoch: ConversationEpoch,
+    chat_backing_health: ChatBackingHealth,
 }
 
 /// `GET /conversation` query. `limit` is explicitly Optional: `None` serves
@@ -240,6 +246,7 @@ struct ConversationBody {
 #[derive(Debug, Deserialize)]
 struct ConversationQuery {
     limit: Option<usize>,
+    epoch: Option<String>,
 }
 
 /// `POST /messages` request body. `op` is required — explicit, never inferred.
@@ -274,15 +281,6 @@ struct EventsQuery {
 
 pub(crate) const HUMAN_THREAD_REPLAY_LIMIT: usize = 12;
 
-/// `POST /messages` response. `turn` is the appended user turn; null for a
-/// bare interrupt, which appends nothing. `state` is the loop-state name at
-/// acceptance time.
-#[derive(Debug, Serialize)]
-struct PostMessageResponse {
-    turn: Option<ChatTurn>,
-    state: String,
-}
-
 /// Server state: the runtime, the resident door, the shared observer slot (for the
 /// context door's freshness poll), the supervisor handle (to signal an
 /// attach), and when the server started (for uptime).
@@ -293,6 +291,7 @@ struct ServerState {
     observer: Arc<ObserverSlot>,
     supervisor: Option<SupervisorHandle>,
     shutdown: ShutdownDoor,
+    discord: Option<DiscordProjection>,
     started_at: OffsetDateTime,
 }
 
@@ -323,12 +322,24 @@ pub(crate) fn router_with_observer(
     supervisor: Option<SupervisorHandle>,
     shutdown: ShutdownDoor,
 ) -> Router {
+    router_with_chat_projection(runtime, resident, observer, supervisor, shutdown, None)
+}
+
+pub(crate) fn router_with_chat_projection(
+    runtime: Arc<WaveRuntime>,
+    resident: ResidentDoor,
+    observer: Arc<ObserverSlot>,
+    supervisor: Option<SupervisorHandle>,
+    shutdown: ShutdownDoor,
+    discord: Option<DiscordProjection>,
+) -> Router {
     let state = ServerState {
         runtime,
         resident,
         observer,
         supervisor,
         shutdown,
+        discord,
         started_at: OffsetDateTime::now_utc(),
     };
     Router::new()
@@ -393,6 +404,16 @@ async fn health_handler(State(state): State<ServerState>) -> Json<HealthBody> {
         .runtime
         .resident_expected()
         .then(|| state.runtime.loop_state().name().to_string());
+    let active_epoch = state.runtime.active_conversation_epoch();
+    let chat_backing_health = if matches!(active_epoch.backing, ChatBacking::Local) {
+        ChatBackingHealth::Ready
+    } else if let Some(discord) = &state.discord {
+        discord.health()
+    } else {
+        ChatBackingHealth::Blocked {
+            detail: "Discord projection is not available on this listener".to_string(),
+        }
+    };
     Json(HealthBody {
         status: "serving".to_string(),
         loop_state,
@@ -400,6 +421,8 @@ async fn health_handler(State(state): State<ServerState>) -> Json<HealthBody> {
         turns: state.runtime.thread_len(),
         paused: state.runtime.paused(),
         uptime_seconds: (OffsetDateTime::now_utc() - state.started_at).whole_seconds(),
+        active_epoch,
+        chat_backing_health,
     })
 }
 
@@ -484,12 +507,74 @@ async fn resident_context_handler(
 async fn conversation_handler(
     State(state): State<ServerState>,
     Query(query): Query<ConversationQuery>,
-) -> Json<ConversationBody> {
+) -> Result<Json<ChatHistorySnapshot>, (StatusCode, String)> {
+    if query.limit == Some(0) {
+        return Err((StatusCode::BAD_REQUEST, "limit must be at least 1".into()));
+    }
     // The tail is taken inside the runtime lock: a `?limit=N` request clones
     // only the N turns it serves, not the whole thread.
-    Json(ConversationBody {
-        turns: state.runtime.thread_tail(query.limit),
-    })
+    let active_epoch = state.runtime.active_conversation_epoch();
+    let epochs = state.runtime.conversation_epochs();
+    let selected_epoch = match query.epoch.as_deref() {
+        Some(id) => epochs
+            .iter()
+            .find(|epoch| epoch.id == id)
+            .cloned()
+            .ok_or_else(|| (StatusCode::NOT_FOUND, format!("unknown chat epoch '{id}'")))?,
+        None => active_epoch.clone(),
+    };
+    let fetch_limit = query.limit.map(|limit| limit.saturating_add(1));
+    let (state_value, detail, mut messages) = match &selected_epoch.backing {
+        ChatBacking::Local => (
+            ChatHistoryState::Available,
+            None,
+            state
+                .runtime
+                .chat_messages(Some(&selected_epoch.id), fetch_limit),
+        ),
+        ChatBacking::Discord { .. }
+            if state
+                .runtime
+                .is_imported_conversation_epoch(&selected_epoch.id) =>
+        {
+            (
+                ChatHistoryState::Unavailable,
+                Some(
+                    "Legacy Discord history has no safe provider boundary; open the channel in Discord"
+                        .to_string(),
+                ),
+                Vec::new(),
+            )
+        }
+        ChatBacking::Discord { .. } => match &state.discord {
+            Some(discord) => match discord
+                .history(&state.runtime, &selected_epoch, fetch_limit)
+                .await
+            {
+                Ok(messages) => (ChatHistoryState::Available, None, messages),
+                Err(error) => (
+                    ChatHistoryState::Unavailable,
+                    Some(error.to_string()),
+                    Vec::new(),
+                ),
+            },
+            None => (
+                ChatHistoryState::Unavailable,
+                Some("Discord history requires the active Wave listener".to_string()),
+                Vec::new(),
+            ),
+        },
+    };
+    let truncated = query.limit.is_some_and(|limit| messages.len() > limit);
+    messages = tail_wave_messages(messages, query.limit);
+    Ok(Json(ChatHistorySnapshot {
+        epochs,
+        selected_epoch_id: Some(selected_epoch.id),
+        state: state_value,
+        detail,
+        messages,
+        truncated,
+    }))
 }
 
 /// The door is opaque on resident ops: this handler validates SHAPE only —
@@ -502,38 +587,50 @@ async fn conversation_handler(
 async fn messages_handler(
     State(state): State<ServerState>,
     Json(body): Json<PostMessage>,
-) -> Result<Json<PostMessageResponse>, (StatusCode, String)> {
+) -> axum::response::Response {
     if body.text.trim().is_empty() && !matches!(body.op, MessageOp::Interrupt) {
-        return Err((
+        return (
             StatusCode::BAD_REQUEST,
-            "text is required for every op but interrupt".to_string(),
-        ));
+            Json(PostMessageErrorResponse {
+                error: "text is required for every op but interrupt".to_string(),
+                epoch: state.runtime.active_conversation_epoch(),
+            }),
+        )
+            .into_response();
     }
-    let turn = state
-        .runtime
-        .try_deliver(body.op, body.text)
-        .map_err(|err| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                format!("message was not accepted: {err}"),
+    let turn = match state.runtime.try_deliver_authored(body.op, body.text) {
+        Ok(turn) => turn,
+        Err(error) => {
+            let status = match &error {
+                ChatWriteError::OpenDiscord => StatusCode::CONFLICT,
+                ChatWriteError::Journal(_) => StatusCode::INTERNAL_SERVER_ERROR,
+            };
+            return (
+                status,
+                Json(PostMessageErrorResponse {
+                    error: format!("message was not accepted: {error}"),
+                    epoch: state.runtime.active_conversation_epoch(),
+                }),
             )
-        })?;
-    Ok(Json(PostMessageResponse {
-        turn,
+                .into_response();
+        }
+    };
+    let message = turn.map(|turn| state.runtime.committed_local_message(turn));
+    Json(PostMessageResponse {
+        message,
         state: state.runtime.loop_state().name().to_string(),
-    }))
+        epoch: state.runtime.active_conversation_epoch(),
+    })
+    .into_response()
 }
 
-/// The served mind's thread as SSE: the loop state, the thread on connect
-/// (open turn included, status `running`), then live frames — `state` on every
-/// transition; `turn` (whole turn, replace-by-id) when a turn opens or
-/// finalizes, with `turn-delta` (one increment, absorb-by-id) for in-turn
-/// growth so a per-token turn does not re-serialize whole each frame; `resync`
-/// when the turn broadcast lagged (the client reconnects for a fresh atomic
-/// snapshot). Snapshot and subscription are atomic in the runtime (broadcasts
-/// share the append lock), so no live frame is
-/// ever older than the replayed snapshot, and the client's delta reconstruction
-/// picks up exactly where the snapshot's open turn left off.
+/// The served mind's thread as SSE. Human subscriptions open with epoch and
+/// backing health, then carry source-bearing `message` frames and plain
+/// `message-delta` increments. Resident inbox subscriptions keep the private
+/// `turn`/`turn-delta` wire. Both emit `resync` when a turn broadcast lags so
+/// the client reconnects for a fresh atomic snapshot. Snapshot and
+/// subscription are atomic in the runtime (broadcasts share the append lock),
+/// so no live frame is older than the replayed snapshot.
 ///
 /// There is no secondary routing scope inside a Wave listener.
 async fn events_handler(
@@ -548,6 +645,46 @@ async fn events_handler(
         Some(query.limit.unwrap_or(HUMAN_THREAD_REPLAY_LIMIT))
     };
     let sub = state.runtime.subscribe_with_snapshot(replay_limit);
+    let epoch = sub.epoch.clone();
+    let (discord_replay, discord_seen, backing_health) =
+        if !include_inbox && matches!(epoch.backing, ChatBacking::Discord { .. }) {
+            match &state.discord {
+                Some(discord) => {
+                    let fetch_limit = replay_limit.unwrap_or(HUMAN_THREAD_REPLAY_LIMIT).max(100);
+                    match discord
+                        .history(&state.runtime, &epoch, Some(fetch_limit))
+                        .await
+                    {
+                        Ok(messages) => {
+                            let seen = discord_message_ids(&messages);
+                            let replay = tail_wave_messages(messages, replay_limit)
+                                .into_iter()
+                                .map(|message| Ok(wave_message_event(&message)))
+                                .collect();
+                            (replay, seen, discord.health())
+                        }
+                        Err(error) => {
+                            let health = match discord.health() {
+                                blocked @ ChatBackingHealth::Blocked { .. } => blocked,
+                                _ => ChatBackingHealth::Retrying {
+                                    detail: error.to_string(),
+                                },
+                            };
+                            (Vec::new(), HashSet::new(), health)
+                        }
+                    }
+                }
+                None => (
+                    Vec::new(),
+                    HashSet::new(),
+                    ChatBackingHealth::Blocked {
+                        detail: "Discord history requires the active Wave listener".to_string(),
+                    },
+                ),
+            }
+        } else {
+            (Vec::new(), HashSet::new(), ChatBackingHealth::Ready)
+        };
     // The resident's subscription replays the pending queue after the
     // thread — its boot inbox. Consumption is validated at the resident
     // door, so a stale replay can never double-consume.
@@ -577,17 +714,48 @@ async fn events_handler(
     } else {
         Vec::new()
     };
+    let turn_replay: Vec<Result<Event, Infallible>> = if include_inbox {
+        sub.turns
+            .into_iter()
+            .map(|turn| Ok(turn_event(&turn)))
+            .collect()
+    } else if matches!(epoch.backing, ChatBacking::Local) {
+        sub.turns
+            .into_iter()
+            .filter_map(|turn| local_message_event(&epoch, turn).map(Ok))
+            .collect()
+    } else {
+        discord_replay
+    };
+    let epoch_replay = (!include_inbox)
+        .then(|| Ok(conversation_epoch_event(&epoch)))
+        .into_iter();
     let replay = stream::iter(
-        std::iter::once(Ok(state_event(&sub.state)))
+        epoch_replay
+            .chain((!include_inbox).then(|| Ok(backing_health_event(&backing_health))))
+            .chain(std::iter::once(Ok(state_event(&sub.state))))
             .chain(sub.playhead.into_iter().map(|p| Ok(playhead_event(&p))))
-            .chain(sub.turns.into_iter().map(|t| Ok(turn_event(&t))))
+            .chain(turn_replay)
             .chain(inbox_replay),
     );
-    // Whole turns ride `turn` frames, in-turn growth rides `turn-delta` frames,
-    // and a lag emits an explicit `resync` (never a silent drop — see
-    // `turn_event_stream`). The frame's wire JSON was serialized once at the
-    // send site.
-    let live_turns = turn_event_stream(sub.turn_rx);
+    // The resident keeps private turn frames; human chat converts the same
+    // broadcasts into source-bearing messages. Both make lag an explicit
+    // `resync`, never a silent drop.
+    let live_turns: BoxedEventStream = if include_inbox {
+        Box::pin(turn_event_stream(sub.turn_rx))
+    } else if matches!(epoch.backing, ChatBacking::Local) {
+        Box::pin(chat_message_event_stream(sub.turn_rx, epoch))
+    } else if let Some(discord) = state.discord.clone() {
+        Box::pin(discord_message_event_stream(
+            discord,
+            state.runtime.clone(),
+            epoch,
+            discord_seen,
+            backing_health,
+        ))
+    } else {
+        Box::pin(stream::empty())
+    };
     // Lagged: fine — the next transition carries the current state.
     let live_states = live_stream(sub.state_rx, |s| state_event(&s));
     let live_playhead = live_stream(sub.playhead_rx, |p| playhead_event(&p));
@@ -666,6 +834,116 @@ fn turn_event_stream(
     })
 }
 
+fn chat_message_event_stream(
+    rx: broadcast::Receiver<TurnBroadcast>,
+    epoch: ConversationEpoch,
+) -> impl Stream<Item = Result<Event, Infallible>> + Send + 'static {
+    stream::unfold(Some(BroadcastStream::new(rx)), move |state| {
+        let epoch = epoch.clone();
+        async move {
+            let mut inner = state?;
+            loop {
+                let recv = inner.next().await?;
+                match recv {
+                    Ok(TurnBroadcast::Whole(frame)) => {
+                        if let Some(event) = local_message_event(&epoch, frame.turn.clone()) {
+                            return Some((Ok(event), Some(inner)));
+                        }
+                    }
+                    Ok(TurnBroadcast::Delta(frame)) => {
+                        let Some(journal_seq) = turn_id_seq(&frame.delta.turn_id) else {
+                            continue;
+                        };
+                        if journal_seq <= epoch.journal_seq {
+                            continue;
+                        }
+                        return Some((
+                            Ok(Event::default().event("message-delta").data(
+                                serde_json::to_string(&frame.delta)
+                                    .expect("TurnDelta serializes to JSON"),
+                            )),
+                            Some(inner),
+                        ));
+                    }
+                    Err(BroadcastStreamRecvError::Lagged(_)) => {
+                        return Some((
+                            Ok(Event::default().event("resync").data("reconnect")),
+                            None,
+                        ));
+                    }
+                }
+            }
+        }
+    })
+}
+
+struct DiscordMessageStreamState {
+    projection: DiscordProjection,
+    runtime: Arc<WaveRuntime>,
+    epoch: ConversationEpoch,
+    seen: HashSet<String>,
+    pending: VecDeque<WaveChatMessage>,
+    health: ChatBackingHealth,
+}
+
+fn discord_message_event_stream(
+    projection: DiscordProjection,
+    runtime: Arc<WaveRuntime>,
+    epoch: ConversationEpoch,
+    seen: HashSet<String>,
+    health: ChatBackingHealth,
+) -> impl Stream<Item = Result<Event, Infallible>> + Send + 'static {
+    let state = DiscordMessageStreamState {
+        projection,
+        runtime,
+        epoch,
+        seen,
+        pending: VecDeque::new(),
+        health,
+    };
+    stream::unfold(state, |mut state| async move {
+        loop {
+            if let Some(message) = state.pending.pop_front() {
+                return Some((Ok(wave_message_event(&message)), state));
+            }
+            let provider_health = state.projection.health();
+            if provider_health != state.health {
+                state.health = provider_health;
+                return Some((Ok(backing_health_event(&state.health)), state));
+            }
+            tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+            match state
+                .projection
+                .history(&state.runtime, &state.epoch, Some(100))
+                .await
+            {
+                Ok(messages) => {
+                    for message in messages {
+                        let Some(id) = discord_message_id(&message) else {
+                            continue;
+                        };
+                        if state.seen.insert(id.to_string()) {
+                            state.pending.push_back(message);
+                        }
+                    }
+                }
+                Err(error) => {
+                    let health = match state.projection.health() {
+                        blocked @ ChatBackingHealth::Blocked { .. } => blocked,
+                        _ => ChatBackingHealth::Retrying {
+                            detail: error.to_string(),
+                        },
+                    };
+                    if health != state.health {
+                        state.health = health;
+                        return Some((Ok(backing_health_event(&state.health)), state));
+                    }
+                }
+            }
+        }
+    })
+}
+
 /// One turn broadcast poll resolved to what it becomes on the wire. A lag is
 /// `Resync`, NEVER a silently dropped frame — that distinction is the whole
 /// point of this substream, so it is pinned by a unit test.
@@ -687,6 +965,68 @@ fn turn_event(turn: &ChatTurn) -> Event {
     Event::default()
         .event("turn")
         .data(serde_json::to_string(turn).expect("ChatTurn serializes to JSON"))
+}
+
+fn conversation_epoch_event(epoch: &ConversationEpoch) -> Event {
+    Event::default()
+        .event("epoch")
+        .data(serde_json::to_string(epoch).expect("ConversationEpoch serializes to JSON"))
+}
+
+fn backing_health_event(health: &ChatBackingHealth) -> Event {
+    Event::default()
+        .event("backing-health")
+        .data(serde_json::to_string(health).expect("ChatBackingHealth serializes to JSON"))
+}
+
+fn wave_message_event(message: &WaveChatMessage) -> Event {
+    Event::default()
+        .event("message")
+        .data(serde_json::to_string(message).expect("WaveChatMessage serializes to JSON"))
+}
+
+fn discord_message_ids(messages: &[WaveChatMessage]) -> HashSet<String> {
+    messages
+        .iter()
+        .filter_map(discord_message_id)
+        .map(str::to_string)
+        .collect()
+}
+
+fn discord_message_id(message: &WaveChatMessage) -> Option<&str> {
+    match &message.source {
+        ChatMessageSource::Discord { message_id, .. } => Some(message_id),
+        ChatMessageSource::Local { .. } => None,
+    }
+}
+
+fn tail_wave_messages(
+    messages: Vec<WaveChatMessage>,
+    limit: Option<usize>,
+) -> Vec<WaveChatMessage> {
+    let take = limit.unwrap_or(messages.len()).min(messages.len());
+    messages[messages.len() - take..].to_vec()
+}
+
+fn local_message_event(epoch: &ConversationEpoch, turn: ChatTurn) -> Option<Event> {
+    let journal_seq = turn_id_seq(&turn.id)?;
+    if journal_seq <= epoch.journal_seq {
+        return None;
+    }
+    let message = WaveChatMessage {
+        epoch_id: epoch.id.clone(),
+        source: ChatMessageSource::Local { journal_seq },
+        turn,
+    };
+    Some(
+        Event::default()
+            .event("message")
+            .data(serde_json::to_string(&message).expect("WaveChatMessage serializes to JSON")),
+    )
+}
+
+fn turn_id_seq(turn_id: &str) -> Option<u64> {
+    turn_id.strip_prefix("turn-")?.parse().ok()
 }
 
 fn playhead_event(playhead: &PlayheadView) -> Event {
@@ -855,6 +1195,34 @@ mod tests {
     }
 
     #[test]
+    fn post_message_response_fixture_round_trips() {
+        let fixture = include_str!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../tests/fixtures/dto/post_message_response.json"
+        ));
+        let response: PostMessageResponse =
+            serde_json::from_str(fixture).expect("decode post message response fixture");
+        let encoded = serde_json::to_string(&response).expect("encode post message response");
+        let decoded: PostMessageResponse =
+            serde_json::from_str(&encoded).expect("re-decode post message response");
+        assert_eq!(decoded, response);
+    }
+
+    #[test]
+    fn post_message_error_response_fixture_round_trips() {
+        let fixture = include_str!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../tests/fixtures/dto/post_message_error_response.json"
+        ));
+        let response: PostMessageErrorResponse =
+            serde_json::from_str(fixture).expect("decode post message error fixture");
+        let encoded = serde_json::to_string(&response).expect("encode post message error");
+        let decoded: PostMessageErrorResponse =
+            serde_json::from_str(&encoded).expect("re-decode post message error");
+        assert_eq!(decoded, response);
+    }
+
+    #[test]
     fn a_lagged_turn_broadcast_maps_to_resync_not_a_dropped_frame() {
         // The distinction this substream exists for: a lag becomes an explicit
         // resync, never a silently swallowed increment.
@@ -1013,7 +1381,11 @@ mod tests {
                 .contains("message was not accepted"));
             assert!(runtime.thread_snapshot().is_empty());
             assert!(runtime.pending_messages().is_empty());
-            assert!(read_events(&journal_path(tmp.path(), "ship")).is_empty());
+            assert_eq!(
+                read_events(&journal_path(tmp.path(), "ship")).len(),
+                1,
+                "only the epoch boundary exists"
+            );
             assert!(matches!(
                 turn_rx.try_recv(),
                 Err(broadcast::error::TryRecvError::Empty)
@@ -1032,15 +1404,16 @@ mod tests {
             .expect("retry response");
         assert_eq!(response.status(), StatusCode::OK);
         let accepted: serde_json::Value = response.json().await.expect("accepted body");
-        assert_eq!(accepted["turn"]["id"], "turn-1");
-        assert_eq!(accepted["turn"]["role"], "user");
-        assert_eq!(accepted["turn"]["text"], "keep this");
+        assert_eq!(accepted["message"]["turn"]["id"], "turn-2");
+        assert_eq!(accepted["message"]["turn"]["role"], "user");
+        assert_eq!(accepted["message"]["turn"]["text"], "keep this");
+        assert_eq!(accepted["message"]["source"]["kind"], "local");
         assert_eq!(runtime.thread_snapshot().len(), 1);
         assert_eq!(runtime.pending_messages().len(), 1);
 
         let events = read_events(&journal_path(tmp.path(), "ship"));
-        assert_eq!(events.len(), 1);
-        assert!(matches!(events[0].kind, EventKind::UserMessage { .. }));
+        assert_eq!(events.len(), 2);
+        assert!(matches!(events[1].kind, EventKind::UserMessage { .. }));
         server.abort();
         let _ = server.await;
         drop(runtime);
@@ -1048,8 +1421,89 @@ mod tests {
         let reopened = WaveRuntime::open("ship".into(), tmp.path().to_path_buf()).expect("reopen");
         let transcript = reopened.thread_snapshot();
         assert_eq!(transcript.len(), 1);
-        assert_eq!(transcript[0].id, "turn-1");
+        assert_eq!(transcript[0].id, "turn-2");
         assert_eq!(transcript[0].text, "keep this");
+    }
+
+    #[tokio::test]
+    async fn discord_backing_rejects_compose_with_open_action_and_no_local_write() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let binding = crate::wave::journal::DiscordChatBinding {
+            guild_id: "guild".into(),
+            channel_id: "channel".into(),
+        };
+        let runtime = WaveRuntime::open_with_backing(
+            "ship".into(),
+            tmp.path().to_path_buf(),
+            ChatBacking::discord(&binding),
+        )
+        .expect("open Discord epoch");
+        let app = router_with_observer(
+            runtime.clone(),
+            ResidentDoor::new("resident"),
+            Arc::new(ObserverSlot::new(runtime.clone(), None)),
+            None,
+            ShutdownDoor::new(),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind");
+        let addr = listener.local_addr().expect("address");
+        let server = tokio::spawn(async move {
+            axum::serve(listener, app).await.ok();
+        });
+        let client = reqwest::Client::new();
+        let before = read_events(&journal_path(tmp.path(), "ship"));
+
+        let response = client
+            .post(format!("http://{addr}/messages"))
+            .json(&serde_json::json!({"op": "message", "text": "shadow"}))
+            .send()
+            .await
+            .expect("compose response");
+        assert_eq!(response.status(), StatusCode::CONFLICT);
+        let rejection: serde_json::Value = response.json().await.expect("rejection JSON");
+        assert_eq!(
+            rejection["epoch"]["backing"]["open"]["kind"],
+            "open_discord"
+        );
+        assert_eq!(
+            rejection["epoch"]["backing"]["open"]["url"],
+            "https://discord.com/channels/guild/channel"
+        );
+        assert_eq!(
+            read_events(&journal_path(tmp.path(), "ship")),
+            before,
+            "Discord rejection appends no local turn"
+        );
+        assert!(runtime.pending_messages().is_empty());
+
+        let interrupt = client
+            .post(format!("http://{addr}/messages"))
+            .json(&serde_json::json!({"op": "interrupt", "text": ""}))
+            .send()
+            .await
+            .expect("bare interrupt response");
+        assert_eq!(interrupt.status(), StatusCode::OK);
+        let interrupt: serde_json::Value = interrupt.json().await.expect("interrupt JSON");
+        assert!(interrupt["message"].is_null());
+
+        let conversation: serde_json::Value = client
+            .get(format!("http://{addr}/conversation"))
+            .send()
+            .await
+            .expect("conversation response")
+            .json()
+            .await
+            .expect("conversation JSON");
+        assert_eq!(conversation["epochs"][0]["backing"]["kind"], "discord");
+        assert_eq!(
+            conversation["selected_epoch_id"],
+            conversation["epochs"][0]["id"]
+        );
+        assert_eq!(conversation["state"], "unavailable");
+        assert_eq!(conversation["messages"], serde_json::json!([]));
+        server.abort();
     }
 
     #[tokio::test]

--- a/rust/loopflow/tests/wave_journal_tests.rs
+++ b/rust/loopflow/tests/wave_journal_tests.rs
@@ -251,6 +251,8 @@ async fn corrupt_trailing_line_is_tolerated_on_reboot() {
 async fn illegal_loop_transition_is_refused() {
     let tmp = tempfile::tempdir().expect("tempdir");
     let rt = open_wave(tmp.path());
+    let path = journal_path(tmp.path(), "ship");
+    let (_, before) = Journal::open(&path).expect("open journal before transition");
 
     assert!(!rt.transition(
         LoopState::Interrupting {
@@ -259,9 +261,9 @@ async fn illegal_loop_transition_is_refused() {
         "nothing to interrupt"
     ));
     assert_eq!(rt.loop_state(), LoopState::Idle, "state untouched");
-    // Refused moves leave no trace in the journal.
-    let (_, events) = Journal::open(&journal_path(tmp.path(), "ship")).expect("open journal");
-    assert!(events.is_empty());
+    // Refused moves add no trace beyond the runtime's durable epoch.
+    let (_, after) = Journal::open(&path).expect("open journal after transition");
+    assert_eq!(after.len(), before.len());
 }
 
 /// `/health` splits listener liveness (`status`, always `serving`) from the

--- a/swift/Loopflow/Models/ChatTurn.swift
+++ b/swift/Loopflow/Models/ChatTurn.swift
@@ -326,7 +326,7 @@ public struct ChatTurn: Codable, Sendable, Hashable, Identifiable {
     /// appends to `items`. The one exception is `commentary` — operational
     /// narration the provider tagged as process, not conclusion — which stays a
     /// discrete item so `turnPresentation` can curate it behind a disclosure.
-    /// The reader applies this to each `turn-delta` frame so its open-turn
+    /// The reader applies this to each incremental turn frame so its open-turn
     /// reconstruction matches the served turn without the whole turn crossing
     /// the wire per token.
     public func absorbing(_ item: ConversationItem) throws -> ChatTurn {
@@ -372,10 +372,10 @@ public struct ChatTurn: Codable, Sendable, Hashable, Identifiable {
     }()
 }
 
-/// One live increment to an open turn: the `turn-delta` SSE frame. Mirrors Rust
-/// `TurnDelta`. The listener sends one per in-turn content delta instead of the
-/// whole `ChatTurn`; the reader applies it with [`ChatTurn/absorbing(_:)`]
-/// against the turn named by `turnId`.
+/// One live increment to an open turn. Human chat carries it in
+/// `message-delta`; the resident stream uses `turn-delta`. Mirrors Rust
+/// `TurnDelta`; the reader applies it with [`ChatTurn/absorbing(_:)`] against
+/// the turn named by `turnId`.
 public struct TurnDelta: Codable, Sendable, Hashable {
     public let turnId: String
     public let item: ConversationItem

--- a/swift/Loopflow/Services/RegistryQuery.swift
+++ b/swift/Loopflow/Services/RegistryQuery.swift
@@ -94,16 +94,22 @@ public struct RegistryQuery: Sendable {
         return try Self.decode(ActivitySnapshot.self, from: stdout)
     }
 
-    /// Latest durable Wave turns from the local journal. This read does not
-    /// require or start a Wave listener; Wave Chat installs it before SSE.
+    /// Bounded history for one conversation epoch. `lf` uses the live backing
+    /// when a listener exists and otherwise folds readable local epochs from
+    /// the journal; this query never starts a Wave listener.
     public func chatHistory(
         wave: String,
         limit: Int = 12,
+        epoch: String? = nil,
         cwd: String?
     ) async throws -> ChatHistorySnapshot {
-        let stdout = try await run([
+        var args = [
             "chat", "--history", "--json", "--limit", String(limit), "--wave", wave,
-        ], cwd)
+        ]
+        if let epoch {
+            args.append(contentsOf: ["--epoch", epoch])
+        }
+        let stdout = try await run(args, cwd)
         return try Self.decode(ChatHistorySnapshot.self, from: stdout)
     }
 

--- a/swift/Loopflow/Services/WaveChatClient.swift
+++ b/swift/Loopflow/Services/WaveChatClient.swift
@@ -2,15 +2,180 @@ import Foundation
 
 // Live client for a wave's chat server. A running `lf wave <name>` publishes its
 // loopback address to `wave/<name>/.wave-endpoint`; this client discovers it,
-// consumes the unified `GET /events` SSE stream (turn, turn-delta, state, and
-// playhead frames; thread replay on connect), and posts messages back. When the
-// pointer file is absent or the server refuses the connection, the connection
-// settles into `.notRunning` and keeps polling so it attaches when the wave starts.
+// consumes the unified `GET /events` SSE stream (epoch, backing-health,
+// message, message-delta, state, and playhead frames), and posts messages back.
+// When the pointer file is absent or the server refuses the connection, the
+// connection settles into `.notRunning` and keeps polling so it attaches when
+// the wave starts.
 
 public enum WaveChatError: Error, Sendable {
     case notRunning
     case badStatus(Int)
     case badEndpoint(String)
+    case openDiscord(ChatAction)
+}
+
+public enum ChatAction: Codable, Sendable, Equatable {
+    case openDiscord(label: String, url: String)
+
+    private enum CodingKeys: String, CodingKey { case kind, label, url }
+
+    public init(from decoder: Decoder) throws {
+        let values = try decoder.container(keyedBy: CodingKeys.self)
+        switch try values.decode(String.self, forKey: .kind) {
+        case "open_discord":
+            self = .openDiscord(
+                label: try values.decode(String.self, forKey: .label),
+                url: try values.decode(String.self, forKey: .url)
+            )
+        default:
+            throw DecodingError.dataCorruptedError(
+                forKey: .kind,
+                in: values,
+                debugDescription: "Unknown Wave Chat action"
+            )
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var values = encoder.container(keyedBy: CodingKeys.self)
+        switch self {
+        case let .openDiscord(label, url):
+            try values.encode("open_discord", forKey: .kind)
+            try values.encode(label, forKey: .label)
+            try values.encode(url, forKey: .url)
+        }
+    }
+}
+
+public enum ChatBacking: Codable, Sendable, Equatable {
+    case local
+    case discord(guildId: String, channelId: String, open: ChatAction)
+
+    private enum CodingKeys: String, CodingKey {
+        case kind
+        case guildId = "guild_id"
+        case channelId = "channel_id"
+        case open
+    }
+
+    public init(from decoder: Decoder) throws {
+        let values = try decoder.container(keyedBy: CodingKeys.self)
+        switch try values.decode(String.self, forKey: .kind) {
+        case "local": self = .local
+        case "discord":
+            self = .discord(
+                guildId: try values.decode(String.self, forKey: .guildId),
+                channelId: try values.decode(String.self, forKey: .channelId),
+                open: try values.decode(ChatAction.self, forKey: .open)
+            )
+        default:
+            throw DecodingError.dataCorruptedError(
+                forKey: .kind,
+                in: values,
+                debugDescription: "Unknown Wave Chat backing"
+            )
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var values = encoder.container(keyedBy: CodingKeys.self)
+        switch self {
+        case .local:
+            try values.encode("local", forKey: .kind)
+        case let .discord(guildId, channelId, open):
+            try values.encode("discord", forKey: .kind)
+            try values.encode(guildId, forKey: .guildId)
+            try values.encode(channelId, forKey: .channelId)
+            try values.encode(open, forKey: .open)
+        }
+    }
+}
+
+public struct ConversationEpoch: Codable, Sendable, Equatable {
+    public let id: String
+    public let number: UInt64
+    public let backing: ChatBacking
+    public let journalSeq: UInt64
+    public let startedAt: String
+    public let endedAt: String?
+
+    private enum CodingKeys: String, CodingKey {
+        case id, number, backing
+        case journalSeq = "journal_seq"
+        case startedAt = "started_at"
+        case endedAt = "ended_at"
+    }
+}
+
+public enum ChatMessageSource: Codable, Sendable, Equatable {
+    case local(journalSeq: UInt64)
+    case discord(
+        guildId: String,
+        channelId: String,
+        messageId: String,
+        authorId: String,
+        url: String
+    )
+
+    private enum CodingKeys: String, CodingKey {
+        case kind
+        case journalSeq = "journal_seq"
+        case guildId = "guild_id"
+        case channelId = "channel_id"
+        case messageId = "message_id"
+        case authorId = "author_id"
+        case url
+    }
+
+    public init(from decoder: Decoder) throws {
+        let values = try decoder.container(keyedBy: CodingKeys.self)
+        switch try values.decode(String.self, forKey: .kind) {
+        case "local":
+            self = .local(journalSeq: try values.decode(UInt64.self, forKey: .journalSeq))
+        case "discord":
+            self = .discord(
+                guildId: try values.decode(String.self, forKey: .guildId),
+                channelId: try values.decode(String.self, forKey: .channelId),
+                messageId: try values.decode(String.self, forKey: .messageId),
+                authorId: try values.decode(String.self, forKey: .authorId),
+                url: try values.decode(String.self, forKey: .url)
+            )
+        default:
+            throw DecodingError.dataCorruptedError(
+                forKey: .kind,
+                in: values,
+                debugDescription: "Unknown Wave Chat message source"
+            )
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var values = encoder.container(keyedBy: CodingKeys.self)
+        switch self {
+        case let .local(journalSeq):
+            try values.encode("local", forKey: .kind)
+            try values.encode(journalSeq, forKey: .journalSeq)
+        case let .discord(guildId, channelId, messageId, authorId, url):
+            try values.encode("discord", forKey: .kind)
+            try values.encode(guildId, forKey: .guildId)
+            try values.encode(channelId, forKey: .channelId)
+            try values.encode(messageId, forKey: .messageId)
+            try values.encode(authorId, forKey: .authorId)
+            try values.encode(url, forKey: .url)
+        }
+    }
+}
+
+public struct WaveChatMessage: Codable, Sendable, Equatable {
+    public let epochId: String
+    public let source: ChatMessageSource
+    public let turn: ChatTurn
+
+    private enum CodingKeys: String, CodingKey {
+        case epochId = "epoch_id"
+        case source, turn
+    }
 }
 
 /// Evidence state of a read-only fold over the durable Wave journal.
@@ -21,30 +186,82 @@ public enum ChatHistoryState: String, Codable, Sendable, Equatable {
     case unavailable
 }
 
+public enum ChatBackingHealth: Codable, Sendable, Equatable {
+    case ready
+    case retrying(detail: String)
+    case blocked(detail: String)
+
+    private enum CodingKeys: String, CodingKey { case state, detail }
+
+    public init(from decoder: Decoder) throws {
+        let values = try decoder.container(keyedBy: CodingKeys.self)
+        switch try values.decode(String.self, forKey: .state) {
+        case "ready": self = .ready
+        case "retrying":
+            self = .retrying(detail: try values.decode(String.self, forKey: .detail))
+        case "blocked":
+            self = .blocked(detail: try values.decode(String.self, forKey: .detail))
+        default:
+            throw DecodingError.dataCorruptedError(
+                forKey: .state,
+                in: values,
+                debugDescription: "Unknown Wave Chat backing health"
+            )
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var values = encoder.container(keyedBy: CodingKeys.self)
+        switch self {
+        case .ready:
+            try values.encode("ready", forKey: .state)
+        case let .retrying(detail):
+            try values.encode("retrying", forKey: .state)
+            try values.encode(detail, forKey: .detail)
+        case let .blocked(detail):
+            try values.encode("blocked", forKey: .state)
+            try values.encode(detail, forKey: .detail)
+        }
+    }
+}
+
 /// Bounded `lf chat --history --json` response. Every field mirrors Rust.
 public struct ChatHistorySnapshot: Codable, Sendable, Equatable {
+    public let epochs: [ConversationEpoch]
+    public let selectedEpochId: String?
     public let state: ChatHistoryState
     public let detail: String?
-    public let turns: [ChatTurn]
+    public let messages: [WaveChatMessage]
     public let truncated: Bool
 
     public init(
+        epochs: [ConversationEpoch],
+        selectedEpochId: String?,
         state: ChatHistoryState,
         detail: String?,
-        turns: [ChatTurn],
+        messages: [WaveChatMessage],
         truncated: Bool
     ) {
+        self.epochs = epochs
+        self.selectedEpochId = selectedEpochId
         self.state = state
         self.detail = detail
-        self.turns = turns
+        self.messages = messages
         self.truncated = truncated
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case epochs
+        case selectedEpochId = "selected_epoch_id"
+        case state, detail, messages, truncated
     }
 }
 
 public typealias ChatHistoryLoader = @Sendable (
     _ repoPath: String,
     _ waveName: String,
-    _ limit: Int
+    _ limit: Int,
+    _ epoch: String?
 ) async throws -> ChatHistorySnapshot
 
 /// Reads the discovery pointer a running wave writes under its `wave/<name>/` dir.
@@ -280,17 +497,22 @@ public func composerVerbs(state: WaveLoopState, hasText: Bool) -> ComposerVerbs 
     }
 }
 
-/// `POST /messages {op, text}` response: the appended user turn (null for a
-/// bare interrupt) plus the loop-state name at acceptance. Mirrors Rust
+/// `POST /messages {op, text}` response: the source-bearing committed message
+/// (null for a bare interrupt), active epoch, and loop state. Mirrors Rust
 /// `PostMessageResponse` (wave/server.rs); pinned by the
 /// `post_message_response.json` fixture in ContractTests.
 struct PostMessageResponse: Decodable {
-    let turn: ChatTurn?
+    let message: WaveChatMessage?
     let state: String
+    let epoch: ConversationEpoch
 }
 
-/// Observable connection to one wave's chat server: the live thread plus a phase
-/// the UI renders (not running / connecting / live).
+struct PostMessageErrorResponse: Decodable {
+    let error: String
+    let epoch: ConversationEpoch
+}
+
+/// Observable connection to one wave's active conversation and backing state.
 @MainActor
 @Observable
 public final class WaveChatConnection {
@@ -304,9 +526,14 @@ public final class WaveChatConnection {
     public let repoPath: String
     public let waveName: String
 
-    public private(set) var turns: [ChatTurn] = []
+    public private(set) var messages: [WaveChatMessage] = []
+    public var turns: [ChatTurn] { messages.map(\.turn) }
+    public private(set) var activeEpoch: ConversationEpoch?
+    public private(set) var epochs: [ConversationEpoch] = []
+    public private(set) var selectedEpoch: ConversationEpoch?
+    public private(set) var backingHealth: ChatBackingHealth = .ready
     public private(set) var phase: Phase = .idle
-    /// Nil while the bounded local read has not completed.
+    /// Nil while the initial bounded history read has not completed.
     public private(set) var historyState: ChatHistoryState?
     public private(set) var historyDetail: String?
     public private(set) var historyTruncated = false
@@ -371,12 +598,22 @@ public final class WaveChatConnection {
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         request.httpBody = try JSONSerialization.data(withJSONObject: ["op": op.rawValue, "text": trimmed])
         let (data, response) = try await session.data(for: request)
-        guard let http = response as? HTTPURLResponse, http.statusCode == 200 else {
-            throw WaveChatError.badStatus((response as? HTTPURLResponse)?.statusCode ?? -1)
+        guard let http = response as? HTTPURLResponse else {
+            throw WaveChatError.badStatus(-1)
+        }
+        guard http.statusCode == 200 else {
+            if http.statusCode == 409,
+               let rejection = try? decoder.decode(PostMessageErrorResponse.self, from: data),
+               case let .discord(_, _, action) = rejection.epoch.backing {
+                applyActiveEpoch(rejection.epoch)
+                throw WaveChatError.openDiscord(action)
+            }
+            throw WaveChatError.badStatus(http.statusCode)
         }
         let posted = try decoder.decode(PostMessageResponse.self, from: data)
-        if let turn = posted.turn {
-            upsert(turn)
+        applyActiveEpoch(posted.epoch)
+        if let message = posted.message {
+            upsert(message)
         }
         if let state = WaveLoopState(rawValue: posted.state) {
             loopState = state
@@ -413,14 +650,7 @@ public final class WaveChatConnection {
     private func loadDurableHistory() async {
         guard let loadHistory else { return }
         do {
-            let snapshot = try await loadHistory(repoPath, waveName, historyLimit)
-            turns = snapshot.turns.sorted { a, b in
-                if a.sequence != b.sequence { return a.sequence < b.sequence }
-                return a.id < b.id
-            }
-            historyState = snapshot.state
-            historyDetail = snapshot.detail
-            historyTruncated = snapshot.truncated
+            applyHistory(try await loadHistory(repoPath, waveName, historyLimit, nil))
         } catch is CancellationError {
             return
         } catch {
@@ -428,6 +658,30 @@ public final class WaveChatConnection {
             historyDetail = "Saved conversation could not be read: \(error.localizedDescription)"
             historyTruncated = false
         }
+    }
+
+    public func selectEpoch(_ id: String) async {
+        guard let loadHistory, epochs.contains(where: { $0.id == id }) else { return }
+        do {
+            applyHistory(try await loadHistory(repoPath, waveName, historyLimit, id))
+        } catch is CancellationError {
+            return
+        } catch {
+            historyState = .unavailable
+            historyDetail = "Conversation epoch could not be read: \(error.localizedDescription)"
+        }
+    }
+
+    private func applyHistory(_ snapshot: ChatHistorySnapshot) {
+        epochs = snapshot.epochs
+        activeEpoch = snapshot.epochs.last
+        selectedEpoch = snapshot.selectedEpochId.flatMap { id in
+            snapshot.epochs.first { $0.id == id }
+        }
+        messages = snapshot.messages.sorted(by: messageOrder)
+        historyState = snapshot.state
+        historyDetail = snapshot.detail
+        historyTruncated = snapshot.truncated
     }
 
     private func stream(endpoint: String) async throws {
@@ -444,9 +698,9 @@ public final class WaveChatConnection {
         guard http.statusCode == 200 else {
             throw WaveChatError.badStatus(http.statusCode)
         }
-        // A fresh stream replays the same journal tail as the bounded local
-        // read. Keep the saved snapshot painted and upsert replay frames by id;
-        // connecting cannot repair a partial or unavailable durable read.
+        // A fresh stream replays the selected backing's bounded history. Keep
+        // the saved snapshot painted and upsert replay frames by id; connecting
+        // cannot repair a partial or unavailable read.
         loopState = .idle
         playhead = nil
         if historyState == nil {
@@ -458,10 +712,9 @@ public final class WaveChatConnection {
         for try await chunk in body {
             for frame in parser.consume(chunk) {
                 if Task.isCancelled { return }
-                // `resync`: the live turn stream lagged, so a `turn-delta` may
-                // have been dropped and the open-turn reconstruction could be
-                // short a fragment. End this connection; `run()` reconnects for
-                // a fresh whole-turn replay into the stable turn ids.
+                // `resync`: the live message stream lagged, so a
+                // `message-delta` may have been dropped. End this connection;
+                // `run()` reconnects for a fresh provider or journal snapshot.
                 if frame.event == "resync" { return }
                 handle(event: frame.event, data: frame.data)
             }
@@ -469,12 +722,11 @@ public final class WaveChatConnection {
     }
 
     /// One SSE frame off `/events`. `state` carries the bare loop-state name
-    /// (sent on subscribe and on every transition); `turn` carries a whole turn
-    /// — sent when a turn opens and finalizes, replacing its id's state;
-    /// `turn-delta` carries one in-turn increment absorbed into the matching
-    /// turn (so a per-token turn does not re-send whole each frame); `resync`
-    /// (handled in `stream`, not here) means the turn stream lagged and the
-    /// connection reconnects. Unknown events drop. A turn payload that fails
+    /// (sent on subscribe and on every transition); `message` carries a whole
+    /// source-bearing message, while `message-delta` grows one local message;
+    /// `resync`
+    /// (handled in `stream`, not here) means the message stream lagged and the
+    /// connection reconnects. Unknown events drop. A message payload that fails
     /// to decode is a hole in the transcript: logged always, asserted in debug
     /// — never silent. Internal for tests.
     func handle(event: String, data: String) {
@@ -489,60 +741,106 @@ public final class WaveChatConnection {
             playhead = snapshot
             return
         }
-        if event == "turn-delta" {
+        if event == "epoch" {
+            guard let json = data.data(using: .utf8),
+                  let epoch = try? decoder.decode(ConversationEpoch.self, from: json) else { return }
+            applyActiveEpoch(epoch)
+            return
+        }
+        if event == "backing-health" {
+            guard let json = data.data(using: .utf8),
+                  let health = try? decoder.decode(ChatBackingHealth.self, from: json) else { return }
+            backingHealth = health
+            return
+        }
+        if event == "message-delta" {
             guard let json = data.data(using: .utf8) else { return }
             do {
                 applyDelta(try decoder.decode(TurnDelta.self, from: json))
             } catch {
-                LoggingService.wave("wave chat: dropped turn-delta frame (\(error)): \(data.prefix(200))")
-                assertionFailure("wave chat turn-delta frame failed to decode: \(error)")
+                LoggingService.wave("wave chat: dropped message-delta frame (\(error)): \(data.prefix(200))")
+                assertionFailure("wave chat message-delta frame failed to decode: \(error)")
             }
             return
         }
-        guard event.isEmpty || event == "turn", let json = data.data(using: .utf8) else { return }
-        do {
-            upsert(try decoder.decode(ChatTurn.self, from: json))
-            if historyState == .missing {
-                historyState = .available
-                historyDetail = nil
+        if event == "message" {
+            guard let json = data.data(using: .utf8) else { return }
+            do {
+                let message = try decoder.decode(WaveChatMessage.self, from: json)
+                if selectedEpoch?.id == message.epochId {
+                    upsert(message)
+                }
+                if historyState == .missing {
+                    historyState = .available
+                    historyDetail = nil
+                }
+            } catch {
+                LoggingService.wave("wave chat: dropped message frame (\(error)): \(data.prefix(200))")
+                assertionFailure("wave chat message frame failed to decode: \(error)")
             }
-        } catch {
-            LoggingService.wave("wave chat: dropped turn frame (\(error)): \(data.prefix(200))")
-            assertionFailure("wave chat turn frame failed to decode: \(error)")
+            return
         }
     }
 
-    /// Grow the open turn named by a `turn-delta` frame through the same
-    /// `absorb` rule the listener folds with. No turn for this id means we
-    /// missed its opening (a gap the server heals with `resync`) — drop the
-    /// delta until the whole-turn replay rebuilds it. Internal for tests.
+    private func applyActiveEpoch(_ epoch: ConversationEpoch) {
+        let followsActive = selectedEpoch == nil || selectedEpoch?.id == activeEpoch?.id
+        activeEpoch = epoch
+        if let index = epochs.firstIndex(where: { $0.id == epoch.id }) {
+            epochs[index] = epoch
+        } else {
+            epochs.append(epoch)
+            epochs.sort { $0.number < $1.number }
+        }
+        if followsActive {
+            selectedEpoch = epoch
+            messages.removeAll { $0.epochId != epoch.id }
+        }
+    }
+
+    /// Grow the open source-bearing message named by a `message-delta` frame
+    /// through the same `absorb` rule the listener folds with. No message for
+    /// this id means we missed its opening (a gap the server heals with
+    /// `resync`) — drop the delta until message replay rebuilds it. Internal
+    /// for tests.
     func applyDelta(_ delta: TurnDelta) {
-        guard let index = turns.firstIndex(where: { $0.id == delta.turnId }) else { return }
+        guard let index = messages.firstIndex(where: { $0.turn.id == delta.turnId }) else { return }
         do {
-            turns[index] = try turns[index].absorbing(delta.item)
+            let message = messages[index]
+            messages[index] = WaveChatMessage(
+                epochId: message.epochId,
+                source: message.source,
+                turn: try message.turn.absorbing(delta.item)
+            )
         } catch {
-            LoggingService.wave("wave chat: turn-delta absorb failed (\(error))")
-            assertionFailure("wave chat turn-delta absorb failed: \(error)")
+            LoggingService.wave("wave chat: message-delta absorb failed (\(error))")
+            assertionFailure("wave chat message-delta absorb failed: \(error)")
         }
     }
 
-    /// Replace a turn already in the thread (an in-progress turn re-sent as it
+    /// Replace a message already in the selected epoch (an in-progress local
+    /// turn re-sent as it
     /// grows, then finalized under the same id), or append a new one. Ordered
     /// by monotonic sequence, id as tie-break: `sort` isn't guaranteed stable
     /// and unparseable ids share a `.max` sentinel sequence, so the tie-break
     /// keeps the order deterministic. A replace skips the sort — the key is
     /// (sequence, id) and both derive from the id, so an in-place frame can't
-    /// move; no reason to re-sort the thread on every SSE growth frame.
+    /// move; no reason to re-sort the epoch on every SSE growth frame.
     /// Internal for tests.
-    func upsert(_ turn: ChatTurn) {
-        if let index = turns.firstIndex(where: { $0.id == turn.id }) {
-            turns[index] = turn
+    func upsert(_ message: WaveChatMessage) {
+        if let index = messages.firstIndex(where: { $0.turn.id == message.turn.id }) {
+            messages[index] = message
             return
         }
-        turns.append(turn)
-        turns.sort { a, b in
-            if a.sequence != b.sequence { return a.sequence < b.sequence }
-            return a.id < b.id
-        }
+        messages.append(message)
+        messages.sort(by: messageOrder)
     }
+
+}
+
+private func messageOrder(_ lhs: WaveChatMessage, _ rhs: WaveChatMessage) -> Bool {
+    if let left = lhs.turn.createdAtDate, let right = rhs.turn.createdAtDate, left != right {
+        return left < right
+    }
+    if lhs.turn.sequence != rhs.turn.sequence { return lhs.turn.sequence < rhs.turn.sequence }
+    return lhs.turn.id < rhs.turn.id
 }

--- a/swift/LoopflowMac/Views/WaveChatView.swift
+++ b/swift/LoopflowMac/Views/WaveChatView.swift
@@ -88,8 +88,13 @@ struct WaveChatView: View {
             let conn = WaveChatConnection(
                 repoPath: repoPath,
                 waveName: waveName,
-                loadHistory: { repoPath, waveName, limit in
-                    try await query.chatHistory(wave: waveName, limit: limit, cwd: repoPath)
+                loadHistory: { repoPath, waveName, limit, epoch in
+                    try await query.chatHistory(
+                        wave: waveName,
+                        limit: limit,
+                        epoch: epoch,
+                        cwd: repoPath
+                    )
                 }
             )
             connection = conn

--- a/swift/LoopflowTests/ContractTests.swift
+++ b/swift/LoopflowTests/ContractTests.swift
@@ -180,25 +180,47 @@ struct ContractTests {
 
     @Test("post_message_response.json decodes through PostMessageResponse")
     func postMessageResponseFixtureParses() throws {
-        // Pins `POST /messages` → `{turn, state}` for the Mac client.
+        // Pins the source-bearing `POST /messages` response for the Mac client.
         let data = try fixtureData("dto/post_message_response.json")
         let posted = try JSONDecoder().decode(PostMessageResponse.self, from: data)
 
-        let turn = try #require(posted.turn)
+        let message = try #require(posted.message)
+        let turn = message.turn
         #expect(turn.id == "turn-4")
         #expect(turn.role == .user)
         #expect(turn.status == .completed)
         #expect(turn.items.isEmpty)
+        #expect(message.source == .local(journalSeq: 4))
+        #expect(posted.epoch.backing == .local)
         #expect(WaveLoopState(rawValue: posted.state) == .turning)
 
-        // `turn` is explicitly Optional: null for a bare interrupt.
+        // `message` is explicitly Optional: null for a bare interrupt.
         var json = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
-        json["turn"] = NSNull()
+        json["message"] = NSNull()
         let bareInterrupt = try JSONDecoder().decode(
             PostMessageResponse.self,
             from: JSONSerialization.data(withJSONObject: json)
         )
-        #expect(bareInterrupt.turn == nil)
+        #expect(bareInterrupt.message == nil)
+    }
+
+    @Test("post_message_error_response.json decodes through PostMessageErrorResponse")
+    func postMessageErrorResponseFixtureParses() throws {
+        let data = try fixtureData("dto/post_message_error_response.json")
+        let rejection = try JSONDecoder().decode(PostMessageErrorResponse.self, from: data)
+
+        #expect(rejection.error.contains("backed by Discord"))
+        #expect(rejection.epoch.number == 2)
+        if case let .discord(guildId, channelId, open) = rejection.epoch.backing {
+            #expect(guildId == "guild-1")
+            #expect(channelId == "channel-1")
+            #expect(open == .openDiscord(
+                label: "Open in Discord",
+                url: "https://discord.com/channels/guild-1/channel-1"
+            ))
+        } else {
+            Issue.record("expected Discord epoch")
+        }
     }
 
     @Test("chat_history.json decodes through the durable history models")
@@ -208,7 +230,7 @@ struct ContractTests {
 
         #expect(snapshot.state == .partial)
         #expect(snapshot.detail?.contains("line 8") == true)
-        #expect(snapshot.turns.map(\.id) == ["turn-7"])
+        #expect(snapshot.messages.map(\.turn.id) == ["turn-7"])
         #expect(snapshot.truncated)
 
         let reencoded = try JSONEncoder().encode(snapshot)

--- a/swift/LoopflowTests/RegistryQueryTests.swift
+++ b/swift/LoopflowTests/RegistryQueryTests.swift
@@ -116,14 +116,14 @@ struct RegistryQueryTests {
         #expect(result.waves.isEmpty)
     }
 
-    @Test("Wave Chat history is a bounded local query")
-    func chatHistoryUsesLocalJournalQuery() async throws {
+    @Test("Wave Chat history uses the backing-aware DTO")
+    func chatHistoryUsesBackingAwareDTO() async throws {
         let query = RegistryQuery { args, cwd in
             #expect(args == [
                 "chat", "--history", "--json", "--limit", "12", "--wave", "product",
             ])
             #expect(cwd == "/tmp/repo")
-            return #"{"state":"missing","detail":"No durable Wave Chat history exists yet.","turns":[],"truncated":false}"#
+            return #"{"epochs":[],"selected_epoch_id":null,"state":"missing","detail":"No durable Wave Chat history exists yet.","messages":[],"truncated":false}"#
         }
 
         let snapshot = try await query.chatHistory(
@@ -132,7 +132,7 @@ struct RegistryQueryTests {
             cwd: "/tmp/repo"
         )
         #expect(snapshot.state == .missing)
-        #expect(snapshot.turns.isEmpty)
+        #expect(snapshot.messages.isEmpty)
         #expect(!snapshot.truncated)
     }
 

--- a/swift/LoopflowTests/WaveChatConnectionTests.swift
+++ b/swift/LoopflowTests/WaveChatConnectionTests.swift
@@ -8,20 +8,54 @@ import Foundation
 import Testing
 @testable import Loopflow
 
+private let localEpochFrame = #"{"id":"chat-epoch-1","number":1,"backing":{"kind":"local"},"journal_seq":1,"started_at":"2026-07-15T04:00:00Z","ended_at":null}"#
+
+private func localJournalSeq(_ turnId: String) -> UInt64 {
+    guard let suffix = turnId.split(separator: "-").last,
+          let sequence = UInt64(suffix) else { return 999 }
+    return max(2, sequence)
+}
+
+private func localMessageFrame(turn: String, turnId: String) -> String {
+    "{\"epoch_id\":\"chat-epoch-1\",\"source\":{\"kind\":\"local\",\"journal_seq\":\(localJournalSeq(turnId))},\"turn\":\(turn)}"
+}
+
 @MainActor
 @Suite("WaveChat streaming upsert")
 struct WaveChatConnectionTests {
     private func connection() -> WaveChatConnection {
-        WaveChatConnection(repoPath: "/tmp/nowhere", waveName: "ship")
+        let connection = WaveChatConnection(repoPath: "/tmp/nowhere", waveName: "ship")
+        connection.handle(event: "epoch", data: localEpochFrame)
+        return connection
     }
 
-    /// A wire-shaped `turn` SSE payload. `text` is spliced raw, so escape
+    private func localEpoch() -> ConversationEpoch {
+        ConversationEpoch(
+            id: "chat-epoch-1",
+            number: 1,
+            backing: .local,
+            journalSeq: 1,
+            startedAt: "2026-07-15T04:00:00Z",
+            endedAt: nil
+        )
+    }
+
+    private func localMessage(_ turn: ChatTurn, epoch: ConversationEpoch) -> WaveChatMessage {
+        WaveChatMessage(
+            epochId: epoch.id,
+            source: .local(journalSeq: UInt64(max(0, turn.sequence))),
+            turn: turn
+        )
+    }
+
+    /// A wire-shaped `message` SSE payload. `text` is spliced raw, so escape
     /// inside it (e.g. `\\n`) as the server would.
     private func frame(id: String, role: String = "assistant", text: String, status: String, items: String = "[]") -> String {
-        "{\"id\":\"\(id)\",\"role\":\"\(role)\",\"text\":\"\(text)\",\"status\":\"\(status)\",\"items\":\(items),\"created_at\":\"2026-07-04T00:00:00Z\"}"
+        let turn = "{\"id\":\"\(id)\",\"role\":\"\(role)\",\"text\":\"\(text)\",\"status\":\"\(status)\",\"items\":\(items),\"created_at\":\"2026-07-04T00:00:00Z\"}"
+        return localMessageFrame(turn: turn, turnId: id)
     }
 
-    /// A wire-shaped `turn-delta` SSE payload growing the turn named `turnId`
+    /// A wire-shaped `message-delta` SSE payload growing the turn named `turnId`
     /// by one item.
     private func deltaFrame(turnId: String, item: String) -> String {
         "{\"turn_id\":\"\(turnId)\",\"item\":\(item)}"
@@ -43,17 +77,22 @@ struct WaveChatConnectionTests {
             body: nil,
             activity: nil
         )
+        let savedEpoch = localEpoch()
+        let savedMessage = localMessage(saved, epoch: savedEpoch)
         let conn = WaveChatConnection(
             repoPath: "/tmp/no-wave-listener",
             waveName: "ship",
-            loadHistory: { repo, wave, limit in
+            loadHistory: { repo, wave, limit, selectedEpoch in
                 #expect(repo == "/tmp/no-wave-listener")
                 #expect(wave == "ship")
                 #expect(limit == 12)
+                #expect(selectedEpoch == nil)
                 return ChatHistorySnapshot(
+                    epochs: [savedEpoch],
+                    selectedEpochId: savedEpoch.id,
                     state: .partial,
                     detail: "Later history is unreadable.",
-                    turns: [saved],
+                    messages: [savedMessage],
                     truncated: true
                 )
             }
@@ -71,7 +110,7 @@ struct WaveChatConnectionTests {
         #expect(conn.historyTruncated)
         #expect(conn.phase == .notRunning)
 
-        conn.handle(event: "turn", data: frame(id: "turn-8", text: "live", status: "completed"))
+        conn.handle(event: "message", data: frame(id: "turn-8", text: "live", status: "completed"))
         #expect(conn.historyState == .partial, "a live frame cannot repair durable history")
     }
 
@@ -80,8 +119,15 @@ struct WaveChatConnectionTests {
         let conn = WaveChatConnection(
             repoPath: "/tmp/no-wave-listener",
             waveName: "ship",
-            loadHistory: { _, _, _ in
-                ChatHistorySnapshot(state: .missing, detail: "No journal.", turns: [], truncated: false)
+            loadHistory: { _, _, _, _ in
+                ChatHistorySnapshot(
+                    epochs: [],
+                    selectedEpochId: nil,
+                    state: .missing,
+                    detail: "No journal.",
+                    messages: [],
+                    truncated: false
+                )
             }
         )
         conn.start()
@@ -90,45 +136,93 @@ struct WaveChatConnectionTests {
         for _ in 0..<100 where conn.historyState == nil {
             try await Task.sleep(for: .milliseconds(5))
         }
-        conn.handle(event: "turn", data: frame(id: "turn-1", text: "now durable", status: "completed"))
+        conn.handle(event: "epoch", data: localEpochFrame)
+        conn.handle(event: "message", data: frame(id: "turn-1", text: "now durable", status: "completed"))
 
         #expect(conn.historyState == .available)
         #expect(conn.historyDetail == nil)
     }
 
-    @Test("turn-delta frames grow the open turn to match a whole-turn reconstruction")
+    @Test("epoch and source-bearing messages replace the active conversation")
+    func epochAndSourceFramesStayClosed() throws {
+        let conn = connection()
+        let local = localEpoch()
+        conn.handle(
+            event: "epoch",
+            data: String(decoding: try JSONEncoder().encode(local), as: UTF8.self)
+        )
+        let localTurn = try ChatTurn(
+            id: "turn-2",
+            role: .user,
+            text: "local",
+            status: .completed,
+            items: [],
+            createdAt: "2026-07-15T04:01:00Z",
+            body: nil,
+            activity: nil
+        )
+        let localMessage = localMessage(localTurn, epoch: local)
+        conn.handle(
+            event: "message",
+            data: String(decoding: try JSONEncoder().encode(localMessage), as: UTF8.self)
+        )
+        #expect(conn.messages == [localMessage])
+
+        let open = ChatAction.openDiscord(
+            label: "Open in Discord",
+            url: "https://discord.com/channels/guild/channel"
+        )
+        let discord = ConversationEpoch(
+            id: "chat-epoch-3",
+            number: 2,
+            backing: .discord(guildId: "guild", channelId: "channel", open: open),
+            journalSeq: 3,
+            startedAt: "2026-07-15T05:00:00Z",
+            endedAt: nil
+        )
+        conn.handle(
+            event: "epoch",
+            data: String(decoding: try JSONEncoder().encode(discord), as: UTF8.self)
+        )
+        #expect(conn.activeEpoch == discord)
+        #expect(conn.selectedEpoch == discord)
+        #expect(conn.messages.isEmpty, "a backing switch cannot stitch the local epoch")
+        #expect(conn.epochs.map(\.id) == [local.id, discord.id])
+    }
+
+    @Test("message-delta frames grow the open source-bearing message")
     func turnDeltaFramesReconstructTheTurn() {
         let conn = connection()
         // The turn opens as a whole (empty, running) frame.
-        conn.handle(event: "turn", data: frame(id: "turn-1", text: "", status: "running"))
+        conn.handle(event: "message", data: frame(id: "turn-1", text: "", status: "running"))
         #expect(conn.turns.count == 1)
         #expect(conn.turns[0].text == "")
 
         // Prose arrives as stream-message increments — concatenated into text,
         // never added to items, exactly as the listener folds.
-        conn.handle(event: "turn-delta", data: deltaFrame(turnId: "turn-1", item: streamMessage(id: "text-0", text: "I fixed ")))
-        conn.handle(event: "turn-delta", data: deltaFrame(turnId: "turn-1", item: streamMessage(id: "text-1", text: "the parser.")))
+        conn.handle(event: "message-delta", data: deltaFrame(turnId: "turn-1", item: streamMessage(id: "text-0", text: "I fixed ")))
+        conn.handle(event: "message-delta", data: deltaFrame(turnId: "turn-1", item: streamMessage(id: "text-1", text: "the parser.")))
         #expect(conn.turns[0].text == "I fixed the parser.")
         #expect(conn.turns[0].items.isEmpty)
 
         // A non-message item appends to items and leaves text alone.
         let tool = "{\"type\":\"tool\",\"id\":\"t-1\",\"name\":\"Bash\",\"status\":\"completed\",\"input\":null,\"output\":\"ok\"}"
-        conn.handle(event: "turn-delta", data: deltaFrame(turnId: "turn-1", item: tool))
+        conn.handle(event: "message-delta", data: deltaFrame(turnId: "turn-1", item: tool))
         #expect(conn.turns[0].text == "I fixed the parser.")
         #expect(conn.turns[0].items.count == 1)
         #expect(conn.turns[0].isInProgress)
 
         // The finalized whole turn re-baselines under the same id.
-        conn.handle(event: "turn", data: frame(id: "turn-1", text: "I fixed the parser.", status: "completed", items: "[\(tool)]"))
+        conn.handle(event: "message", data: frame(id: "turn-1", text: "I fixed the parser.", status: "completed", items: "[\(tool)]"))
         #expect(conn.turns.count == 1)
         #expect(!conn.turns[0].isInProgress)
     }
 
-    @Test("a turn-delta for an unknown turn id is dropped, not misapplied")
+    @Test("a message-delta for an unknown turn id is dropped, not misapplied")
     func deltaForUnknownTurnDrops() {
         let conn = connection()
-        conn.handle(event: "turn", data: frame(id: "turn-1", text: "hi", status: "running"))
-        conn.handle(event: "turn-delta", data: deltaFrame(turnId: "turn-99", item: streamMessage(id: "text-0", text: "stray")))
+        conn.handle(event: "message", data: frame(id: "turn-1", text: "hi", status: "running"))
+        conn.handle(event: "message-delta", data: deltaFrame(turnId: "turn-99", item: streamMessage(id: "text-0", text: "stray")))
         #expect(conn.turns.count == 1)
         #expect(conn.turns[0].text == "hi", "a delta for a turn we never opened changes nothing")
     }
@@ -136,8 +230,8 @@ struct WaveChatConnectionTests {
     @Test("repeated same-id frames grow the turn in place and finalize it")
     func sameIdFramesUpdateInPlace() {
         let conn = connection()
-        conn.handle(event: "turn", data: frame(id: "turn-1", role: "user", text: "status?", status: "completed"))
-        conn.handle(event: "turn", data: frame(id: "turn-2", text: "thinking", status: "running"))
+        conn.handle(event: "message", data: frame(id: "turn-1", role: "user", text: "status?", status: "completed"))
+        conn.handle(event: "message", data: frame(id: "turn-2", text: "thinking", status: "running"))
 
         #expect(conn.turns.count == 2)
         #expect(conn.turns[1].isInProgress)
@@ -145,14 +239,14 @@ struct WaveChatConnectionTests {
 
         // The open turn re-sent with more text and a first item.
         let items = "[{\"type\":\"tool\",\"id\":\"item-0\",\"name\":\"Bash\",\"status\":\"completed\",\"input\":null,\"output\":\"ok\"}]"
-        conn.handle(event: "turn", data: frame(id: "turn-2", text: "thinking\\nmore", status: "running", items: items))
+        conn.handle(event: "message", data: frame(id: "turn-2", text: "thinking\\nmore", status: "running", items: items))
         #expect(conn.turns.count == 2, "same id replaces, never appends")
         #expect(conn.turns[1].text == "thinking\nmore")
         #expect(conn.turns[1].items.count == 1)
         #expect(conn.turns[1].isInProgress)
 
         // Finalization flips the status under the same id.
-        conn.handle(event: "turn", data: frame(id: "turn-2", text: "thinking\\nmore", status: "completed", items: items))
+        conn.handle(event: "message", data: frame(id: "turn-2", text: "thinking\\nmore", status: "completed", items: items))
         #expect(conn.turns.count == 2)
         #expect(!conn.turns[1].isInProgress)
         #expect(conn.turns.map(\.id) == ["turn-1", "turn-2"])
@@ -161,12 +255,12 @@ struct WaveChatConnectionTests {
     @Test("running turns can finalize as failed or interrupted")
     func terminalStatusFlips() {
         let conn = connection()
-        conn.handle(event: "turn", data: frame(id: "turn-1", text: "a", status: "running"))
-        conn.handle(event: "turn", data: frame(id: "turn-1", text: "a", status: "interrupted"))
+        conn.handle(event: "message", data: frame(id: "turn-1", text: "a", status: "running"))
+        conn.handle(event: "message", data: frame(id: "turn-1", text: "a", status: "interrupted"))
         #expect(conn.turns[0].status == .interrupted)
 
-        conn.handle(event: "turn", data: frame(id: "turn-2", text: "b", status: "running"))
-        conn.handle(event: "turn", data: frame(id: "turn-2", text: "b", status: "failed"))
+        conn.handle(event: "message", data: frame(id: "turn-2", text: "b", status: "running"))
+        conn.handle(event: "message", data: frame(id: "turn-2", text: "b", status: "failed"))
         #expect(conn.turns[1].status == .failed)
         #expect(conn.turns.allSatisfy { !$0.isInProgress })
     }
@@ -176,13 +270,13 @@ struct WaveChatConnectionTests {
         let conn = connection()
         // Replay serves the open turn after the finalized thread; a user turn
         // committed mid-turn can also arrive out of id order.
-        conn.handle(event: "turn", data: frame(id: "turn-3", role: "user", text: "hey", status: "completed"))
-        conn.handle(event: "turn", data: frame(id: "turn-2", text: "grinding", status: "running"))
+        conn.handle(event: "message", data: frame(id: "turn-3", role: "user", text: "hey", status: "completed"))
+        conn.handle(event: "message", data: frame(id: "turn-2", text: "grinding", status: "running"))
         #expect(conn.turns.map(\.id) == ["turn-2", "turn-3"])
 
         // A replace frame (same id, so the same (sequence, id) sort key) skips
         // the sort — the order must survive the in-place growth untouched.
-        conn.handle(event: "turn", data: frame(id: "turn-2", text: "grinding\\nstill", status: "running"))
+        conn.handle(event: "message", data: frame(id: "turn-2", text: "grinding\\nstill", status: "running"))
         #expect(conn.turns.map(\.id) == ["turn-2", "turn-3"])
         #expect(conn.turns[0].text == "grinding\nstill")
     }
@@ -191,9 +285,9 @@ struct WaveChatConnectionTests {
     func unparseableIdsAreDeterministic() {
         let conn = connection()
         // Both fall to the `.max` sentinel sequence; id breaks the tie.
-        conn.handle(event: "turn", data: frame(id: "weird-b", text: "b", status: "completed"))
-        conn.handle(event: "turn", data: frame(id: "weird-a", text: "a", status: "completed"))
-        conn.handle(event: "turn", data: frame(id: "turn-7", text: "real", status: "completed"))
+        conn.handle(event: "message", data: frame(id: "weird-b", text: "b", status: "completed"))
+        conn.handle(event: "message", data: frame(id: "weird-a", text: "a", status: "completed"))
+        conn.handle(event: "message", data: frame(id: "turn-7", text: "real", status: "completed"))
         #expect(conn.turns.map(\.id) == ["turn-7", "weird-a", "weird-b"])
     }
 
@@ -275,7 +369,8 @@ struct WaveChatConnectionTests {
         let conn = connection()
         var parser = SSEFrameParser()
         var frames: [SSEFrameParser.Frame] = []
-        let stream = "event: state\ndata: turning\n\nevent: turn\ndata: \(currentTurnFrame)\n\n"
+        let message = localMessageFrame(turn: currentTurnFrame, turnId: "turn-101")
+        let stream = "event: state\ndata: turning\n\nevent: message\ndata: \(message)\n\n"
         for byte in stream.utf8 {
             if let frame = parser.consume(byte) { frames.append(frame) }
         }

--- a/swift/README.md
+++ b/swift/README.md
@@ -25,7 +25,7 @@ fleet.
 
 The previous Wave workspace remains available in repository and Portfolio
 windows while its proven inspectors and Chat surface move into the new root.
-Wave Chat paints the bounded local journal tail before SSE, keeps it visible
+Wave Chat loads the active backing's bounded history before SSE, keeps it visible
 through reconnects, and rolls equivalent operational failures into one
 disclosed notice. Cold launch does not start a chat transcript read.
 Commands, tools, file edits, and loop bookkeeping stay in the journal;

--- a/tests/fixtures/dto/chat_history.json
+++ b/tests/fixtures/dto/chat_history.json
@@ -1,16 +1,48 @@
 {
+  "epochs": [
+    {
+      "id": "chat-epoch-1",
+      "number": 1,
+      "backing": { "kind": "local" },
+      "journal_seq": 1,
+      "started_at": "2026-07-15T04:00:00Z",
+      "ended_at": "2026-07-15T05:00:00Z"
+    },
+    {
+      "id": "chat-epoch-8",
+      "number": 2,
+      "backing": {
+        "kind": "discord",
+        "guild_id": "guild-1",
+        "channel_id": "channel-1",
+        "open": {
+          "kind": "open_discord",
+          "label": "Open in Discord",
+          "url": "https://discord.com/channels/guild-1/channel-1"
+        }
+      },
+      "journal_seq": 8,
+      "started_at": "2026-07-15T05:00:00Z",
+      "ended_at": null
+    }
+  ],
+  "selected_epoch_id": "chat-epoch-1",
   "state": "partial",
   "detail": "Durable Wave Chat history stops at unreadable line 8.",
-  "turns": [
+  "messages": [
     {
-      "id": "turn-7",
-      "role": "user",
-      "text": "Keep the saved thread visible while reconnecting.",
-      "status": "completed",
-      "items": [],
-      "created_at": "2026-07-15T04:00:00Z",
-      "body": null,
-      "activity": null
+      "epoch_id": "chat-epoch-1",
+      "source": { "kind": "local", "journal_seq": 7 },
+      "turn": {
+        "id": "turn-7",
+        "role": "user",
+        "text": "Keep the saved thread visible while reconnecting.",
+        "status": "completed",
+        "items": [],
+        "created_at": "2026-07-15T04:00:00Z",
+        "body": null,
+        "activity": null
+      }
     }
   ],
   "truncated": true

--- a/tests/fixtures/dto/post_message_error_response.json
+++ b/tests/fixtures/dto/post_message_error_response.json
@@ -1,0 +1,20 @@
+{
+  "error": "message was not accepted: this Wave chat is backed by Discord",
+  "epoch": {
+    "id": "chat-epoch-8",
+    "number": 2,
+    "backing": {
+      "kind": "discord",
+      "guild_id": "guild-1",
+      "channel_id": "channel-1",
+      "open": {
+        "kind": "open_discord",
+        "label": "Open in Discord",
+        "url": "https://discord.com/channels/guild-1/channel-1"
+      }
+    },
+    "journal_seq": 8,
+    "started_at": "2026-07-15T05:00:00Z",
+    "ended_at": null
+  }
+}

--- a/tests/fixtures/dto/post_message_response.json
+++ b/tests/fixtures/dto/post_message_response.json
@@ -1,13 +1,25 @@
 {
-  "turn": {
-    "id": "turn-4",
-    "role": "user",
-    "text": "Focus on the failing test first.",
-    "status": "completed",
-    "items": [],
-    "created_at": "2026-07-04T12:00:00Z",
-    "body": null,
-    "activity": null
+  "message": {
+    "epoch_id": "chat-epoch-1",
+    "source": { "kind": "local", "journal_seq": 4 },
+    "turn": {
+      "id": "turn-4",
+      "role": "user",
+      "text": "Focus on the failing test first.",
+      "status": "completed",
+      "items": [],
+      "created_at": "2026-07-04T12:00:00Z",
+      "body": null,
+      "activity": null
+    }
   },
-  "state": "turning"
+  "state": "turning",
+  "epoch": {
+    "id": "chat-epoch-1",
+    "number": 1,
+    "backing": { "kind": "local" },
+    "journal_seq": 1,
+    "started_at": "2026-07-04T11:59:00Z",
+    "ended_at": null
+  }
 }


### PR DESCRIPTION
## Usage

```bash
lf wave product
lf chat --wave product "What needs attention?"
lf chat --history --json --wave product
lf chat --history --json --wave product --epoch chat-epoch-42
```

## Summary

Give each Wave one explicit local or Discord conversation at a time. Backing changes create immutable epochs, preventing local and Discord messages from being stitched into a misleading shared transcript while preserving earlier history for inspection.

## Changes

- Model chat backing, health, message provenance, and conversation epochs across the Rust and Swift contracts
- Import legacy journal history into durable epochs and resume an epoch when its backing is unchanged
- Project Discord history directly from Discord without storing a duplicate presentation transcript
- Reject local compose while Discord is authoritative with a typed Open-in-Discord action, while retaining bare interrupts
- Add epoch selection to `lf chat --history` and expose epoch/source information through HTTP, SSE, CLI follow, and the Mac client
- Publish Discord agent speech only after the provider confirms its message id