### PR TITLE
mac: inspect selected Work runs

### DIFF
--- a/docs/agent-api.md
+++ b/docs/agent-api.md
@@ -129,6 +129,7 @@ Every read the conducting surfaces offer is `--json`:
 lf ls --json                # every durable Wave and its Home/runtime evidence
 lf status <wave> --json     # live Project → Task hierarchy
 lf roadmap --json           # every open Task across every wave
+lf runs --project parser --json
 lf runs --task INF-123 --json
 lf trace <exec-id> --json
 ```

--- a/docs/conducting.md
+++ b/docs/conducting.md
@@ -24,6 +24,7 @@ command.
 
 ```bash
 lf runs --wave infra          # recent agent-backed runs with token evidence
+lf runs --project parser      # one Project, filtered before the result cap
 lf execs                      # recent lf processes across all repos
 lf trace <exec-id>            # reconstruct one process tree
 lf trace <id> --content       # include prompt/conversation bodies (gated)

--- a/docs/lf.md
+++ b/docs/lf.md
@@ -412,6 +412,7 @@ lf ls --json                    # every durable Wave and its Home/runtime eviden
 lf status <wave> --json         # one Wave's Work hierarchy, Runs, and attention
 lf roadmap --json               # current plan across Waves joined to runtime truth
 lf runs                         # one row per skill call: context, tokens, cost
+lf runs --project parser        # one Project's Runs, filtered before the result cap
 lf execs                        # one row per lf process
 lf trace 66863649               # select an exec or trace; render its process tree
 lf trace 66863649 --json        # inspect the same tree and its skill invocations

--- a/rust/loopflow/src/bin/lf.rs
+++ b/rust/loopflow/src/bin/lf.rs
@@ -1447,6 +1447,7 @@ fn main() -> anyhow::Result<()> {
             }
             Some(Commands::Runs {
                 task,
+                project,
                 wave,
                 json,
                 cmd,
@@ -1457,6 +1458,7 @@ fn main() -> anyhow::Result<()> {
                 None => loopflow::lf::commands::runs::list(
                     *json,
                     wave.as_deref(),
+                    project.as_deref(),
                     task.as_deref(),
                 ),
             },

--- a/rust/loopflow/src/lf/commands/runs.rs
+++ b/rust/loopflow/src/lf/commands/runs.rs
@@ -20,12 +20,13 @@ use crate::wave::journal::short_id;
 const WINDOW_DAYS: i64 = 7;
 const MAX_RUNS: usize = 50;
 
-/// A drill filter over the run ledger. Both constituents scope the same invocation
-/// set: `wave` narrows to one Wave, `task` to one roadmap Task by its Linear
-/// issue identifier — the key that joins a roadmap row to its runs.
+/// A drill filter over the run ledger. Every field scopes the same invocation
+/// set: `wave` narrows to one Wave, `project` to one roadmap Project by slug,
+/// and `task` to one roadmap Task by its Linear issue identifier.
 #[derive(Debug, Clone, Copy, Default)]
 pub(crate) struct RunFilter<'a> {
     pub wave: Option<&'a str>,
+    pub project: Option<&'a str>,
     pub task: Option<&'a str>,
 }
 
@@ -34,14 +35,17 @@ impl RunFilter<'_> {
         self.wave
             .is_none_or(|wave| invocation.wave.as_deref() == Some(wave))
             && self
+                .project
+                .is_none_or(|project| invocation.project.as_deref() == Some(project))
+            && self
                 .task
                 .is_none_or(|task| invocation.task.as_deref() == Some(task))
     }
 }
 
 /// The skill runs matching a filter, newest first, capped. One reader behind
-/// `lf runs`, its `--wave`/`--task` drills, and `lf status`'s Runs evidence, so
-/// the surfaces can never disagree on what a run is.
+/// `lf runs`, its Work drills, and `lf status`'s Runs evidence, so the surfaces
+/// can never disagree on what a run is.
 pub(crate) fn collect_runs(filter: RunFilter) -> Result<(Vec<SkillRunEntry>, bool)> {
     let store = open_ledger().map_err(|err| anyhow!("run ledger unavailable: {err}"))?;
     let since = chrono::Utc::now().timestamp() - WINDOW_DAYS * 24 * 3600;
@@ -69,10 +73,19 @@ pub(crate) fn collect_runs(filter: RunFilter) -> Result<(Vec<SkillRunEntry>, boo
     Ok((runs, truncated))
 }
 
-/// `lf runs [--wave <name>] [--task <id>]`: recent agent-backed skill invocations,
-/// optionally drilled to one Wave or one roadmap Task.
-pub fn list(json: bool, wave: Option<&str>, task: Option<&str>) -> Result<()> {
-    let (runs, _truncated) = collect_runs(RunFilter { wave, task })?;
+/// `lf runs [--wave <name>] [--project <slug>] [--task <id>]`: recent
+/// agent-backed skill invocations, optionally drilled to one Work owner.
+pub fn list(
+    json: bool,
+    wave: Option<&str>,
+    project: Option<&str>,
+    task: Option<&str>,
+) -> Result<()> {
+    let (runs, _truncated) = collect_runs(RunFilter {
+        wave,
+        project,
+        task,
+    })?;
 
     if json {
         println!("{}", serde_json::to_string(&runs)?);
@@ -80,14 +93,21 @@ pub fn list(json: bool, wave: Option<&str>, task: Option<&str>) -> Result<()> {
     }
 
     if runs.is_empty() {
-        match (wave, task) {
-            (_, Some(task)) => {
+        match (wave, project, task) {
+            (_, _, Some(task)) => {
                 println!("No skill runs recorded for {task} in the last {WINDOW_DAYS} days.")
             }
-            (Some(wave), None) => {
+            (_, Some(project), None) => {
+                println!(
+                    "No skill runs recorded for project/{project} in the last {WINDOW_DAYS} days."
+                )
+            }
+            (Some(wave), None, None) => {
                 println!("No skill runs recorded for wave/{wave} in the last {WINDOW_DAYS} days.")
             }
-            (None, None) => println!("No skill runs recorded in the last {WINDOW_DAYS} days."),
+            (None, None, None) => {
+                println!("No skill runs recorded in the last {WINDOW_DAYS} days.")
+            }
         }
         return Ok(());
     }
@@ -1060,6 +1080,7 @@ pub struct ExecLedgerEntry {
 pub(crate) fn wave_runs(wave: &str) -> Result<(Vec<SkillRunEntry>, bool)> {
     collect_runs(RunFilter {
         wave: Some(wave),
+        project: None,
         task: None,
     })
 }

--- a/rust/loopflow/src/lf/mod.rs
+++ b/rust/loopflow/src/lf/mod.rs
@@ -499,6 +499,9 @@ pub enum Commands {
         /// Drill to one roadmap Task by its Linear issue identifier (e.g. W2-122)
         #[arg(long)]
         task: Option<String>,
+        /// Drill to one roadmap Project by slug
+        #[arg(long)]
+        project: Option<String>,
         /// Scope to one Wave by name
         #[arg(long)]
         wave: Option<String>,

--- a/rust/loopflow/tests/status_tests.rs
+++ b/rust/loopflow/tests/status_tests.rs
@@ -506,6 +506,22 @@ fn runs_drill_to_one_task_by_issue_identifier() {
     assert_eq!(missed.as_array().expect("run array").len(), 0);
 }
 
+/// Project drill applies before the result cap, using the slug carried by the
+/// invocation rather than inferring ownership from its Wave or Task.
+#[test]
+fn runs_drill_to_one_project_by_slug() {
+    let home = tempfile::tempdir().expect("tempdir");
+    seed(home.path(), "audit-project-drill");
+
+    let matched = runs_json_filtered(home.path(), &["--project", "auditability"]);
+    let matched = matched.as_array().expect("run array");
+    assert_eq!(matched.len(), 1);
+    assert_eq!(matched[0]["project"], "auditability");
+
+    let missed = runs_json_filtered(home.path(), &["--project", "no-such-project"]);
+    assert_eq!(missed.as_array().expect("run array").len(), 0);
+}
+
 /// The wave drill mirrors the internal scoping `lf status` uses.
 #[test]
 fn runs_drill_to_one_wave_by_name() {

--- a/swift/Loopflow/Services/RegistryQuery.swift
+++ b/swift/Loopflow/Services/RegistryQuery.swift
@@ -154,11 +154,39 @@ public struct RegistryQuery: Sendable {
         return try Self.decode(TaskFileSnapshot.self, from: stdout)
     }
 
-    /// Recent agent-backed skill calls across every Wave, with their context and
-    /// token evidence. Process diagnostics live in `lf execs`.
-    public func recentRuns() async throws -> [SkillRunEntry] {
-        let stdout = try await run(["runs", "--json"], nil)
+    /// Recent agent-backed skill calls, optionally drilled to one Wave, Project,
+    /// or Task, with their context and token evidence. Process diagnostics live
+    /// in `lf execs`.
+    public func recentRuns(
+        wave: String? = nil,
+        project: String? = nil,
+        task: String? = nil
+    ) async throws -> [SkillRunEntry] {
+        var args = ["runs"]
+        if let wave { args.append(contentsOf: ["--wave", wave]) }
+        if let project { args.append(contentsOf: ["--project", project]) }
+        if let task { args.append(contentsOf: ["--task", task]) }
+        args.append("--json")
+        let stdout = try await run(args, nil)
         return try Self.decode([SkillRunEntry].self, from: stdout)
+    }
+
+    /// Resolve one visible Run to the latest captured turn for its exact
+    /// invocation. Trace bodies remain unopened until `traceContent` is called.
+    public func traceAddress(for entry: SkillRunEntry) async throws -> TraceAddress {
+        let stdout = try await run(["trace", entry.id, "--json"], nil)
+        let trace = try Self.decode(TraceIndexSnapshot.self, from: stdout)
+        guard let turn = trace.turns
+            .filter({ $0.invocationId == entry.id })
+            .max(by: { $0.ordinal < $1.ordinal })
+        else {
+            throw RegistryQueryError("Run \(entry.id) has no captured trace turn")
+        }
+        return TraceAddress(
+            runId: trace.traceId,
+            invocationId: entry.id,
+            turnId: turn.id
+        )
     }
 
     /// Every active normalized Invocation across the machine.
@@ -569,6 +597,30 @@ public struct SkillRunEntry: Decodable, Sendable, Identifiable, Hashable {
         case costUsd = "cost_usd"
         case durationSecs = "duration_secs"
         case captureStatus = "capture_status"
+    }
+}
+
+/// Narrow decoding view over `lf trace <run> --json`. Rust owns the full trace
+/// graph; the control room needs only the immutable ids for an explicit content
+/// request.
+public struct TraceIndexSnapshot: Decodable, Sendable {
+    public let traceId: String
+    public let turns: [TraceTurnIndex]
+
+    enum CodingKeys: String, CodingKey {
+        case turns
+        case traceId = "trace_id"
+    }
+}
+
+public struct TraceTurnIndex: Decodable, Sendable {
+    public let id: String
+    public let invocationId: String
+    public let ordinal: Int
+
+    enum CodingKeys: String, CodingKey {
+        case id, ordinal
+        case invocationId = "invocation_id"
     }
 }
 

--- a/swift/LoopflowMac/ControlRoomFixture.swift
+++ b/swift/LoopflowMac/ControlRoomFixture.swift
@@ -16,6 +16,7 @@ enum ControlRoomFixture {
                     roadmap: .available(snapshot),
                     waves: .available([]),
                     activity: .available(try emptyActivity()),
+                    selectedRuns: .available([]),
                     repos: [],
                     fixed: true
                 )
@@ -23,13 +24,16 @@ enum ControlRoomFixture {
                 let fixture = try loadRoadmap(sourceFile: sourceFile)
                 let reading: ControlRoomReading<RoadmapSnapshot>
                 let activity: ControlRoomReading<ActivitySnapshot>
+                let runs: ControlRoomReading<[SkillRunEntry]>
                 switch MockWaveFixture.detailState {
                 case .selected:
                     reading = .available(fixture.roadmap)
                     activity = .available(try loadActivity(sourceFile: sourceFile))
+                    runs = .available(try loadRuns(sourceFile: sourceFile))
                 case .loading:
                     reading = .loading
                     activity = .loading
+                    runs = .loading
                 case .error:
                     reading = .unavailable(
                         lastGood: nil,
@@ -39,11 +43,16 @@ enum ControlRoomFixture {
                         lastGood: nil,
                         reason: "live process evidence is unavailable"
                     )
+                    runs = .unavailable(
+                        lastGood: nil,
+                        reason: "recent Run evidence is unavailable"
+                    )
                 }
                 model.applyFixture(
                     roadmap: reading,
                     waves: .available(fixture.waves),
                     activity: activity,
+                    selectedRuns: runs,
                     repos: fixture.repos,
                     fixed: true
                 )
@@ -62,6 +71,7 @@ enum ControlRoomFixture {
                 ),
                 waves: .unavailable(lastGood: nil, reason: error.localizedDescription),
                 activity: .unavailable(lastGood: nil, reason: error.localizedDescription),
+                selectedRuns: .unavailable(lastGood: nil, reason: error.localizedDescription),
                 repos: [],
                 fixed: true
             )
@@ -87,6 +97,11 @@ enum ControlRoomFixture {
     private static func loadActivity(sourceFile: String) throws -> ActivitySnapshot {
         let url = try fixtureURL(named: "activity_snapshot.json", sourceFile: sourceFile)
         return try JSONDecoder().decode(ActivitySnapshot.self, from: Data(contentsOf: url))
+    }
+
+    private static func loadRuns(sourceFile: String) throws -> [SkillRunEntry] {
+        let url = try fixtureURL(named: "recent_runs.json", sourceFile: sourceFile)
+        return try JSONDecoder().decode([SkillRunEntry].self, from: Data(contentsOf: url))
     }
 
     private static func emptyActivity() throws -> ActivitySnapshot {

--- a/swift/LoopflowMac/ControlRoomModel.swift
+++ b/swift/LoopflowMac/ControlRoomModel.swift
@@ -2,7 +2,7 @@ import Foundation
 import Loopflow
 import Observation
 
-enum ControlRoomSelection: Equatable, Hashable {
+enum ControlRoomSelection: Equatable, Hashable, Sendable {
     case wave(waveId: String)
     case project(waveId: String, projectId: String)
     case task(waveId: String, taskId: String)
@@ -13,6 +13,13 @@ enum ControlRoomSelection: Equatable, Hashable {
             waveId
         }
     }
+}
+
+struct SelectedRunTarget: Equatable, Sendable {
+    let selection: ControlRoomSelection
+    let wave: String
+    let project: String?
+    let task: String?
 }
 
 enum ControlRoomReading<Value> {
@@ -87,12 +94,15 @@ final class ControlRoomModel {
     private(set) var roadmap: ControlRoomReading<RoadmapSnapshot> = .loading
     private(set) var waves: ControlRoomReading<[Wave]> = .loading
     private(set) var activity: ControlRoomReading<ActivitySnapshot> = .loading
+    private(set) var selectedRuns: ControlRoomReading<[SkillRunEntry]> = .available([])
+    private(set) var selectedRunTarget: SelectedRunTarget?
     private(set) var repos: [PortfolioRepo] = []
     private(set) var authoredWavesByRepo: [String: [String]] = [:]
     private(set) var isRefreshing = false
 
     private let query: RegistryQuery
     private var usesFixedFixture = false
+    private var selectedRunsGeneration = 0
 
     init(query: RegistryQuery, repoPath: String? = nil) {
         self.query = query
@@ -230,8 +240,55 @@ final class ControlRoomModel {
     }
 
     func select(_ selection: ControlRoomSelection?) {
-        self.selection = selection
+        setSelection(selection)
         clearSelectionIfOutsideScope()
+    }
+
+    func refreshSelectedRuns() async {
+        guard !usesFixedFixture else { return }
+        selectedRunsGeneration &+= 1
+        let generation = selectedRunsGeneration
+        guard let selection, let target = runTarget(for: selection) else {
+            selectedRunTarget = nil
+            selectedRuns = .available([])
+            return
+        }
+
+        let previous = selectedRunTarget?.selection == selection ? selectedRuns.value : nil
+        selectedRunTarget = target
+        if previous == nil { selectedRuns = .loading }
+
+        let result: Result<[SkillRunEntry], Error>
+        do {
+            let runs = try await query.recentRuns(
+                wave: target.wave,
+                project: target.project,
+                task: target.task
+            )
+            result = .success(runs.filter { run in
+                run.wave == target.wave
+                    && (target.project == nil || run.project == target.project)
+                    && (target.task == nil || run.task == target.task)
+            })
+        } catch {
+            result = .failure(error)
+        }
+
+        guard self.selection == selection, selectedRunsGeneration == generation else { return }
+        selectedRuns = reading(from: result, lastGood: previous)
+    }
+
+    func runs(for selection: ControlRoomSelection) -> [SkillRunEntry] {
+        guard let target = runTarget(for: selection) else { return [] }
+        return (selectedRuns.value ?? []).filter { run in
+            run.wave == target.wave
+                && (target.project == nil || run.project == target.project)
+                && (target.task == nil || run.task == target.task)
+        }
+    }
+
+    func traceAddress(for run: SkillRunEntry) async throws -> TraceAddress {
+        try await query.traceAddress(for: run)
     }
 
     func wave(id: String) -> WaveRoadmap? {
@@ -260,7 +317,7 @@ final class ControlRoomModel {
         guard let selection else { return }
         let visibleIds = Set(visibleWaves.map(\.id) + visibleRoadmaps.map { $0.wave.id })
         guard visibleIds.contains(selection.waveId) else {
-            self.selection = nil
+            setSelection(nil)
             return
         }
 
@@ -269,11 +326,11 @@ final class ControlRoomModel {
             break
         case .project(let waveId, let projectId):
             if project(waveId: waveId, projectId: projectId) == nil {
-                self.selection = .wave(waveId: waveId)
+                setSelection(.wave(waveId: waveId))
             }
         case .task(let waveId, let taskId):
             if task(waveId: waveId, taskId: taskId) == nil {
-                self.selection = .wave(waveId: waveId)
+                setSelection(.wave(waveId: waveId))
             }
         }
     }
@@ -282,12 +339,14 @@ final class ControlRoomModel {
         roadmap: ControlRoomReading<RoadmapSnapshot>,
         waves: ControlRoomReading<[Wave]>,
         activity: ControlRoomReading<ActivitySnapshot>,
+        selectedRuns: ControlRoomReading<[SkillRunEntry]> = .available([]),
         repos: [PortfolioRepo],
         fixed: Bool = false
     ) {
         self.roadmap = roadmap
         self.waves = waves
         self.activity = activity
+        self.selectedRuns = selectedRuns
         self.repos = repos
         authoredWavesByRepo = [:]
         usesFixedFixture = fixed
@@ -307,10 +366,62 @@ final class ControlRoomModel {
         "\(WaveOrigin.resolve(repo).normalizedFilePath)#\(name)"
     }
 
+    private func runTarget(for selection: ControlRoomSelection) -> SelectedRunTarget? {
+        switch selection {
+        case .wave(let waveId):
+            let name: String
+            if let wave = wave(id: waveId)?.wave {
+                name = wave.name
+            } else if let wave = rosterWave(id: waveId) {
+                name = wave.api.name
+            } else {
+                return nil
+            }
+            return SelectedRunTarget(
+                selection: selection,
+                wave: name,
+                project: nil,
+                task: nil
+            )
+        case .project(let waveId, let projectId):
+            guard let wave = wave(id: waveId)?.wave,
+                  let project = project(waveId: waveId, projectId: projectId)
+            else { return nil }
+            return SelectedRunTarget(
+                selection: selection,
+                wave: wave.name,
+                project: project.project.slug,
+                task: nil
+            )
+        case .task(let waveId, let taskId):
+            guard let wave = wave(id: waveId)?.wave,
+                  let selected = task(waveId: waveId, taskId: taskId)
+            else { return nil }
+            return SelectedRunTarget(
+                selection: selection,
+                wave: wave.name,
+                project: selected.project.project.slug,
+                task: selected.task.task.identifier
+            )
+        }
+    }
+
+    private func setSelection(_ selection: ControlRoomSelection?) {
+        guard self.selection != selection else { return }
+        selectedRunsGeneration &+= 1
+        self.selection = selection
+        selectedRunTarget = selection.flatMap { runTarget(for: $0) }
+        if selection == nil {
+            selectedRuns = .available([])
+        } else if !usesFixedFixture {
+            selectedRuns = .loading
+        }
+    }
+
     private func selectRequestedWaveIfNeeded() {
         guard selection == nil, let requested = AppTestMode.selectBranch else { return }
         guard let wave = visibleRoadmaps.first(where: { $0.wave.name == requested }) else { return }
-        selection = .wave(waveId: wave.wave.id)
+        setSelection(.wave(waveId: wave.wave.id))
     }
 
     private func readRoadmap() async -> Result<RoadmapSnapshot, Error> {

--- a/swift/LoopflowMac/Views/ControlRoomView.swift
+++ b/swift/LoopflowMac/Views/ControlRoomView.swift
@@ -29,7 +29,13 @@ struct ControlRoomView: View {
                 ControlRoomSidebar(model: model)
                     .frame(minWidth: 205, idealWidth: 245, maxWidth: 290)
 
-                RoadmapView(model: model, selection: $model.selection)
+                RoadmapView(
+                    model: model,
+                    selection: Binding(
+                        get: { model.selection },
+                        set: { model.select($0) }
+                    )
+                )
                     .frame(minWidth: 390, idealWidth: 650, maxWidth: .infinity)
                     .accessibilityIdentifier("control-room-work")
 
@@ -193,6 +199,9 @@ private struct ControlRoomInspector: View {
     @Environment(\.palette) private var palette
     @State private var isSettingTurnIntent = false
     @State private var turnIntentError: String?
+    @State private var openingTraceId: String?
+    @State private var traceError: String?
+    @State private var traceRequest: TraceAddress?
 
     var body: some View {
         VStack(spacing: 0) {
@@ -225,6 +234,22 @@ private struct ControlRoomInspector: View {
         .background(palette.surface)
         .accessibilityElement(children: .contain)
         .accessibilityIdentifier("control-room-inspector")
+        .task(id: model.selection) {
+            traceError = nil
+            guard model.selection != nil else { return }
+            while !Task.isCancelled {
+                await model.refreshSelectedRuns()
+                do {
+                    try await Task.sleep(for: .seconds(15))
+                } catch {
+                    return
+                }
+            }
+        }
+        .sheet(item: $traceRequest) { address in
+            TraceEvidenceView(address: address)
+                .frame(minWidth: 900, minHeight: 620)
+        }
     }
 
     @ViewBuilder
@@ -240,6 +265,7 @@ private struct ControlRoomInspector: View {
                     case .task(let waveId, let taskId):
                         taskDetail(waveId: waveId, taskId: taskId)
                     }
+                    runHistory(selection)
                 }
                 .padding(Spacing.lg)
                 .frame(maxWidth: .infinity, alignment: .leading)
@@ -385,6 +411,97 @@ private struct ControlRoomInspector: View {
         }
     }
 
+    @ViewBuilder
+    private func runHistory(_ selection: ControlRoomSelection) -> some View {
+        VStack(alignment: .leading, spacing: Spacing.sm) {
+            HStack {
+                Text("Recent runs")
+                    .font(Typography.caption(10).weight(.semibold))
+                    .foregroundStyle(palette.textSecondary)
+                    .textCase(.uppercase)
+                Spacer()
+                if case .available(let runs) = model.selectedRuns, runs.count > 6 {
+                    Text("Latest 6")
+                        .font(Typography.caption(9))
+                        .foregroundStyle(palette.textSecondary)
+                }
+            }
+
+            if model.selectedRuns.isLoading {
+                ProgressView("Reading Runs…")
+                    .controlSize(.small)
+                    .accessibilityIdentifier("control-room-runs-loading")
+            } else {
+                let runs = model.runs(for: selection)
+                if runs.isEmpty, model.selectedRuns.errorMessage == nil {
+                    Text("No recent attributed Runs.")
+                        .font(Typography.body(11))
+                        .foregroundStyle(palette.textSecondary)
+                        .accessibilityIdentifier("control-room-runs-empty")
+                } else {
+                    ForEach(Array(runs.prefix(6))) { run in
+                        runCard(run)
+                    }
+                }
+                if let reason = model.selectedRuns.errorMessage {
+                    unavailable(reason)
+                        .accessibilityIdentifier("control-room-runs-unavailable")
+                }
+            }
+
+            if let traceError {
+                unavailable(traceError)
+                    .accessibilityIdentifier("control-room-trace-error")
+            }
+        }
+        .accessibilityElement(children: .contain)
+        .accessibilityIdentifier("control-room-run-history")
+    }
+
+    private func runCard(_ run: SkillRunEntry) -> some View {
+        VStack(alignment: .leading, spacing: Spacing.xs) {
+            HStack(alignment: .firstTextBaseline, spacing: Spacing.xs) {
+                Circle()
+                    .fill(runColor(run))
+                    .frame(width: 7, height: 7)
+                Text(runLabel(run))
+                    .font(Typography.body(11).weight(.semibold))
+                    .foregroundStyle(palette.text)
+                    .lineLimit(1)
+                Spacer(minLength: 0)
+                Text(run.status)
+                    .font(Typography.caption(9).weight(.semibold))
+                    .foregroundStyle(runColor(run))
+            }
+
+            Text("\(run.provider)\(run.model.map { ":\($0)" } ?? "") · \(runStarted(run))")
+                .font(Typography.caption(9))
+                .foregroundStyle(palette.textSecondary)
+                .lineLimit(1)
+
+            HStack(spacing: Spacing.sm) {
+                Text(runEvidence(run))
+                    .font(Typography.caption(9))
+                    .foregroundStyle(palette.textSecondary)
+                    .lineLimit(1)
+                Spacer(minLength: 0)
+                Button(openingTraceId == run.id ? "Opening…" : "Open trace") {
+                    Task { await openTrace(run) }
+                }
+                .buttonStyle(.plain)
+                .font(Typography.caption(9).weight(.semibold))
+                .foregroundStyle(Color.loopflowBurgundy)
+                .disabled(openingTraceId != nil)
+                .accessibilityIdentifier("control-room-open-trace-\(run.id)")
+            }
+        }
+        .padding(Spacing.sm)
+        .background(palette.surfaceMuted)
+        .clipShape(RoundedRectangle(cornerRadius: CornerRadius.sm))
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("\(runLabel(run)), \(run.status), \(runEvidence(run))")
+    }
+
     private func eyebrow(_ value: String) -> some View {
         Text(value.uppercased())
             .font(Typography.caption(9).weight(.bold))
@@ -452,6 +569,39 @@ private struct ControlRoomInspector: View {
             .textSelection(.enabled)
     }
 
+    private func runLabel(_ run: SkillRunEntry) -> String {
+        guard let flow = run.flow, flow != run.skill else { return run.skill }
+        return "\(flow) / \(run.skill)"
+    }
+
+    private func runStarted(_ run: SkillRunEntry) -> String {
+        Date(timeIntervalSince1970: TimeInterval(run.started))
+            .formatted(date: .abbreviated, time: .shortened)
+    }
+
+    private func runEvidence(_ run: SkillRunEntry) -> String {
+        var evidence: [String] = []
+        if run.inputTokens != nil || run.outputTokens != nil {
+            let tokens = (run.inputTokens ?? 0) + (run.outputTokens ?? 0)
+            evidence.append("\(tokens.formatted()) tokens")
+        }
+        evidence.append(run.turns == 1 ? "1 turn" : "\(run.turns) turns")
+        if let cost = run.costUsd {
+            evidence.append(cost.formatted(.currency(code: "USD")))
+        }
+        return evidence.joined(separator: " · ")
+    }
+
+    private func runColor(_ run: SkillRunEntry) -> Color {
+        if run.ended == nil { return .statusInfo }
+        switch run.status.lowercased() {
+        case "ok", "completed", "succeeded": return .statusSuccess
+        case "failed", "error": return .statusError
+        case "interrupted": return .statusWarning
+        default: return .statusNeutral
+        }
+    }
+
     private func waveName(_ waveId: String) -> String {
         model.wave(id: waveId)?.wave.name ?? model.rosterWave(id: waveId)?.displayName ?? "Wave"
     }
@@ -465,6 +615,18 @@ private struct ControlRoomInspector: View {
             try await model.setWavePaused(waveId: waveId, paused: paused)
         } catch {
             turnIntentError = error.localizedDescription
+        }
+    }
+
+    @MainActor
+    private func openTrace(_ run: SkillRunEntry) async {
+        openingTraceId = run.id
+        traceError = nil
+        defer { openingTraceId = nil }
+        do {
+            traceRequest = try await model.traceAddress(for: run)
+        } catch {
+            traceError = error.localizedDescription
         }
     }
 

--- a/swift/LoopflowTests/ControlRoomModelTests.swift
+++ b/swift/LoopflowTests/ControlRoomModelTests.swift
@@ -122,12 +122,83 @@ struct ControlRoomModelTests {
         #expect(model.fleetSummary?.liveListeners == 0)
         #expect(model.fleetSummary?.unservedRuns == 1)
     }
+
+    @Test("Selected Runs require explicit Wave, Project, and Task attribution")
+    func selectedRunsFollowWorkAttribution() async throws {
+        let fixture = try ControlRoomTestFixture.load()
+        let model = ControlRoomModel(query: fixture.query)
+        await model.refresh()
+
+        model.select(.wave(waveId: "wave-1"))
+        await model.refreshSelectedRuns()
+        #expect(model.runs(for: .wave(waveId: "wave-1")).map(\.id)
+            == ["invocation-product-run"])
+
+        model.select(.project(waveId: "wave-1", projectId: "project-1"))
+        await model.refreshSelectedRuns()
+        #expect(model.runs(for: .project(waveId: "wave-1", projectId: "project-1")).map(\.id)
+            == ["invocation-product-run"])
+
+        model.select(.task(waveId: "wave-1", taskId: "issue-now"))
+        await model.refreshSelectedRuns()
+        #expect(model.runs(for: .task(waveId: "wave-1", taskId: "issue-now")).map(\.id)
+            == ["invocation-product-run"])
+
+        model.select(.task(waveId: "wave-1", taskId: "issue-available"))
+        await model.refreshSelectedRuns()
+        #expect(model.runs(for: .task(waveId: "wave-1", taskId: "issue-available")).isEmpty)
+    }
+
+    @Test("A late Run query cannot replace evidence for a newer selection")
+    func staleRunQueryDoesNotReplaceNewSelection() async throws {
+        let fixture = try ControlRoomTestFixture.load()
+        var staleRuns = try #require(
+            JSONSerialization.jsonObject(with: Data(fixture.runsJSON.utf8))
+                as? [[String: Any]]
+        )
+        staleRuns[0]["id"] = "invocation-stale-wave"
+        staleRuns[0]["project"] = NSNull()
+        staleRuns[0]["task"] = NSNull()
+        let staleData = try JSONSerialization.data(withJSONObject: staleRuns)
+        let staleJSON = try #require(String(data: staleData, encoding: .utf8))
+        let selectedJSON = fixture.runsJSON
+        let deferred = DeferredRunResponse()
+        let query = RegistryQuery { args, _ in
+            guard args.first == "runs" else {
+                throw RegistryQueryError("unexpected command \(args.joined(separator: " "))")
+            }
+            if args.contains("W2-144") { return selectedJSON }
+            return await deferred.response()
+        }
+        let model = ControlRoomModel(query: query)
+        model.applyFixture(
+            roadmap: .available(fixture.roadmap),
+            waves: .available(fixture.waves),
+            activity: .available(fixture.activity),
+            repos: []
+        )
+
+        model.select(.wave(waveId: "wave-1"))
+        let staleRefresh = Task { await model.refreshSelectedRuns() }
+        await deferred.waitUntilRequested()
+
+        model.select(.task(waveId: "wave-1", taskId: "issue-now"))
+        await model.refreshSelectedRuns()
+        #expect(model.selectedRuns.value?.map(\.id) == ["invocation-product-run"])
+
+        await deferred.release(staleJSON)
+        await staleRefresh.value
+
+        #expect(model.selection == .task(waveId: "wave-1", taskId: "issue-now"))
+        #expect(model.selectedRuns.value?.map(\.id) == ["invocation-product-run"])
+    }
 }
 
 private struct ControlRoomTestFixture {
     let roadmap: RoadmapSnapshot
     let waves: [Wave]
     let activity: ActivitySnapshot
+    let runsJSON: String
     let query: RegistryQuery
 
     static func load(sourceFile: String = #filePath) throws -> ControlRoomTestFixture {
@@ -141,6 +212,8 @@ private struct ControlRoomTestFixture {
         let activityURL = url.deletingLastPathComponent().appendingPathComponent("activity_snapshot.json")
         let activityData = try Data(contentsOf: activityURL)
         let activity = try JSONDecoder().decode(ActivitySnapshot.self, from: activityData)
+        let runsURL = url.deletingLastPathComponent().appendingPathComponent("recent_runs.json")
+        let runsData = try Data(contentsOf: runsURL)
         let object = try #require(JSONSerialization.jsonObject(with: roadmapData) as? [String: Any])
         let roadmapWaves = try #require(object["waves"] as? [[String: Any]])
         let waveObjects = try roadmapWaves.map { try #require($0["wave"] as? [String: Any]) }
@@ -150,11 +223,13 @@ private struct ControlRoomTestFixture {
         let roadmapJSON = try #require(String(data: roadmapData, encoding: .utf8))
         let wavesJSON = try #require(String(data: waveData, encoding: .utf8))
         let activityJSON = try #require(String(data: activityData, encoding: .utf8))
+        let runsJSON = try #require(String(data: runsData, encoding: .utf8))
         let query = RegistryQuery { args, _ in
             switch args.first {
             case "roadmap": roadmapJSON
             case "ls": wavesJSON
             case "ps": activityJSON
+            case "runs": runsJSON
             default: throw RegistryQueryError("unexpected command \(args.joined(separator: " "))")
             }
         }
@@ -162,8 +237,34 @@ private struct ControlRoomTestFixture {
             roadmap: roadmap,
             waves: waves,
             activity: activity,
+            runsJSON: runsJSON,
             query: query
         )
+    }
+}
+
+private actor DeferredRunResponse {
+    private var responseContinuation: CheckedContinuation<String, Never>?
+    private var requestContinuation: CheckedContinuation<Void, Never>?
+
+    func response() async -> String {
+        await withCheckedContinuation { continuation in
+            responseContinuation = continuation
+            requestContinuation?.resume()
+            requestContinuation = nil
+        }
+    }
+
+    func waitUntilRequested() async {
+        if responseContinuation != nil { return }
+        await withCheckedContinuation { continuation in
+            requestContinuation = continuation
+        }
+    }
+
+    func release(_ response: String) {
+        responseContinuation?.resume(returning: response)
+        responseContinuation = nil
     }
 }
 #endif

--- a/swift/LoopflowTests/RegistryQueryTests.swift
+++ b/swift/LoopflowTests/RegistryQueryTests.swift
@@ -275,9 +275,20 @@ struct RegistryQueryTests {
         [{"id":"invocation-1","trace_id":"abc","exec_id":"span-1","parent_exec_id":null,"repo":"/src/loopflow","worktree":"/src/loopflow","wave":"goals","project":"auditability","task":"W2-122","flow":"build","skill":"gate","status":"ok","started":100,"ended":110,"turns":1,"system_tokens":100,"task_tokens":50,"supplied_context_tokens":150,"input_tokens":1000,"output_tokens":200,"reasoning_tokens":null,"cache_read_tokens":800,"cache_write_tokens":null,"cost_usd":0.25,"duration_secs":10.0,"provider":"claude","model":"opus","surface":"headless","capture_status":"complete"},
          {"id":"invocation-2","trace_id":"def","exec_id":"span-2","parent_exec_id":null,"repo":"/src/loopflow","worktree":"/src/loopflow","wave":"goals","project":null,"task":null,"flow":null,"skill":"debug","status":"running","started":120,"ended":null,"turns":0,"system_tokens":0,"task_tokens":0,"supplied_context_tokens":0,"input_tokens":null,"output_tokens":null,"reasoning_tokens":null,"cache_read_tokens":null,"cache_write_tokens":null,"cost_usd":null,"duration_secs":null,"provider":"claude","model":null,"surface":"headless","capture_status":"pending"}]
         """
-        let query = RegistryQuery { _, _ in json }
+        let query = RegistryQuery { args, cwd in
+            #expect(args == [
+                "runs", "--wave", "goals", "--project", "auditability",
+                "--task", "W2-122", "--json",
+            ])
+            #expect(cwd == nil)
+            return json
+        }
 
-        let runs = try await query.recentRuns()
+        let runs = try await query.recentRuns(
+            wave: "goals",
+            project: "auditability",
+            task: "W2-122"
+        )
         #expect(runs.count == 2)
         #expect(runs[0].id == "invocation-1")
         #expect(runs[0].traceId == "abc")
@@ -293,6 +304,54 @@ struct RegistryQueryTests {
         #expect(runs[0].task == "W2-122")
         #expect(runs[1].project == nil)
         #expect(runs[1].task == nil)
+    }
+
+    @Test("A visible Run opens its exact latest captured turn")
+    func runResolvesLatestTraceAddress() async throws {
+        let runJSON = """
+        [{"id":"invocation-1","trace_id":"trace-1","exec_id":"span-1","parent_exec_id":null,"repo":"/src/loopflow","worktree":"/src/loopflow","wave":"product","project":"mac-surface-ux","task":"W2-144","flow":"task","skill":"implement","status":"ok","started":100,"ended":110,"turns":2,"system_tokens":100,"task_tokens":50,"supplied_context_tokens":150,"input_tokens":1000,"output_tokens":200,"reasoning_tokens":null,"cache_read_tokens":800,"cache_write_tokens":null,"cost_usd":0.25,"duration_secs":10.0,"provider":"codex","model":"gpt-5","surface":"headless","capture_status":"complete"}]
+        """
+        let traceJSON = """
+        {"trace_id":"trace-1","spans":[],"invocations":[],"turns":[
+          {"id":"turn-new","invocation_id":"invocation-1","ordinal":2},
+          {"id":"turn-other","invocation_id":"invocation-2","ordinal":9},
+          {"id":"turn-old","invocation_id":"invocation-1","ordinal":1}
+        ],"asks":[],"assets":[],"decisions":[]}
+        """
+        let query = RegistryQuery { args, _ in
+            switch args {
+            case ["runs", "--json"]: runJSON
+            case ["trace", "invocation-1", "--json"]: traceJSON
+            default: throw RegistryQueryError("unexpected argv: \(args)")
+            }
+        }
+
+        let runs = try await query.recentRuns()
+        let run = try #require(runs.first)
+        let address = try await query.traceAddress(for: run)
+
+        #expect(address == TraceAddress(
+            runId: "trace-1",
+            invocationId: "invocation-1",
+            turnId: "turn-new"
+        ))
+    }
+
+    @Test("A Run without a captured turn stays explicitly unavailable")
+    func runWithoutTurnHasNoTraceAddress() async throws {
+        let runJSON = """
+        [{"id":"invocation-1","trace_id":"trace-1","exec_id":"span-1","parent_exec_id":null,"repo":"/src/loopflow","worktree":"/src/loopflow","wave":"product","project":null,"task":null,"flow":null,"skill":"design","status":"running","started":100,"ended":null,"turns":0,"system_tokens":0,"task_tokens":0,"supplied_context_tokens":0,"input_tokens":null,"output_tokens":null,"reasoning_tokens":null,"cache_read_tokens":null,"cache_write_tokens":null,"cost_usd":null,"duration_secs":null,"provider":"codex","model":null,"surface":"headless","capture_status":"pending"}]
+        """
+        let query = RegistryQuery { args, _ in
+            if args == ["runs", "--json"] { return runJSON }
+            return #"{"trace_id":"trace-1","turns":[]}"#
+        }
+        let runs = try await query.recentRuns()
+        let run = try #require(runs.first)
+
+        await #expect(throws: RegistryQueryError.self) {
+            _ = try await query.traceAddress(for: run)
+        }
     }
 
     @Test("lf ps decodes the shared live activity snapshot")

--- a/swift/README.md
+++ b/swift/README.md
@@ -14,9 +14,13 @@ five-minute output, measured tokens, and orphaned or unclaimed providers from
 `lf ps --json`. Beside that activity it keeps Wave count, active Runs,
 answering listeners, active Project/Task counts, and Run-without-listener
 warnings from `lf ls --json`. Selecting a Wave, Project, or Task preserves the
-surrounding live view. The control room reads `lf roadmap --json`,
-`lf ls --json`, and `lf ps --json` once per refresh; repository scope filters
-the Work and Wave snapshots locally while agent activity remains machine-wide.
+surrounding live view and loads its explicitly attributed recent Runs. Open a
+Run to inspect its exact captured prompt and conversation in the existing trace
+sheet. The control room reads `lf roadmap --json`, `lf ls --json`, and
+`lf ps --json` once per refresh; selection reads filtered `lf runs --json`
+evidence on demand and refreshes it while that Work stays selected. Repository
+scope filters the Work and Wave snapshots locally while agent activity remains
+machine-wide.
 
 Loading, empty, stale-last-good, and unavailable reads stay distinct. Wave and
 agent readings fail independently. A failed refresh keeps the last useful
@@ -74,7 +78,8 @@ and observation spans.
   `lf ls/status/roadmap/ps/runs/usage/doctor/tokens/context/trace --json`; the app
   does not maintain a second roadmap or lifecycle database. Unavailable per-Wave
   evidence renders its reason, and refresh failures leave the last successful
-  roadmap or selected Wave detail visible.
+  roadmap or selected Run history visible. Prompt and conversation bodies load
+  only after **Open trace**.
 - **Per-Wave SSE** owns live motion. `WaveChatConnection` first reads
   `lf chat --history --json`, then connects only to the selected Wave's
   `/events` stream and upserts its replay before continuing live.

--- a/tests/fixtures/dto/recent_runs.json
+++ b/tests/fixtures/dto/recent_runs.json
@@ -1,0 +1,33 @@
+[
+  {
+    "id": "invocation-product-run",
+    "trace_id": "trace-product-run",
+    "exec_id": "exec-product-run",
+    "parent_exec_id": null,
+    "repo": "/src/loopflow",
+    "worktree": "/src/loopflow.sessions",
+    "wave": "product",
+    "project": "loopflow-api",
+    "task": "W2-144",
+    "flow": "task",
+    "skill": "task_pursue",
+    "status": "ok",
+    "started": 1784604000,
+    "ended": 1784604900,
+    "turns": 3,
+    "system_tokens": 4200,
+    "task_tokens": 1800,
+    "supplied_context_tokens": 6000,
+    "input_tokens": 18400,
+    "output_tokens": 5200,
+    "reasoning_tokens": 2100,
+    "cache_read_tokens": 12300,
+    "cache_write_tokens": 600,
+    "cost_usd": 0.74,
+    "duration_secs": 900.0,
+    "provider": "codex",
+    "model": "gpt-5",
+    "surface": "headless",
+    "capture_status": "complete"
+  }
+]


### PR DESCRIPTION
## Usage\n\n    lf runs --project parser --json\n\nOpen Loopflow, select a Wave, Project, or Task, then use Open trace on a Recent runs card.\n\n## Summary\n\nTurn the primary control-room inspector into an execution evidence drill-down. Selected Work now keeps explicitly attributed Run history current and opens the exact captured prompt and conversation without leaving the app.\n\n## Changes\n\n- filter Wave, Project, and Task Runs before the ledger result cap\n- preserve last-good evidence and reject stale selection responses\n- reuse the existing trace evidence sheet behind an explicit action\n- prove populated, loading, unavailable, and empty states at 900px and 1440px\n