### PR TITLE
pm: make repository team the sole linear authority

### DIFF
--- a/.lf/config.yaml
+++ b/.lf/config.yaml
@@ -5,8 +5,8 @@ branch_names:
 pm:
   provider: linear
   linear_team: 3871bed0-8c95-4077-ab72-728327d615b3
-linear:
-  team: 60558c53-2169-49f8-a76a-1f4586705aa9
+internal:
+  use_rust: true
 release:
   targets:
     default:
@@ -24,5 +24,3 @@ release:
       - run
       - python
       - scripts/publish_release.py
-internal:
-  use_rust: true

--- a/rust/loopflow/tests/repository_team_matrix.rs
+++ b/rust/loopflow/tests/repository_team_matrix.rs
@@ -492,14 +492,17 @@ fn repository_team_matrix() {
     assert!(error.contains("lf pm reteam --apply"), "{error}");
     assert!(error.contains("PRD-44"), "{error}");
 
-    // PRD-44 stages the repository target without deleting any legacy
-    // authority before the provider migration verifies successfully.
+    // PRD-44 leaves the repository Team as the sole PM authority after the
+    // provider migration verifies successfully.
     let source = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..");
     let config = std::fs::read_to_string(source.join(".lf/config.yaml")).unwrap();
-    assert!(config.contains("linear:\n  team:"));
     assert!(config.contains("linear_team:"));
-    let product = std::fs::read_to_string(source.join("wave/product/GOAL.md")).unwrap();
-    assert!(product.contains("linear_team:"));
+    assert!(!config.contains("linear:\n  team:"));
+    for wave in ["infrastructure", "intelligence", "product"] {
+        let goal = std::fs::read_to_string(source.join(format!("wave/{wave}/GOAL.md"))).unwrap();
+        assert!(!goal.contains("provider: linear"), "{wave}");
+        assert!(!goal.contains("linear_team:"), "{wave}");
+    }
 
     println!("one Team team-loo: Survival — A real task reaches done; Survival / Infrastructure — Gmail; LOO-1 and LOO-2 resolve independently");
 }

--- a/wave/infrastructure/GOAL.md
+++ b/wave/infrastructure/GOAL.md
@@ -1,13 +1,11 @@
 ---
 crons:
-  - flow: telemetry-daily
-    schedule: "0 0 9 * * *"
-  - flow: release-run
-    schedule: "0 0 10 * * *"
+- flow: telemetry-daily
+  schedule: 0 0 9 * * *
+- flow: release-run
+  schedule: 0 0 10 * * *
 pm:
-  provider: linear
   linear_initiative: 218967b6-a760-4b7c-9a46-11d9d61a42c2
-  linear_team: 08c8d501-791d-4db0-a14c-15599d365955
 ---
 
 ## Objective

--- a/wave/intelligence/GOAL.md
+++ b/wave/intelligence/GOAL.md
@@ -3,9 +3,7 @@ crons:
 - flow: telemetry-daily
   schedule: 0 0 8 * * * *
 pm:
-  provider: linear
   linear_initiative: 1e3d8674-6fbf-4aa8-9bee-1da0fa70d1b7
-  linear_team: 7de894bd-17da-403a-9d71-93c40afe9367
 ---
 
 ## Objective

--- a/wave/product/GOAL.md
+++ b/wave/product/GOAL.md
@@ -4,13 +4,11 @@ crons:
   schedule: 0 0 8 * * * *
 chat:
   provider: discord
-  home_id: "home_39860354aaca640c2ccb50bf6ca609d8"
-  guild_id: "1333122108699709535"
-  channel_id: "1528936130748223519"
+  home_id: home_39860354aaca640c2ccb50bf6ca609d8
+  guild_id: '1333122108699709535'
+  channel_id: '1528936130748223519'
 pm:
-  provider: linear
   linear_initiative: 33e774b0-ec3b-4bd6-a4f8-07676f9e897b
-  linear_team: e894ffa1-bc38-4382-af89-2e1d89884f4e
 ---
 
 ## Objective


### PR DESCRIPTION
## Usage

```bash
cargo test -p loopflow --test repository_team_matrix
```

## Summary

Consolidates Linear Team authority at the repository level so PM configuration has one canonical Team. Waves retain their initiative mappings without independently selecting a provider or Team, preventing conflicting ownership across repository and wave configuration.

## Changes

- Removed the legacy repository `linear.team` setting
- Removed wave-level Linear provider and Team overrides
- Kept wave-specific Linear initiative mappings intact
- Updated the repository Team matrix to verify repository-only authority