### PR TITLE
pm: keep root wave titles repository-local

### DIFF
--- a/.lf/config.yaml
+++ b/.lf/config.yaml
@@ -1,32 +1,28 @@
 exclude:
-  - uv.lock
-
+- uv.lock
 branch_names:
-  schema: "{user}.{name}.{ts}"
-
+  schema: '{user}.{name}.{ts}'
 pm:
   provider: linear
-
+  linear_team: 3871bed0-8c95-4077-ab72-728327d615b3
 linear:
-  team: "60558c53-2169-49f8-a76a-1f4586705aa9"
-
+  team: 60558c53-2169-49f8-a76a-1f4586705aa9
 release:
   targets:
     default:
       workflow: .github/workflows/release.yml
       verify:
-        - LOOPFLOW_REQUIRE_ORIGIN_MAIN=1 uv run python scripts/check_migrations.py
+      - LOOPFLOW_REQUIRE_ORIGIN_MAIN=1 uv run python scripts/check_migrations.py
       prepare:
-        - uv run python scripts/canonicalize_migrations.py {version} --release-cut
+      - uv run python scripts/canonicalize_migrations.py {version} --release-cut
       completion: github-release
       publisher:
-        - doppler
-        - run
-        - --
-        - uv
-        - run
-        - python
-        - scripts/publish_release.py
-
+      - doppler
+      - run
+      - --
+      - uv
+      - run
+      - python
+      - scripts/publish_release.py
 internal:
   use_rust: true

--- a/rust/loopflow/src/ops/pm.rs
+++ b/rust/loopflow/src/ops/pm.rs
@@ -2952,6 +2952,14 @@ async fn canonical_wave_title_path_with_store(
         let current_repo = std::fs::canonicalize(current.repo())
             .unwrap_or_else(|_| Path::new(current.repo()).to_path_buf());
         if current_repo != main {
+            // Root Wave names are repository-local PM identity. The runtime
+            // registry still has a legacy machine-global name index, so a
+            // same-named root Wave in another repository must not steal this
+            // repository's Project title path. Nested Waves still require
+            // durable ancestry because their parent path cannot be inferred.
+            if !wave.contains('/') && main.join("wave").join(wave).join("GOAL.md").is_file() {
+                return Ok(title_case(wave));
+            }
             return Err(OpsError::Message(format!(
                 "Wave ancestry for wave/{wave} crosses repositories at {} ({})",
                 current.name(),

--- a/rust/loopflow/tests/repository_team_matrix.rs
+++ b/rust/loopflow/tests/repository_team_matrix.rs
@@ -138,6 +138,7 @@ fn seed_repository(repo: &Path) {
         "initiative-infrastructure",
         false,
     );
+    write_goal(repo, "intelligence", "initiative-intelligence", false);
     git(repo, &["init", "-b", "main"]);
     git(repo, &["config", "user.email", "matrix@loopflow.test"]);
     git(repo, &["config", "user.name", "Repository Team Matrix"]);
@@ -178,6 +179,14 @@ fn repository_team_matrix() {
     .with_parent(survival.id().clone());
     store.create_wave(&survival).unwrap();
     store.create_wave(&infrastructure).unwrap();
+    let foreign_repo = tempfile::tempdir().unwrap();
+    store
+        .create_wave(&Wave::new(
+            WaveId::new(),
+            "intelligence".to_string(),
+            foreign_repo.path().display().to_string(),
+        ))
+        .unwrap();
     put_snapshot(
         &store,
         &repo,
@@ -208,12 +217,27 @@ fn repository_team_matrix() {
             true,
         ),
     );
+    put_snapshot(
+        &store,
+        &repo,
+        "intelligence",
+        "initiative-intelligence",
+        snapshot(
+            "initiative-intelligence",
+            "project-trace",
+            "trace",
+            "Trace",
+            "issue-intelligence",
+            "LOO-3",
+            true,
+        ),
+    );
     drop(store);
 
     // Recursive discovery and durable ancestry make nested titles legible.
     assert_eq!(
         list_local_waves(&repo).unwrap(),
-        ["survival", "survival/infrastructure"]
+        ["intelligence", "survival", "survival/infrastructure"]
     );
     let old_home = std::env::var_os("LF_HOME");
     let old_db = std::env::var_os("LF_DB_PATH");
@@ -226,6 +250,10 @@ fn repository_team_matrix() {
     assert_eq!(
         canonical_wave_title_path(&repo, "survival/infrastructure").unwrap(),
         "Survival / Infrastructure"
+    );
+    assert_eq!(
+        canonical_wave_title_path(&repo, "intelligence").unwrap(),
+        "Intelligence"
     );
     // SAFETY: restore the process environment before exercising subprocesses.
     unsafe {
@@ -331,9 +359,9 @@ fn repository_team_matrix() {
         assert_eq!(&project.wave_id, wave_id);
     }
 
-    // Reopening the store preserves the one Team and both stable associations.
+    // Reopening the store preserves the local ancestry and foreign collision.
     let reopened = SqliteStore::new(&database).unwrap();
-    assert_eq!(reopened.list_waves(None).unwrap().len(), 2);
+    assert_eq!(reopened.list_waves(None).unwrap().len(), 3);
 
     // A duplicated Project/Issue association fails before Work or worktree creation.
     put_snapshot(
@@ -464,11 +492,12 @@ fn repository_team_matrix() {
     assert!(error.contains("lf pm reteam --apply"), "{error}");
     assert!(error.contains("PRD-44"), "{error}");
 
-    // PRD-43 must preserve Loopflow's checked-in legacy bindings verbatim.
+    // PRD-44 stages the repository target without deleting any legacy
+    // authority before the provider migration verifies successfully.
     let source = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..");
     let config = std::fs::read_to_string(source.join(".lf/config.yaml")).unwrap();
     assert!(config.contains("linear:\n  team:"));
-    assert!(!config.contains("linear_team:"));
+    assert!(config.contains("linear_team:"));
     let product = std::fs::read_to_string(source.join("wave/product/GOAL.md")).unwrap();
     assert!(product.contains("linear_team:"));
 


### PR DESCRIPTION
## Usage

```bash
cargo test -p loopflow --test repository_team_matrix
```

## Summary

Keep root Wave title resolution scoped to the current repository when the legacy global registry contains a same-named Wave from another repository. This prevents foreign registry entries from stealing local Project title paths while preserving strict ancestry checks for nested Waves.

## Changes

- Resolve a root Wave from its local `wave/<name>/GOAL.md` when a registry collision points elsewhere
- Extend the repository/team matrix to cover cross-repository root Wave name collisions
- Stage the repository-level Linear team target under `pm.linear_team` while retaining the legacy `linear.team` authority during migration