### PR TITLE
lf activity: expose durable Work history

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Watch the whole machine:
 lf ls                  # every durable Wave and its Home/runtime evidence
 lf roadmap             # every open Task across every wave, bucketed by need
 lf status designer     # one wave's live Project → Task hierarchy
+lf activity            # durable Work changes with exact Run, PR, and Steer proof
 lf trace <exec-id>     # what one agent did — and exactly what it was told
 lf ps                  # rank live call trees by cumulative completed output
 lf top                 # refresh call-tree rates, age, idle time, and health

--- a/docs/agent-api.md
+++ b/docs/agent-api.md
@@ -129,14 +129,17 @@ Every read the conducting surfaces offer is `--json`:
 lf ls --json                # every durable Wave and its Home/runtime evidence
 lf status <wave> --json     # live Project → Task hierarchy
 lf roadmap --json           # every open Task across every wave
+lf activity --task INF-123 --json
 lf runs --project parser --json
 lf runs --task INF-123 --json
 lf trace <exec-id> --json
 ```
 
 `lf ls` is the registry plane, `lf status` is the focused operational view,
-and `lf roadmap` joins the current Linear plan to that runtime truth. Agents
-consume those projections; they do not rebuild the joins.
+and `lf roadmap` joins the current Linear plan to that runtime truth.
+`lf activity` is the ordered durable history; each item reuses `WorkRef` and
+carries one typed fact with its Run, Task PR, or Steer evidence. Agents consume
+those projections; they do not rebuild the joins.
 
 Wave lifecycle uses the same durable `WorkStatus` as Project and Task work:
 `ready`, `running`, `waiting`, `done`, or `abandoned`. `live` stays separate —

--- a/docs/conducting.md
+++ b/docs/conducting.md
@@ -12,6 +12,7 @@ local ledger. Use `lf ps --json` for a machine-readable activity frame and
 lf ls                  # every wave, running and stopped, live servers marked
 lf status <wave>       # one wave's Project → Task hierarchy, runs, attention
 lf roadmap             # every open Task across every wave
+lf activity            # what changed, newest first, with durable evidence
 ```
 
 `lf roadmap` buckets the whole machine's work by what it needs: **Now** (live
@@ -19,6 +20,10 @@ and advancing), **Needs attention** (a User-routed Ask or recovery),
 **Available**, **Later**. It overlays live evidence on
 the Linear-backed plan, so the answer to "where is my attention needed" is one
 command.
+
+`lf activity` orders durable Work creation, Run, Task PR, and Steer facts.
+Filter with `--wave`, `--project`, or `--task`; filters apply before `--limit`.
+It is history, not another live process model: `lf ps` owns current motion.
 
 ## Drill down
 

--- a/docs/lf.md
+++ b/docs/lf.md
@@ -411,6 +411,8 @@ Waves sharing `main`.
 lf ls --json                    # every durable Wave and its Home/runtime evidence
 lf status <wave> --json         # one Wave's Work hierarchy, Runs, and attention
 lf roadmap --json               # current plan across Waves joined to runtime truth
+lf activity                     # durable Work changes, newest first
+lf activity --task INF-123 --json # filter before the bounded typed snapshot
 lf runs                         # one row per skill call: context, tokens, cost
 lf runs --project parser        # one Project's Runs, filtered before the result cap
 lf execs                        # one row per lf process
@@ -437,7 +439,9 @@ lf doctor --json                # machine-readable audit
 
 `lf ls` reads the Wave registry. `lf status` focuses one Wave's operational
 truth. `lf roadmap` overlays the current Linear-backed plan without creating a
-second runtime model.
+second runtime model. `lf activity` orders durable Work creation, Run, Task PR,
+and Steer facts; it reuses `WorkRef` identity and does not read reconstructable
+Task or Project wake events.
 
 `lf ps` and `lf top` show OS-live processes only. Exact PID/start-time receipts
 attach `lf` processes to call records; exact ancestry attaches provider

--- a/rust/loopflow/src/bin/lf.rs
+++ b/rust/loopflow/src/bin/lf.rs
@@ -1445,6 +1445,21 @@ fn main() -> anyhow::Result<()> {
             Some(Commands::Roadmap { wave, json }) => {
                 loopflow::lf::commands::waves::roadmap(wave.as_deref(), *json)
             }
+            Some(Commands::Activity {
+                since,
+                limit,
+                wave,
+                project,
+                task,
+                json,
+            }) => loopflow::lf::commands::activity::run(
+                since,
+                *limit,
+                wave.as_deref(),
+                project.as_deref(),
+                task.as_deref(),
+                *json,
+            ),
             Some(Commands::Runs {
                 task,
                 project,

--- a/rust/loopflow/src/lf/commands/activity.rs
+++ b/rust/loopflow/src/lf/commands/activity.rs
@@ -1,0 +1,774 @@
+//! `lf activity` — one ordered record of durable Work facts.
+
+use std::collections::HashMap;
+
+use anyhow::{anyhow, Result};
+use serde::{Deserialize, Serialize};
+use time::OffsetDateTime;
+
+use crate::durable::{Author, Steer, SteerId, WorkRef};
+use crate::lf::commands::runs::{collect_run_activity_since, SkillRunEntry};
+use crate::lf::commands::util::parse_since;
+use crate::lf::commands::WorkFilter;
+use crate::project::Project;
+use crate::store::sqlite::SqliteStore;
+use crate::task::{GithubPr, PrMergeRequest, Task, TaskPr, TaskPrId};
+use crate::wave::Wave;
+
+const MAX_LIMIT: usize = 200;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WorkActivitySnapshot {
+    pub generated_at: i64,
+    pub since: i64,
+    pub limit: usize,
+    pub truncated: bool,
+    pub items: Vec<WorkActivityEntry>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WorkActivityEntry {
+    pub id: String,
+    pub recorded_at: i64,
+    pub summary: String,
+    pub work: WorkRef,
+    /// Current human label: Wave name, Project slug, or Task identifier.
+    pub subject: String,
+    pub fact: WorkActivityFact,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum WorkActivityFact {
+    WorkCreated,
+    RunStarted {
+        invocation_id: String,
+        trace_id: String,
+        exec_id: String,
+    },
+    RunFinished {
+        invocation_id: String,
+        trace_id: String,
+        exec_id: String,
+        status: String,
+    },
+    PrStarted {
+        id: TaskPrId,
+    },
+    PrPublishRequested {
+        id: TaskPrId,
+        github: Option<GithubPr>,
+    },
+    PrMergeRequested {
+        id: TaskPrId,
+        request: PrMergeRequest,
+        github: Option<GithubPr>,
+    },
+    PrMerged {
+        id: TaskPrId,
+        github: Option<GithubPr>,
+        merge_commit: String,
+    },
+    PrAbandoned {
+        id: TaskPrId,
+        github: Option<GithubPr>,
+    },
+    SteerIssued {
+        id: SteerId,
+        author: Author,
+    },
+}
+
+#[derive(Debug)]
+struct WorkCatalog {
+    owners: HashMap<WorkRef, WorkOwner>,
+}
+
+#[derive(Debug, Clone)]
+struct WorkOwner {
+    work: WorkRef,
+    subject: String,
+    wave: String,
+    project: Option<String>,
+    task: Option<String>,
+    created_at: Option<i64>,
+}
+
+pub fn run(
+    since_value: &str,
+    limit: usize,
+    wave: Option<&str>,
+    project: Option<&str>,
+    task: Option<&str>,
+    json: bool,
+) -> Result<()> {
+    let generated_at = OffsetDateTime::now_utc();
+    let since = parse_since(since_value, generated_at)?.unix_timestamp();
+    if limit == 0 || limit > MAX_LIMIT {
+        return Err(anyhow!(
+            "--limit must be between 1 and {MAX_LIMIT}; got {}",
+            limit
+        ));
+    }
+
+    let filter = WorkFilter {
+        wave,
+        project,
+        task,
+    };
+    let path = crate::store::database_path_from_env()?;
+    let snapshot = if path.exists() {
+        let store = SqliteStore::new(&path)?;
+        build_snapshot(&store, generated_at.unix_timestamp(), since, limit, filter)?
+    } else {
+        WorkActivitySnapshot {
+            generated_at: generated_at.unix_timestamp(),
+            since,
+            limit,
+            truncated: false,
+            items: Vec::new(),
+        }
+    };
+
+    if json {
+        println!("{}", serde_json::to_string(&snapshot)?);
+    } else {
+        print_snapshot(&snapshot);
+    }
+    Ok(())
+}
+
+fn build_snapshot(
+    store: &SqliteStore,
+    generated_at: i64,
+    since: i64,
+    limit: usize,
+    filter: WorkFilter<'_>,
+) -> Result<WorkActivitySnapshot> {
+    let waves = store
+        .list_waves(None)
+        .map_err(|error| anyhow!("failed to read Waves: {error}"))?;
+    let projects = store
+        .list_projects(None)
+        .map_err(|error| anyhow!("failed to read Projects: {error}"))?;
+    let tasks = store
+        .list_tasks(None)
+        .map_err(|error| anyhow!("failed to read Tasks: {error}"))?;
+    let catalog = WorkCatalog::new(&waves, &projects, &tasks)?;
+
+    let mut entries = catalog.creation_entries(since);
+    for task in &tasks {
+        let work = catalog
+            .owners
+            .get(&WorkRef::Task(task.id.clone()))
+            .ok_or_else(|| anyhow!("Task {} is missing from the Work catalog", task.id))?;
+        for pr in store
+            .task_prs(&task.id)
+            .map_err(|error| anyhow!("failed to read PRs for {}: {error}", task.plan.identifier))?
+        {
+            entries.extend(pr_entries(&pr, work, since));
+        }
+    }
+
+    let runs = collect_run_activity_since(store, filter, since)?;
+    for run in runs {
+        if let Some(work) = catalog.resolve_run(&run) {
+            entries.extend(run_entries(&run, work, since));
+        }
+    }
+
+    let steers = store
+        .list_steers_since(since)
+        .map_err(|error| anyhow!("failed to read Steers: {error}"))?;
+    for steer in steers {
+        if let Some(work) = catalog.owners.get(&steer.work) {
+            entries.push(steer_entry(&steer, work));
+        }
+    }
+
+    Ok(finalize_snapshot(
+        entries,
+        generated_at,
+        since,
+        limit,
+        &catalog,
+        filter,
+    ))
+}
+
+impl WorkCatalog {
+    fn new(waves: &[Wave], projects: &[Project], tasks: &[Task]) -> Result<Self> {
+        let mut catalog = Self {
+            owners: HashMap::new(),
+        };
+        for wave in waves {
+            let work = WorkRef::Wave(wave.id().clone());
+            catalog.owners.insert(
+                work.clone(),
+                WorkOwner {
+                    work,
+                    subject: wave.name().to_string(),
+                    wave: wave.name().to_string(),
+                    project: None,
+                    task: None,
+                    created_at: wave.created_at().map(OffsetDateTime::unix_timestamp),
+                },
+            );
+        }
+        for project in projects {
+            let wave = catalog
+                .owners
+                .get(&WorkRef::Wave(project.wave_id.clone()))
+                .ok_or_else(|| {
+                    anyhow!(
+                        "Project {} refers to missing Wave {}",
+                        project.plan.slug,
+                        project.wave_id
+                    )
+                })?
+                .wave
+                .clone();
+            let work = WorkRef::Project(project.id.clone());
+            catalog.owners.insert(
+                work.clone(),
+                WorkOwner {
+                    work,
+                    subject: project.plan.slug.clone(),
+                    wave,
+                    project: Some(project.plan.slug.clone()),
+                    task: None,
+                    created_at: Some(project.created_at.unix_timestamp()),
+                },
+            );
+        }
+        for task in tasks {
+            let project = catalog
+                .owners
+                .get(&WorkRef::Project(task.project_id.clone()))
+                .ok_or_else(|| {
+                    anyhow!(
+                        "Task {} refers to missing Project {}",
+                        task.plan.identifier,
+                        task.project_id
+                    )
+                })?;
+            let work = WorkRef::Task(task.id.clone());
+            catalog.owners.insert(
+                work.clone(),
+                WorkOwner {
+                    work,
+                    subject: task.plan.identifier.clone(),
+                    wave: project.wave.clone(),
+                    project: project.project.clone(),
+                    task: Some(task.plan.identifier.clone()),
+                    created_at: Some(task.created_at.unix_timestamp()),
+                },
+            );
+        }
+        Ok(catalog)
+    }
+
+    fn resolve_run(&self, run: &SkillRunEntry) -> Option<&WorkOwner> {
+        if let Some(task) = run.task.as_deref() {
+            return unique_match(self.owners.values().filter(|owner| {
+                owner.task.as_deref() == Some(task)
+                    && run
+                        .project
+                        .as_deref()
+                        .is_none_or(|value| owner.project.as_deref() == Some(value))
+                    && run.wave.as_deref().is_none_or(|value| value == owner.wave)
+            }));
+        }
+        if let Some(project) = run.project.as_deref() {
+            return unique_match(self.owners.values().filter(|owner| {
+                owner.task.is_none()
+                    && owner.project.as_deref() == Some(project)
+                    && run.wave.as_deref().is_none_or(|value| value == owner.wave)
+            }));
+        }
+        let wave = run.wave.as_deref()?;
+        unique_match(
+            self.owners
+                .values()
+                .filter(|owner| owner.project.is_none() && owner.wave == wave),
+        )
+    }
+
+    fn creation_entries(&self, since: i64) -> Vec<WorkActivityEntry> {
+        self.owners
+            .values()
+            .filter_map(|owner| {
+                let recorded_at = owner.created_at.filter(|value| *value >= since)?;
+                let kind = match &owner.work {
+                    WorkRef::Wave(_) => "Wave",
+                    WorkRef::Project(_) => "Project",
+                    WorkRef::Task(_) => "Task",
+                };
+                Some(activity_entry(
+                    format!("{}:{}:created", owner.work.kind(), owner.work.id()),
+                    recorded_at,
+                    format!("{kind} {} created", owner.subject),
+                    owner,
+                    WorkActivityFact::WorkCreated,
+                ))
+            })
+            .collect()
+    }
+}
+
+fn unique_match<'a>(mut matches: impl Iterator<Item = &'a WorkOwner>) -> Option<&'a WorkOwner> {
+    let value = matches.next()?;
+    matches.next().is_none().then_some(value)
+}
+
+fn activity_entry(
+    id: String,
+    recorded_at: i64,
+    summary: String,
+    owner: &WorkOwner,
+    fact: WorkActivityFact,
+) -> WorkActivityEntry {
+    WorkActivityEntry {
+        id,
+        recorded_at,
+        summary,
+        work: owner.work.clone(),
+        subject: owner.subject.clone(),
+        fact,
+    }
+}
+
+fn run_entries(run: &SkillRunEntry, work: &WorkOwner, since: i64) -> Vec<WorkActivityEntry> {
+    let label = run
+        .flow
+        .as_deref()
+        .filter(|flow| *flow != run.skill)
+        .map(|flow| format!("{flow}/{}", run.skill))
+        .unwrap_or_else(|| run.skill.clone());
+    let mut entries = Vec::new();
+    if run.started >= since {
+        entries.push(activity_entry(
+            format!("run:{}:started", run.id),
+            run.started,
+            format!("{label} started"),
+            work,
+            WorkActivityFact::RunStarted {
+                invocation_id: run.id.clone(),
+                trace_id: run.trace_id.clone(),
+                exec_id: run.exec_id.clone(),
+            },
+        ));
+    }
+    if let Some(ended) = run.ended.filter(|ended| *ended >= since) {
+        entries.push(activity_entry(
+            format!("run:{}:finished", run.id),
+            ended,
+            format!("{label} finished {}", run.status),
+            work,
+            WorkActivityFact::RunFinished {
+                invocation_id: run.id.clone(),
+                trace_id: run.trace_id.clone(),
+                exec_id: run.exec_id.clone(),
+                status: run.status.clone(),
+            },
+        ));
+    }
+    entries
+}
+
+fn pr_entries(pr: &TaskPr, work: &WorkOwner, since: i64) -> Vec<WorkActivityEntry> {
+    let github = pr.github();
+    let reference = github
+        .map(|github| format!("PR #{}", github.number))
+        .unwrap_or_else(|| format!("PR {}", pr.slug));
+    let mut entries = Vec::new();
+    if pr.created_at.unix_timestamp() >= since {
+        entries.push(activity_entry(
+            format!("pr:{}:started", pr.id),
+            pr.created_at.unix_timestamp(),
+            format!("PR work started on {}", pr.branch),
+            work,
+            WorkActivityFact::PrStarted { id: pr.id.clone() },
+        ));
+    }
+    if let Some(publication) = pr
+        .publication
+        .as_ref()
+        .filter(|publication| publication.requested_at.unix_timestamp() >= since)
+    {
+        entries.push(activity_entry(
+            format!("pr:{}:publish_requested", pr.id),
+            publication.requested_at.unix_timestamp(),
+            format!("Publication requested for {reference}"),
+            work,
+            WorkActivityFact::PrPublishRequested {
+                id: pr.id.clone(),
+                github: publication.github.clone(),
+            },
+        ));
+    }
+    if let Some(request) = pr
+        .publication
+        .as_ref()
+        .and_then(|publication| publication.merge.as_ref())
+        .filter(|request| request.requested_at.unix_timestamp() >= since)
+    {
+        entries.push(activity_entry(
+            format!("pr:{}:merge_requested", pr.id),
+            request.requested_at.unix_timestamp(),
+            format!("Merge requested for {reference}"),
+            work,
+            WorkActivityFact::PrMergeRequested {
+                id: pr.id.clone(),
+                request: request.clone(),
+                github: github.cloned(),
+            },
+        ));
+    }
+    if let Some(merge_commit) = pr
+        .merge_commit
+        .as_ref()
+        .filter(|_| pr.updated_at.unix_timestamp() >= since)
+    {
+        entries.push(activity_entry(
+            format!("pr:{}:merged", pr.id),
+            pr.updated_at.unix_timestamp(),
+            format!("{reference} merged"),
+            work,
+            WorkActivityFact::PrMerged {
+                id: pr.id.clone(),
+                github: github.cloned(),
+                merge_commit: merge_commit.clone(),
+            },
+        ));
+    }
+    if let Some(abandoned_at) = pr
+        .abandoned_at
+        .filter(|abandoned_at| abandoned_at.unix_timestamp() >= since)
+    {
+        entries.push(activity_entry(
+            format!("pr:{}:abandoned", pr.id),
+            abandoned_at.unix_timestamp(),
+            format!("{reference} abandoned"),
+            work,
+            WorkActivityFact::PrAbandoned {
+                id: pr.id.clone(),
+                github: github.cloned(),
+            },
+        ));
+    }
+    entries
+}
+
+fn steer_entry(steer: &Steer, work: &WorkOwner) -> WorkActivityEntry {
+    activity_entry(
+        format!("steer:{}", steer.id),
+        steer.issued_at.unix_timestamp(),
+        format!("Steered: {}", steer.text),
+        work,
+        WorkActivityFact::SteerIssued {
+            id: steer.id.clone(),
+            author: steer.author.clone(),
+        },
+    )
+}
+
+fn finalize_snapshot(
+    mut entries: Vec<WorkActivityEntry>,
+    generated_at: i64,
+    since: i64,
+    limit: usize,
+    catalog: &WorkCatalog,
+    filter: WorkFilter<'_>,
+) -> WorkActivitySnapshot {
+    entries.retain(|entry| {
+        catalog.owners.get(&entry.work).is_some_and(|owner| {
+            filter.matches(
+                Some(&owner.wave),
+                owner.project.as_deref(),
+                owner.task.as_deref(),
+            )
+        })
+    });
+    entries.sort_by(|left, right| {
+        right
+            .recorded_at
+            .cmp(&left.recorded_at)
+            .then_with(|| right.id.cmp(&left.id))
+    });
+    let truncated = entries.len() > limit;
+    entries.truncate(limit);
+    WorkActivitySnapshot {
+        generated_at,
+        since,
+        limit,
+        truncated,
+        items: entries,
+    }
+}
+
+fn print_snapshot(snapshot: &WorkActivitySnapshot) {
+    if snapshot.items.is_empty() {
+        println!("No durable Work activity recorded in this window.");
+        return;
+    }
+    println!("TIME              WORK             ACTIVITY");
+    for item in &snapshot.items {
+        let time = OffsetDateTime::from_unix_timestamp(item.recorded_at)
+            .map(|value| {
+                format!(
+                    "{:04}-{:02}-{:02} {:02}:{:02}",
+                    value.year(),
+                    u8::from(value.month()),
+                    value.day(),
+                    value.hour(),
+                    value.minute()
+                )
+            })
+            .unwrap_or_else(|_| item.recorded_at.to_string());
+        println!(
+            "{time:<17} {work:<16} {summary}",
+            work = item.subject,
+            summary = item.summary
+        );
+    }
+    if snapshot.truncated {
+        println!("… more activity exists; increase --limit to inspect it.");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::task::{
+        AfterMerge, GithubPr, PrMergeMode, PrMergeRequest, PrPublication, TaskId, TaskPrId,
+    };
+
+    fn task_owner(identifier: &str, project: &str, wave: &str) -> WorkOwner {
+        WorkOwner {
+            work: WorkRef::Task(TaskId::new()),
+            subject: identifier.to_string(),
+            wave: wave.to_string(),
+            project: Some(project.to_string()),
+            task: Some(identifier.to_string()),
+            created_at: None,
+        }
+    }
+
+    fn catalog(owners: &[WorkOwner]) -> WorkCatalog {
+        WorkCatalog {
+            owners: owners
+                .iter()
+                .map(|owner| (owner.work.clone(), owner.clone()))
+                .collect(),
+        }
+    }
+
+    fn entry(id: &str, recorded_at: i64, owner: &WorkOwner) -> WorkActivityEntry {
+        activity_entry(
+            id.to_string(),
+            recorded_at,
+            id.to_string(),
+            owner,
+            WorkActivityFact::WorkCreated,
+        )
+    }
+
+    #[test]
+    fn filters_apply_before_ordering_and_cap() {
+        let other = task_owner("W2-2", "other", "live");
+        let target = task_owner("W2-1", "control", "live");
+        let catalog = catalog(&[other.clone(), target.clone()]);
+        let entries = vec![
+            entry("other-new", 30, &other),
+            entry("target-old", 10, &target),
+            entry("target-new", 20, &target),
+        ];
+        let snapshot = finalize_snapshot(
+            entries,
+            40,
+            0,
+            1,
+            &catalog,
+            WorkFilter {
+                wave: Some("live"),
+                project: Some("control"),
+                task: Some("W2-1"),
+            },
+        );
+
+        assert!(snapshot.truncated);
+        assert_eq!(snapshot.items[0].id, "target-new");
+    }
+
+    #[test]
+    fn ordering_has_a_stable_tie_breaker() {
+        let owner = task_owner("W2-1", "control", "live");
+        let catalog = catalog(std::slice::from_ref(&owner));
+        let snapshot = finalize_snapshot(
+            vec![entry("a", 10, &owner), entry("b", 10, &owner)],
+            20,
+            0,
+            50,
+            &catalog,
+            WorkFilter::default(),
+        );
+        assert_eq!(
+            snapshot
+                .items
+                .iter()
+                .map(|item| item.id.as_str())
+                .collect::<Vec<_>>(),
+            ["b", "a"]
+        );
+    }
+
+    #[test]
+    fn conflicting_filters_return_no_activity() {
+        let owner = task_owner("W2-1", "control", "live");
+        let catalog = catalog(std::slice::from_ref(&owner));
+        let snapshot = finalize_snapshot(
+            vec![entry("target", 10, &owner)],
+            20,
+            0,
+            50,
+            &catalog,
+            WorkFilter {
+                wave: Some("another-wave"),
+                project: Some("control"),
+                task: Some("W2-1"),
+            },
+        );
+        assert!(snapshot.items.is_empty());
+        assert!(!snapshot.truncated);
+    }
+
+    #[test]
+    fn run_start_and_finish_are_distinct_traceable_claims() {
+        let run = SkillRunEntry {
+            id: "invocation-1".to_string(),
+            trace_id: "trace-1".to_string(),
+            exec_id: "exec-1".to_string(),
+            parent_exec_id: None,
+            repo: "/repo".to_string(),
+            worktree: "/repo.task".to_string(),
+            wave: Some("live".to_string()),
+            project: Some("control".to_string()),
+            task: Some("W2-1".to_string()),
+            flow: Some("task_pursue".to_string()),
+            skill: "implement".to_string(),
+            status: "complete".to_string(),
+            started: 10,
+            ended: Some(20),
+            turns: 1,
+            system_tokens: 0,
+            task_tokens: 0,
+            supplied_context_tokens: 0,
+            input_tokens: None,
+            output_tokens: None,
+            reasoning_tokens: None,
+            cache_read_tokens: None,
+            cache_write_tokens: None,
+            cost_usd: None,
+            duration_secs: Some(10.0),
+            provider: "codex".to_string(),
+            model: None,
+            surface: "cli".to_string(),
+            capture_status: "complete".to_string(),
+        };
+
+        let entries = run_entries(&run, &task_owner("W2-1", "control", "live"), 0);
+        assert!(matches!(
+            entries[0].fact,
+            WorkActivityFact::RunStarted { .. }
+        ));
+        assert!(matches!(
+            &entries[1].fact,
+            WorkActivityFact::RunFinished {
+                invocation_id,
+                trace_id,
+                exec_id,
+                status,
+            } if invocation_id == "invocation-1"
+                && trace_id == "trace-1"
+                && exec_id == "exec-1"
+                && status == "complete"
+        ));
+    }
+
+    #[test]
+    fn wire_reuses_work_reference_and_one_fact_tag() {
+        let owner = task_owner("W2-1", "control", "live");
+        let value = serde_json::to_value(entry("created", 10, &owner)).unwrap();
+
+        assert_eq!(value["work"]["kind"], "task");
+        assert_eq!(value["work"]["id"], owner.work.id());
+        assert_eq!(value["subject"], "W2-1");
+        assert_eq!(value["fact"]["kind"], "work_created");
+        assert!(value.get("evidence").is_none());
+        assert!(value.get("kind").is_none());
+    }
+
+    #[test]
+    fn serial_pr_stages_preserve_their_distinct_evidence() {
+        let pr = TaskPr {
+            id: TaskPrId::new(),
+            task_id: TaskId::new(),
+            sequence: 2,
+            slug: "activity-query".to_string(),
+            branch: "jack/activity-query".to_string(),
+            base_commit: "base".to_string(),
+            parent_pr_id: None,
+            publication: Some(PrPublication {
+                requested_at: OffsetDateTime::from_unix_timestamp(20).unwrap(),
+                github: Some(GithubPr {
+                    number: 140,
+                    url: "https://github.com/loopflowstudio/loopflow/pull/140".to_string(),
+                    head_sha: Some("head".to_string()),
+                }),
+                merge: Some(PrMergeRequest {
+                    mode: PrMergeMode::Auto,
+                    requested_at: OffsetDateTime::from_unix_timestamp(30).unwrap(),
+                    head_sha: "head".to_string(),
+                    after_merge: AfterMerge::ContinueTask,
+                    next_slug: None,
+                }),
+            }),
+            merge_commit: Some("merge".to_string()),
+            abandoned_at: None,
+            ci_observation: None,
+            github_observation: None,
+            linear_attachment_id: None,
+            linear_comment_id: None,
+            linear_link_error: None,
+            created_at: OffsetDateTime::from_unix_timestamp(10).unwrap(),
+            updated_at: OffsetDateTime::from_unix_timestamp(40).unwrap(),
+        };
+
+        let entries = pr_entries(&pr, &task_owner("W2-1", "control", "live"), 0);
+
+        assert!(matches!(
+            entries[0].fact,
+            WorkActivityFact::PrStarted { .. }
+        ));
+        assert!(matches!(
+            entries[1].fact,
+            WorkActivityFact::PrPublishRequested { .. }
+        ));
+        assert!(matches!(
+            entries[2].fact,
+            WorkActivityFact::PrMergeRequested { .. }
+        ));
+        assert!(matches!(
+            &entries[3].fact,
+            WorkActivityFact::PrMerged {
+                github: Some(github),
+                merge_commit,
+                ..
+            } if github.url.ends_with("/140") && merge_commit == "merge"
+        ));
+        assert!(entries
+            .iter()
+            .all(|entry| entry.id.contains(pr.id.as_str())));
+    }
+}

--- a/rust/loopflow/src/lf/commands/ci.rs
+++ b/rust/loopflow/src/lf/commands/ci.rs
@@ -6,6 +6,7 @@ use anyhow::{anyhow, Result};
 use serde::Serialize;
 use time::{format_description::well_known::Rfc3339, Duration, OffsetDateTime};
 
+use crate::lf::commands::util::parse_since;
 use crate::lf::output::truncate;
 use crate::store::ci_incidents::CiIncidentReportRow;
 use crate::store::open_existing_store;
@@ -95,34 +96,6 @@ pub fn run(since: &str, wave: Option<&str>, repo: Option<&str>, json: bool) -> R
         print_report(&report);
     }
     Ok(())
-}
-
-fn parse_since(value: &str, now: OffsetDateTime) -> Result<OffsetDateTime> {
-    if let Ok(timestamp) = OffsetDateTime::parse(value, &Rfc3339) {
-        return Ok(timestamp);
-    }
-    let (amount, unit) = value.split_at(value.len().saturating_sub(1));
-    let amount: i64 = amount
-        .parse()
-        .map_err(|_| anyhow!("invalid --since '{value}'; use 7d, 24h, 30m, or RFC3339"))?;
-    if amount < 0 {
-        return Err(anyhow!("--since duration must be non-negative"));
-    }
-    let seconds_per_unit = match unit {
-        "d" => 86_400,
-        "h" => 3_600,
-        "m" => 60,
-        _ => {
-            return Err(anyhow!(
-                "invalid --since '{value}'; use 7d, 24h, 30m, or RFC3339"
-            ));
-        }
-    };
-    let seconds = amount
-        .checked_mul(seconds_per_unit)
-        .ok_or_else(|| anyhow!("--since duration is too large"))?;
-    now.checked_sub(Duration::seconds(seconds))
-        .ok_or_else(|| anyhow!("--since duration is too large"))
 }
 
 fn build_report(
@@ -363,7 +336,7 @@ fn print_report(report: &CiReportDto) {
 #[cfg(test)]
 mod tests {
     use super::{parse_since, percentile, summarize, CiIncidentDto};
-    use time::{Duration, OffsetDateTime};
+    use time::OffsetDateTime;
 
     fn green_incident(trigger: Option<&str>, responded: Option<&str>) -> CiIncidentDto {
         CiIncidentDto {
@@ -459,11 +432,14 @@ mod tests {
 
     #[test]
     fn relative_and_absolute_since_values_parse() {
-        let now = OffsetDateTime::UNIX_EPOCH + Duration::days(10);
-        assert_eq!(parse_since("7d", now).unwrap(), now - Duration::days(7));
+        let now = OffsetDateTime::UNIX_EPOCH + time::Duration::days(10);
+        assert_eq!(
+            parse_since("7d", now).unwrap(),
+            now - time::Duration::days(7)
+        );
         assert_eq!(
             parse_since("1970-01-02T00:00:00Z", now).unwrap(),
-            OffsetDateTime::UNIX_EPOCH + Duration::days(1)
+            OffsetDateTime::UNIX_EPOCH + time::Duration::days(1)
         );
         assert!(parse_since("week", now).is_err());
     }

--- a/rust/loopflow/src/lf/commands/mod.rs
+++ b/rust/loopflow/src/lf/commands/mod.rs
@@ -1,3 +1,4 @@
+pub mod activity;
 pub mod ask;
 pub mod auth;
 pub mod chat;
@@ -25,3 +26,26 @@ pub mod util;
 pub mod wave_intent;
 pub mod waves;
 pub mod work;
+
+/// One drill over the Wave → Project → Task Work hierarchy.
+#[derive(Debug, Clone, Copy, Default)]
+pub(crate) struct WorkFilter<'a> {
+    pub wave: Option<&'a str>,
+    pub project: Option<&'a str>,
+    pub task: Option<&'a str>,
+}
+
+impl WorkFilter<'_> {
+    pub(crate) fn matches(
+        &self,
+        wave: Option<&str>,
+        project: Option<&str>,
+        task: Option<&str>,
+    ) -> bool {
+        self.wave.is_none_or(|expected| wave == Some(expected))
+            && self
+                .project
+                .is_none_or(|expected| project == Some(expected))
+            && self.task.is_none_or(|expected| task == Some(expected))
+    }
+}

--- a/rust/loopflow/src/lf/commands/runs.rs
+++ b/rust/loopflow/src/lf/commands/runs.rs
@@ -12,6 +12,7 @@ use std::path::Path;
 use anyhow::{anyhow, Result};
 
 use crate::journal::open_ledger;
+use crate::lf::commands::WorkFilter;
 use crate::lf::output::{format_cost, truncate, Colors};
 use crate::store::sqlite::SqliteStore;
 use crate::store::{RunEventRow, TurnSpendRow};
@@ -20,35 +21,18 @@ use crate::wave::journal::short_id;
 const WINDOW_DAYS: i64 = 7;
 const MAX_RUNS: usize = 50;
 
-/// A drill filter over the run ledger. Every field scopes the same invocation
-/// set: `wave` narrows to one Wave, `project` to one roadmap Project by slug,
-/// and `task` to one roadmap Task by its Linear issue identifier.
-#[derive(Debug, Clone, Copy, Default)]
-pub(crate) struct RunFilter<'a> {
-    pub wave: Option<&'a str>,
-    pub project: Option<&'a str>,
-    pub task: Option<&'a str>,
-}
-
-impl RunFilter<'_> {
-    fn matches(&self, invocation: &crate::trace::AgentInvocationRow) -> bool {
-        self.wave
-            .is_none_or(|wave| invocation.wave.as_deref() == Some(wave))
-            && self
-                .project
-                .is_none_or(|project| invocation.project.as_deref() == Some(project))
-            && self
-                .task
-                .is_none_or(|task| invocation.task.as_deref() == Some(task))
-    }
-}
-
 /// The skill runs matching a filter, newest first, capped. One reader behind
 /// `lf runs`, its Work drills, and `lf status`'s Runs evidence, so the surfaces
 /// can never disagree on what a run is.
-pub(crate) fn collect_runs(filter: RunFilter) -> Result<(Vec<SkillRunEntry>, bool)> {
-    let store = open_ledger().map_err(|err| anyhow!("run ledger unavailable: {err}"))?;
+pub(crate) fn collect_runs(filter: WorkFilter) -> Result<(Vec<SkillRunEntry>, bool)> {
     let since = chrono::Utc::now().timestamp() - WINDOW_DAYS * 24 * 3600;
+    let mut runs = collect_runs_started_since(filter, since)?;
+    let truncated = cap_runs(&mut runs);
+    Ok((runs, truncated))
+}
+
+fn collect_runs_started_since(filter: WorkFilter, since: i64) -> Result<Vec<SkillRunEntry>> {
+    let store = open_ledger().map_err(|err| anyhow!("run ledger unavailable: {err}"))?;
     let events = store
         .list_run_events_since(since)
         .map_err(|err| anyhow!("failed to read run ledger: {err}"))?;
@@ -57,8 +41,49 @@ pub(crate) fn collect_runs(filter: RunFilter) -> Result<(Vec<SkillRunEntry>, boo
         .map_err(|err| anyhow!("failed to read skill invocations: {err}"))?
         .into_iter()
         .filter(|invocation| invocation.skill.is_some())
-        .filter(|invocation| filter.matches(invocation))
+        .filter(|invocation| {
+            filter.matches(
+                invocation.wave.as_deref(),
+                invocation.project.as_deref(),
+                invocation.task.as_deref(),
+            )
+        })
         .collect::<Vec<_>>();
+    summarize_filtered_runs(&store, events, invocations)
+}
+
+/// The filtered Run definition without a presentation cap. Compound activity
+/// surfaces include both starts and finishes inside their requested window,
+/// then cap only after joining Runs to their other durable facts.
+pub(crate) fn collect_run_activity_since(
+    store: &SqliteStore,
+    filter: WorkFilter,
+    since: i64,
+) -> Result<Vec<SkillRunEntry>> {
+    let events = store
+        .list_run_events_since(since)
+        .map_err(|err| anyhow!("failed to read run ledger: {err}"))?;
+    let invocations = store
+        .agent_invocations_with_activity_since(since)
+        .map_err(|err| anyhow!("failed to read skill invocations: {err}"))?
+        .into_iter()
+        .filter(|invocation| invocation.skill.is_some())
+        .filter(|invocation| {
+            filter.matches(
+                invocation.wave.as_deref(),
+                invocation.project.as_deref(),
+                invocation.task.as_deref(),
+            )
+        })
+        .collect::<Vec<_>>();
+    summarize_filtered_runs(store, events, invocations)
+}
+
+fn summarize_filtered_runs(
+    store: &SqliteStore,
+    events: Vec<RunEventRow>,
+    invocations: Vec<crate::trace::AgentInvocationRow>,
+) -> Result<Vec<SkillRunEntry>> {
     let invocation_ids = invocations
         .iter()
         .map(|invocation| invocation.id.clone())
@@ -69,8 +94,7 @@ pub(crate) fn collect_runs(filter: RunFilter) -> Result<(Vec<SkillRunEntry>, boo
 
     let mut runs = summarize_runs(&events, &invocations, &turns);
     sort_runs(&mut runs);
-    let truncated = cap_runs(&mut runs);
-    Ok((runs, truncated))
+    Ok(runs)
 }
 
 /// `lf runs [--wave <name>] [--project <slug>] [--task <id>]`: recent
@@ -81,7 +105,7 @@ pub fn list(
     project: Option<&str>,
     task: Option<&str>,
 ) -> Result<()> {
-    let (runs, _truncated) = collect_runs(RunFilter {
+    let (runs, _truncated) = collect_runs(WorkFilter {
         wave,
         project,
         task,
@@ -1078,7 +1102,7 @@ pub struct ExecLedgerEntry {
 
 /// The skill runs one Wave produced, newest first.
 pub(crate) fn wave_runs(wave: &str) -> Result<(Vec<SkillRunEntry>, bool)> {
-    collect_runs(RunFilter {
+    collect_runs(WorkFilter {
         wave: Some(wave),
         project: None,
         task: None,

--- a/rust/loopflow/src/lf/commands/util.rs
+++ b/rust/loopflow/src/lf/commands/util.rs
@@ -2,12 +2,41 @@ use anyhow::{anyhow, bail, Result};
 use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use time::{format_description::well_known::Rfc3339, Duration, OffsetDateTime};
 
 use crate::engine::{check_cli_available, codex_permission_args, workspace_add_dirs, LaunchTarget};
 use crate::provider_auth::Provider;
 
 pub fn find_repo_root() -> Result<PathBuf> {
     crate::engine::repo::find_repo_root()
+}
+
+pub(crate) fn parse_since(value: &str, now: OffsetDateTime) -> Result<OffsetDateTime> {
+    if let Ok(timestamp) = OffsetDateTime::parse(value, &Rfc3339) {
+        return Ok(timestamp);
+    }
+    let (amount, unit) = value.split_at(value.len().saturating_sub(1));
+    let amount: i64 = amount
+        .parse()
+        .map_err(|_| anyhow!("invalid --since '{value}'; use 7d, 24h, 30m, or RFC3339"))?;
+    if amount < 0 {
+        return Err(anyhow!("--since duration must be non-negative"));
+    }
+    let seconds_per_unit = match unit {
+        "d" => 86_400,
+        "h" => 3_600,
+        "m" => 60,
+        _ => {
+            return Err(anyhow!(
+                "invalid --since '{value}'; use 7d, 24h, 30m, or RFC3339"
+            ));
+        }
+    };
+    let seconds = amount
+        .checked_mul(seconds_per_unit)
+        .ok_or_else(|| anyhow!("--since duration is too large"))?;
+    now.checked_sub(Duration::seconds(seconds))
+        .ok_or_else(|| anyhow!("--since duration is too large"))
 }
 
 /// Message text from the args (joined) or stdin (heredoc-friendly). The

--- a/rust/loopflow/src/lf/mod.rs
+++ b/rust/loopflow/src/lf/mod.rs
@@ -494,6 +494,27 @@ pub enum Commands {
         #[arg(long)]
         json: bool,
     },
+    /// Show one ordered record of durable Work, Run, PR, and Steer facts
+    Activity {
+        /// Relative window (7d, 24h, 30m) or RFC3339 start
+        #[arg(long, default_value = "7d")]
+        since: String,
+        /// Maximum rows after Work filters (1-200)
+        #[arg(long, default_value_t = 50)]
+        limit: usize,
+        /// Scope to one Wave by name
+        #[arg(long)]
+        wave: Option<String>,
+        /// Scope to one Project by slug
+        #[arg(long)]
+        project: Option<String>,
+        /// Scope to one Task by Linear identifier
+        #[arg(long)]
+        task: Option<String>,
+        /// Emit the typed activity snapshot as JSON
+        #[arg(long)]
+        json: bool,
+    },
     /// Show recent agent-backed skill runs with context and token evidence
     Runs {
         /// Drill to one roadmap Task by its Linear issue identifier (e.g. W2-122)
@@ -1730,6 +1751,40 @@ mod tests {
                 repo: Some(repo),
                 json: true,
             }) if since == "24h" && wave == "infrastructure" && repo == "loopflowstudio/loopflow"
+        ));
+    }
+
+    #[test]
+    fn activity_accepts_composed_work_filters() {
+        let cli = Cli::try_parse_from([
+            "lf",
+            "activity",
+            "--since",
+            "24h",
+            "--limit",
+            "100",
+            "--wave",
+            "live",
+            "--project",
+            "control-room",
+            "--task",
+            "W2-140",
+            "--json",
+        ])
+        .expect("parse Activity query");
+        assert!(matches!(
+            cli.command,
+            Some(Commands::Activity {
+                since,
+                limit: 100,
+                wave: Some(wave),
+                project: Some(project),
+                task: Some(task),
+                json: true,
+            }) if since == "24h"
+                && wave == "live"
+                && project == "control-room"
+                && task == "W2-140"
         ));
     }
 

--- a/rust/loopflow/src/store/sqlite.rs
+++ b/rust/loopflow/src/store/sqlite.rs
@@ -1817,6 +1817,25 @@ impl SqliteStore {
         )
     }
 
+    /// Invocations with a start or finish fact at or after `since`.
+    pub fn agent_invocations_with_activity_since(
+        &self,
+        since: i64,
+    ) -> StoreResult<Vec<AgentInvocationRow>> {
+        self.query_agent_invocations(
+            "SELECT id, run_id, process_id, started_at, ended_at, repo, worktree, wave, flow,
+                    skill, project, task, provider, model, surface, capture_status,
+                    incomplete_reason, outcome, artifact_dir, conversation_path,
+                    provider_events_path, provider_session_id, provider_session_path,
+                    conversation_event_count, conversation_bytes, supervising_run_id,
+                    account_id, resume_token, answer_ask_id
+             FROM agent_invocations
+             WHERE started_at >= ?1 OR ended_at >= ?1
+             ORDER BY started_at, rowid",
+            params![since],
+        )
+    }
+
     fn query_agent_invocations(
         &self,
         sql: &str,

--- a/rust/loopflow/src/store/sqlite/durable.rs
+++ b/rust/loopflow/src/store/sqlite/durable.rs
@@ -1455,6 +1455,65 @@ impl SqliteStore {
         Ok(receipt)
     }
 
+    /// Every durable Steer recorded at or after `since`, newest first.
+    ///
+    /// This joins through historical Epochs so completed and reopened Work does
+    /// not lose its authored direction from inspection surfaces.
+    pub fn list_steers_since(&self, since: i64) -> StoreResult<Vec<Steer>> {
+        let conn = self.conn.lock().expect("store mutex poisoned");
+        let mut statement = conn.prepare(
+            "SELECT s.id, s.epoch_id, s.rev, s.author_kind, s.author_run_id,
+                    s.text, s.issued_at, e.wave_id, e.project_id, e.task_id
+             FROM steers s
+             JOIN epochs e ON e.id=s.epoch_id
+             WHERE s.issued_at >= ?1
+             ORDER BY s.issued_at DESC, s.id DESC",
+        )?;
+        let rows = statement.query_map([since], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, i64>(2)?,
+                row.get::<_, String>(3)?,
+                row.get::<_, Option<String>>(4)?,
+                row.get::<_, String>(5)?,
+                row.get::<_, i64>(6)?,
+                row.get::<_, Option<String>>(7)?,
+                row.get::<_, Option<String>>(8)?,
+                row.get::<_, Option<String>>(9)?,
+            ))
+        })?;
+        let mut steers = Vec::new();
+        for row in rows {
+            let (
+                id,
+                epoch_id,
+                revision,
+                author_kind,
+                author_run_id,
+                text,
+                issued_at,
+                wave_id,
+                project_id,
+                task_id,
+            ) = row?;
+            let work = parse_work_columns(wave_id, project_id, task_id)?;
+            steers.push(decode_steer(
+                (
+                    id,
+                    epoch_id,
+                    revision,
+                    author_kind,
+                    author_run_id,
+                    text,
+                    issued_at,
+                ),
+                work,
+            )?);
+        }
+        Ok(steers)
+    }
+
     pub(crate) fn append_steer_in(
         tx: &Transaction<'_>,
         work: &WorkRef,
@@ -3407,7 +3466,7 @@ fn boundary_seed_for_epoch_in(
         .map(|basis| basis.revision as i64)
         .unwrap_or(-1);
     let mut statement = conn.prepare(
-        "SELECT id, rev, author_kind, author_run_id, text, issued_at
+        "SELECT id, epoch_id, rev, author_kind, author_run_id, text, issued_at
          FROM steers WHERE epoch_id=?1 AND rev > ?2 AND rev <= ?3 ORDER BY rev",
     )?;
     let rows = statement.query_map(
@@ -3415,43 +3474,18 @@ fn boundary_seed_for_epoch_in(
         |row| {
             Ok((
                 row.get::<_, String>(0)?,
-                row.get::<_, i64>(1)?,
-                row.get::<_, String>(2)?,
-                row.get::<_, Option<String>>(3)?,
-                row.get::<_, String>(4)?,
-                row.get::<_, i64>(5)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, i64>(2)?,
+                row.get::<_, String>(3)?,
+                row.get::<_, Option<String>>(4)?,
+                row.get::<_, String>(5)?,
+                row.get::<_, i64>(6)?,
             ))
         },
     )?;
     let mut steers = Vec::new();
     for row in rows {
-        let (id, revision, author_kind, author_run_id, text, issued_at) = row?;
-        let author = match (author_kind.as_str(), author_run_id) {
-            ("user", None) => Author::User,
-            ("run", Some(id)) => Author::Run(RunId::parse(&id).map_err(|error| {
-                StoreError::InvalidData(format!("invalid stored Run id: {error}"))
-            })?),
-            _ => {
-                return Err(StoreError::InvalidData(
-                    "stored Steer author is inconsistent".to_string(),
-                ))
-            }
-        };
-        steers.push(Steer {
-            id: SteerId::parse(&id).map_err(|error| {
-                StoreError::InvalidData(format!("invalid stored Steer id: {error}"))
-            })?,
-            work: work.clone(),
-            basis: Basis {
-                epoch_id: epoch_id.clone(),
-                revision: revision as u64,
-            },
-            author,
-            text,
-            issued_at: OffsetDateTime::from_unix_timestamp(issued_at).map_err(|error| {
-                StoreError::InvalidData(format!("invalid Steer timestamp: {error}"))
-            })?,
-        });
+        steers.push(decode_steer(row?, work.clone())?);
     }
     Ok(BoundarySeed {
         basis: Basis { epoch_id, revision },
@@ -3512,18 +3546,52 @@ fn work_for_epoch(conn: &Connection, epoch_id: &EpochId) -> StoreResult<WorkRef>
             ))
         },
     )?;
-    match row {
-        (Some(id), None, None) => Ok(WorkRef::Wave(WaveId::parse(&id).map_err(|error| {
-            StoreError::InvalidData(format!("invalid stored Wave id: {error}"))
-        })?)),
-        (None, Some(id), None) => Ok(WorkRef::Project(ProjectId::parse(&id).map_err(
-            |error| StoreError::InvalidData(format!("invalid stored Project id: {error}")),
-        )?)),
-        (None, None, Some(id)) => Ok(WorkRef::Task(TaskId::parse(&id).map_err(|error| {
-            StoreError::InvalidData(format!("invalid stored Task id: {error}"))
-        })?)),
+    parse_work_columns(row.0, row.1, row.2)
+}
+
+type SteerFields = (String, String, i64, String, Option<String>, String, i64);
+
+fn decode_steer(fields: SteerFields, work: WorkRef) -> StoreResult<Steer> {
+    let (id, epoch_id, revision, author_kind, author_run_id, text, issued_at) = fields;
+    let author = match (author_kind.as_str(), author_run_id) {
+        ("user", None) => Author::User,
+        ("run", Some(id)) => Author::Run(RunId::parse(&id).map_err(invalid_durable)?),
+        _ => {
+            return Err(StoreError::InvalidData(
+                "stored Steer author is inconsistent".to_string(),
+            ))
+        }
+    };
+    Ok(Steer {
+        id: SteerId::parse(&id).map_err(invalid_durable)?,
+        work,
+        basis: Basis {
+            epoch_id: EpochId::parse(&epoch_id).map_err(invalid_durable)?,
+            revision: u64::try_from(revision).map_err(|_| {
+                StoreError::InvalidData(format!("invalid stored Steer revision: {revision}"))
+            })?,
+        },
+        author,
+        text,
+        issued_at: OffsetDateTime::from_unix_timestamp(issued_at).map_err(|error| {
+            StoreError::InvalidData(format!("invalid Steer timestamp: {error}"))
+        })?,
+    })
+}
+
+fn parse_work_columns(
+    wave_id: Option<String>,
+    project_id: Option<String>,
+    task_id: Option<String>,
+) -> StoreResult<WorkRef> {
+    match (wave_id, project_id, task_id) {
+        (Some(id), None, None) => Ok(WorkRef::Wave(WaveId::parse(&id).map_err(invalid_durable)?)),
+        (None, Some(id), None) => Ok(WorkRef::Project(
+            ProjectId::parse(&id).map_err(invalid_durable)?,
+        )),
+        (None, None, Some(id)) => Ok(WorkRef::Task(TaskId::parse(&id).map_err(invalid_durable)?)),
         _ => Err(StoreError::InvalidData(
-            "stored Epoch owns an invalid Work reference".to_string(),
+            "stored Epoch Work identity is inconsistent".to_string(),
         )),
     }
 }
@@ -3619,7 +3687,7 @@ fn to_sql_error(error: impl std::fmt::Display) -> rusqlite::Error {
 #[cfg(test)]
 mod durable_store_tests {
     use crate::durable::{
-        AdvanceReceipt, AnswerRoute, AskExchange, AskId, BoundaryState, Containment,
+        AdvanceReceipt, AnswerRoute, AskExchange, AskId, Author, BoundaryState, Containment,
         ContainmentObservation, EpochId, InvocationRoute, RunAdvance, RunControl, RunState,
         RunTrigger, StopCause, WorkRef,
     };
@@ -3655,6 +3723,67 @@ mod durable_store_tests {
         }
         let work = WorkRef::Wave(wave_id);
         (dir, store, work)
+    }
+
+    #[test]
+    fn activity_steers_span_historical_epochs() {
+        let (dir, store, work) = store_with_wave();
+        let first = store
+            .append_steer(&work, &Author::User, "first direction", None)
+            .unwrap();
+        let second_epoch = EpochId::new();
+        let conn = rusqlite::Connection::open(dir.path().join("loopflow.db")).unwrap();
+        conn.execute(
+            "UPDATE epochs SET state='done', terminal_at=1700000010
+             WHERE id=?1",
+            [first.steer.basis.epoch_id.as_str()],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO epochs (
+                id, number, wave_id, project_id, task_id, state, current_rev,
+                created_at, terminal_at
+             ) VALUES (?1, 2, ?2, NULL, NULL, 'open', 0, 1700000020, NULL)",
+            rusqlite::params![second_epoch.as_str(), work.id()],
+        )
+        .unwrap();
+        drop(conn);
+        let second = store
+            .append_steer(&work, &Author::User, "second direction", None)
+            .unwrap();
+        let conn = rusqlite::Connection::open(dir.path().join("loopflow.db")).unwrap();
+        conn.execute(
+            "UPDATE steers SET issued_at=1700000001 WHERE id=?1",
+            [first.steer.id.as_str()],
+        )
+        .unwrap();
+        conn.execute(
+            "UPDATE steers SET issued_at=1700000021 WHERE id=?1",
+            [second.steer.id.as_str()],
+        )
+        .unwrap();
+
+        let steers = store.list_steers_since(0).unwrap();
+
+        assert_eq!(
+            steers
+                .iter()
+                .map(|steer| steer.text.as_str())
+                .collect::<Vec<_>>(),
+            ["second direction", "first direction"]
+        );
+        assert_eq!(steers[0].basis.epoch_id, second.steer.basis.epoch_id);
+        assert_eq!(steers[1].basis.epoch_id, first.steer.basis.epoch_id);
+        assert!(steers.iter().all(|steer| steer.work == work));
+        assert_eq!(
+            store
+                .list_steers_since(1_700_000_010)
+                .unwrap()
+                .into_iter()
+                .map(|steer| steer.id)
+                .collect::<Vec<_>>(),
+            [second.steer.id]
+        );
     }
 
     fn start_invocation(

--- a/rust/loopflow/tests/wave_resolution_matrix.rs
+++ b/rust/loopflow/tests/wave_resolution_matrix.rs
@@ -86,7 +86,7 @@ const AMBIENT_ONLY: &[&[&str]] = &[];
 /// Commands whose optional `--wave` narrows a machine-wide result instead of
 /// selecting ambient Wave context. These must not inherit `LF_WAVE_ID` or
 /// reject names absent from the registry.
-const FILTER_ONLY: &[&[&str]] = &[&["ci"], &["runs"]];
+const FILTER_ONLY: &[&[&str]] = &[&["activity"], &["ci"], &["runs"]];
 
 const COMMANDS: &[Cmd] = &[
     // ── Reads ────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Usage

```bash
lf activity
lf activity --task INF-123 --json
lf activity --project parser --since 24h --limit 100
```

## Summary

Add one bounded, read-only timeline of durable Work facts for control-room clients. It projects existing Work creation, Run, Task PR, and Steer records; `lf ps` remains the live process view and Chat remains a secondary interaction surface.

## Changes

- emit stable, newest-first rows with exact `WorkRef`, Run trace, PR, and author evidence
- compose Wave, Project, and Task filters before the result cap
- reuse existing domain types and one shared Work filter instead of introducing Activity-specific identity, author, or query vocabularies
- read historical-epoch Steers and Runs that start or finish inside the window
- document the durable-history versus live-motion boundary

No activity table, event bus, migration, daemon, or chat transcript mirror is introduced.