### PR TITLE
pr settlement: observe queued merge requests

### DIFF
--- a/rust/loopflow/src/ops/land.rs
+++ b/rust/loopflow/src/ops/land.rs
@@ -80,7 +80,46 @@ fn prepare_pr(
     crate::ops::task::verify_task_pr_range(&repo_root)?;
     {
         let _mutation = crate::ops::task::lock_task_pr_mutation(&repo_root)?;
-        crate::ops::task::clear_task_pr_merge_before_head_mutation(&repo_root, true)?;
+        if matches!(finalize, Finalize::AutoMerge) && matches!(integration, Integration::Required) {
+            let after_merge = if options.complete {
+                crate::task::AfterMerge::CompleteTask
+            } else {
+                crate::task::AfterMerge::ContinueTask
+            };
+            if let Some((number, head)) = crate::ops::task::matching_task_pr_merge_request(
+                &repo_root,
+                crate::task::PrMergeMode::Auto,
+                after_merge,
+                options.next_slug.as_deref(),
+            )? {
+                if let Some(pr) = crate::ops::pr::current_pr(&repo_root)? {
+                    if pr.number == u64::from(number)
+                        && pr.head_sha.as_deref() == Some(head.as_str())
+                        && crate::ops::pr::auto_merge_enabled(&repo_root, pr.number)?
+                    {
+                        progress.status("Pull request is already armed for this exact head");
+                        return Ok(Some(pr));
+                    }
+                }
+            }
+        }
+        let cleared_task_request =
+            crate::ops::task::clear_task_pr_merge_before_head_mutation(&repo_root, true)?;
+        if !options.local && !cleared_task_request {
+            // Wave and other non-Task PRs have no durable Task request to
+            // revoke, but GitHub may still have this branch in its merge queue.
+            // Dequeue it before rebase/push; otherwise GitHub rejects the head
+            // update and the repair cannot publish.
+            if let Some(pr) = crate::ops::pr::current_pr(&repo_root)? {
+                let number = u32::try_from(pr.number).map_err(|_| {
+                    OpsError::Message(format!(
+                        "pull request #{} exceeds supported range",
+                        pr.number
+                    ))
+                })?;
+                crate::ops::pr::disable_auto_merge(&repo_root, number)?;
+            }
+        }
     }
     match integration {
         Integration::Required => prepare_land(&repo_root, options, progress)?,

--- a/rust/loopflow/src/ops/pr.rs
+++ b/rust/loopflow/src/ops/pr.rs
@@ -356,23 +356,27 @@ pub fn current_pr(repo: &Path) -> OpsResult<Option<PrInfo>> {
 }
 
 pub(crate) fn auto_merge_enabled(repo: &Path, number: u64) -> OpsResult<bool> {
+    let query = "query($owner:String!,$name:String!,$number:Int!){repository(owner:$owner,name:$name){pullRequest(number:$number){autoMergeRequest{enabledAt} mergeQueueEntry{id}}}}";
     let observation = Command::new("gh")
         .args([
-            "pr",
-            "view",
-            &number.to_string(),
-            "--json",
-            "autoMergeRequest",
+            "api",
+            "graphql",
+            "-F",
+            "owner={owner}",
+            "-F",
+            "name={repo}",
+            "-F",
+            &format!("number={number}"),
+            "-f",
+            &format!("query={query}"),
             "--jq",
-            ".autoMergeRequest != null",
+            ".data.repository.pullRequest | (.autoMergeRequest != null) or (.mergeQueueEntry != null)",
         ])
         .current_dir(repo)
         .output()?;
     if !observation.status.success() {
         return Err(OpsError::CommandFailed {
-            command: format!(
-                "gh pr view {number} --json autoMergeRequest --jq .autoMergeRequest!=null"
-            ),
+            command: format!("gh api graphql [pull request #{number} merge request]"),
             stderr: stderr_from_output(&observation),
         });
     }
@@ -392,14 +396,14 @@ pub(crate) fn disable_auto_merge(repo: &Path, number: u32) -> OpsResult<()> {
         return Ok(());
     }
     let output = Command::new("gh")
-        .args(["pr", "merge", &number.to_string(), "--disable"])
+        .args(["pr", "merge", &number.to_string(), "--disable-auto"])
         .current_dir(repo)
         .output()?;
     if output.status.success() {
         return Ok(());
     }
     Err(OpsError::CommandFailed {
-        command: format!("gh pr merge {number} --disable"),
+        command: format!("gh pr merge {number} --disable-auto"),
         stderr: stderr_from_output(&output),
     })
 }

--- a/rust/loopflow/src/ops/task.rs
+++ b/rust/loopflow/src/ops/task.rs
@@ -1227,6 +1227,54 @@ pub(crate) fn request_task_pr_publication(repo: &Path) -> OpsResult<bool> {
     })
 }
 
+/// The exact clean Task settlement already represented by local HEAD and the
+/// stored GitHub head. `land` uses this read before any head mutation so a
+/// replay can observe an already-armed request instead of clearing it.
+pub(crate) fn matching_task_pr_merge_request(
+    repo: &Path,
+    mode: PrMergeMode,
+    after_merge: AfterMerge,
+    next_slug: Option<&str>,
+) -> OpsResult<Option<(u32, String)>> {
+    let next_slug = next_slug.map(parse_pr_slug).transpose()?;
+    if after_merge == AfterMerge::CompleteTask && next_slug.is_some() {
+        return Err(task_error("--complete and --next cannot be used together"));
+    }
+    block_on_task(async move {
+        let TaskAuthority::Authority { store, task, .. } = resolve_task_authority(repo).await?
+        else {
+            return Ok(None);
+        };
+        if !is_clean(repo)? {
+            return Ok(None);
+        }
+        let branch = current_branch(repo)?;
+        let head = rev_parse(repo, "HEAD")?;
+        let pr = store
+            .active_task_pr(&task.id)
+            .await
+            .map_err(|error| task_error(format!("failed to read active PR: {error}")))?
+            .ok_or_else(|| task_error(format!("Task {} has no active PR", task.plan.identifier)))?;
+        if branch.as_deref() != Some(pr.branch.as_str()) {
+            return Ok(None);
+        }
+        let Some(github) = pr.github() else {
+            return Ok(None);
+        };
+        let Some(request) = pr.merge_request() else {
+            return Ok(None);
+        };
+        if github.head_sha.as_deref() != Some(head.as_str())
+            || request.mode != mode
+            || request.after_merge != after_merge
+            || request.next_slug != next_slug
+        {
+            return Ok(None);
+        }
+        Ok(Some((github.number, head)))
+    })
+}
+
 /// Clear settlement intent before a Loopflow-owned operation can move the PR
 /// head. Auto-merge is revoked remotely first; a crash between the two steps is
 /// replay-safe because the next attempt observes it already disabled.

--- a/rust/loopflow/tests/land_tests.rs
+++ b/rust/loopflow/tests/land_tests.rs
@@ -56,12 +56,13 @@ if [ "$1 $2" = "pr create" ]; then
   exit 0
 fi
 
+if [ "$1 $2" = "api graphql" ]; then
+  echo 'false'
+  exit 0
+fi
+
 if [ "$1 $2" = "pr view" ]; then
-  if [ "$4" = "--json" ] && [ "$5" = "autoMergeRequest" ]; then
-    echo 'false'
-  else
-    echo 'https://example.com/pr/1'
-  fi
+  echo 'https://example.com/pr/1'
   exit 0
 fi
 
@@ -96,11 +97,12 @@ if [ "$1 $2" = "pr create" ]; then
   exit 0
 fi
 
+if [ "$1 $2" = "api graphql" ]; then
+  if [ -f "$auto_state" ]; then echo 'true'; else echo 'false'; fi
+  exit 0
+fi
+
 if [ "$1 $2" = "pr view" ]; then
-  if [ "$4" = "--json" ] && [ "$5" = "autoMergeRequest" ]; then
-    if [ -f "$auto_state" ]; then echo 'true'; else echo 'false'; fi
-    exit 0
-  fi
   echo "https://example.com/pr/1"
   exit 0
 fi
@@ -119,6 +121,7 @@ fn gh_existing_pr_script(log_path: &str) -> String {
     format!(
         r#"#!/bin/sh
 auto_state="{log_path}.auto"
+queue_state="{log_path}.queued"
 if [ "$1" = "--version" ]; then
   exit 0
 fi
@@ -128,16 +131,16 @@ if [ "$1 $2" = "pr list" ]; then
   echo "[{{\"url\":\"https://example.com/pr/912\",\"state\":\"OPEN\",\"isDraft\":false,\"number\":912,\"mergeCommit\":null,\"headRefOid\":\"$head\"}}]"
   exit 0
 fi
+if [ "$1 $2" = "api graphql" ]; then
+  if [ -f "$auto_state" ] || [ -f "$queue_state" ]; then echo 'true'; else echo 'false'; fi
+  exit 0
+fi
 if [ "$1 $2" = "pr view" ]; then
-  if [ "$4" = "--json" ] && [ "$5" = "autoMergeRequest" ]; then
-    if [ -f "$auto_state" ]; then echo 'true'; else echo 'false'; fi
-    exit 0
-  fi
   echo 'https://example.com/pr/912'
   exit 0
 fi
-if [ "$1 $2 $3 $4" = "pr merge 912 --disable" ]; then
-  rm -f "$auto_state"
+if [ "$1 $2 $3 $4" = "pr merge 912 --disable-auto" ]; then
+  rm -f "$auto_state" "$queue_state"
   exit 0
 fi
 if [ "$1 $2" = "pr merge" ]; then
@@ -189,12 +192,12 @@ if [ "$1 $2" = "pr list" ]; then
   echo "[{{\"url\":\"https://example.com/pr/912\",\"state\":\"OPEN\",\"isDraft\":false,\"number\":912,\"mergeCommit\":null,\"headRefOid\":\"$head\"}}]"
   exit 0
 fi
+if [ "$1 $2" = "api graphql" ]; then
+  echo 'false'
+  exit 0
+fi
 if [ "$1 $2" = "pr view" ]; then
-  if [ "$4" = "--json" ] && [ "$5" = "autoMergeRequest" ]; then
-    echo 'false'
-  else
-    echo 'https://example.com/pr/912'
-  fi
+  echo 'https://example.com/pr/912'
   exit 0
 fi
 if [ "$1 $2" = "pr merge" ]; then
@@ -1026,7 +1029,7 @@ fn latest_land_disposition_wins_before_merge() {
         "pr merge --squash --auto --match-head-commit {revised_head}"
     )));
     let first_disable = log
-        .find("pr merge 912 --disable")
+        .find("pr merge 912 --disable-auto")
         .expect("pre-existing Auto is replaced");
     let first_arm = log
         .find("pr merge --squash --auto --match-head-commit")
@@ -1036,7 +1039,7 @@ fn latest_land_disposition_wins_before_merge() {
         "external Auto must be replaced by the exact-head command:\n{log}"
     );
     let disable = log
-        .rfind("pr merge 912 --disable")
+        .rfind("pr merge 912 --disable-auto")
         .expect("second land revokes prior Auto request");
     if revised_head != head {
         let push = log
@@ -1080,8 +1083,140 @@ fn latest_land_disposition_wins_before_merge() {
     assert_eq!(request.mode, PrMergeMode::User);
     assert_eq!(request.head_sha, submitted_head);
     let log = fs::read_to_string(&log_path).expect("read gh log");
-    assert!(log.contains("pr merge 912 --disable"));
+    assert!(log.contains("pr merge 912 --disable-auto"));
     assert!(log.contains("pr edit --add-assignee @me"));
+}
+
+#[test]
+fn repeated_identical_land_preserves_the_armed_task_request() {
+    let home = tempfile::TempDir::new().expect("temp home");
+    let repo = TestRepo::new();
+    let log_path = home.path().join("gh.log");
+    let script = gh_existing_pr_script(log_path.to_string_lossy().as_ref());
+    let _env = EnvGuard::with_lf_home(
+        &[("gh", script.as_str()), ("open", noop_open_script())],
+        home.path(),
+    );
+    let base = repo.head_sha();
+    let branch = "jack/replay-safe-land";
+    repo.create_branch(branch);
+    repo.create_file("feature.txt", "feature");
+    repo.stage_all();
+    repo.commit("feature work");
+    repo.push_new_branch(branch);
+    let task = register_task(home.path(), repo.path(), branch, &base);
+    let options = LandOptions {
+        strict: true,
+        local: false,
+        create_pr: false,
+        complete: true,
+        next_slug: None,
+        worktree: None,
+        commit_message: None,
+        pr_title: Some("test title".to_string()),
+        pr_body: Some("test body".to_string()),
+        agent: None,
+    };
+
+    land(repo.path(), &options, &NullProgress).expect("first land arms the request");
+    let armed_head = repo.head_sha();
+    let first_log = fs::read_to_string(&log_path).expect("read first gh log");
+    let first_merge_calls = first_log
+        .lines()
+        .filter(|line| line.starts_with("pr merge"))
+        .count();
+
+    land(repo.path(), &options, &NullProgress).expect("identical land is replay-safe");
+
+    assert_eq!(
+        repo.head_sha(),
+        armed_head,
+        "replay must not rewrite the head"
+    );
+    let pr = tokio::runtime::Runtime::new()
+        .expect("task runtime")
+        .block_on(task.store.active_task_pr(&task.task.id))
+        .expect("read active PR")
+        .expect("active PR");
+    let request = pr.merge_request().expect("preserved merge request");
+    assert_eq!(request.mode, PrMergeMode::Auto);
+    assert_eq!(request.after_merge, AfterMerge::CompleteTask);
+    assert_eq!(request.head_sha, armed_head);
+    let replay_log = fs::read_to_string(&log_path).expect("read replay gh log");
+    assert_eq!(
+        replay_log
+            .lines()
+            .filter(|line| line.starts_with("pr merge"))
+            .count(),
+        first_merge_calls,
+        "replay must neither disable nor arm auto-merge again:\n{replay_log}"
+    );
+    assert!(!replay_log.contains("--disable-auto"));
+}
+
+#[test]
+fn non_task_land_leaves_the_merge_queue_before_pushing_a_new_head() {
+    let home = tempfile::TempDir::new().expect("temp home");
+    let repo = TestRepo::new();
+    let log_path = home.path().join("gh.log");
+    let script = gh_existing_pr_script(log_path.to_string_lossy().as_ref());
+    let _env = EnvGuard::with_lf_home(
+        &[("gh", script.as_str()), ("open", noop_open_script())],
+        home.path(),
+    );
+    let branch = "jack/wave-repair";
+    repo.create_branch(branch);
+    repo.create_file("feature.txt", "feature");
+    repo.stage_all();
+    repo.commit("feature work");
+    repo.push_new_branch(branch);
+    fs::write(format!("{}.queued", log_path.display()), "queued")
+        .expect("seed remote auto-merge state");
+    let hook = repo.bare_path().join("hooks/pre-receive");
+    fs::write(
+        &hook,
+        format!(
+            "#!/bin/sh\necho git-push >> '{}'\ncat >/dev/null\n",
+            log_path.display()
+        ),
+    )
+    .expect("write remote push hook");
+    let mut permissions = fs::metadata(&hook)
+        .expect("read hook metadata")
+        .permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(&hook, permissions).expect("make push hook executable");
+
+    land(
+        repo.path(),
+        &LandOptions {
+            strict: true,
+            local: false,
+            create_pr: false,
+            complete: false,
+            next_slug: None,
+            worktree: None,
+            commit_message: None,
+            pr_title: Some("test title".to_string()),
+            pr_body: Some("test body".to_string()),
+            agent: None,
+        },
+        &NullProgress,
+    )
+    .expect("non-Task land");
+
+    let log = fs::read_to_string(&log_path).expect("read gh log");
+    let disable = log
+        .find("pr merge 912 --disable-auto")
+        .expect("queued Auto is revoked");
+    let push = log.find("git-push").expect("prepared head is pushed");
+    let arm = log
+        .rfind("pr merge --squash --auto --match-head-commit")
+        .expect("prepared head is re-armed");
+    assert!(
+        disable < push && push < arm,
+        "unexpected settlement order:\n{log}"
+    );
 }
 
 #[test]

--- a/rust/loopflow/tests/pr_tests.rs
+++ b/rust/loopflow/tests/pr_tests.rs
@@ -84,15 +84,15 @@ echo "$@" >> "{log_path}"
 if [ "$1" = "--version" ]; then
   exit 0
 fi
+if [ "$1 $2" = "api graphql" ]; then
+  echo 'true'
+  exit 0
+fi
 if [ "$1" = "api" ]; then
   echo '{{"merged":false,"state":"open","draft":false,"merge_commit_sha":null,"number":912,"html_url":"https://example.com/pr/912","head":{{"sha":"new-head"}}}}'
   exit 0
 fi
-if [ "$1 $2" = "pr view" ]; then
-  echo 'true'
-  exit 0
-fi
-if [ "$1 $2 $3 $4" = "pr merge 912 --disable" ]; then
+if [ "$1 $2 $3 $4" = "pr merge 912 --disable-auto" ]; then
   exit 0
 fi
 exit 0
@@ -107,16 +107,16 @@ echo "$@" >> "{log_path}"
 if [ "$1" = "--version" ]; then
   exit 0
 fi
+if [ "$1 $2" = "api graphql" ]; then
+  echo 'true'
+  exit 0
+fi
 if [ "$1" = "api" ]; then
   head="$(git rev-parse HEAD)"
   printf '{{"merged":false,"state":"open","draft":false,"merge_commit_sha":null,"number":912,"html_url":"https://example.com/pr/912","head":{{"sha":"%s"}}}}\n' "$head"
   exit 0
 fi
-if [ "$1 $2" = "pr view" ]; then
-  echo 'true'
-  exit 0
-fi
-if [ "$1 $2 $3 $4" = "pr merge 912 --disable" ]; then
+if [ "$1 $2 $3 $4" = "pr merge 912 --disable-auto" ]; then
   exit 0
 fi
 exit 0
@@ -500,7 +500,7 @@ fn changed_head_revokes_auto_merge_and_clears_the_stale_request() {
     assert!(persisted.merge_request().is_none());
     assert_eq!(persisted.after_merge(), AfterMerge::ContinueTask);
     let log = std::fs::read_to_string(log_path).expect("read gh log");
-    assert!(log.contains("pr merge 912 --disable"));
+    assert!(log.contains("pr merge 912 --disable-auto"));
 }
 
 #[test]
@@ -549,7 +549,7 @@ fn task_resume_revokes_auto_merge_before_restarting_authored_work() {
         .expect("active PR");
     assert!(persisted.merge_request().is_none());
     let log = std::fs::read_to_string(log_path).expect("read gh log");
-    assert!(log.contains("pr merge 912 --disable"));
+    assert!(log.contains("pr merge 912 --disable-auto"));
 }
 
 #[test]
@@ -624,7 +624,9 @@ fn pushed_task_commit_revokes_auto_before_exposing_the_new_head() {
         .expect("active PR");
     assert!(persisted.merge_request().is_none());
     let log = fs::read_to_string(log_path).expect("read operation log");
-    let disable = log.find("pr merge 912 --disable").expect("Auto is revoked");
+    let disable = log
+        .find("pr merge 912 --disable-auto")
+        .expect("Auto is revoked");
     let push = log.find("git-push").expect("new head is pushed");
     assert!(disable < push, "Auto must be revoked before push:\n{log}");
 }

--- a/rust/loopflow/tests/task_pr_range_tests.rs
+++ b/rust/loopflow/tests/task_pr_range_tests.rs
@@ -55,11 +55,11 @@ if [ "$1 $2" = "pr list" ]; then
   echo '[{{"url":"https://example.com/pr/925","state":"OPEN","isDraft":false,"number":925,"mergeCommit":null,"headRefOid":"head-925"}}]'
   exit 0
 fi
+if [ "$1 $2" = "api graphql" ]; then
+  if [ -f "$auto_state" ]; then echo 'true'; else echo 'false'; fi
+  exit 0
+fi
 if [ "$1 $2" = "pr view" ]; then
-  if [ "$4" = "--json" ] && [ "$5" = "autoMergeRequest" ]; then
-    if [ -f "$auto_state" ]; then echo 'true'; else echo 'false'; fi
-    exit 0
-  fi
   echo 'https://example.com/pr/925'
   exit 0
 fi
@@ -79,11 +79,11 @@ if [ "$1" = "--version" ]; then
   exit 0
 fi
 echo "$@" >> "{log_path}"
-if [ "$1 $2" = "pr view" ]; then
+if [ "$1 $2" = "api graphql" ]; then
   echo 'true'
   exit 0
 fi
-if [ "$1 $2 $3 $4" = "pr merge 912 --disable" ]; then
+if [ "$1 $2 $3 $4" = "pr merge 912 --disable-auto" ]; then
   exit 0
 fi
 exit 0
@@ -413,7 +413,9 @@ fn rebase_revokes_auto_before_force_pushing_a_new_task_head() {
         .expect("active PR");
     assert!(persisted.merge_request().is_none());
     let log = fs::read_to_string(log_path).expect("read operation log");
-    let disable = log.find("pr merge 912 --disable").expect("Auto is revoked");
+    let disable = log
+        .find("pr merge 912 --disable-auto")
+        .expect("Auto is revoked");
     let push = log.find("git-push").expect("rebased head is pushed");
     assert!(
         disable < push,


### PR DESCRIPTION
Prevents Loopflow from trying to replace the head of a PR that GitHub has already admitted to the merge queue.

The remote settlement read now observes both auto-merge requests and actual merge-queue entries through GitHub GraphQL. Non-Task remote land leaves either state before pushing; local-only land remains offline. Exact Task replays preserve an already-armed request.

Proof: queue-specific landing, local cleanup, replay, changed-disposition, auto-merge, and rebase-ordering tests; cargo fmt and clippy.