### PR TITLE
install: promote lf and lfd as one control-plane release

### DIFF
--- a/.github/workflows/nightly-packages.yml
+++ b/.github/workflows/nightly-packages.yml
@@ -48,12 +48,14 @@ jobs:
         with:
           shared-key: nightly-packages-${{ matrix.target }}
       - name: Build package binaries
-        run: cargo build --release --target ${{ matrix.target }} -p loopflow --bin lf
+        run: >-
+          cargo build --release --target ${{ matrix.target }} -p loopflow
+          --bin lf --bin lfd
       - name: Package binaries
         run: |
           set -euo pipefail
           cd target/${{ matrix.target }}/release
-          tar czf ../../../lf-${{ matrix.target }}.tar.gz lf
+          tar czf ../../../lf-${{ matrix.target }}.tar.gz lf lfd
       - name: Smoke test package
         run: |
           set -euo pipefail
@@ -62,6 +64,8 @@ jobs:
           package-smoke/lf --version
           package-smoke/lf --help > /dev/null
           package-smoke/lf --list > /dev/null
+          package-smoke/lfd --version
+          package-smoke/lfd --help > /dev/null
       - uses: actions/upload-artifact@v7
         with:
           name: nightly-${{ matrix.target }}

--- a/README.md
+++ b/README.md
@@ -130,8 +130,8 @@ corpus at [/llms-full.txt](https://loopflow.studio/llms-full.txt).
 ## Developing loopflow
 
 ```bash
-uv run python scripts/install.py local --use   # build lf + Loopflow.app from this checkout, make active
-uv run python scripts/install.py refresh       # fast CLI-only rebuild from the default branch
+uv run python scripts/install.py local --use   # build lf + lfd + Loopflow.app from this checkout, make active
+uv run python scripts/install.py refresh       # fast control-plane rebuild from the default branch
 ```
 
 `TESTING.md` covers the test suites; `STYLE.md` is the governing style guide;

--- a/python/tests/test_install_script.py
+++ b/python/tests/test_install_script.py
@@ -65,6 +65,7 @@ def _stage_build_artifacts(root: Path) -> None:
     cargo_rel = root / "target" / "release"
     cargo_rel.mkdir(parents=True)
     _write_fake_macho(cargo_rel / "lf")
+    _write_fake_macho(cargo_rel / "lfd")
 
 
 def _make_spec(root: Path) -> install.BundleSpec:
@@ -113,6 +114,17 @@ temporary.unlink(missing_ok=True)
 temporary.symlink_to(immutable)
 temporary.replace(cli_target)
 
+daemon_source = option("--daemon-source")
+daemon_target = option("--daemon-target")
+daemon_target.parent.mkdir(parents=True, exist_ok=True)
+daemon_immutable = immutable.with_name("immutable-lfd")
+shutil.copy2(daemon_source, daemon_immutable)
+daemon_immutable.chmod(0o555)
+daemon_temporary = daemon_target.with_name(".lfd.fake-boundary")
+daemon_temporary.unlink(missing_ok=True)
+daemon_temporary.symlink_to(daemon_immutable)
+daemon_temporary.replace(daemon_target)
+
 if "--app-source" in args:
     app_source = option("--app-source")
     app_target = option("--app-target")
@@ -158,7 +170,7 @@ def _patch_subprocess(
 # --- Tests ---
 
 
-def test_install_loopflow_bundles_only_the_lf_helper(
+def test_install_loopflow_bundles_the_control_plane_helpers(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     root = tmp_path / "repo"
@@ -170,6 +182,7 @@ def test_install_loopflow_bundles_only_the_lf_helper(
 
     assert (spec.macos_dir / "Loopflow").exists()
     assert (spec.macos_dir / "lf").exists()
+    assert (spec.macos_dir / "lfd").exists()
 
     stamped = plistlib.loads((spec.contents_dir / "Info.plist").read_bytes())
     assert stamped["CFBundleShortVersionString"] == "9.9.9"
@@ -191,7 +204,7 @@ def test_verify_bundle_rejects_wrong_architecture(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     spec = _make_spec(tmp_path / "repo")
-    _stage_bundle(spec, binaries=("Loopflow", "lf"))
+    _stage_bundle(spec, binaries=("Loopflow", "lf", "lfd"))
     _patch_subprocess(monkeypatch, archs=["sparc64"])
 
     with pytest.raises(install.StageError, match="built for sparc64"):
@@ -200,7 +213,7 @@ def test_verify_bundle_rejects_wrong_architecture(
 
 def test_verify_bundle_rejects_non_macho(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     spec = _make_spec(tmp_path / "repo")
-    _stage_bundle(spec, binaries=("Loopflow", "lf"))
+    _stage_bundle(spec, binaries=("Loopflow", "lf", "lfd"))
     _patch_subprocess(monkeypatch, archs=[])  # lipo fails -> not Mach-O
 
     with pytest.raises(install.StageError, match="not a Mach-O"):
@@ -284,6 +297,7 @@ def test_refresh_routes_default_no_pull_and_custom_dir_through_rust_promotion(
     root = tmp_path / "repo"
     candidate = root / "target" / "release" / "lf"
     _write_fake_promotion_boundary(candidate)
+    _write_fake_macho(candidate.with_name("lfd"))
     install_dir = tmp_path / "custom-bin"
     install_dir.mkdir()
     (install_dir / "lf").write_text("python-direct-copy")
@@ -306,6 +320,8 @@ def test_refresh_routes_default_no_pull_and_custom_dir_through_rust_promotion(
 
     assert (install_dir / "lf").is_symlink()
     assert (install_dir / "lf").resolve() == immutable
+    assert (install_dir / "lfd").is_symlink()
+    assert (install_dir / "lfd").resolve().read_bytes() == b"fake-macho"
     command = log.read_text()
     assert command.startswith("install promote ")
     assert f"--cli-target {install_dir / 'lf'}" in command
@@ -349,6 +365,7 @@ def test_refresh_builds_unchanged_main_when_lf_is_missing(
     root = tmp_path / "repo"
     candidate = root / "target/release/lf"
     _write_fake_promotion_boundary(candidate)
+    _write_fake_macho(candidate.with_name("lfd"))
     install_dir = tmp_path / "bin"
     install_dir.mkdir()
     log = tmp_path / "promotion.log"
@@ -492,8 +509,11 @@ def test_local_use_routes_cli_app_bundled_helper_and_skills_through_rust_promoti
     installed_app = applications / "Loopflow.app"
     assert (installed_app / ".rust-promotion-boundary").read_text() == "committed"
     assert (installed_app / "Contents" / "MacOS" / "lf").exists()
+    assert (installed_app / "Contents" / "MacOS" / "lfd").exists()
     assert not (applications / "Concerto.app").exists()
     command = log.read_text()
     assert f"--app-source {local_bin / 'Loopflow.app'}" in command
     assert f"--app-target {installed_app}" in command
+    assert f"--daemon-source {local_bin / 'lfd'}" in command
+    assert f"--daemon-target {install_dir / 'lfd'}" in command
     assert "--sync-skills" in command

--- a/python/tests/test_release_automation.py
+++ b/python/tests/test_release_automation.py
@@ -259,7 +259,10 @@ def test_infrastructure_cron_runs_the_host_release_after_telemetry():
 def test_release_installer_uses_the_promotion_boundary_to_activate_the_binary():
     installer = (ROOT / "release/install.sh").read_text()
 
-    assert '"$src" install promote --cli-target "$dst"' in installer
+    assert '"$src" install promote \\' in installer
+    assert '--cli-target "$dst"' in installer
+    assert '--daemon-source "$daemon_src"' in installer
+    assert '--daemon-target "$daemon_dst"' in installer
     assert 'mv -f "$tmp" "$dst"' not in installer
 
 

--- a/python/tests/test_release_loopflow.py
+++ b/python/tests/test_release_loopflow.py
@@ -40,6 +40,23 @@ def test_release_bundle_renames_swift_product_to_bundle_executable(tmp_path: Pat
     assert not (app_macos_dir / "LoopflowMac").exists()
 
 
+def test_release_bundle_carries_the_control_plane_pair(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    release_dir = tmp_path / "release"
+    release_dir.mkdir()
+    for name in ("lf", "lfd"):
+        (release_dir / name).write_bytes(f"release-{name}".encode())
+    app_macos_dir = tmp_path / "Loopflow.app/Contents/MacOS"
+    app_macos_dir.mkdir(parents=True)
+    monkeypatch.setenv("LF_RELEASE_BINARY", str(release_dir / "lf"))
+
+    release_loopflow._copy_bundled_tools(app_macos_dir)
+
+    assert (app_macos_dir / "lf").read_bytes() == b"release-lf"
+    assert (app_macos_dir / "lfd").read_bytes() == b"release-lfd"
+
+
 def test_release_command_reports_timeout(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:

--- a/python/tests/test_release_publisher.py
+++ b/python/tests/test_release_publisher.py
@@ -9,13 +9,17 @@ from scripts import publish_release
 
 
 def _native_artifacts(directory: Path) -> None:
-    binary = directory / "lf"
-    binary.write_bytes(b"loopflow release binary")
+    binaries = []
+    for name in ("lf", "lfd"):
+        binary = directory / name
+        binary.write_bytes(f"loopflow release {name}".encode())
+        binaries.append(binary)
     for target in publish_release.TARGETS:
         package_dir = directory / target
         package_dir.mkdir()
         with tarfile.open(package_dir / f"lf-{target}.tar.gz", "w:gz") as package:
-            package.add(binary, arcname="lf")
+            for binary in binaries:
+                package.add(binary, arcname=binary.name)
 
 
 def test_publisher_requires_the_complete_native_matrix(tmp_path: Path):
@@ -33,7 +37,23 @@ def test_publisher_rejects_unexpected_archive_contents(tmp_path: Path):
         package.addfile(member, io.BytesIO(b"nope"))
 
     with pytest.raises(RuntimeError, match="unexpected archive contents"):
-        publish_release._extract_arm_binary((archive,), tmp_path)
+        publish_release._extract_arm_binaries((archive,), tmp_path)
+
+
+def test_publisher_extracts_the_arm_control_plane_pair(tmp_path: Path):
+    artifacts = tmp_path / "artifacts"
+    artifacts.mkdir()
+    _native_artifacts(artifacts)
+    archives = publish_release._find_native_archives(artifacts)
+    output = tmp_path / "extracted"
+    output.mkdir()
+
+    cli, daemon = publish_release._extract_arm_binaries(archives, output)
+
+    assert cli.read_bytes() == b"loopflow release lf"
+    assert daemon.read_bytes() == b"loopflow release lfd"
+    assert cli.stat().st_mode & 0o111
+    assert daemon.stat().st_mode & 0o111
 
 
 def test_publisher_completes_all_stages_before_marking_release_published(

--- a/python/tests/test_shell_installer.py
+++ b/python/tests/test_shell_installer.py
@@ -17,7 +17,7 @@ RELEASE_INSTALLER = REPO_ROOT / "release" / "install.sh"
 
 
 def _write_stubs(stub_dir: Path) -> None:
-    """Stub curl (logs args, fakes the download) and tar (drops lf)."""
+    """Stub curl and tar without touching the network."""
     stub_dir.mkdir(parents=True, exist_ok=True)
     curl = stub_dir / "curl"
     curl.write_text(
@@ -39,6 +39,10 @@ def _write_stubs(stub_dir: Path) -> None:
         "printf '%s\\n' \"$*\" >> \"$LFTEST_PROMOTE_LOG\"\n"
         "exit 0\n"
         "LF\n"
+        '  cat > "$dir/lfd" <<\'LFD\'\n'
+        "#!/bin/sh\n"
+        "exit 0\n"
+        "LFD\n"
         "fi\n"
         "exit 0\n"
     )
@@ -116,9 +120,16 @@ def test_downloaded_candidate_owns_activation(
 ) -> None:
     result = _run(installer, [], env)
     assert result.returncode == 0, result.stderr
-    assert (tmp_path / "promote.log").read_text().strip() == (
-        f"install promote --cli-target {tmp_path / 'dest/lf'}"
-    )
+    args = (tmp_path / "promote.log").read_text().split()
+    assert args[:4] == [
+        "install",
+        "promote",
+        "--cli-target",
+        str(tmp_path / "dest/lf"),
+    ]
+    assert args[4] == "--daemon-source"
+    assert Path(args[5]).name == "lfd"
+    assert args[6:] == ["--daemon-target", str(tmp_path / "dest/lfd")]
 
 
 def test_missing_version_value_fails_clearly(installer: Path, env: dict[str, str]) -> None:

--- a/release/install.sh
+++ b/release/install.sh
@@ -99,11 +99,16 @@ main() {
   tar -xzf "$tarball" -C "$tmpdir"
 
   src="$tmpdir/lf"
+  daemon_src="$tmpdir/lfd"
   dst="$install_dir/lf"
-  chmod +x "$src"
-  "$src" install promote --cli-target "$dst"
+  daemon_dst="$install_dir/lfd"
+  chmod +x "$src" "$daemon_src"
+  "$src" install promote \
+    --cli-target "$dst" \
+    --daemon-source "$daemon_src" \
+    --daemon-target "$daemon_dst"
 
-  echo "Installed to $install_dir/lf"
+  echo "Installed to $install_dir/lf and $install_dir/lfd"
 
   case ":$PATH:" in
     *":$install_dir:"*) ;;

--- a/rust/loopflow/src/bin/lf.rs
+++ b/rust/loopflow/src/bin/lf.rs
@@ -1194,23 +1194,36 @@ fn main() -> anyhow::Result<()> {
             InstallCommand::Preflight { json } => loopflow::lf::commands::install::preflight(*json),
             InstallCommand::Promote {
                 cli_target,
+                daemon_source,
+                daemon_target,
                 app_source,
                 app_target,
                 legacy_app_target,
                 sync_skills,
                 preview,
             } => loopflow::lf::commands::install::promote(
-                cli_target,
-                app_source.as_deref(),
-                app_target.as_deref(),
-                legacy_app_target.as_deref(),
+                loopflow::lf::commands::install::PromotionArtifacts {
+                    cli_target,
+                    daemon_source,
+                    daemon_target,
+                    app_source: app_source.as_deref(),
+                    app_target: app_target.as_deref(),
+                    legacy_app_target: legacy_app_target.as_deref(),
+                },
                 *sync_skills,
                 *preview,
             ),
             InstallCommand::Rollback {
                 cli_target,
                 candidate,
-            } => loopflow::lf::commands::install::rollback(cli_target, candidate),
+                daemon_target,
+                daemon_candidate,
+            } => loopflow::lf::commands::install::rollback(
+                cli_target,
+                candidate,
+                daemon_target,
+                daemon_candidate,
+            ),
         };
     }
 

--- a/rust/loopflow/src/bin/lfd.rs
+++ b/rust/loopflow/src/bin/lfd.rs
@@ -131,7 +131,7 @@ fn init_tracing() -> anyhow::Result<()> {
 #[derive(Parser)]
 #[command(name = "lfd")]
 #[command(about = "Loopflow Home daemon: Wave startup, webhook ingress, and liveness")]
-#[command(version)]
+#[command(version = loopflow::build_info::BUILD_VERSION)]
 struct Cli {
     #[command(subcommand)]
     command: Commands,

--- a/rust/loopflow/src/engine/process.rs
+++ b/rust/loopflow/src/engine/process.rs
@@ -47,35 +47,57 @@ pub(crate) fn resolve_lf_binary() -> PathBuf {
 }
 
 pub(crate) fn resolve_lfd_binary() -> PathBuf {
-    if let Ok(path) = std::env::var("CARGO_BIN_EXE_lfd") {
-        let trimmed = path.trim();
-        if !trimmed.is_empty() {
-            return PathBuf::from(trimmed);
-        }
-    }
+    let cargo_override = std::env::var("CARGO_BIN_EXE_lfd")
+        .ok()
+        .filter(|path| !path.trim().is_empty())
+        .map(PathBuf::from);
     let lf = resolve_lf_binary();
-    if let Some(parent) = lf.parent() {
-        let sibling = parent.join("lfd");
-        if sibling.exists() {
-            return sibling;
-        }
-    }
-    if let Ok(current) = std::env::current_exe() {
-        if current
-            .file_name()
+    let lf_sibling = lf
+        .parent()
+        .map(|parent| parent.join("lfd"))
+        .filter(|path| path.is_file());
+    let invoked_sibling = std::env::args_os()
+        .next()
+        .map(PathBuf::from)
+        .and_then(|invoked| invoked.parent().map(|parent| parent.join("lfd")))
+        .filter(|path| path.is_file());
+    let path_binary = which_on_path(Path::new("lfd"));
+    let current = std::env::current_exe().ok().filter(|path| {
+        path.file_name()
             .and_then(|name| name.to_str())
             .is_some_and(|name| name == "lfd")
-        {
-            return current;
-        }
-        if let Some(parent) = current.parent() {
-            let sibling = parent.join("lfd");
-            if sibling.exists() {
-                return sibling;
-            }
+    });
+
+    select_lfd_binary(
+        crate::build_info::provenance(),
+        cargo_override,
+        lf_sibling,
+        invoked_sibling,
+        path_binary,
+        current,
+    )
+}
+
+fn select_lfd_binary(
+    provenance: crate::build_info::BuildProvenance,
+    cargo_override: Option<PathBuf>,
+    lf_sibling: Option<PathBuf>,
+    invoked_sibling: Option<PathBuf>,
+    path_binary: Option<PathBuf>,
+    current_lfd: Option<PathBuf>,
+) -> PathBuf {
+    if let Some(path) = cargo_override {
+        return path;
+    }
+    if provenance == crate::build_info::BuildProvenance::Development {
+        if let Some(path) = lf_sibling {
+            return path;
         }
     }
-    PathBuf::from("lfd")
+    invoked_sibling
+        .or(path_binary)
+        .or(current_lfd)
+        .unwrap_or_else(|| PathBuf::from("lfd"))
 }
 
 fn select_binary_override(
@@ -529,7 +551,8 @@ mod tests {
 
     use super::{
         extend_session_control_context, forwarded_authority_env_names, lf_session_shell_command,
-        pin_control_binary, select_binary_override, select_current_home_binary, tmux_installed,
+        pin_control_binary, select_binary_override, select_current_home_binary, select_lfd_binary,
+        tmux_installed,
     };
     use crate::build_info::BuildProvenance;
     use crate::child::ChildExecutionContext;
@@ -573,6 +596,32 @@ mod tests {
                 Some("/ambient/lf".into()),
             ),
             Some(PathBuf::from("/production/lf"))
+        );
+    }
+
+    #[test]
+    fn release_daemon_resolution_prefers_the_promoted_target_over_a_stale_store_sibling() {
+        assert_eq!(
+            select_lfd_binary(
+                BuildProvenance::Release,
+                None,
+                Some(PathBuf::from("/home/op/.lf/bin/lfd")),
+                None,
+                Some(PathBuf::from("/home/op/.local/bin/lfd")),
+                None,
+            ),
+            PathBuf::from("/home/op/.local/bin/lfd")
+        );
+        assert_eq!(
+            select_lfd_binary(
+                BuildProvenance::Development,
+                None,
+                Some(PathBuf::from("/repo/target/debug/lfd")),
+                None,
+                Some(PathBuf::from("/home/op/.local/bin/lfd")),
+                None,
+            ),
+            PathBuf::from("/repo/target/debug/lfd")
         );
     }
 

--- a/rust/loopflow/src/lf/commands/install.rs
+++ b/rust/loopflow/src/lf/commands/install.rs
@@ -683,7 +683,7 @@ fn binary_digest(path: &Path) -> Result<String> {
 /// refused rather than overwrite a retained (possibly rollback) artifact. The
 /// staged file is read-only (`0o555`), fsynced, digested from the copied bytes,
 /// and published by atomic rename.
-fn stage_binary(source: &Path, bin_dir: &Path) -> Result<PathBuf> {
+fn stage_binary_as(source: &Path, bin_dir: &Path, name: &str) -> Result<PathBuf> {
     fs::create_dir_all(bin_dir).with_context(|| format!("create {}", bin_dir.display()))?;
     let tmp = bin_dir.join(format!(
         ".lf-stage-{}-{}",
@@ -697,7 +697,7 @@ fn stage_binary(source: &Path, bin_dir: &Path) -> Result<PathBuf> {
         fs::File::open(&tmp).and_then(|file| file.sync_all())?;
 
         let digest = binary_digest(&tmp)?;
-        let dest = bin_dir.join(format!("lf-{digest}"));
+        let dest = bin_dir.join(format!("{name}-{digest}"));
         if dest.exists() {
             if binary_digest(&dest)? != digest {
                 return Err(anyhow!(
@@ -722,41 +722,56 @@ fn stage_binary(source: &Path, bin_dir: &Path) -> Result<PathBuf> {
     result
 }
 
+fn stage_binary(source: &Path, bin_dir: &Path) -> Result<PathBuf> {
+    stage_binary_as(source, bin_dir, "lf")
+}
+
+fn stage_daemon_binary(source: &Path, bin_dir: &Path) -> Result<PathBuf> {
+    stage_binary_as(source, bin_dir, "lfd")
+}
+
 /// Copy the prior global executable into immutable content-addressed storage.
 /// Symlink targets are resolved relative to the link's parent; regular files are
 /// copied directly. The returned path owns rollback bytes independently of a
 /// mutable worktree or a target that is about to be replaced.
 fn preserve_prior_binary(cli_target: &Path, bin_dir: &Path) -> Result<Option<PathBuf>> {
-    let metadata = match fs::symlink_metadata(cli_target) {
+    preserve_prior_binary_as(cli_target, bin_dir, "lf")
+}
+
+fn preserve_prior_daemon(daemon_target: &Path, bin_dir: &Path) -> Result<Option<PathBuf>> {
+    preserve_prior_binary_as(daemon_target, bin_dir, "lfd")
+}
+
+fn preserve_prior_binary_as(target: &Path, bin_dir: &Path, name: &str) -> Result<Option<PathBuf>> {
+    let metadata = match fs::symlink_metadata(target) {
         Ok(metadata) => metadata,
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
         Err(error) => {
-            return Err(error)
-                .with_context(|| format!("inspect prior CLI {}", cli_target.display()))
+            return Err(error).with_context(|| format!("inspect prior {name} {}", target.display()))
         }
     };
     let source = if metadata.file_type().is_symlink() {
-        let target = fs::read_link(cli_target)
-            .with_context(|| format!("read prior CLI symlink {}", cli_target.display()))?;
-        if target.is_absolute() {
-            target
+        let linked = fs::read_link(target)
+            .with_context(|| format!("read prior {name} symlink {}", target.display()))?;
+        if linked.is_absolute() {
+            linked
         } else {
-            cli_target
+            target
                 .parent()
                 .unwrap_or_else(|| Path::new("."))
-                .join(target)
+                .join(linked)
         }
     } else if metadata.is_file() {
-        cli_target.to_path_buf()
+        target.to_path_buf()
     } else {
         return Err(anyhow!(
-            "prior CLI {} is neither a file nor a symlink",
-            cli_target.display()
+            "prior {name} {} is neither a file nor a symlink",
+            target.display()
         ));
     };
-    stage_binary(&source, bin_dir)
+    stage_binary_as(&source, bin_dir, name)
         .map(Some)
-        .with_context(|| format!("preserve prior compatible binary from {}", source.display()))
+        .with_context(|| format!("preserve prior {name} binary from {}", source.display()))
 }
 
 /// Point `cli_target` at `dest_binary` by an atomic temp-symlink + rename, so the
@@ -772,13 +787,16 @@ fn commit_cli_symlink(cli_target: &Path, dest_binary: &Path) -> Result<()> {
     let _ = fs::remove_file(&tmp);
     std::os::unix::fs::symlink(dest_binary, &tmp)
         .with_context(|| format!("stage symlink {}", tmp.display()))?;
-    fs::rename(&tmp, cli_target).with_context(|| {
-        format!(
-            "commit {} -> {}",
-            cli_target.display(),
-            dest_binary.display()
-        )
-    })?;
+    if let Err(error) = fs::rename(&tmp, cli_target) {
+        let _ = fs::remove_file(&tmp);
+        return Err(error).with_context(|| {
+            format!(
+                "commit {} -> {}",
+                cli_target.display(),
+                dest_binary.display()
+            )
+        });
+    }
     fs::File::open(parent)
         .and_then(|directory| directory.sync_all())
         .with_context(|| format!("persist CLI commit in {}", parent.display()))?;
@@ -843,6 +861,13 @@ struct AppPromotion<'a> {
     legacy_target: Option<&'a Path>,
     expected_candidate: &'a CandidateIdentity,
     expected_verdict: &'a Verdict,
+}
+
+struct DaemonPromotion<'a> {
+    source: &'a Path,
+    target: &'a Path,
+    bin_dir: &'a Path,
+    expected_candidate: &'a CandidateIdentity,
 }
 
 fn stage_app_bundle(plan: &AppPromotion<'_>) -> Result<PathBuf> {
@@ -952,33 +977,41 @@ fn publish_cli(verdict: &Verdict, plan: &CliPromotion) -> Result<(PathBuf, Optio
     Ok((dest, rollback))
 }
 
-fn activate_cli_then_advance(
-    verdict: &Verdict,
-    plan: &CliPromotion,
-    advance_frontier: impl FnOnce() -> Result<()>,
-) -> Result<(PathBuf, Option<PathBuf>)> {
-    let published = publish_cli(verdict, plan)?;
-    if matches!(verdict, Verdict::PromoteAndMigrate) {
-        advance_frontier()?;
-    }
-    Ok(published)
-}
-
 fn activate_install_then_advance(
     verdict: &Verdict,
     cli: &CliPromotion<'_>,
+    daemon: Option<&DaemonPromotion<'_>>,
     app: Option<&AppPromotion<'_>>,
     advance_frontier: impl FnOnce() -> Result<()>,
-) -> Result<(PathBuf, Option<PathBuf>)> {
+) -> Result<(PathBuf, Option<PathBuf>, Option<PathBuf>)> {
     if matches!(verdict, Verdict::Reject { .. }) {
-        return publish_cli(verdict, cli);
+        return publish_cli(verdict, cli).map(|(dest, rollback)| (dest, rollback, None));
     }
 
-    // Stage every fallible app copy before the safety-critical CLI commit. A
-    // missing or unreadable bundle therefore leaves every global target old.
+    // Stage every fallible artifact before either control-plane target moves.
+    // A missing, unreadable, or mismatched daemon/app leaves the global pair
+    // untouched.
     let staged_app = app.map(stage_app_bundle).transpose()?;
-    let published = match activate_cli_then_advance(verdict, cli, advance_frontier) {
-        Ok(published) => published,
+    let staged_daemon = match daemon
+        .map(|plan| {
+            validate_daemon_candidate(plan.source, plan.expected_candidate)?;
+            stage_daemon_binary(plan.source, plan.bin_dir)
+        })
+        .transpose()
+    {
+        Ok(staged) => staged,
+        Err(error) => {
+            if let Some(staged) = &staged_app {
+                let _ = remove_path(staged);
+            }
+            return Err(error);
+        }
+    };
+    let prior_daemon = match daemon
+        .map(|plan| preserve_prior_daemon(plan.target, plan.bin_dir))
+        .transpose()
+    {
+        Ok(prior) => prior.flatten(),
         Err(error) => {
             if let Some(staged) = &staged_app {
                 let _ = remove_path(staged);
@@ -987,13 +1020,51 @@ fn activate_install_then_advance(
         }
     };
 
+    if let (Some(plan), Some(staged)) = (daemon, staged_daemon.as_deref()) {
+        if let Err(error) = commit_cli_symlink(plan.target, staged) {
+            if let Some(staged) = &staged_app {
+                let _ = remove_path(staged);
+            }
+            return Err(error);
+        }
+    }
+    let published = match publish_cli(verdict, cli) {
+        Ok(published) => published,
+        Err(error) => {
+            if let Some(plan) = daemon {
+                let restored = match prior_daemon.as_deref() {
+                    Some(prior) => commit_cli_symlink(plan.target, prior),
+                    None => remove_path(plan.target),
+                };
+                if let Err(restore_error) = restored {
+                    return Err(anyhow!(
+                        "{error}; restoring prior lfd target also failed: {restore_error}"
+                    ));
+                }
+            }
+            if let Some(staged) = &staged_app {
+                let _ = remove_path(staged);
+            }
+            return Err(error);
+        }
+    };
+
+    if matches!(verdict, Verdict::PromoteAndMigrate) {
+        if let Err(error) = advance_frontier() {
+            if let Some(staged) = &staged_app {
+                let _ = remove_path(staged);
+            }
+            return Err(error);
+        }
+    }
+
     if let (Some(staged), Some(app)) = (staged_app.as_deref(), app) {
         if let Err(error) = commit_app_bundle(staged, app) {
             let _ = remove_path(staged);
             return Err(error);
         }
     }
-    Ok(published)
+    Ok((published.0, published.1, prior_daemon))
 }
 
 #[derive(Debug, Deserialize)]
@@ -1035,6 +1106,29 @@ fn validate_staged_app_helper(
             preflight.verdict
         ));
     }
+    validate_daemon_candidate(&staged_app.join("Contents/MacOS/lfd"), expected_candidate)
+}
+
+fn validate_daemon_candidate(daemon: &Path, expected_candidate: &CandidateIdentity) -> Result<()> {
+    let output = Command::new(daemon)
+        .arg("--version")
+        .output()
+        .with_context(|| format!("run daemon candidate {}", daemon.display()))?;
+    if !output.status.success() {
+        return Err(anyhow!(
+            "daemon candidate {} did not report its version: {}",
+            daemon.display(),
+            String::from_utf8_lossy(&output.stderr).trim()
+        ));
+    }
+    let actual = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    let expected = format!("lfd {}", expected_candidate.display_version());
+    if actual != expected {
+        return Err(anyhow!(
+            "daemon candidate {} is not the promoted candidate: expected {expected:?}, got {actual:?}",
+            daemon.display()
+        ));
+    }
     Ok(())
 }
 
@@ -1056,7 +1150,7 @@ fn activate_rollback(cli_target: &Path, candidate: &Path, verdict: &Verdict) -> 
     commit_cli_symlink(cli_target, candidate)
 }
 
-fn retained_binary_path(candidate: &Path, bin_dir: &Path) -> Result<PathBuf> {
+fn retained_binary_path_as(candidate: &Path, bin_dir: &Path, name: &str) -> Result<PathBuf> {
     let candidate = fs::canonicalize(candidate)
         .with_context(|| format!("resolve retained executable {}", candidate.display()))?;
     let bin_dir = fs::canonicalize(bin_dir)
@@ -1069,7 +1163,7 @@ fn retained_binary_path(candidate: &Path, bin_dir: &Path) -> Result<PathBuf> {
         ));
     }
     let digest = binary_digest(&candidate)?;
-    let expected = format!("lf-{digest}");
+    let expected = format!("{name}-{digest}");
     if candidate.file_name().and_then(|name| name.to_str()) != Some(expected.as_str()) {
         return Err(anyhow!(
             "retained executable {} does not match its content address {expected}",
@@ -1079,19 +1173,39 @@ fn retained_binary_path(candidate: &Path, bin_dir: &Path) -> Result<PathBuf> {
     Ok(candidate)
 }
 
-fn render_retained_prior(prior: &Path, cli_target: &Path) {
-    match read_binary_preflight(prior).and_then(|preflight| {
+fn retained_binary_path(candidate: &Path, bin_dir: &Path) -> Result<PathBuf> {
+    retained_binary_path_as(candidate, bin_dir, "lf")
+}
+
+fn retained_daemon_path(candidate: &Path, bin_dir: &Path) -> Result<PathBuf> {
+    retained_binary_path_as(candidate, bin_dir, "lfd")
+}
+
+fn render_retained_pair(
+    prior_cli: Option<&Path>,
+    prior_daemon: Option<&Path>,
+    cli_target: &Path,
+    daemon_target: &Path,
+) {
+    let (Some(prior_cli), Some(prior_daemon)) = (prior_cli, prior_daemon) else {
+        println!("no complete prior control-plane pair retained; rollback is unavailable");
+        return;
+    };
+    match read_binary_preflight(prior_cli).and_then(|preflight| {
         validate_rollback_verdict(&preflight.verdict)?;
-        Ok(preflight.verdict)
+        validate_daemon_candidate(prior_daemon, &preflight.candidate)
     }) {
         Ok(_) => println!(
-            "rollback available: lf install rollback --cli-target {} --candidate {}",
+            "rollback available: lf install rollback --cli-target {} --candidate {} --daemon-target {} --daemon-candidate {}",
             cli_target.display(),
-            prior.display()
+            prior_cli.display(),
+            daemon_target.display(),
+            prior_daemon.display()
         ),
         Err(error) => println!(
-            "prior executable retained as historical bytes (not rollback-compatible): {} ({error})",
-            prior.display()
+            "prior control-plane bytes retained but not rollback-compatible: {}, {} ({error})",
+            prior_cli.display(),
+            prior_daemon.display()
         ),
     }
 }
@@ -1101,17 +1215,24 @@ fn render_retained_prior(prior: &Path, cli_target: &Path) {
 /// count, decides via the merged `decide()`, and — unless refused or preview —
 /// content-addresses itself into `~/.lf/bin` and atomically repoints `cli_target`.
 /// A refusal leaves every target unchanged.
+#[derive(Debug)]
+pub struct PromotionArtifacts<'a> {
+    pub cli_target: &'a Path,
+    pub daemon_source: &'a Path,
+    pub daemon_target: &'a Path,
+    pub app_source: Option<&'a Path>,
+    pub app_target: Option<&'a Path>,
+    pub legacy_app_target: Option<&'a Path>,
+}
+
 pub fn promote(
-    cli_target: &Path,
-    app_source: Option<&Path>,
-    app_target: Option<&Path>,
-    legacy_app_target: Option<&Path>,
+    artifacts: PromotionArtifacts<'_>,
     sync_skills: bool,
     preview_only: bool,
 ) -> Result<()> {
-    let app_paths = match (app_source, app_target) {
-        (Some(source), Some(target)) => Some((source, target, legacy_app_target)),
-        (None, None) if legacy_app_target.is_none() => None,
+    let app_paths = match (artifacts.app_source, artifacts.app_target) {
+        (Some(source), Some(target)) => Some((source, target, artifacts.legacy_app_target)),
+        (None, None) if artifacts.legacy_app_target.is_none() => None,
         _ => {
             return Err(anyhow!(
                 "--app-source and --app-target must be supplied together; --legacy-app-target requires both"
@@ -1134,7 +1255,7 @@ pub fn promote(
 
     if let Verdict::Reject { reasons } = &preview.verdict {
         return Err(anyhow!(
-            "promotion refused; ~/.local/bin/lf and the app are unchanged:\n  - {}",
+            "promotion refused; lf, lfd, and the app are unchanged:\n  - {}",
             reasons.join("\n  - ")
         ));
     }
@@ -1149,13 +1270,20 @@ pub fn promote(
     // both the current and pending frontiers, so every later failure leaves a
     // compatible machine-global command. The exclusive lock keeps reservations
     // out through the under-lock recount, activation, and migration.
-    let (dest, rollback) = activate_install_then_advance(
+    let daemon = DaemonPromotion {
+        source: artifacts.daemon_source,
+        target: artifacts.daemon_target,
+        bin_dir: bin_dir.as_path(),
+        expected_candidate: &preview.candidate,
+    };
+    let (dest, rollback, daemon_rollback) = activate_install_then_advance(
         &preview.verdict,
         &CliPromotion {
             candidate_binary: candidate.as_path(),
-            cli_target,
+            cli_target: artifacts.cli_target,
             bin_dir: bin_dir.as_path(),
         },
+        Some(&daemon),
         app.as_ref(),
         || {
             crate::store::sqlite::SqliteStore::open_as_promotion_boundary(&store_path)
@@ -1169,13 +1297,26 @@ pub fn promote(
     println!(
         "promoted {}: {} -> {}",
         preview.candidate.display_version(),
-        cli_target.display(),
+        artifacts.cli_target.display(),
         dest.display()
     );
-    match rollback {
-        Some(prior) => render_retained_prior(&prior, cli_target),
-        None => println!("no prior binary retained (target did not exist)"),
-    }
+    let active_daemon = fs::canonicalize(artifacts.daemon_target).with_context(|| {
+        format!(
+            "resolve promoted daemon {}",
+            artifacts.daemon_target.display()
+        )
+    })?;
+    println!(
+        "promoted lfd: {} -> {}",
+        artifacts.daemon_target.display(),
+        active_daemon.display()
+    );
+    render_retained_pair(
+        rollback.as_deref(),
+        daemon_rollback.as_deref(),
+        artifacts.cli_target,
+        artifacts.daemon_target,
+    );
     if let Some(app) = &app {
         println!(
             "installed app: {} -> {}",
@@ -1197,32 +1338,71 @@ pub fn promote(
 /// Activate retained immutable bytes only when that binary's own preflight
 /// recognizes the current store exactly. The exclusive lock keeps the frontier
 /// and active-Run set stable between the preflight and symlink commit.
-pub fn rollback(cli_target: &Path, candidate: &Path) -> Result<()> {
+pub fn rollback(
+    cli_target: &Path,
+    candidate: &Path,
+    daemon_target: &Path,
+    daemon_candidate: &Path,
+) -> Result<()> {
     let _lock = crate::promotion_lock::acquire_exclusive()
         .context("acquire the exclusive promotion lock")?;
-    let candidate = rollback_from_store(cli_target, candidate, &lf_bin_dir())?;
+    let (candidate, daemon_candidate) = rollback_from_store(
+        cli_target,
+        candidate,
+        daemon_target,
+        daemon_candidate,
+        &lf_bin_dir(),
+    )?;
     println!(
         "rolled back: {} -> {}",
         cli_target.display(),
         candidate.display()
     );
+    println!(
+        "rolled back lfd: {} -> {}",
+        daemon_target.display(),
+        daemon_candidate.display()
+    );
     Ok(())
 }
 
-fn rollback_from_store(cli_target: &Path, candidate: &Path, bin_dir: &Path) -> Result<PathBuf> {
+fn rollback_from_store(
+    cli_target: &Path,
+    candidate: &Path,
+    daemon_target: &Path,
+    daemon_candidate: &Path,
+    bin_dir: &Path,
+) -> Result<(PathBuf, PathBuf)> {
     let candidate = retained_binary_path(candidate, bin_dir)?;
+    let daemon_candidate = retained_daemon_path(daemon_candidate, bin_dir)?;
     let preflight = read_binary_preflight(&candidate)?;
-    activate_rollback(cli_target, &candidate, &preflight.verdict)?;
-    Ok(candidate)
+    validate_rollback_verdict(&preflight.verdict)?;
+    validate_daemon_candidate(&daemon_candidate, &preflight.candidate)?;
+
+    let current_daemon = preserve_prior_daemon(daemon_target, bin_dir)?;
+    commit_cli_symlink(daemon_target, &daemon_candidate)?;
+    if let Err(error) = activate_rollback(cli_target, &candidate, &preflight.verdict) {
+        let restored = match current_daemon.as_deref() {
+            Some(current) => commit_cli_symlink(daemon_target, current),
+            None => remove_path(daemon_target),
+        };
+        if let Err(restore_error) = restored {
+            return Err(anyhow!(
+                "{error}; restoring current lfd target also failed: {restore_error}"
+            ));
+        }
+        return Err(error);
+    }
+    Ok((candidate, daemon_candidate))
 }
 
 #[cfg(test)]
 mod promote_tests {
     use super::{
-        activate_cli_then_advance, activate_install_then_advance, commit_app_bundle,
-        commit_cli_symlink, copy_tree, preserve_prior_binary, publish_cli, retained_binary_path,
-        rollback_from_store, stage_binary, validate_rollback_verdict, AppPromotion,
-        CandidateIdentity, CliPromotion, Verdict,
+        activate_install_then_advance, commit_app_bundle, commit_cli_symlink, copy_tree,
+        preserve_prior_binary, publish_cli, retained_binary_path, rollback_from_store,
+        stage_binary, stage_daemon_binary, validate_rollback_verdict, AppPromotion,
+        CandidateIdentity, CliPromotion, DaemonPromotion, Verdict,
     };
     use anyhow::anyhow;
     use std::fs;
@@ -1242,7 +1422,17 @@ mod promote_tests {
         let helpers = root.join("Contents/MacOS");
         fs::create_dir_all(&helpers).unwrap();
         write_preflight_binary(&helpers.join("lf"), candidate, verdict);
+        write_daemon_binary(&helpers.join("lfd"), candidate);
         fs::write(root.join("new-app"), b"new").unwrap();
+    }
+
+    fn write_daemon_binary(path: &std::path::Path, candidate: &CandidateIdentity) {
+        fs::write(
+            path,
+            format!("#!/bin/sh\necho 'lfd {}'\n", candidate.display_version()),
+        )
+        .unwrap();
+        fs::set_permissions(path, fs::Permissions::from_mode(0o755)).unwrap();
     }
 
     #[test]
@@ -1392,6 +1582,131 @@ mod promote_tests {
     }
 
     #[test]
+    fn promotion_advances_cli_and_daemon_as_one_validated_pair() {
+        let dir = tempfile::tempdir().unwrap();
+        let bin_dir = dir.path().join("immutable");
+        let cli_source = dir.path().join("candidate-lf");
+        let daemon_source = dir.path().join("candidate-lfd");
+        let cli_target = dir.path().join("bin/lf");
+        let daemon_target = dir.path().join("bin/lfd");
+        fs::create_dir_all(cli_target.parent().unwrap()).unwrap();
+        fs::write(&cli_source, b"candidate-cli").unwrap();
+        fs::write(&cli_target, b"prior-cli").unwrap();
+        fs::write(&daemon_target, b"prior-daemon").unwrap();
+        let identity = CandidateIdentity::current();
+        write_daemon_binary(&daemon_source, &identity);
+
+        let (active_cli, prior_cli, prior_daemon) = activate_install_then_advance(
+            &Verdict::Promote,
+            &CliPromotion {
+                candidate_binary: &cli_source,
+                cli_target: &cli_target,
+                bin_dir: &bin_dir,
+            },
+            Some(&DaemonPromotion {
+                source: &daemon_source,
+                target: &daemon_target,
+                bin_dir: &bin_dir,
+                expected_candidate: &identity,
+            }),
+            None,
+            || Ok(()),
+        )
+        .unwrap();
+
+        assert_eq!(fs::read_link(&cli_target).unwrap(), active_cli);
+        assert_eq!(fs::read(&cli_target).unwrap(), b"candidate-cli");
+        assert_eq!(
+            fs::read(&daemon_target).unwrap(),
+            fs::read(&daemon_source).unwrap()
+        );
+        assert_eq!(fs::read(prior_cli.unwrap()).unwrap(), b"prior-cli");
+        assert_eq!(fs::read(prior_daemon.unwrap()).unwrap(), b"prior-daemon");
+    }
+
+    #[test]
+    fn mismatched_daemon_leaves_both_control_plane_targets_untouched() {
+        let dir = tempfile::tempdir().unwrap();
+        let bin_dir = dir.path().join("immutable");
+        let cli_source = dir.path().join("candidate-lf");
+        let daemon_source = dir.path().join("candidate-lfd");
+        let cli_target = dir.path().join("lf");
+        let daemon_target = dir.path().join("lfd");
+        fs::write(&cli_source, b"candidate-cli").unwrap();
+        fs::write(&cli_target, b"prior-cli").unwrap();
+        fs::write(&daemon_target, b"prior-daemon").unwrap();
+        fs::write(&daemon_source, b"#!/bin/sh\necho 'lfd 0.0.0+other'\n").unwrap();
+        fs::set_permissions(&daemon_source, fs::Permissions::from_mode(0o755)).unwrap();
+        let identity = CandidateIdentity::current();
+
+        let error = activate_install_then_advance(
+            &Verdict::Promote,
+            &CliPromotion {
+                candidate_binary: &cli_source,
+                cli_target: &cli_target,
+                bin_dir: &bin_dir,
+            },
+            Some(&DaemonPromotion {
+                source: &daemon_source,
+                target: &daemon_target,
+                bin_dir: &bin_dir,
+                expected_candidate: &identity,
+            }),
+            None,
+            || Ok(()),
+        )
+        .unwrap_err();
+
+        assert!(
+            error.to_string().contains("not the promoted candidate"),
+            "{error}"
+        );
+        assert_eq!(fs::read(&cli_target).unwrap(), b"prior-cli");
+        assert_eq!(fs::read(&daemon_target).unwrap(), b"prior-daemon");
+        assert!(!bin_dir.exists());
+    }
+
+    #[test]
+    fn failed_cli_activation_restores_the_prior_daemon() {
+        let dir = tempfile::tempdir().unwrap();
+        let bin_dir = dir.path().join("immutable");
+        let cli_source = dir.path().join("candidate-lf");
+        let daemon_source = dir.path().join("candidate-lfd");
+        let cli_target = dir.path().join("lf");
+        let daemon_target = dir.path().join("lfd");
+        fs::write(&cli_source, b"candidate-cli").unwrap();
+        fs::create_dir(&cli_target).unwrap();
+        fs::write(&daemon_target, b"prior-daemon").unwrap();
+        let identity = CandidateIdentity::current();
+        write_daemon_binary(&daemon_source, &identity);
+
+        let error = activate_install_then_advance(
+            &Verdict::Promote,
+            &CliPromotion {
+                candidate_binary: &cli_source,
+                cli_target: &cli_target,
+                bin_dir: &bin_dir,
+            },
+            Some(&DaemonPromotion {
+                source: &daemon_source,
+                target: &daemon_target,
+                bin_dir: &bin_dir,
+                expected_candidate: &identity,
+            }),
+            None,
+            || Ok(()),
+        )
+        .unwrap_err();
+
+        assert!(
+            error.to_string().contains("neither a file nor a symlink"),
+            "{error}"
+        );
+        assert!(cli_target.is_dir());
+        assert_eq!(fs::read(&daemon_target).unwrap(), b"prior-daemon");
+    }
+
+    #[test]
     fn a_frontier_failure_leaves_the_compatible_candidate_global() {
         let dir = tempfile::tempdir().unwrap();
         let target = dir.path().join("lf");
@@ -1400,13 +1715,15 @@ mod promote_tests {
         fs::write(&candidate, b"candidate-knows-pending-frontier").unwrap();
         let bin_dir = dir.path().join("bin");
 
-        let error = activate_cli_then_advance(
+        let error = activate_install_then_advance(
             &Verdict::PromoteAndMigrate,
             &CliPromotion {
                 candidate_binary: &candidate,
                 cli_target: &target,
                 bin_dir: &bin_dir,
             },
+            None,
+            None,
             || Err(anyhow!("migration fsync failed")),
         )
         .unwrap_err();
@@ -1455,6 +1772,7 @@ mod promote_tests {
                 cli_target: &cli_target,
                 bin_dir: &bin_dir,
             },
+            None,
             Some(&AppPromotion {
                 source: &app_source,
                 target: &app_target,
@@ -1511,6 +1829,7 @@ mod promote_tests {
                 cli_target: &cli_target,
                 bin_dir: &bin_dir,
             },
+            None,
             Some(&AppPromotion {
                 source: &app_source,
                 target: &app_target,
@@ -1544,7 +1863,20 @@ mod promote_tests {
         let retained = stage_binary(&source, &bin_dir).unwrap();
         fs::write(&cli_target, b"current-compatible").unwrap();
 
-        let error = rollback_from_store(&cli_target, &retained, &bin_dir).unwrap_err();
+        let daemon_source = dir.path().join("prior-lfd");
+        write_daemon_binary(&daemon_source, &CandidateIdentity::current());
+        let daemon_candidate = stage_daemon_binary(&daemon_source, &bin_dir).unwrap();
+        let daemon_target = dir.path().join("lfd");
+        fs::write(&daemon_target, b"current-compatible-daemon").unwrap();
+
+        let error = rollback_from_store(
+            &cli_target,
+            &retained,
+            &daemon_target,
+            &daemon_candidate,
+            &bin_dir,
+        )
+        .unwrap_err();
 
         assert!(
             error.to_string().contains("not rollback-compatible"),
@@ -1552,6 +1884,39 @@ mod promote_tests {
         );
         assert_eq!(fs::read(&cli_target).unwrap(), b"current-compatible");
         assert!(!cli_target.is_symlink());
+    }
+
+    #[test]
+    fn rollback_restores_a_validated_cli_and_daemon_pair() {
+        let dir = tempfile::tempdir().unwrap();
+        let bin_dir = dir.path().join("immutable");
+        let identity = CandidateIdentity::current();
+        let prior_cli_source = dir.path().join("prior-lf");
+        let prior_daemon_source = dir.path().join("prior-lfd");
+        write_preflight_binary(&prior_cli_source, &identity, &Verdict::Promote);
+        write_daemon_binary(&prior_daemon_source, &identity);
+        let prior_cli = stage_binary(&prior_cli_source, &bin_dir).unwrap();
+        let prior_daemon = stage_daemon_binary(&prior_daemon_source, &bin_dir).unwrap();
+        let cli_target = dir.path().join("bin/lf");
+        let daemon_target = dir.path().join("bin/lfd");
+        fs::create_dir_all(cli_target.parent().unwrap()).unwrap();
+        fs::write(&cli_target, b"current-cli").unwrap();
+        fs::write(&daemon_target, b"current-daemon").unwrap();
+
+        let restored = rollback_from_store(
+            &cli_target,
+            &prior_cli,
+            &daemon_target,
+            &prior_daemon,
+            &bin_dir,
+        )
+        .unwrap();
+
+        let prior_cli = fs::canonicalize(prior_cli).unwrap();
+        let prior_daemon = fs::canonicalize(prior_daemon).unwrap();
+        assert_eq!(restored, (prior_cli.clone(), prior_daemon.clone()));
+        assert_eq!(fs::read_link(&cli_target).unwrap(), prior_cli);
+        assert_eq!(fs::read_link(&daemon_target).unwrap(), prior_daemon);
     }
 
     #[test]
@@ -1718,6 +2083,7 @@ mod promote_tests {
                 cli_target: &cli_target,
                 bin_dir: &bin_dir,
             },
+            None,
             Some(&app),
             || Err(anyhow!("migration fsync failed")),
         )

--- a/rust/loopflow/src/lf/mod.rs
+++ b/rust/loopflow/src/lf/mod.rs
@@ -1034,6 +1034,12 @@ pub enum InstallCommand {
         /// The global CLI symlink to replace (e.g. ~/.local/bin/lf).
         #[arg(long)]
         cli_target: PathBuf,
+        /// The staged lfd built from the same candidate source.
+        #[arg(long)]
+        daemon_source: PathBuf,
+        /// The global lfd symlink to replace (e.g. ~/.local/bin/lfd).
+        #[arg(long)]
+        daemon_target: PathBuf,
         /// A staged Loopflow.app bundle to install alongside the CLI.
         #[arg(long)]
         app_source: Option<PathBuf>,
@@ -1059,6 +1065,12 @@ pub enum InstallCommand {
         /// The immutable content-addressed prior executable to activate.
         #[arg(long)]
         candidate: PathBuf,
+        /// The global lfd symlink to restore with the CLI.
+        #[arg(long)]
+        daemon_target: PathBuf,
+        /// The retained immutable lfd binary paired with the CLI candidate.
+        #[arg(long)]
+        daemon_candidate: PathBuf,
     },
 }
 

--- a/rust/loopflow/tests/lfd_tests.rs
+++ b/rust/loopflow/tests/lfd_tests.rs
@@ -111,6 +111,20 @@ fn spawn_lfd(repo: &std::path::Path, db_path: &std::path::Path, addr: SocketAddr
     ChildGuard(child)
 }
 
+#[test]
+fn lfd_reports_the_control_plane_build_version() {
+    let output = Command::new(env!("CARGO_BIN_EXE_lfd"))
+        .arg("--version")
+        .output()
+        .expect("run lfd --version");
+
+    assert!(output.status.success());
+    assert_eq!(
+        String::from_utf8(output.stdout).unwrap(),
+        format!("lfd {}\n", loopflow::build_info::BUILD_VERSION)
+    );
+}
+
 #[tokio::test]
 async fn lfd_dedups_signed_deliveries_across_restart() {
     let repo = tempfile::tempdir().expect("repo tempdir");

--- a/scripts/install.py
+++ b/scripts/install.py
@@ -5,7 +5,7 @@
     install.py local --use      # promote this worktree onto PATH and /Applications
     install.py local --skip swift
     install.py local -n         # dry run
-    install.py refresh          # update lf when the default branch moves
+    install.py refresh          # update lf + lfd when the default branch moves
 
 Remote releases happen via `lf release patch` -> merge -> auto-tag -> CI.
 """
@@ -84,6 +84,7 @@ def default_bundle_spec(root: Path = ROOT) -> BundleSpec:
         executables=(
             swift / ".build" / "release" / "LoopflowMac",
             cargo_release / "lf",
+            cargo_release / "lfd",
         ),
         info_plist=swift / "LoopflowMac" / "Info.plist",
         resources=(
@@ -214,9 +215,19 @@ def _build_binaries() -> None:
 
 
 def _build_cli_binaries() -> None:
-    typer.echo("Building lf (cargo release)...")
+    typer.echo("Building lf + lfd (cargo release)...")
     _run_or_raise(
-        ["cargo", "build", "--release", "-p", "loopflow", "--bin", "lf"],
+        [
+            "cargo",
+            "build",
+            "--release",
+            "-p",
+            "loopflow",
+            "--bin",
+            "lf",
+            "--bin",
+            "lfd",
+        ],
         "cargo",
         cwd=ROOT,
         env=_release_build_env(),
@@ -329,9 +340,10 @@ def _resolve_install_dir() -> Path:
 
 
 def _stage_binaries(local_bin: Path) -> None:
-    """Copy freshly built lf into this worktree's local-bin/."""
+    """Copy freshly built control binaries into this worktree's local-bin/."""
     local_bin.mkdir(parents=True, exist_ok=True)
     _atomic_install(ROOT / "target" / "release" / "lf", local_bin / "lf")
+    _atomic_install(ROOT / "target" / "release" / "lfd", local_bin / "lfd")
 
 
 def _require_complete_schema_for_promotion(repo: Path) -> None:
@@ -363,6 +375,10 @@ def _promote_with_candidate(
         "promote",
         "--cli-target",
         str(install_dir / "lf"),
+        "--daemon-source",
+        str(candidate.with_name("lfd")),
+        "--daemon-target",
+        str(install_dir / "lfd"),
         "--sync-skills",
     ]
     if app_source is not None:
@@ -451,7 +467,7 @@ def _codesign_identity() -> str:
 
 
 def _verify_bundle_layout(spec: BundleSpec) -> None:
-    """Verify the app executable and bundled `lf` helper.
+    """Verify the app executable and bundled control helpers.
 
     Every declared executable must exist, be executable, and be a Mach-O binary
     that includes the current architecture. Catches missing files, wrong-arch

--- a/scripts/loopflow-dev.py
+++ b/scripts/loopflow-dev.py
@@ -463,17 +463,26 @@ def _apply_dev_identity(plist: Path) -> None:
 
 def _copy_bundled_tools(app_macos_dir: Path, profile: str) -> None:
     if profile == "release":
-        cargo_cmd = ["cargo", "build", "--locked", "--release", "--bin", "lf"]
+        cargo_cmd = [
+            "cargo",
+            "build",
+            "--locked",
+            "--release",
+            "--bin",
+            "lf",
+            "--bin",
+            "lfd",
+        ]
         bin_dir = REPO_ROOT / "target" / "release"
     else:
-        cargo_cmd = ["cargo", "build", "--locked", "--bin", "lf"]
+        cargo_cmd = ["cargo", "build", "--locked", "--bin", "lf", "--bin", "lfd"]
         bin_dir = REPO_ROOT / "target" / "debug"
 
     result = run(cargo_cmd, cwd=REPO_ROOT, check=False)
     if result.returncode != 0:
-        raise RuntimeError("Failed to build bundled lf binary")
+        raise RuntimeError("Failed to build bundled control binaries")
 
-    for binary in ("lf",):
+    for binary in ("lf", "lfd"):
         source = bin_dir / binary
         if not source.exists():
             raise RuntimeError(f"Missing built binary: {source}")

--- a/scripts/publish_release.py
+++ b/scripts/publish_release.py
@@ -122,20 +122,26 @@ def _find_native_archives(artifact_dir: Path) -> tuple[Path, ...]:
     return tuple(archives)
 
 
-def _extract_arm_binary(archives: tuple[Path, ...], output_dir: Path) -> Path:
+def _extract_arm_binaries(archives: tuple[Path, ...], output_dir: Path) -> tuple[Path, Path]:
     arm_archive = next(path for path in archives if "aarch64-apple-darwin" in path.name)
     with tarfile.open(arm_archive, "r:gz") as package:
         members = package.getmembers()
-        if len(members) != 1 or members[0].name != "lf" or not members[0].isfile():
+        if sorted(member.name for member in members) != ["lf", "lfd"] or not all(
+            member.isfile() for member in members
+        ):
             raise RuntimeError(f"unexpected archive contents in {arm_archive.name}")
-        source = package.extractfile(members[0])
-        if source is None:
-            raise RuntimeError(f"could not read lf from {arm_archive.name}")
-        with (output_dir / "lf").open("wb") as destination:
-            shutil.copyfileobj(source, destination)
-    binary = output_dir / "lf"
-    binary.chmod(0o755)
-    return binary
+        binaries = []
+        for name in ("lf", "lfd"):
+            member = next(member for member in members if member.name == name)
+            source = package.extractfile(member)
+            if source is None:
+                raise RuntimeError(f"could not read {name} from {arm_archive.name}")
+            binary = output_dir / name
+            with binary.open("wb") as destination:
+                shutil.copyfileobj(source, destination)
+            binary.chmod(0o755)
+            binaries.append(binary)
+    return binaries[0], binaries[1]
 
 
 def _sha256(path: Path) -> str:
@@ -213,7 +219,7 @@ def publish_release(tag: str, artifact_dir: Path) -> PublishReceipt:
 
     stages: list[str] = ["artifacts_verified"]
     with tempfile.TemporaryDirectory() as temp:
-        arm_binary = _extract_arm_binary(archives, Path(temp))
+        arm_binary, _arm_daemon = _extract_arm_binaries(archives, Path(temp))
         env = {
             **os.environ,
             "LF_RELEASE_BINARY": str(arm_binary),

--- a/scripts/release-loopflow.py
+++ b/scripts/release-loopflow.py
@@ -141,7 +141,15 @@ def _copy_bundled_tools(app_macos_dir: Path) -> None:
     if release_binary:
         bin_dir = Path(release_binary).parent
     else:
-        cargo_cmd = ["cargo", "build", "--release", "--bin", "lf"]
+        cargo_cmd = [
+            "cargo",
+            "build",
+            "--release",
+            "--bin",
+            "lf",
+            "--bin",
+            "lfd",
+        ]
         bin_dir = REPO_ROOT / "target" / "release"
         result = run(
             cargo_cmd,
@@ -151,10 +159,10 @@ def _copy_bundled_tools(app_macos_dir: Path) -> None:
             env={**os.environ, "LOOPFLOW_BUILD_PROVENANCE": "release"},
         )
         if result.returncode != 0:
-            raise RuntimeError("Failed to build bundled lf binary")
+            raise RuntimeError("Failed to build bundled control binaries")
 
-    for binary in ("lf",):
-        source = Path(release_binary) if release_binary else bin_dir / binary
+    for binary in ("lf", "lfd"):
+        source = bin_dir / binary
         if not source.exists():
             raise RuntimeError(f"Missing built binary: {source}")
         shutil.copy(source, app_macos_dir / binary)


### PR DESCRIPTION
## Try it!

```bash
uv run python scripts/install.py refresh
lf --version
lfd --version
lf start product --json
```

`lf` and `lfd` should report the same build revision, both global targets
should point at immutable artifacts, and Product Wave startup should reach a
schema-compatible daemon.

## Intent

Wave startup was failing because release promotion advanced `lf` and the
production database while launchd kept an old `lfd`. Make the CLI, daemon, and
app helpers one validated installation unit across every local and published
packaging path.

## Key decisions

- Rust's promotion lock owns both symlinks and paired rollback.
- Every fallible artifact validates before either target moves.
- The daemon target moves first and is restored if CLI activation fails.
- Development builds keep their isolated build-tree daemon; release builds
  prefer the promoted global daemon over historical generic siblings.

## Not included

This does not add a resident-daemon handoff protocol or change Discord chat
semantics. It restores the control-plane compatibility required for the
existing Discord-backed and local Wave chat surfaces to run reliably.
