### PR TITLE
wave chat: add durable discord compose

### DIFF
--- a/docs/waves.md
+++ b/docs/waves.md
@@ -134,7 +134,20 @@ chat:
 ---
 ```
 
-Start the Wave with `LF_DISCORD_TOKEN` injected by Doppler:
+Store the bot token in the Home daemon repository's Doppler config, reload the
+service, then start the Wave:
+
+```bash
+doppler secrets set LF_DISCORD_TOKEN > /dev/null
+doppler run -- lfd install
+lf start product
+```
+
+The service file retains only the non-secret Doppler project and config names.
+`lfd` resolves the token from Doppler once at boot and keeps it inside the
+trusted Home process. The Wave resident and its provider children never
+inherit it. Reload the service after changing or rotating the token. For a
+foreground listener without `lfd`, inject the same secret for that process:
 
 ```bash
 doppler run -- lf wave product
@@ -147,10 +160,13 @@ conversation epoch. Earlier local epochs stay selectable and read-only.
 
 Discord is the transcript authority while its epoch is active. Loopflow reads
 bounded history from Discord on demand and stores no duplicate presentation
-transcript. `lf chat "text"` returns an Open-in-Discord action as a rejection
-instead of appending a hidden local message. Agent speech appears only after
-Discord returns its provider message id. Every API message names its epoch and
-exact local journal event or Discord message source.
+transcript. The Mac composer and `lf chat "text"` post through the bot, visibly
+prefix the message with the Wave name, and preserve message, steer, or interrupt
+intent when the provider echo reaches the resident. The Open in Discord action
+stays beside the native composer. A provider failure never falls through to a
+hidden local message. Human and agent speech appears only after Discord returns
+its provider message id. Every API message names its epoch and exact local
+journal event or Discord message source.
 
 Loopflow retains source-linked inputs until the resident consumes them,
 execution turns, deterministic send intents, cursors, and provider receipts as

--- a/rust/loopflow/src/bin/lfd.rs
+++ b/rust/loopflow/src/bin/lfd.rs
@@ -222,6 +222,8 @@ fn main() -> anyhow::Result<()> {
                 lf_home: std::env::var_os("LF_HOME").map(std::path::PathBuf::from),
                 db_path: std::env::var_os("LF_DB_PATH").map(std::path::PathBuf::from),
                 path_env: std::env::var("PATH").ok(),
+                doppler_project: std::env::var("DOPPLER_PROJECT").ok(),
+                doppler_config: std::env::var("DOPPLER_CONFIG").ok(),
             };
             let file = lfd::service::install(&spec)?;
             println!(
@@ -229,9 +231,7 @@ fn main() -> anyhow::Result<()> {
                 file.platform,
                 file.path.display()
             );
-            println!(
-                "webhook credentials are read from the environment or Doppler at daemon startup"
-            );
+            println!("credentials are resolved from environment or Doppler at daemon startup");
             Ok(())
         }
         Commands::Status => {

--- a/rust/loopflow/src/engine/process.rs
+++ b/rust/loopflow/src/engine/process.rs
@@ -11,6 +11,39 @@ pub(crate) fn current_process_group_id() -> Option<u32> {
     u32::try_from(process_group).ok().filter(|id| *id > 1)
 }
 
+pub(crate) fn process_group_observation(
+    process_group: i64,
+) -> crate::durable::ContainmentObservation {
+    use crate::durable::ContainmentObservation;
+
+    #[cfg(unix)]
+    {
+        let Ok(process_group) = i32::try_from(process_group) else {
+            return ContainmentObservation::Unprovable;
+        };
+        if process_group <= 1 {
+            return ContainmentObservation::Unprovable;
+        }
+        // SAFETY: a negative pid selects one process group and signal 0 only
+        // probes its existence; no pointers are used and no signal is sent.
+        let result = unsafe { libc::kill(-process_group, 0) };
+        if result == 0 {
+            return ContainmentObservation::Present;
+        }
+        match std::io::Error::last_os_error().raw_os_error() {
+            Some(libc::ESRCH) => ContainmentObservation::Absent,
+            Some(libc::EPERM) => ContainmentObservation::Present,
+            _ => ContainmentObservation::Unprovable,
+        }
+    }
+
+    #[cfg(not(unix))]
+    {
+        let _ = process_group;
+        ContainmentObservation::Unprovable
+    }
+}
+
 pub(crate) fn resolve_lf_binary() -> PathBuf {
     if let Some(path) = select_binary_override(
         crate::build_info::provenance(),
@@ -221,7 +254,7 @@ fn resolve_current_home_lf_binary() -> PathBuf {
 
 /// The current Home `lf`, resolved to an absolute path that exists. Mirrors
 /// [`resolve_pinned_lf_binary`] but over [`resolve_current_home_lf_binary`].
-fn resolve_current_home_lf_binary_checked() -> Result<PathBuf> {
+pub(crate) fn resolve_current_home_lf_binary_checked() -> Result<PathBuf> {
     let candidate = resolve_current_home_lf_binary();
     if candidate.is_absolute() {
         return if candidate.exists() {

--- a/rust/loopflow/src/lf/commands/chat.rs
+++ b/rust/loopflow/src/lf/commands/chat.rs
@@ -2,9 +2,10 @@
 //!
 //! One door, `POST /messages` on the wave's server. `--steer` uses the `steer`
 //! op, reaching a live steer-capable turn and otherwise queueing for the next
-//! one. The default `message` op queues for the loop, unattributed — the same
-//! human act journals the same way on every surface (the Mac composer sends
-//! the identical op).
+//! one. The default `message` op queues for the loop. Local chat commits it to
+//! the journal; Discord chat posts the same op through its provider-backed
+//! composer and queues the canonical provider echo. The Mac composer uses the
+//! identical door.
 //!
 //! # Targeting
 //! - default: the invoking context's wave from `LF_WAVE_ID`.
@@ -343,7 +344,11 @@ async fn post_message(endpoint: &str, text: &str, steer: bool) -> Result<()> {
     } else {
         MessageOp::Message
     };
-    let body = serde_json::json!({ "op": op, "text": text });
+    let body = serde_json::json!({
+        "id": uuid::Uuid::new_v4().to_string(),
+        "op": op,
+        "text": text,
+    });
     post_json(endpoint, "/messages", &body).await?;
     Ok(())
 }

--- a/rust/loopflow/src/lfd/mod.rs
+++ b/rust/loopflow/src/lfd/mod.rs
@@ -45,6 +45,7 @@ use axum::routing::{get, post};
 use axum::{Json, Router};
 use fs2::FileExt;
 use hmac::{Hmac, Mac};
+use secrecy::SecretString;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use time::OffsetDateTime;
@@ -104,11 +105,12 @@ async fn build_state(
     store: Arc<Store>,
     linear: Option<LinearConfig>,
     github: Option<GithubConfig>,
+    discord_token: Option<SecretString>,
 ) -> anyhow::Result<LfdState> {
     let local = store.local_home().await?;
     Ok(LfdState {
         repo_root,
-        wave_host: WaveHost::new(local.id, store.clone()),
+        wave_host: WaveHost::new(local.id, store.clone(), discord_token),
         control_token: Arc::new(uuid::Uuid::new_v4().to_string()),
         store,
         linear,
@@ -849,7 +851,16 @@ pub async fn serve(
              gate this listener at the network boundary"
         );
     }
-    let state = build_state(repo_root.clone(), store, linear, github_config(&repo_root)).await?;
+    let discord_token =
+        config_value(&repo_root, crate::wave::discord::TOKEN_ENV).map(SecretString::new);
+    let state = build_state(
+        repo_root.clone(),
+        store,
+        linear,
+        github_config(&repo_root),
+        discord_token,
+    )
+    .await?;
     let _home_lock = lock_home(state.wave_host.home_id())?;
     let wave_host = state.wave_host.clone();
     let reconciliation = tokio::spawn({
@@ -1103,7 +1114,7 @@ mod tests {
     }
 
     async fn make_state(repo: &Path, store: Arc<Store>, linear: Option<LinearConfig>) -> LfdState {
-        build_state(repo.to_path_buf(), store, linear, None)
+        build_state(repo.to_path_buf(), store, linear, None, None)
             .await
             .unwrap()
     }

--- a/rust/loopflow/src/lfd/service.rs
+++ b/rust/loopflow/src/lfd/service.rs
@@ -29,6 +29,10 @@ pub struct ServiceSpec {
     /// Executable search path captured at install time so launchd can find
     /// Homebrew tools such as `gh` and `doppler`.
     pub path_env: Option<String>,
+    /// Non-secret Doppler project selection captured from `doppler run`.
+    pub doppler_project: Option<String>,
+    /// Non-secret Doppler config selection captured from `doppler run`.
+    pub doppler_config: Option<String>,
 }
 
 /// Where the rendered service file lands, and how it is loaded, per platform.
@@ -98,6 +102,18 @@ pub fn render_launchd_plist(spec: &ServiceSpec) -> String {
             xml_escape(path)
         ));
     }
+    if let Some(project) = &spec.doppler_project {
+        env.push_str(&format!(
+            "        <key>DOPPLER_PROJECT</key>\n        <string>{}</string>\n",
+            xml_escape(project)
+        ));
+    }
+    if let Some(config) = &spec.doppler_config {
+        env.push_str(&format!(
+            "        <key>DOPPLER_CONFIG</key>\n        <string>{}</string>\n",
+            xml_escape(config)
+        ));
+    }
     let env_block = if env.is_empty() {
         String::new()
     } else {
@@ -149,6 +165,18 @@ pub fn render_systemd_unit(spec: &ServiceSpec) -> String {
     }
     if let Some(path) = &spec.path_env {
         env_lines.push_str(&format!("Environment=PATH={}\n", shell_escape(path)));
+    }
+    if let Some(project) = &spec.doppler_project {
+        env_lines.push_str(&format!(
+            "Environment=DOPPLER_PROJECT={}\n",
+            shell_escape(project)
+        ));
+    }
+    if let Some(config) = &spec.doppler_config {
+        env_lines.push_str(&format!(
+            "Environment=DOPPLER_CONFIG={}\n",
+            shell_escape(config)
+        ));
     }
     let exec_start = shell_escape(&spec.lfd_path.to_string_lossy());
     format!(
@@ -331,6 +359,8 @@ mod tests {
             lf_home: Some(PathBuf::from("/home/op/.lf")),
             db_path: None,
             path_env: Some("/opt/homebrew/bin:/usr/bin:/bin".to_string()),
+            doppler_project: Some("loopflow".to_string()),
+            doppler_config: Some("dev".to_string()),
         }
     }
 
@@ -349,6 +379,10 @@ mod tests {
         assert!(plist.contains("/home/op/src/loopflow</string>"));
         assert!(plist.contains("<key>PATH</key>"));
         assert!(plist.contains("/opt/homebrew/bin:/usr/bin:/bin"));
+        assert!(plist.contains("<key>DOPPLER_PROJECT</key>"));
+        assert!(plist.contains("<string>loopflow</string>"));
+        assert!(plist.contains("<key>DOPPLER_CONFIG</key>"));
+        assert!(plist.contains("<string>dev</string>"));
         assert_eq!(plist.matches("<string>/dev/null</string>").count(), 2);
         // Secrets must never appear in the file.
         assert!(!plist.contains("WEBHOOK_SECRET"));
@@ -368,6 +402,8 @@ mod tests {
         assert!(unit.contains("StandardError=null"));
         assert!(unit.contains("Environment=LF_HOME=/home/op/.lf"));
         assert!(unit.contains("Environment=PATH=/opt/homebrew/bin:/usr/bin:/bin"));
+        assert!(unit.contains("Environment=DOPPLER_PROJECT=loopflow"));
+        assert!(unit.contains("Environment=DOPPLER_CONFIG=dev"));
         assert!(unit.contains("WantedBy=default.target"));
         assert!(!unit.contains("WEBHOOK_SECRET"));
     }
@@ -381,6 +417,8 @@ mod tests {
             lf_home: None,
             db_path: None,
             path_env: None,
+            doppler_project: None,
+            doppler_config: None,
         };
         let plist = render_launchd_plist(&bare);
         assert!(!plist.contains("EnvironmentVariables"));

--- a/rust/loopflow/src/store/children.rs
+++ b/rust/loopflow/src/store/children.rs
@@ -171,11 +171,7 @@ impl Store {
             .await
         {
             Ok(reserved) => reserved,
-            Err(super::StoreError::Sqlite(error))
-                if error.sqlite_error_code() == Some(rusqlite::ErrorCode::ConstraintViolation) =>
-            {
-                return Ok(None);
-            }
+            Err(super::StoreError::RunFenced { .. }) => return Ok(None),
             Err(error) => return Err(error),
         };
         self.advance_run(
@@ -668,11 +664,7 @@ impl Store {
             .await
         {
             Ok(reserved) => reserved,
-            Err(super::StoreError::Sqlite(error))
-                if error.sqlite_error_code() == Some(rusqlite::ErrorCode::ConstraintViolation) =>
-            {
-                return Ok(None);
-            }
+            Err(super::StoreError::RunFenced { .. }) => return Ok(None),
             Err(error) => return Err(error),
         };
         self.advance_run(

--- a/rust/loopflow/src/store/durable.rs
+++ b/rust/loopflow/src/store/durable.rs
@@ -779,6 +779,23 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn reserving_a_fenced_run_names_the_existing_authority() {
+        let (store, work) = wave_work().await;
+        let (run, _) = store.reserve_run(&work, RunTrigger::User).await.unwrap();
+
+        let error = store
+            .reserve_run(&work, RunTrigger::User)
+            .await
+            .expect_err("second Run must remain fenced");
+
+        assert!(matches!(
+            error,
+            StoreError::RunFenced { run_id, state, .. }
+                if run_id == run.id && state == RunState::Reserved
+        ));
+    }
+
+    #[tokio::test]
     async fn one_run_can_supervise_overlapping_invocations_without_changing_containment() {
         let (store, work) = wave_work().await;
         let (lease, first) = start_invocation(&store, &work).await;

--- a/rust/loopflow/src/store/mod.rs
+++ b/rust/loopflow/src/store/mod.rs
@@ -96,6 +96,12 @@ pub enum StoreError {
     NotFound,
     #[error("invalid data: {0}")]
     InvalidData(String),
+    #[error("cannot reserve {target} while Run {run_id} is {state:?}")]
+    RunFenced {
+        target: String,
+        run_id: crate::durable::RunId,
+        state: crate::durable::RunState,
+    },
     #[error("{target} generation {generation} no longer holds its write lease")]
     LeaseRevoked { target: String, generation: u32 },
     #[error("stale Basis: expected {expected}, current {current}")]

--- a/rust/loopflow/src/store/sqlite/durable.rs
+++ b/rust/loopflow/src/store/sqlite/durable.rs
@@ -151,6 +151,13 @@ impl SqliteStore {
         let tx = conn.transaction_with_behavior(TransactionBehavior::Immediate)?;
         let epoch = current_epoch_in(&tx, work)?;
         let home_id = reserving_home_in(&tx, work)?;
+        if let Some(run) = run_for_epoch_in(&tx, &epoch.id)? {
+            return Err(StoreError::RunFenced {
+                target: format!("{} {}", work.kind(), work.id()),
+                run_id: run.id,
+                state: run.state,
+            });
+        }
         resolve_wait_for_trigger(&tx, &epoch, trigger)?;
         let token = RunLeaseToken::new();
         let run = Run {

--- a/rust/loopflow/src/wave/discord.rs
+++ b/rust/loopflow/src/wave/discord.rs
@@ -23,7 +23,7 @@ use tokio::sync::watch;
 use crate::chat::turns::{ChatRole, ChatTurn};
 use crate::durable::HomeId;
 use crate::wave::chat::{ChatBackingHealth, ChatMessageSource, ConversationEpoch, WaveChatMessage};
-use crate::wave::journal::{DiscordChatBinding, DiscordMessageSource};
+use crate::wave::journal::{DiscordChatBinding, DiscordMessageSource, MessageOp};
 use crate::wave::runtime::WaveRuntime;
 
 pub const TOKEN_ENV: &str = "LF_DISCORD_TOKEN";
@@ -31,6 +31,7 @@ const API_BASE: &str = "https://discord.com/api/v10";
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
 const POLL_CADENCE: Duration = Duration::from_secs(2);
 const ERROR_BACKOFF: Duration = Duration::from_secs(10);
+const MESSAGE_LIMIT: usize = 2_000;
 const VIEW_CHANNEL: u64 = 1 << 10;
 const SEND_MESSAGES: u64 = 1 << 11;
 const READ_MESSAGE_HISTORY: u64 = 1 << 16;
@@ -54,6 +55,8 @@ pub enum DiscordError {
     MissingPermissions(String),
     #[error("Discord returned an invalid permission value: {0}")]
     InvalidPermission(String),
+    #[error("Discord messages are limited to {limit} characters; this message has {actual}")]
+    MessageTooLong { limit: usize, actual: usize },
     #[error("Discord chat binding is owned by Home {owner}; current Home is {current}")]
     WrongHome { owner: String, current: String },
     #[error(
@@ -156,9 +159,12 @@ impl DiscordClient {
     }
 
     fn from_token(token: Option<String>, base_url: &str) -> Result<Self, DiscordError> {
+        Self::from_secret(token.map(SecretString::new), base_url)
+    }
+
+    fn from_secret(token: Option<SecretString>, base_url: &str) -> Result<Self, DiscordError> {
         let token = token
-            .filter(|value| !value.trim().is_empty())
-            .map(SecretString::new)
+            .filter(|value| !value.expose_secret().trim().is_empty())
             .ok_or(DiscordError::MissingToken)?;
         Self::new(token, base_url)
     }
@@ -262,9 +268,14 @@ impl DiscordAdapter {
         binding: DiscordChatBinding,
         owner_home_id: &HomeId,
         local_home_id: &HomeId,
+        token: Option<SecretString>,
     ) -> Result<Self, DiscordError> {
         let lease = DiscordBindingLease::acquire(&binding, owner_home_id, local_home_id)?;
-        let mut adapter = Self::preflight_with_client(DiscordClient::from_env()?, binding).await?;
+        let client = match token {
+            Some(token) => DiscordClient::from_secret(Some(token), API_BASE)?,
+            None => DiscordClient::from_env()?,
+        };
+        let mut adapter = Self::preflight_with_client(client, binding).await?;
         adapter._lease = Some(lease);
         Ok(adapter)
     }
@@ -438,7 +449,23 @@ impl DiscordAdapter {
             return Ok(());
         }
         if message.author.id == self.bot_user_id {
-            self.reconcile_echo(runtime, &message)?;
+            if self.reconcile_echo(runtime, &message)? {
+                return Ok(());
+            }
+            let Some((op, text)) = parse_authored_content(runtime.name(), &message.content) else {
+                return Ok(());
+            };
+            runtime
+                .try_deliver_discord_authored(
+                    text,
+                    DiscordMessageSource {
+                        binding: self.binding.clone(),
+                        message_id: message.id,
+                        author_id: message.author.id,
+                    },
+                    op,
+                )
+                .context("journal Discord app input")?;
             return Ok(());
         }
         if message.author.bot == Some(true)
@@ -461,23 +488,24 @@ impl DiscordAdapter {
         Ok(())
     }
 
-    fn reconcile_echo(&self, runtime: &WaveRuntime, message: &Message) -> Result<()> {
-        let Some(reply_id) = message
+    fn reconcile_echo(&self, runtime: &WaveRuntime, message: &Message) -> Result<bool> {
+        let reply_id = message
             .message_reference
             .as_ref()
-            .and_then(|reference| reference.message_id.as_deref())
-        else {
-            return Ok(());
-        };
+            .and_then(|reference| reference.message_id.as_deref());
         for delivery in runtime.discord_snapshot().deliveries {
-            let Some(reply_to) = delivery.reply_to() else {
-                continue;
-            };
-            if reply_to.binding != self.binding {
+            if delivery.binding != self.binding {
                 continue;
             }
-            if reply_to.message_id != reply_id {
+            if delivery.reply_to().map(|source| source.message_id.as_str()) != reply_id {
                 continue;
+            }
+            if delivery
+                .confirmed
+                .values()
+                .any(|provider_id| provider_id == &message.id)
+            {
+                return Ok(true);
             }
             if let Some(part) = delivery
                 .parts
@@ -492,10 +520,10 @@ impl DiscordAdapter {
                         message.id.clone(),
                     )
                     .context("journal reconciled Discord send")?;
-                break;
+                return Ok(true);
             }
         }
-        Ok(())
+        Ok(false)
     }
 
     async fn deliver_pending(&self, runtime: &WaveRuntime) -> Result<()> {
@@ -538,6 +566,64 @@ impl DiscordProjection {
         self.health.borrow().clone()
     }
 
+    pub(crate) async fn post_authored(
+        &self,
+        runtime: &WaveRuntime,
+        op: MessageOp,
+        text: &str,
+        request_id: &str,
+    ) -> Result<WaveChatMessage, DiscordError> {
+        let epoch = runtime.active_conversation_epoch();
+        if epoch.backing.discord_binding().as_ref() != Some(&self.binding) {
+            return Err(DiscordError::Binding(format!(
+                "active chat epoch {} is not backed by channel {}/{}",
+                epoch.id, self.binding.guild_id, self.binding.channel_id
+            )));
+        }
+        let content = authored_content(runtime.name(), op, text);
+        let actual = content.chars().count();
+        if actual > MESSAGE_LIMIT {
+            return Err(DiscordError::MessageTooLong {
+                limit: MESSAGE_LIMIT,
+                actual,
+            });
+        }
+        let nonce = authored_nonce(request_id);
+        let path = format!("/channels/{}/messages", self.binding.channel_id);
+        let body = CreateMessage {
+            content: &content,
+            nonce: &nonce,
+            enforce_nonce: true,
+            allowed_mentions: AllowedMentions { parse: Vec::new() },
+            message_reference: None,
+        };
+        let sent: Message = match self.client.post(&path, &body).await {
+            Err(error) if error.retryable() => self.client.post(&path, &body).await?,
+            result => result?,
+        };
+        if sent.author.id != self.bot_user_id {
+            return Err(DiscordError::Binding(format!(
+                "authored message {} was returned with unexpected author {}",
+                sent.id, sent.author.id
+            )));
+        }
+        let Some((sent_op, sent_text)) = parse_authored_content(runtime.name(), &sent.content)
+        else {
+            return Err(DiscordError::Binding(format!(
+                "authored message {} did not retain its Loopflow header",
+                sent.id
+            )));
+        };
+        if sent_op != op || sent_text != text {
+            return Err(DiscordError::Binding(format!(
+                "request id already committed a different Discord message {}",
+                sent.id
+            )));
+        }
+        project_message(&self.binding, &epoch, sent, ChatRole::User, sent_text)
+            .map_err(|error| DiscordError::Binding(error.to_string()))
+    }
+
     pub async fn history(
         &self,
         runtime: &WaveRuntime,
@@ -577,38 +663,20 @@ impl DiscordProjection {
                 {
                     return None;
                 }
-                let role = if message.author.id == self.bot_user_id {
-                    if !confirmed.contains(&message.id) {
-                        return None;
+                let (role, text) = if message.author.id == self.bot_user_id {
+                    if confirmed.contains(&message.id) {
+                        (ChatRole::Assistant, message.content.clone())
+                    } else {
+                        let (_, text) = parse_authored_content(runtime.name(), &message.content)?;
+                        (ChatRole::User, text)
                     }
-                    ChatRole::Assistant
                 } else {
                     if message.author.bot == Some(true) {
                         return None;
                     }
-                    ChatRole::User
+                    (ChatRole::User, message.content.clone())
                 };
-                let created_at = snowflake_timestamp(&message.id)
-                    .and_then(|timestamp| {
-                        timestamp
-                            .format(&time::format_description::well_known::Rfc3339)
-                            .map_err(anyhow::Error::from)
-                    })
-                    .ok()?;
-                let mut turn = ChatTurn::user(format!("discord-{}", message.id), message.content);
-                turn.role = role;
-                turn.created_at = created_at;
-                Some(WaveChatMessage {
-                    epoch_id: epoch.id.clone(),
-                    source: ChatMessageSource::Discord {
-                        guild_id: self.binding.guild_id.clone(),
-                        channel_id: self.binding.channel_id.clone(),
-                        message_id: message.id.clone(),
-                        author_id: message.author.id,
-                        url: self.binding.message_url(&message.id),
-                    },
-                    turn,
-                })
+                project_message(&self.binding, epoch, message, role, text).ok()
             })
             .collect::<Vec<_>>();
         if projected.len() > requested {
@@ -662,6 +730,64 @@ fn message_in_epoch(message: &Message, epoch: &ConversationEpoch) -> Result<bool
         })
         .transpose()?;
     Ok(timestamp >= started_at && ended_at.is_none_or(|ended_at| timestamp < ended_at))
+}
+
+fn authored_content(wave: &str, op: MessageOp, text: &str) -> String {
+    format!("{}\n{text}", authored_header(wave, op))
+}
+
+fn authored_header(wave: &str, op: MessageOp) -> String {
+    let action = match op {
+        MessageOp::Message => String::new(),
+        MessageOp::Steer => " · steer".to_string(),
+        MessageOp::Interrupt => " · interrupt".to_string(),
+    };
+    format!("**[{wave} · Loopflow app{action}]**")
+}
+
+fn parse_authored_content(wave: &str, content: &str) -> Option<(MessageOp, String)> {
+    for op in [MessageOp::Message, MessageOp::Steer, MessageOp::Interrupt] {
+        let header = authored_header(wave, op);
+        if let Some(text) = content
+            .strip_prefix(&header)
+            .and_then(|rest| rest.strip_prefix('\n'))
+        {
+            return Some((op, text.to_string()));
+        }
+    }
+    None
+}
+
+fn authored_nonce(request_id: &str) -> String {
+    let mut digest = Sha256::new();
+    digest.update(b"loopflow-discord-authored\0");
+    digest.update(request_id.as_bytes());
+    format!("lf-u-{}", &format!("{:x}", digest.finalize())[..16])
+}
+
+fn project_message(
+    binding: &DiscordChatBinding,
+    epoch: &ConversationEpoch,
+    message: Message,
+    role: ChatRole,
+    text: String,
+) -> Result<WaveChatMessage> {
+    let created_at =
+        snowflake_timestamp(&message.id)?.format(&time::format_description::well_known::Rfc3339)?;
+    let mut turn = ChatTurn::user(format!("discord-{}", message.id), text);
+    turn.role = role;
+    turn.created_at = created_at;
+    Ok(WaveChatMessage {
+        epoch_id: epoch.id.clone(),
+        source: ChatMessageSource::Discord {
+            guild_id: binding.guild_id.clone(),
+            channel_id: binding.channel_id.clone(),
+            message_id: message.id.clone(),
+            author_id: message.author.id,
+            url: binding.message_url(&message.id),
+        },
+        turn,
+    })
 }
 
 fn snowflake_timestamp(value: &str) -> Result<time::OffsetDateTime> {
@@ -878,6 +1004,7 @@ mod tests {
         permissions: u64,
         channel_kind: u8,
         messages: Vec<Message>,
+        nonces: HashMap<String, Message>,
         posts: usize,
         lose_next_post_response: bool,
         channel_status: Option<u16>,
@@ -997,15 +1124,22 @@ mod tests {
                 let body: serde_json::Value = serde_json::from_slice(&body).expect("message body");
                 assert_eq!(body["allowed_mentions"]["parse"], json!([]));
                 assert_eq!(body["enforce_nonce"], true);
-                assert!(body["nonce"].as_str().expect("nonce").len() <= 25);
+                let nonce = body["nonce"].as_str().expect("nonce").to_string();
+                assert!(nonce.len() <= 25);
                 let mut fixture = fixture.lock().expect("fixture");
                 fixture.posts += 1;
+                if let Some(message) = fixture.nonces.get(&nonce) {
+                    return json_response(
+                        StatusCode::OK,
+                        serde_json::to_value(message).expect("message"),
+                    );
+                }
                 let id = fixture
                     .messages
                     .last()
                     .and_then(|message| message.id.parse::<u64>().ok())
-                    .unwrap_or(0)
-                    + 1;
+                    .map(|id| id + 1)
+                    .unwrap_or_else(|| snowflake_at_offset(1, fixture.posts as u64));
                 let message = Message {
                     id: id.to_string(),
                     author: User {
@@ -1022,6 +1156,7 @@ mod tests {
                     }),
                 };
                 fixture.messages.push(message.clone());
+                fixture.nonces.insert(nonce, message.clone());
                 if std::mem::take(&mut fixture.lose_next_post_response) {
                     Response::builder()
                         .status(StatusCode::OK)
@@ -1059,6 +1194,7 @@ mod tests {
             permissions: VIEW_CHANNEL | READ_MESSAGE_HISTORY | SEND_MESSAGES,
             channel_kind: 0,
             messages,
+            nonces: HashMap::new(),
             posts: 0,
             lose_next_post_response: false,
             channel_status: None,
@@ -1104,7 +1240,7 @@ mod tests {
         let local = HomeId::new();
         let owner = HomeId::new();
 
-        let error = DiscordAdapter::preflight(binding(), &owner, &local)
+        let error = DiscordAdapter::preflight(binding(), &owner, &local, None)
             .await
             .expect_err("another Home must not reach token or Discord preflight");
 
@@ -1332,6 +1468,106 @@ mod tests {
             "provider-committed answer"
         );
         server.abort();
+    }
+
+    #[tokio::test]
+    async fn native_compose_posts_to_discord_and_reenters_as_a_steer() {
+        let fixture = fixture(Vec::new());
+        let (base_url, discord_server) = fixture_server(fixture.clone()).await;
+        let client = DiscordClient::from_token(Some("fixture-token".into()), &base_url)
+            .expect("fixture client");
+        let adapter = DiscordAdapter::preflight_with_client(client, binding())
+            .await
+            .expect("preflight");
+        let projection = adapter.projection();
+        let temp = tempfile::tempdir().expect("tempdir");
+        let runtime = WaveRuntime::open_with_backing(
+            "ship".into(),
+            temp.path().to_path_buf(),
+            ChatBacking::discord(&binding()),
+        )
+        .expect("runtime");
+        adapter.attach(&runtime).expect("attach");
+        fixture.lock().expect("fixture").lose_next_post_response = true;
+        let app = crate::wave::server::router_with_chat_projection(
+            runtime.clone(),
+            crate::wave::server::ResidentDoor::new("resident"),
+            Arc::new(crate::wave::registry::ObserverSlot::new(
+                runtime.clone(),
+                None,
+            )),
+            None,
+            crate::wave::server::ShutdownDoor::new(),
+            Some(projection.clone()),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind Wave listener");
+        let address = listener.local_addr().expect("Wave listener address");
+        let wave_server = tokio::spawn(async move {
+            axum::serve(listener, app).await.expect("serve Wave");
+        });
+
+        let client = reqwest::Client::new();
+        let url = format!("http://{address}/messages");
+        let body = json!({
+            "id": "request-1",
+            "op": "steer",
+            "text": "favor reliability"
+        });
+        let response = client
+            .post(&url)
+            .json(&body)
+            .send()
+            .await
+            .expect("post native message");
+        assert_eq!(response.status(), StatusCode::OK);
+        let posted: crate::wave::chat::PostMessageResponse =
+            response.json().await.expect("posted response");
+        let posted = posted.message.expect("provider-backed message");
+        assert_eq!(posted.turn.role, ChatRole::User);
+        assert_eq!(posted.turn.text, "favor reliability");
+        assert!(matches!(&posted.source, ChatMessageSource::Discord { .. }));
+        assert_eq!(
+            fixture.lock().expect("fixture").messages[0].content,
+            "**[ship · Loopflow app · steer]**\nfavor reliability"
+        );
+        let retried: crate::wave::chat::PostMessageResponse = client
+            .post(&url)
+            .json(&body)
+            .send()
+            .await
+            .expect("retry native message")
+            .json()
+            .await
+            .expect("retry response");
+        assert_eq!(
+            retried.message.expect("retried message").source,
+            posted.source
+        );
+        assert_eq!(fixture.lock().expect("fixture").messages.len(), 1);
+        assert_eq!(fixture.lock().expect("fixture").posts, 3);
+
+        adapter.sync_once(&runtime).await.expect("ingest bot echo");
+        let pending = runtime.pending_messages();
+        assert_eq!(pending.len(), 1);
+        assert_eq!(pending[0].op, MessageOp::Steer);
+        assert!(pending[0].text.ends_with("favor reliability"));
+        adapter
+            .sync_once(&runtime)
+            .await
+            .expect("repeat sync stays idempotent");
+        assert_eq!(runtime.pending_messages().len(), 1);
+        let history = projection
+            .history(&runtime, &runtime.active_conversation_epoch(), Some(12))
+            .await
+            .expect("native provider history");
+        assert_eq!(history.len(), 1);
+        assert_eq!(history[0].turn.role, ChatRole::User);
+        assert_eq!(history[0].turn.text, "favor reliability");
+
+        wave_server.abort();
+        discord_server.abort();
     }
 
     #[tokio::test]

--- a/rust/loopflow/src/wave/journal.rs
+++ b/rust/loopflow/src/wave/journal.rs
@@ -264,6 +264,12 @@ pub enum EventKind {
         text: String,
         source: DiscordMessageSource,
     },
+    DiscordAuthoredMessage {
+        id: MessageId,
+        op: MessageOp,
+        text: String,
+        source: DiscordMessageSource,
+    },
     DiscordChatCursorAdvanced {
         binding: DiscordChatBinding,
         message_id: String,
@@ -555,6 +561,16 @@ impl Narrator {
             )),
             EventKind::DiscordUserMessage { id, text, source } => info(format!(
                 "discord ← \"{}\" ({id}, {})",
+                ellipsize(text, 60),
+                source.message_id
+            )),
+            EventKind::DiscordAuthoredMessage {
+                id,
+                op,
+                text,
+                source,
+            } => info(format!(
+                "discord app ← ({op:?}) \"{}\" ({id}, {})",
                 ellipsize(text, 60),
                 source.message_id
             )),
@@ -1203,6 +1219,28 @@ pub fn fold_thread(events: &[Event]) -> ThreadFold {
                 }
                 messages.insert(id.clone(), message);
             }
+            EventKind::DiscordAuthoredMessage {
+                id,
+                op,
+                text,
+                source,
+            } => {
+                let turn_id = format!("turn-{}", event.seq);
+                let mut turn = ChatTurn::user(turn_id.clone(), text.clone());
+                turn.created_at = event.at_rfc3339();
+                turns.push(turn);
+                discord_turn_bindings.insert(turn_id, source.binding.clone());
+                let message = PendingMessage {
+                    id: id.clone(),
+                    op: *op,
+                    text: format!("[{}]\n{}", source.uri(), text),
+                    source: Some(source.clone()),
+                };
+                if !consumed_messages.contains(id) {
+                    pending_messages.push(message.clone());
+                }
+                messages.insert(id.clone(), message);
+            }
             EventKind::DiscordChatCursorAdvanced {
                 binding,
                 message_id,
@@ -1634,6 +1672,12 @@ mod tests {
                 text: "question".into(),
                 source: discord_source(),
             },
+            EventKind::DiscordAuthoredMessage {
+                id: MessageId("msg-3".into()),
+                op: MessageOp::Steer,
+                text: "change course".into(),
+                source: discord_source(),
+            },
             EventKind::DiscordChatCursorAdvanced {
                 binding: discord_binding(),
                 message_id: "101".into(),
@@ -1785,6 +1829,12 @@ mod tests {
             EventKind::DiscordUserMessage {
                 id: MessageId("msg-2".into()),
                 text: "question".into(),
+                source: discord_source(),
+            },
+            EventKind::DiscordAuthoredMessage {
+                id: MessageId("msg-3".into()),
+                op: MessageOp::Steer,
+                text: "change course".into(),
                 source: discord_source(),
             },
             EventKind::DiscordChatCursorAdvanced {

--- a/rust/loopflow/src/wave/mod.rs
+++ b/rust/loopflow/src/wave/mod.rs
@@ -71,6 +71,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use anyhow::{anyhow, Result};
+use secrecy::SecretString;
 
 use crate::engine::repo::find_repo_root;
 use crate::engine::wave_config::{try_read_wave_config, WaveChatConfig};
@@ -106,6 +107,7 @@ pub fn run(name: &str, force: bool) -> Result<()> {
             registry_config,
             force,
             true,
+            None,
             shutdown_signal(),
         )
         .await
@@ -225,14 +227,16 @@ impl Drop for WaveRunGuard {
     }
 }
 
-/// The production resident spawner: `lf __resident <wave>`, run by this
-/// same executable, endpoint + token + Wave context in env. The
-/// resident's stdout/stderr inherit — one `lf wave` terminal shows both
-/// halves, today's UX.
+/// The production resident spawner: `lf __resident <wave>`, run by the
+/// current Home's `lf` binary with endpoint + token + Wave context in env.
+/// The resident's stdout/stderr inherit — one `lf wave` terminal shows both
+/// halves, today's UX. Resolving `lf` explicitly matters when the listener is
+/// hosted in-process by `lfd`: the daemon does not own the hidden subcommand.
 // TODO(M1): keep this shutdown contract in the wave/supervisor owner: stand
 // the respawn ladder down before terminating the resident, honor interrupt
 // cleanup, and keep SIGKILL deadlines in the supervisor path.
 fn resident_spawner(
+    lf_bin: PathBuf,
     wave: String,
     repo_root: PathBuf,
     endpoint: String,
@@ -240,7 +244,8 @@ fn resident_spawner(
     resident_env: Vec<(String, String)>,
 ) -> supervisor::SpawnResident {
     Box::new(move || {
-        let mut command = resident_command(&wave, &repo_root, &endpoint, &token, &resident_env)?;
+        let mut command =
+            resident_command(&lf_bin, &wave, &repo_root, &endpoint, &token, &resident_env);
         // No kill_on_drop: shutdown stops the supervisor FIRST (so a TERM'd
         // resident's exit isn't journaled as a failure), then SIGTERMs the
         // resident by pid — its hooks stop the vendor process group. A
@@ -252,14 +257,14 @@ fn resident_spawner(
 }
 
 fn resident_command(
+    lf_bin: &Path,
     wave: &str,
     repo_root: &Path,
     endpoint: &str,
     token: &str,
     resident_env: &[(String, String)],
-) -> std::io::Result<tokio::process::Command> {
-    let exe = std::env::current_exe()?;
-    let mut command = tokio::process::Command::new(exe);
+) -> tokio::process::Command {
+    let mut command = tokio::process::Command::new(lf_bin);
     command
         .arg(RESIDENT_SUBCOMMAND)
         .arg(wave)
@@ -275,7 +280,7 @@ fn resident_command(
         command.env(key, value);
     }
     command.env_remove(discord::TOKEN_ENV);
-    Ok(command)
+    command
 }
 
 /// Serve the wave until `shutdown` resolves. Vendor-free by construction:
@@ -291,6 +296,7 @@ pub(crate) async fn run_listener(
     registry_config: Option<registry::RegistryConfig>,
     force: bool,
     spawn_resident: bool,
+    discord_token: Option<SecretString>,
     shutdown: impl Future<Output = ()> + Send + 'static,
 ) -> Result<()> {
     // File-level one-brain floor, before anything else: an existing pointer
@@ -319,6 +325,9 @@ pub(crate) async fn run_listener(
     // writes nothing.
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
     let addr = listener.local_addr()?;
+    let resident_lf = spawn_resident
+        .then(crate::engine::process::resolve_current_home_lf_binary_checked)
+        .transpose()?;
 
     let (chat_backing, discord_adapter) =
         match try_read_wave_config(&repo_root, &wave)?.and_then(|config| config.chat) {
@@ -336,8 +345,13 @@ pub(crate) async fn run_listener(
                     channel_id,
                 };
                 let backing = ChatBacking::discord(&binding);
-                let adapter =
-                    discord::DiscordAdapter::preflight(binding, &home_id, &local_home.id).await?;
+                let adapter = discord::DiscordAdapter::preflight(
+                    binding,
+                    &home_id,
+                    &local_home.id,
+                    discord_token,
+                )
+                .await?;
                 (backing, Some(adapter))
             }
             Some(WaveChatConfig::Local) | None => (ChatBacking::Local, None),
@@ -417,8 +431,9 @@ pub(crate) async fn run_listener(
     // The keeper's watch: resident liveness, respawn ladder, interrupt
     // janitor. Runs even without a spawner — the pen-side anti-wedges (janitor, attach
     // probe) never depend on who spawned the resident.
-    let spawner = spawn_resident.then(|| {
+    let spawner = resident_lf.map(|lf_bin| {
         resident_spawner(
+            lf_bin,
             wave.clone(),
             repo_root.clone(),
             addr.to_string(),
@@ -574,13 +589,14 @@ mod tests {
     #[test]
     fn discord_chat_token_is_explicitly_scrubbed_from_the_resident() {
         let command = resident_command(
+            Path::new("/paired/bin/lf"),
             "goals",
             Path::new("/tmp"),
             "127.0.0.1:1234",
             "resident-token",
             &[(discord::TOKEN_ENV.to_string(), "must-not-pass".to_string())],
-        )
-        .expect("resident command");
+        );
+        assert_eq!(command.as_std().get_program(), "/paired/bin/lf");
         assert!(command
             .as_std()
             .get_envs()
@@ -1453,7 +1469,7 @@ mod tests {
         let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
         let repo2 = repo.clone();
         let handle = tokio::spawn(async move {
-            run_listener(repo2, "ship".into(), None, false, false, async {
+            run_listener(repo2, "ship".into(), None, false, false, None, async {
                 let _ = shutdown_rx.await;
             })
             .await
@@ -1493,6 +1509,7 @@ mod tests {
                 None,
                 false,
                 false,
+                None,
                 std::future::pending(),
             )
             .await
@@ -1522,6 +1539,7 @@ mod tests {
                 None,
                 false,
                 false,
+                None,
                 std::future::pending(),
             )
             .await
@@ -1576,7 +1594,7 @@ mod tests {
         let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
         let repo2 = repo.clone();
         let handle = tokio::spawn(async move {
-            run_listener(repo2, "ship".into(), None, false, false, async {
+            run_listener(repo2, "ship".into(), None, false, false, None, async {
                 let _ = shutdown_rx.await;
             })
             .await
@@ -1605,7 +1623,7 @@ mod tests {
         let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
         let repo2 = repo.clone();
         let first = tokio::spawn(async move {
-            run_listener(repo2, "ship".into(), None, false, false, async {
+            run_listener(repo2, "ship".into(), None, false, false, None, async {
                 let _ = shutdown_rx.await;
             })
             .await
@@ -1616,9 +1634,17 @@ mod tests {
 
         // Second server: probed live, refused, pointer untouched.
         let (_shutdown_tx2, shutdown_rx2) = tokio::sync::oneshot::channel::<()>();
-        let err = run_listener(repo.clone(), "ship".into(), None, false, false, async {
-            let _ = shutdown_rx2.await;
-        })
+        let err = run_listener(
+            repo.clone(),
+            "ship".into(),
+            None,
+            false,
+            false,
+            None,
+            async {
+                let _ = shutdown_rx2.await;
+            },
+        )
         .await
         .expect_err("live endpoint refuses a second server");
         assert!(

--- a/rust/loopflow/src/wave/runtime.rs
+++ b/rust/loopflow/src/wave/runtime.rs
@@ -194,6 +194,21 @@ pub struct DiscordSnapshot {
     pub deliveries: Vec<DiscordDelivery>,
 }
 
+#[derive(Debug, Clone, Copy)]
+enum DiscordInput {
+    Provider,
+    Authored(MessageOp),
+}
+
+impl DiscordInput {
+    fn op(self) -> MessageOp {
+        match self {
+            Self::Provider => MessageOp::Message,
+            Self::Authored(op) => op,
+        }
+    }
+}
+
 /// The assistant turn in progress. `turn` is the snapshot the wire watches
 /// grow (status `Running`), re-broadcast on every content delta and committed
 /// to `thread` under the same id at finalization; the rest is bookkeeping that
@@ -595,6 +610,24 @@ impl WaveRuntime {
         text: String,
         source: DiscordMessageSource,
     ) -> Result<bool, JournalAppendError> {
+        self.try_deliver_discord_input(text, source, DiscordInput::Provider)
+    }
+
+    pub(crate) fn try_deliver_discord_authored(
+        &self,
+        text: String,
+        source: DiscordMessageSource,
+        op: MessageOp,
+    ) -> Result<bool, JournalAppendError> {
+        self.try_deliver_discord_input(text, source, DiscordInput::Authored(op))
+    }
+
+    fn try_deliver_discord_input(
+        &self,
+        text: String,
+        source: DiscordMessageSource,
+        input: DiscordInput,
+    ) -> Result<bool, JournalAppendError> {
         let mut inner = self.inner();
         let active_binding = inner
             .conversation_epochs
@@ -610,20 +643,29 @@ impl WaveRuntime {
         }) {
             return Ok(false);
         }
-        let event = inner
-            .journal
-            .try_append(|seq| EventKind::DiscordUserMessage {
-                id: MessageId(format!("msg-{seq}")),
-                text: text.clone(),
-                source: source.clone(),
-            })?;
+        let event = inner.journal.try_append(|seq| {
+            let id = MessageId(format!("msg-{seq}"));
+            match input {
+                DiscordInput::Provider => EventKind::DiscordUserMessage {
+                    id,
+                    text: text.clone(),
+                    source: source.clone(),
+                },
+                DiscordInput::Authored(op) => EventKind::DiscordAuthoredMessage {
+                    id,
+                    op,
+                    text: text.clone(),
+                    source: source.clone(),
+                },
+            }
+        })?;
         let id = MessageId(format!("msg-{}", event.seq));
         let mut turn = ChatTurn::user(format!("turn-{}", event.seq), text.clone());
         turn.created_at = event.at_rfc3339();
         self.commit_locked(&mut inner, turn);
         let pending = PendingMessage {
             id,
-            op: MessageOp::Message,
+            op: input.op(),
             text: format!("[{}]\n{}", source.uri(), text),
             source: Some(source.clone()),
         };
@@ -1131,9 +1173,10 @@ impl WaveRuntime {
     /// backing; authored text never falls through to a local shadow thread.
     ///
     /// # Errors
-    /// Discord-backed authored text is rejected; the active epoch owns its
-    /// Open-in-Discord action. Local journal append failures leave every
-    /// projection untouched.
+    /// Discord-backed authored text is rejected at this local write boundary;
+    /// the server routes it through the attached provider before calling here.
+    /// Without a provider attachment, the active epoch owns its Open-in-Discord
+    /// action. Local journal append failures leave every projection untouched.
     pub fn try_deliver_authored(
         &self,
         op: MessageOp,
@@ -2991,6 +3034,43 @@ mod tests {
                 .cursor
                 .as_deref(),
             Some("101")
+        );
+    }
+
+    #[test]
+    fn discord_app_steer_keeps_its_operation_after_restart() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let binding = DiscordChatBinding {
+            guild_id: "guild".into(),
+            channel_id: "channel".into(),
+        };
+        let source = DiscordMessageSource {
+            binding: binding.clone(),
+            message_id: "102".into(),
+            author_id: "bot".into(),
+        };
+        let rt = open_discord_runtime(tmp.path(), &binding);
+        rt.try_attach_discord(binding.clone(), "bot".into(), Some("101".into()))
+            .expect("attach at current head");
+
+        assert!(rt
+            .try_deliver_discord_authored("change course".into(), source.clone(), MessageOp::Steer)
+            .expect("journal app steer"));
+        assert!(!rt
+            .try_deliver_discord_authored("change course".into(), source.clone(), MessageOp::Steer)
+            .expect("deduplicate app steer"));
+        assert_eq!(rt.pending_messages()[0].op, MessageOp::Steer);
+
+        drop(rt);
+        let reopened = open_discord_runtime(tmp.path(), &binding);
+        assert_eq!(reopened.pending_messages().len(), 1);
+        assert_eq!(reopened.pending_messages()[0].op, MessageOp::Steer);
+        assert_eq!(
+            reopened.pending_messages()[0]
+                .source
+                .as_ref()
+                .expect("Discord source"),
+            &source
         );
     }
 

--- a/rust/loopflow/src/wave/server.rs
+++ b/rust/loopflow/src/wave/server.rs
@@ -54,14 +54,16 @@
 //!   - `GET /resident/context` → `{playhead, provider_session}` — the
 //!     pre-turn snapshot and optional typed provider thread; serving it drains
 //!     pending child observations first.
-//! - `POST /messages {op, text}` → `{turn, state}`. `op` is
+//! - `POST /messages {id?, op, text}` → `{message, state, epoch}`. `op` is
 //!   required — `"message"` (queued; the next turn answers it), `"steer"`
 //!   (into the live turn when the harness supports it, else degrades to a
 //!   queued message), `"interrupt"` (cancel the open turn; non-empty text
 //!   becomes the next turn — "interrupt & send"; while idle, an interrupt is
 //!   a no-op success). `text` may be empty only for `interrupt` (400
-//!   otherwise). `turn` is the appended user `Turn`,
-//!   or null for a bare interrupt (nothing was said); `state` is the
+//!   otherwise). A local epoch journals immediately; a Discord epoch uses
+//!   `id` as an enforced provider nonce and returns the source-bearing provider
+//!   message, which the adapter then queues from its canonical Discord id.
+//!   `message` is null only for a bare interrupt (nothing was said); `state` is the
 //!   loop-state name when the request was accepted — ops are applied by the
 //!   loop asynchronously, so watch the stream's `state` events for the
 //!   outcome.
@@ -101,7 +103,7 @@ use crate::wave::chat::{
     ChatBacking, ChatBackingHealth, ChatHistorySnapshot, ChatHistoryState, ChatMessageSource,
     ConversationEpoch, PostMessageErrorResponse, PostMessageResponse, WaveChatMessage,
 };
-use crate::wave::discord::DiscordProjection;
+use crate::wave::discord::{DiscordError, DiscordProjection};
 use crate::wave::journal::{MessageOp, PendingMessage};
 use crate::wave::playhead::PlayheadView;
 use crate::wave::registry::{process_alive, ObserverSlot, StoreObserver};
@@ -250,9 +252,11 @@ struct ConversationQuery {
 }
 
 /// `POST /messages` request body. `op` is required — explicit, never inferred.
+/// `id` becomes the Discord nonce when the active epoch is provider-backed.
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 struct PostMessage {
+    id: Option<String>,
     op: MessageOp,
     text: String,
 }
@@ -597,6 +601,43 @@ async fn messages_handler(
             }),
         )
             .into_response();
+    }
+    let active_epoch = state.runtime.active_conversation_epoch();
+    if !body.text.trim().is_empty() && matches!(active_epoch.backing, ChatBacking::Discord { .. }) {
+        if let Some(discord) = &state.discord {
+            let request_id = body
+                .id
+                .as_deref()
+                .filter(|id| !id.trim().is_empty())
+                .map(str::to_string)
+                .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
+            return match discord
+                .post_authored(&state.runtime, body.op, body.text.trim(), &request_id)
+                .await
+            {
+                Ok(message) => Json(PostMessageResponse {
+                    message: Some(message),
+                    state: state.runtime.loop_state().name().to_string(),
+                    epoch: active_epoch,
+                })
+                .into_response(),
+                Err(error) => {
+                    let status = if matches!(error, DiscordError::MessageTooLong { .. }) {
+                        StatusCode::BAD_REQUEST
+                    } else {
+                        StatusCode::BAD_GATEWAY
+                    };
+                    (
+                        status,
+                        Json(PostMessageErrorResponse {
+                            error: format!("message was not accepted: {error}"),
+                            epoch: active_epoch,
+                        }),
+                    )
+                        .into_response()
+                }
+            };
+        }
     }
     let turn = match state.runtime.try_deliver_authored(body.op, body.text) {
         Ok(turn) => turn,

--- a/rust/loopflow/src/wave/supervisor.rs
+++ b/rust/loopflow/src/wave/supervisor.rs
@@ -60,7 +60,7 @@ pub const ATTACH_PROBE: Duration = Duration::from_secs(10);
 
 /// Spawn one resident process. Production spawns `lf __resident <name>` with the
 /// resident endpoint/token in its environment
-/// (the current executable); tests spawn whatever stands in for a resident.
+/// (the current Home's resolved `lf`); tests spawn whatever stands in for a resident.
 /// A closure, not a trait: the supervisor needs exactly one behavior.
 pub type SpawnResident = Box<dyn FnMut() -> std::io::Result<Child> + Send>;
 

--- a/rust/loopflow/src/wave_host.rs
+++ b/rust/loopflow/src/wave_host.rs
@@ -7,9 +7,10 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::{anyhow, Result};
+use secrecy::SecretString;
 use tokio::sync::Mutex;
 
-use crate::durable::{HomeId, WorkRef};
+use crate::durable::{Containment, ContainmentObservation, HomeId, RunState, WorkRef};
 use crate::id::WaveId;
 use crate::store::SharedStore;
 use crate::wave::{self, registry, Wave};
@@ -20,17 +21,23 @@ pub(crate) const RECONCILE_INTERVAL: Duration = Duration::from_secs(30);
 pub(crate) struct WaveHost {
     home_id: HomeId,
     store: SharedStore,
-    waves: Arc<Mutex<HashMap<WaveId, tokio::task::JoinHandle<()>>>>,
+    waves: Arc<Mutex<HashMap<WaveId, tokio::task::JoinHandle<Result<()>>>>>,
     suppressed: Arc<Mutex<HashSet<WaveId>>>,
+    discord_token: Option<SecretString>,
 }
 
 impl WaveHost {
-    pub(crate) fn new(home_id: HomeId, store: SharedStore) -> Self {
+    pub(crate) fn new(
+        home_id: HomeId,
+        store: SharedStore,
+        discord_token: Option<SecretString>,
+    ) -> Self {
         Self {
             home_id,
             store,
             waves: Arc::new(Mutex::new(HashMap::new())),
             suppressed: Arc::new(Mutex::new(HashSet::new())),
+            discord_token,
         }
     }
 
@@ -142,17 +149,27 @@ impl WaveHost {
         let mut tasks = self.waves.lock().await;
         if tasks.get(wave_id).is_some_and(|task| !task.is_finished()) {
             drop(tasks);
-            wait_for_wave(&repo, wave.name()).await.ok_or_else(|| {
-                anyhow!(
-                    "Wave {} is starting but did not publish a live endpoint",
-                    wave.name()
-                )
-            })?;
-            return Ok(());
+            if self
+                .wait_for_wave(wave_id, &repo, wave.name())
+                .await
+                .is_some()
+            {
+                return Ok(());
+            }
+            return Err(self
+                .startup_failure(wave_id, wave.name())
+                .await
+                .unwrap_or_else(|| {
+                    anyhow!(
+                        "Wave {} is starting but did not publish a live endpoint",
+                        wave.name()
+                    )
+                }));
         }
         if let Some(task) = tasks.remove(wave_id) {
             task.abort();
         }
+        self.reconcile_run_slot(&wave).await?;
         let config = registry::RegistryConfig {
             store: self.store.clone(),
             wave: wave.clone(),
@@ -160,26 +177,105 @@ impl WaveHost {
         let name = wave.name().to_string();
         let task_name = name.clone();
         let listener_repo = repo.clone();
+        let discord_token = self.discord_token.clone();
         let task = tokio::spawn(async move {
-            if let Err(error) = wave::run_listener(
+            let result = wave::run_listener(
                 listener_repo,
                 task_name.clone(),
                 Some(config),
                 false,
                 true,
+                discord_token,
                 pending(),
             )
-            .await
-            {
+            .await;
+            if let Err(error) = &result {
                 tracing::error!(wave = task_name, %error, "Wave listener stopped");
             }
+            result
         });
         tasks.insert(wave_id.clone(), task);
         drop(tasks);
-        wait_for_wave(&repo, &name)
+        if self.wait_for_wave(wave_id, &repo, &name).await.is_some() {
+            return Ok(());
+        }
+        Err(self
+            .startup_failure(wave_id, &name)
             .await
-            .ok_or_else(|| anyhow!("Wave {name} did not publish a live endpoint"))?;
+            .unwrap_or_else(|| anyhow!("Wave {name} did not publish a live endpoint")))
+    }
+
+    async fn reconcile_run_slot(&self, wave: &Wave) -> Result<()> {
+        let work = WorkRef::Wave(wave.id().clone());
+        let Some(run) = self.store.current_run(&work).await? else {
+            return Ok(());
+        };
+        let observation = match &run.containment {
+            Some(Containment::ProcessGroup { id }) => {
+                crate::engine::process::process_group_observation(*id)
+            }
+            Some(Containment::Tmux { .. }) => ContainmentObservation::Unprovable,
+            None if run.state == RunState::Reserved
+                && run.created_at + time::Duration::seconds(10)
+                    <= time::OffsetDateTime::now_utc() =>
+            {
+                ContainmentObservation::Absent
+            }
+            None => ContainmentObservation::Unprovable,
+        };
+        if observation != ContainmentObservation::Absent {
+            return Err(anyhow!(
+                "Wave {} already has Run {} in {:?}; containment is {:?}",
+                wave.name(),
+                run.id,
+                run.state,
+                observation
+            ));
+        }
+        self.store
+            .recover_run(&run.id, ContainmentObservation::Absent)
+            .await?;
+        tracing::warn!(
+            wave = wave.name(),
+            run = %run.id,
+            "recovered Wave Run after its containment disappeared"
+        );
         Ok(())
+    }
+
+    async fn startup_failure(&self, wave_id: &WaveId, name: &str) -> Option<anyhow::Error> {
+        let task = {
+            let mut tasks = self.waves.lock().await;
+            if tasks.get(wave_id).is_some_and(|task| task.is_finished()) {
+                tasks.remove(wave_id)
+            } else {
+                None
+            }
+        }?;
+        Some(match task.await {
+            Ok(Ok(())) => anyhow!("Wave {name} stopped before publishing a live endpoint"),
+            Ok(Err(error)) => anyhow!("Wave {name} failed to start: {error}"),
+            Err(error) => anyhow!("Wave {name} listener task failed: {error}"),
+        })
+    }
+
+    async fn wait_for_wave(&self, wave_id: &WaveId, repo: &Path, name: &str) -> Option<String> {
+        for _ in 0..40 {
+            if let Some(endpoint) = wave::server::live_endpoint(repo, name).await {
+                return Some(endpoint);
+            }
+            if self
+                .waves
+                .lock()
+                .await
+                .get(wave_id)
+                .is_some_and(|task| task.is_finished())
+            {
+                return None;
+            }
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+        None
     }
 
     pub(crate) async fn shutdown(&self) {
@@ -200,16 +296,6 @@ impl WaveHost {
         }
         waves.clear();
     }
-}
-
-async fn wait_for_wave(repo: &Path, name: &str) -> Option<String> {
-    for _ in 0..40 {
-        if let Some(endpoint) = wave::server::live_endpoint(repo, name).await {
-            return Some(endpoint);
-        }
-        tokio::time::sleep(Duration::from_millis(100)).await;
-    }
-    None
 }
 
 pub(crate) async fn waves_for_home(
@@ -250,14 +336,82 @@ pub(crate) async fn waves_for_home(
 
 #[cfg(test)]
 mod tests {
+    use std::ffi::OsString;
     use std::sync::Arc;
 
-    use crate::durable::{HomeId, WorkRef};
+    use crate::durable::{Containment, HomeId, RunAdvance, RunState, RunTrigger, WorkRef};
     use crate::id::WaveId;
     use crate::store::{open_store, StorageConfig};
     use crate::wave::Wave;
 
     use super::{waves_for_home, WaveHost};
+
+    struct EnvRestore(Vec<(&'static str, Option<OsString>)>);
+
+    impl EnvRestore {
+        fn capture(names: &[&'static str]) -> Self {
+            Self(
+                names
+                    .iter()
+                    .map(|name| (*name, std::env::var_os(name)))
+                    .collect(),
+            )
+        }
+    }
+
+    impl Drop for EnvRestore {
+        fn drop(&mut self) {
+            for (name, value) in &self.0 {
+                match value {
+                    Some(value) => std::env::set_var(name, value),
+                    None => std::env::remove_var(name),
+                }
+            }
+        }
+    }
+
+    async fn wave_host_with_run(
+        process_group: i64,
+    ) -> (tempfile::TempDir, WaveHost, Wave, crate::durable::RunId) {
+        let directory = tempfile::tempdir().expect("create temp directory");
+        let repo = directory.path().join("repo");
+        std::fs::create_dir_all(repo.join("wave/product")).expect("create Wave directory");
+        std::fs::write(repo.join("wave/product/GOAL.md"), "Product Wave.\n")
+            .expect("write Wave goal");
+        let store = Arc::new(
+            open_store(&StorageConfig::sqlite(directory.path().join("registry.db")))
+                .await
+                .expect("open store"),
+        );
+        let local = store.local_home().await.expect("read local Home");
+        let wave = Wave::new(
+            WaveId::new(),
+            "product".to_string(),
+            repo.display().to_string(),
+        );
+        store.create_wave(&wave).await.expect("create Wave");
+        let work = WorkRef::Wave(wave.id().clone());
+        let (run, lease) = store
+            .reserve_run(&work, RunTrigger::User)
+            .await
+            .expect("reserve Wave Run");
+        store
+            .advance_run(
+                &lease,
+                RunAdvance::RunStarting {
+                    containment: Containment::ProcessGroup { id: process_group },
+                    cwd: repo,
+                },
+            )
+            .await
+            .expect("start Wave Run");
+        (
+            directory,
+            WaveHost::new(local.id, store, None),
+            wave,
+            run.id,
+        )
+    }
 
     #[tokio::test]
     async fn home_start_selects_only_assigned_and_locally_placed_waves() {
@@ -342,7 +496,7 @@ mod tests {
             repo.display().to_string(),
         );
         store.create_wave(&wave).await.expect("create Wave");
-        let host = WaveHost::new(local.id, store);
+        let host = WaveHost::new(local.id, store, None);
         host.suppressed.lock().await.insert(wave.id().clone());
 
         host.reconcile().await;
@@ -350,5 +504,124 @@ mod tests {
         assert!(crate::wave::server::live_endpoint(&repo, wave.name())
             .await
             .is_none());
+    }
+
+    #[allow(clippy::await_holding_lock)]
+    #[tokio::test]
+    async fn wave_start_returns_the_listener_preflight_error() {
+        let _env_lock = crate::journal::test_env_lock();
+        let _restore = EnvRestore::capture(&["LF_BIN", crate::wave::discord::TOKEN_ENV]);
+        std::env::set_var(
+            "LF_BIN",
+            std::env::current_exe().expect("resolve test executable"),
+        );
+        std::env::remove_var(crate::wave::discord::TOKEN_ENV);
+        let directory = tempfile::tempdir().expect("create temp directory");
+        let repo = directory.path().join("repo");
+        std::fs::create_dir_all(repo.join("wave/product")).expect("create Wave directory");
+        let store = Arc::new(
+            open_store(&StorageConfig::sqlite(directory.path().join("registry.db")))
+                .await
+                .expect("open store"),
+        );
+        let local = store.local_home().await.expect("read local Home");
+        std::fs::write(
+            repo.join("wave/product/GOAL.md"),
+            format!(
+                "---\nchat:\n  provider: discord\n  home_id: \"{}\"\n  guild_id: \"guild\"\n  channel_id: \"channel\"\n---\nDiscord-backed product.\n",
+                local.id
+            ),
+        )
+        .expect("write Wave goal");
+        let wave = Wave::new(
+            WaveId::new(),
+            "product".to_string(),
+            repo.display().to_string(),
+        );
+        store.create_wave(&wave).await.expect("create Wave");
+        let host = WaveHost::new(local.id, store, None);
+
+        let error = host
+            .start_waves(vec![wave.id().clone()])
+            .await
+            .expect_err("Discord Wave without a token must fail");
+
+        assert!(
+            error.to_string().contains(crate::wave::discord::TOKEN_ENV),
+            "startup should preserve the actionable listener error: {error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn restart_releases_a_wave_run_with_a_gone_process_group() {
+        let absent_group = i64::from(i32::MAX);
+        assert_eq!(
+            crate::engine::process::process_group_observation(absent_group),
+            crate::durable::ContainmentObservation::Absent
+        );
+        let (_directory, host, wave, prior_run_id) = wave_host_with_run(absent_group).await;
+
+        host.reconcile_run_slot(&wave)
+            .await
+            .expect("recover stale Wave Run");
+
+        let work = WorkRef::Wave(wave.id().clone());
+        assert!(host.store.current_run(&work).await.unwrap().is_none());
+        let (next, _) = host
+            .store
+            .reserve_run(
+                &work,
+                RunTrigger::Recovery {
+                    prior_run_id: prior_run_id.clone(),
+                },
+            )
+            .await
+            .expect("reserve replacement Wave Run");
+        assert_eq!(next.retry_of, Some(prior_run_id));
+    }
+
+    #[tokio::test]
+    async fn restart_keeps_a_live_wave_run_fenced() {
+        let process_group = crate::engine::process::current_process_group_id()
+            .expect("test process has a process group");
+        let (_directory, host, wave, run_id) = wave_host_with_run(i64::from(process_group)).await;
+
+        let error = host
+            .reconcile_run_slot(&wave)
+            .await
+            .expect_err("live Wave Run must remain fenced");
+
+        assert!(error.to_string().contains(run_id.as_str()));
+        assert!(error.to_string().contains("Present"));
+        let current = host
+            .store
+            .current_run(&WorkRef::Wave(wave.id().clone()))
+            .await
+            .unwrap()
+            .expect("live Run remains current");
+        assert_eq!(current.id, run_id);
+        assert_eq!(current.state, RunState::Active);
+    }
+
+    #[tokio::test]
+    async fn restart_keeps_unprovable_wave_containment_fenced() {
+        let (_directory, host, wave, run_id) = wave_host_with_run(i64::MAX).await;
+
+        let error = host
+            .reconcile_run_slot(&wave)
+            .await
+            .expect_err("unprovable Wave Run must remain fenced");
+
+        assert!(error.to_string().contains(run_id.as_str()));
+        assert!(error.to_string().contains("Unprovable"));
+        assert_eq!(
+            host.store
+                .current_run(&WorkRef::Wave(wave.id().clone()))
+                .await
+                .unwrap()
+                .expect("unprovable Run remains current")
+                .id,
+            run_id
+        );
     }
 }

--- a/swift/Loopflow/Services/WaveChatClient.swift
+++ b/swift/Loopflow/Services/WaveChatClient.swift
@@ -107,7 +107,7 @@ public enum ChatBacking: Codable, Sendable, Equatable {
 public enum WaveChatComposeRoute: Sendable, Equatable {
     case unavailable
     case local
-    case openDiscord(ChatAction)
+    case discord(ChatAction)
     case archived
 }
 
@@ -123,7 +123,7 @@ public func waveChatComposeRoute(
     case .local:
         return .local
     case let .discord(_, _, open):
-        return .openDiscord(open)
+        return .discord(open)
     }
 }
 
@@ -487,7 +487,7 @@ public enum WaveLoopState: String, Equatable, Sendable {
 }
 
 /// How a posted message asks to be handled — the required `op` of the
-/// `POST /messages {op, text}` body. Explicit at the API, never inferred.
+/// `POST /messages {id, op, text}` body. Explicit at the API, never inferred.
 public enum WaveMessageOp: String, Equatable, Sendable {
     /// Queued; the loop's next turn answers it.
     case message
@@ -631,7 +631,9 @@ public final class WaveChatConnection {
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        request.httpBody = try JSONSerialization.data(withJSONObject: ["op": op.rawValue, "text": trimmed])
+        request.httpBody = try JSONSerialization.data(
+            withJSONObject: ["id": UUID().uuidString, "op": op.rawValue, "text": trimmed]
+        )
         let (data, response) = try await session.data(for: request)
         guard let http = response as? HTTPURLResponse else {
             throw WaveChatError.badStatus(-1)

--- a/swift/LoopflowMac/Views/WaveChatView.swift
+++ b/swift/LoopflowMac/Views/WaveChatView.swift
@@ -573,7 +573,7 @@ struct WaveChatView: View {
         switch composeRoute {
         case .unavailable, .local:
             localComposer
-        case let .openDiscord(action):
+        case let .discord(action):
             discordComposer(action)
         case .archived:
             archivedComposer
@@ -595,34 +595,27 @@ struct WaveChatView: View {
     }
 
     private func discordComposer(_ action: ChatAction) -> some View {
-        HStack(alignment: .center, spacing: Spacing.lg) {
-            VStack(alignment: .leading, spacing: Spacing.xxs) {
-                Text("Discord is the active conversation")
+        VStack(alignment: .leading, spacing: Spacing.sm) {
+            HStack(spacing: Spacing.sm) {
+                Label("Synced with Discord", systemImage: "bubble.left.and.bubble.right")
                     .font(Typography.caption().weight(.semibold))
-                    .foregroundStyle(palette.text)
-                Text("Messages appear here live. Reply in Discord so the Wave keeps one thread.")
-                    .font(Typography.caption(11))
                     .foregroundStyle(palette.textSecondary)
-                if hasText {
-                    Text("Unsent draft: \(composerText)")
-                        .font(Typography.caption(11))
-                        .foregroundStyle(palette.textSecondary)
-                        .lineLimit(2)
-                        .textSelection(.enabled)
+                Spacer(minLength: 0)
+                if let url = action.url {
+                    Link(destination: url) {
+                        Label(action.label, systemImage: "arrow.up.right")
+                    }
+                    .font(Typography.caption(11))
+                    .accessibilityIdentifier("wave-chat-open-discord")
                 }
             }
-            Spacer(minLength: 0)
-            if let url = action.url {
-                Link(destination: url) {
-                    Label(action.label, systemImage: "arrow.up.right")
-                }
-                .buttonStyle(DarkButtonStyle())
-                .accessibilityIdentifier("wave-chat-open-discord")
-            } else {
-                Text("Discord link unavailable")
+            if let sendError {
+                Text(sendError)
                     .font(Typography.caption())
                     .foregroundStyle(Color.statusError)
+                    .accessibilityIdentifier("wave-chat-send-error")
             }
+            composerRow
         }
         .padding(Spacing.lg)
         .background(palette.background)

--- a/swift/LoopflowTests/WaveChatConnectionTests.swift
+++ b/swift/LoopflowTests/WaveChatConnectionTests.swift
@@ -92,7 +92,7 @@ struct WaveChatConnectionTests {
         #expect(waveChatComposeRoute(activeEpoch: local, selectedEpoch: local) == .local)
         #expect(
             waveChatComposeRoute(activeEpoch: discord, selectedEpoch: discord)
-                == .openDiscord(
+                == .discord(
                     .openDiscord(
                         label: "Open in Discord",
                         url: "https://discord.com/channels/guild/channel"

--- a/wave/product/MEMORY.md
+++ b/wave/product/MEMORY.md
@@ -65,6 +65,13 @@ they mean the Mac surface.
 
 - `lf` and durable store projections define the product API; Mac and iOS
   consume that model rather than inventing a parallel lifecycle.
+- **Terminal-only and agent-embedded Loopflow are normal primary modes.** Chat
+  is an optional shared steering and observation surface, never a prerequisite
+  for operating Loopflow or an onboarding funnel every user must enter.
+- **Wave Chat is asynchronous steering, not a low-latency support chat.**
+  Durable inputs preserve order and may wait behind existing Wave work; surfaces
+  show delivered, queued, and working state instead of implying an immediate
+  conversational reply.
 - App surfaces navigate, present, and Steer Work. A view, terminal, provider
   process, or listener is never the source of Work or Ask/Answer truth.
 - A provider session is AgentInvocation continuity, not Work identity.


### PR DESCRIPTION
## Usage

```bash
doppler secrets set LF_DISCORD_TOKEN > /dev/null
doppler run -- lfd install
lf start product
lf chat -w product --steer "ship the parser fix first"
```

The Mac Wave Chat composer uses the same Discord-backed route, while Open in Discord remains available.

## Summary

This PR turns Discord-backed Wave Chat into a shared native compose surface instead of a read-only handoff. CLI and Mac messages post through the Loopflow bot, receive a canonical Discord identity, and re-enter the resident with message, steer, or interrupt intent intact. It also hardens `lfd` hosting so Discord Waves restart safely without exposing the bot token to residents or provider children.

## Changes

- Added idempotent provider posting, visible Wave attribution, message-length validation, retry handling, and durable operation preservation
- Kept Discord authoritative by journaling canonical provider echoes instead of creating a hidden local transcript
- Loaded the Discord token once in `lfd` while persisting only non-secret Doppler project and config selectors in service files
- Spawned residents with the current Home `lf` binary and surfaced actionable listener preflight failures
- Recovered stale Run slots only when process containment is proven absent, while keeping live or unprovable Runs fenced
- Enabled the Mac composer for Discord epochs with inline delivery errors and the existing Open in Discord action