### PR TITLE
wave runtime: preserve launches and receipts under load

### DIFF
--- a/rust/loopflow/src/engine/process.rs
+++ b/rust/loopflow/src/engine/process.rs
@@ -1,3 +1,6 @@
+use std::fs::OpenOptions;
+use std::io::Write;
+use std::os::unix::fs::OpenOptionsExt;
 use std::path::{Path, PathBuf};
 
 use anyhow::{anyhow, Result};
@@ -343,19 +346,46 @@ pub(crate) async fn start_tmux_window_with_env(
         .map(|(key, value)| (key.as_str(), value.as_str()))
         .collect::<Vec<_>>();
     let shell_command = lf_session_shell_command(argv, &environment);
+    let launcher = write_tmux_launcher(&shell_command)?;
     let status = tokio::process::Command::new("tmux")
         .args(["new-window", "-d", "-t", session, "-n", window, "-c"])
         .arg(cwd)
-        .args(["/bin/zsh", "-lc", &shell_command])
+        .args(["/bin/zsh"])
+        .arg(&launcher)
         .status()
-        .await
-        .map_err(|error| anyhow!("tmux failed to spawn window: {error}"))?;
+        .await;
+    let status = match status {
+        Ok(status) => status,
+        Err(error) => {
+            let _ = std::fs::remove_file(&launcher);
+            return Err(anyhow!("tmux failed to spawn window: {error}"));
+        }
+    };
     if !status.success() {
+        let _ = std::fs::remove_file(&launcher);
         return Err(anyhow!(
             "tmux failed to launch window '{window}' in session '{session}'"
         ));
     }
     Ok(())
+}
+
+fn write_tmux_launcher(shell_command: &str) -> Result<PathBuf> {
+    let path = std::env::temp_dir().join(format!(
+        "loopflow-tmux-{}.zsh",
+        uuid::Uuid::new_v4().simple()
+    ));
+    let mut file = OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .mode(0o600)
+        .open(&path)?;
+    writeln!(
+        file,
+        "#!/bin/zsh\nlauncher=$0\n/bin/rm -f -- \"$launcher\"\n{shell_command}"
+    )?;
+    file.sync_all()?;
+    Ok(path)
 }
 fn extend_session_control_context(
     child_env: &mut Vec<(String, String)>,

--- a/rust/loopflow/src/store/migrations.rs
+++ b/rust/loopflow/src/store/migrations.rs
@@ -6,6 +6,7 @@ use std::fs::OpenOptions;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
+use crate::store::sqlite::SQLITE_WRITE_BUSY_TIMEOUT;
 use crate::store::{StoreError, StoreResult};
 use fs2::FileExt;
 use rusqlite::OptionalExtension;
@@ -765,7 +766,8 @@ pub(crate) fn apply_sqlite_with_backup(
     conn: &rusqlite::Connection,
     path: &Path,
 ) -> StoreResult<()> {
-    conn.execute_batch("PRAGMA journal_mode = WAL; PRAGMA busy_timeout = 5000;")?;
+    conn.busy_timeout(SQLITE_WRITE_BUSY_TIMEOUT)?;
+    conn.execute_batch("PRAGMA journal_mode = WAL;")?;
     let lock_path = path.with_file_name(format!(
         "{}.migration.lock",
         path.file_name()

--- a/rust/loopflow/src/store/sqlite.rs
+++ b/rust/loopflow/src/store/sqlite.rs
@@ -1,5 +1,6 @@
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
+use std::time::Duration;
 
 use rusqlite::{params, Connection, OptionalExtension, ToSql, TransactionBehavior};
 
@@ -24,6 +25,11 @@ mod children;
 mod ci_incidents;
 mod durable;
 mod provider_deliveries;
+
+/// A fleet can legitimately queue longer than SQLite's common five-second
+/// default while every process opens and records its first receipt. Durable
+/// writes wait for that bounded local contention instead of dropping evidence.
+pub(crate) const SQLITE_WRITE_BUSY_TIMEOUT: Duration = Duration::from_secs(15);
 
 #[derive(Debug, Clone)]
 pub struct SqliteStore {
@@ -361,9 +367,10 @@ impl SqliteStore {
         }
 
         let mut conn = Connection::open(path)?;
-        conn.execute_batch(
-            "PRAGMA journal_mode = WAL; PRAGMA busy_timeout = 5000; PRAGMA foreign_keys = ON;",
-        )?;
+        // Install the handler before journal-mode negotiation: that pragma can
+        // itself meet another process opening the same WAL database.
+        conn.busy_timeout(SQLITE_WRITE_BUSY_TIMEOUT)?;
+        conn.execute_batch("PRAGMA journal_mode = WAL; PRAGMA foreign_keys = ON;")?;
 
         if !may_apply_migrations {
             // Validate the applied history first (preserving divergent/incompatible


### PR DESCRIPTION
## Usage

```bash
lf start <wave>
```

## Summary

Hardens two process boundaries that surfaced while dogfooding long-running Waves. Tmux now launches long environment-bearing commands through a mode-0600 self-unlinking script instead of one fragile inline shell argument. SQLite installs its busy handler before WAL negotiation and gives a 51-process fleet enough bounded time to serialize durable execution receipts instead of losing one to contention.

## Verification

- `cargo test -p loopflow engine::process`
- `cargo test -p loopflow --test store_contention -- --nocapture`
- migration lock tests
- `cargo fmt --check`
- `cargo clippy -p loopflow -- -D warnings`