### PR TITLE
task runtime: repair stale flow pins and bound recovery

### DIFF
--- a/rust/loopflow/src/ops/child.rs
+++ b/rust/loopflow/src/ops/child.rs
@@ -114,7 +114,7 @@ impl Child {
         }
         match self {
             Self::Project(project) => super::project::launch_project_process(store, project).await,
-            Self::Task(task) => super::task::relaunch_inactive_process(store, task).await,
+            Self::Task(task) => super::task::resume_inactive_process(store, task).await,
         }
     }
 }

--- a/rust/loopflow/src/ops/task.rs
+++ b/rust/loopflow/src/ops/task.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::{BTreeMap, BTreeSet, HashSet};
 use std::fs::{File, OpenOptions};
 use std::path::{Component, Path, PathBuf};
 use std::process::Command;
@@ -7,8 +7,8 @@ use std::time::{Duration, Instant};
 
 use crate::child::ChildRef;
 use crate::durable::{
-    AgentInvocation, AuthenticatedRequest, Containment, ContainmentObservation, ControlCtx,
-    RunLease, RunState, WorkRef, WorkStatus,
+    AgentInvocation, AuthenticatedRequest, Containment, ContainmentObservation, ControlCtx, Run,
+    RunLease, RunState, RunTrigger, WaitOn, WorkRef, WorkStatus,
 };
 use crate::engine::config::{load_config_or_default, parse_agent};
 use crate::engine::git::{
@@ -848,6 +848,22 @@ fn resolve_task_lifecycle(
     Ok(crate::task::TaskLifecyclePlan::standard(
         first, loop_flow, finally,
     ))
+}
+
+fn validate_task_lifecycle(task: &Task) -> OpsResult<()> {
+    for (phase, flow, allow_ops) in [
+        ("first", &task.lifecycle.first.flow, false),
+        ("loop", &task.lifecycle.loop_.flow, false),
+        ("finally", &task.lifecycle.finally.flow, true),
+    ] {
+        resolve_task_flow(&task.worktree, flow, allow_ops).map_err(|error| {
+            task_error(format!(
+                "Task {} cannot launch: pinned {phase} flow {flow:?} is invalid: {error}",
+                task.plan.identifier
+            ))
+        })?;
+    }
+    Ok(())
 }
 
 fn resolve_task_flow(repo: &Path, requested: &str, allow_ops: bool) -> OpsResult<String> {
@@ -2091,13 +2107,207 @@ pub(crate) async fn relaunch_inactive_process(
     store: &SharedStore,
     task: &mut Task,
 ) -> OpsResult<()> {
+    relaunch_inactive_process_with_trigger(store, task, None).await
+}
+
+pub(crate) async fn resume_inactive_process(store: &SharedStore, task: &mut Task) -> OpsResult<()> {
+    relaunch_inactive_process_with_trigger(store, task, Some(RunTrigger::User)).await
+}
+
+async fn relaunch_inactive_process_with_trigger(
+    store: &SharedStore,
+    task: &mut Task,
+    trigger: Option<RunTrigger>,
+) -> OpsResult<()> {
     let Some(_) = ensure_working_pr(store, task).await? else {
         return Err(task_error(format!(
             "Task {} is terminal and cannot start a Run",
             task.plan.identifier
         )));
     };
-    launch_task_process(store, task, None).await
+    launch_task_process(store, task, trigger).await
+}
+
+const MAX_AUTOMATIC_TASK_RECOVERY_RUNS: usize = 3;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum AutomaticTaskRelaunch {
+    Idle,
+    Launch(RunTrigger),
+    Exhausted {
+        basis: crate::durable::Basis,
+        recoveries: usize,
+        error: String,
+    },
+}
+
+async fn task_recovery_chain(store: &SharedStore, latest: Run) -> OpsResult<(usize, Run)> {
+    let mut seen = HashSet::new();
+    let mut recoveries = 0;
+    let mut run = latest;
+    loop {
+        if !seen.insert(run.id.clone()) {
+            return Err(task_error(format!(
+                "Task recovery chain contains a cycle at Run {}",
+                run.id
+            )));
+        }
+        let Some(prior_run_id) = run.retry_of.clone() else {
+            return Ok((recoveries, run));
+        };
+        recoveries += 1;
+        run = store
+            .run_by_id(&prior_run_id)
+            .await
+            .map_err(|error| task_error(format!("failed to read Task recovery chain: {error}")))?;
+    }
+}
+
+fn failed_run_made_durable_progress(events: &[crate::task::TaskEvent]) -> bool {
+    events
+        .iter()
+        .skip(1)
+        .take_while(|event| !matches!(event.kind, TaskEventKind::Started))
+        .any(|event| !matches!(event.kind, TaskEventKind::Failed { .. }))
+}
+
+async fn plan_automatic_task_relaunch(
+    store: &SharedStore,
+    task: &Task,
+) -> OpsResult<AutomaticTaskRelaunch> {
+    let work = store
+        .work_for_child(&ChildRef::Task(task.id.clone()))
+        .await
+        .map_err(|error| task_error(error.to_string()))?;
+    if !matches!(
+        store
+            .work_status(&work)
+            .await
+            .map_err(|error| task_error(error.to_string()))?,
+        WorkStatus::Ready
+    ) {
+        return Ok(AutomaticTaskRelaunch::Idle);
+    }
+    let basis = store
+        .current_epoch(&work)
+        .await
+        .map_err(|error| task_error(error.to_string()))?
+        .current_basis;
+    let Some(crate::task::TaskEvent {
+        kind: TaskEventKind::Failed { error, resumable },
+        ..
+    }) = store
+        .latest_task_event(&task.id)
+        .await
+        .map_err(|error| task_error(error.to_string()))?
+    else {
+        return Ok(AutomaticTaskRelaunch::Launch(RunTrigger::Input { basis }));
+    };
+    let Some(latest_run) = store
+        .latest_run(&work)
+        .await
+        .map_err(|error| task_error(error.to_string()))?
+    else {
+        return Ok(AutomaticTaskRelaunch::Launch(RunTrigger::Input { basis }));
+    };
+    let (recoveries, root) = task_recovery_chain(store, latest_run.clone()).await?;
+    let recent_events = store
+        .recent_task_events(&task.id, 16)
+        .await
+        .map_err(|store_error| task_error(store_error.to_string()))?;
+    let durable_progress = failed_run_made_durable_progress(&recent_events);
+    let input_advanced = match &root.trigger {
+        RunTrigger::Input { basis: prior } => {
+            prior.epoch_id != basis.epoch_id || prior.revision < basis.revision
+        }
+        _ => false,
+    };
+    if durable_progress || input_advanced {
+        return Ok(AutomaticTaskRelaunch::Launch(RunTrigger::Input { basis }));
+    }
+    if resumable && recoveries < MAX_AUTOMATIC_TASK_RECOVERY_RUNS {
+        return Ok(AutomaticTaskRelaunch::Launch(RunTrigger::Recovery {
+            prior_run_id: latest_run.id,
+        }));
+    }
+    Ok(AutomaticTaskRelaunch::Exhausted {
+        basis,
+        recoveries,
+        error,
+    })
+}
+
+async fn prepare_automatic_task_relaunch(
+    store: &SharedStore,
+    task: &Task,
+) -> OpsResult<Option<RunTrigger>> {
+    match plan_automatic_task_relaunch(store, task).await? {
+        AutomaticTaskRelaunch::Idle => Ok(None),
+        AutomaticTaskRelaunch::Launch(trigger) => Ok(Some(trigger)),
+        AutomaticTaskRelaunch::Exhausted {
+            basis,
+            recoveries,
+            error,
+        } => {
+            let work = store
+                .work_for_child(&ChildRef::Task(task.id.clone()))
+                .await
+                .map_err(|store_error| task_error(store_error.to_string()))?;
+            let (_, lease) = store
+                .reserve_run(
+                    &work,
+                    RunTrigger::Input {
+                        basis: basis.clone(),
+                    },
+                )
+                .await
+                .map_err(|store_error| {
+                    task_error(format!(
+                        "failed to reserve exhausted Task recovery Run: {store_error}"
+                    ))
+                })?;
+            store
+                .advance_run(
+                    &lease,
+                    crate::durable::RunAdvance::Wait {
+                        on: WaitOn::Input {
+                            after: basis.clone(),
+                        },
+                    },
+                )
+                .await
+                .map_err(|store_error| {
+                    task_error(format!(
+                        "failed to park exhausted Task recovery: {store_error}"
+                    ))
+                })?;
+            tracing::warn!(
+                task = %task.plan.identifier,
+                recoveries,
+                limit = MAX_AUTOMATIC_TASK_RECOVERY_RUNS,
+                %error,
+                "automatic Task recovery exhausted; waiting for durable input"
+            );
+            Ok(None)
+        }
+    }
+}
+
+async fn relaunch_inactive_process_automatically(
+    store: &SharedStore,
+    task: &mut Task,
+) -> OpsResult<()> {
+    let Some(_) = ensure_working_pr(store, task).await? else {
+        return Err(task_error(format!(
+            "Task {} is terminal and cannot start a Run",
+            task.plan.identifier
+        )));
+    };
+    validate_task_lifecycle(task)?;
+    let Some(trigger) = prepare_automatic_task_relaunch(store, task).await? else {
+        return Ok(());
+    };
+    launch_task_process(store, task, Some(trigger)).await
 }
 
 async fn relaunch_for_ci_incident(
@@ -2111,18 +2321,13 @@ async fn relaunch_for_ci_incident(
             task.plan.identifier
         )));
     };
-    launch_task_process(
-        store,
-        task,
-        Some(crate::durable::RunTrigger::CiIncident { incident_id }),
-    )
-    .await
+    launch_task_process(store, task, Some(RunTrigger::CiIncident { incident_id })).await
 }
 
 async fn launch_task_process(
     store: &SharedStore,
     task: &mut Task,
-    trigger: Option<crate::durable::RunTrigger>,
+    trigger: Option<RunTrigger>,
 ) -> OpsResult<()> {
     let work = store
         .work_for_child(&ChildRef::Task(task.id.clone()))
@@ -2136,9 +2341,10 @@ async fn launch_task_process(
     {
         return Ok(());
     }
+    validate_task_lifecycle(task)?;
     let trigger = match trigger {
         Some(trigger) => trigger,
-        None => crate::durable::RunTrigger::Input {
+        None => RunTrigger::Input {
             basis: store
                 .current_epoch(&work)
                 .await
@@ -2276,7 +2482,7 @@ async fn mark_task_body_lost(store: &SharedStore, task: &mut Task) -> OpsResult<
         );
         return Ok(());
     }
-    relaunch_inactive_process(store, task).await
+    relaunch_inactive_process_automatically(store, task).await
 }
 
 /// Let one live Project body supervise the progress leases of its Task bodies.
@@ -2345,7 +2551,7 @@ pub(crate) async fn reconcile_project_tasks(
                 task_work_status(store, task).await?,
                 WorkStatus::Running { .. }
             ) {
-                relaunch_inactive_process(store, task).await?;
+                relaunch_inactive_process_automatically(store, task).await?;
             }
         } else {
             let Some(pr) = observed.as_ref() else {
@@ -2360,7 +2566,7 @@ pub(crate) async fn reconcile_project_tasks(
             {
                 // Publication is not settlement. Keep executing the authored
                 // Task flow unless submit/land requested a merge for this head.
-                relaunch_inactive_process(store, task).await?;
+                relaunch_inactive_process_automatically(store, task).await?;
             }
         }
     }
@@ -2493,12 +2699,13 @@ pub(crate) async fn route_ci_incident(
     let Some(incident) = current_ci_incident(pr) else {
         return Ok(());
     };
-    if !matches!(
-        task_work_status(store, task).await?,
-        WorkStatus::Running { .. }
-    ) {
-        let mut task = task.clone();
-        relaunch_for_ci_incident(store, &mut task, incident.identity.clone()).await?;
+    match task_work_status(store, task).await? {
+        WorkStatus::Ready => {
+            let mut task = task.clone();
+            relaunch_for_ci_incident(store, &mut task, incident.identity.clone()).await?;
+        }
+        WorkStatus::Running { .. } => {}
+        WorkStatus::Waiting { .. } | WorkStatus::Done | WorkStatus::Abandoned => return Ok(()),
     }
     let work = store
         .work_for_child(&ChildRef::Task(task.id.clone()))
@@ -4750,11 +4957,159 @@ pub fn task_wait(issue: &str, until: TaskWaitUntil, timeout: Option<Duration>) -
 
 #[cfg(test)]
 mod tests {
+    use std::ffi::OsString;
+    #[cfg(unix)]
+    use std::os::unix::fs::PermissionsExt;
+
     use super::{
-        ensure_task_flow_override, lock_task_pr_mutation, resolve_task_lifecycle,
-        resolve_task_start_input, TaskFlowOverrides,
+        ensure_task_flow_override, launch_task_process, lock_task_pr_mutation,
+        prepare_automatic_task_relaunch, resolve_task_lifecycle, resolve_task_start_input,
+        TaskFlowOverrides, MAX_AUTOMATIC_TASK_RECOVERY_RUNS,
     };
+    use crate::child::ChildRef;
+    use crate::durable::{RunTrigger, WorkRef, WorkStatus};
+    use crate::planning::{LinearIssueId, LinearProjectId, ProjectPlan, TaskPlan};
     use crate::pm::ProjectFlowPlan;
+    use crate::project::{Project, ProjectId};
+    use crate::store::{open_store, SharedStore, StorageConfig};
+    use crate::task::{
+        Observation, PmWritebackState, Task, TaskEventKind, TaskId, TaskLifecyclePhase,
+        TaskLifecyclePlan, TaskPr, TaskPrId,
+    };
+    use crate::wave::Wave;
+
+    struct TaskFixture {
+        _database: tempfile::TempDir,
+        database_path: std::path::PathBuf,
+        store: SharedStore,
+        task: Task,
+        work: WorkRef,
+    }
+
+    struct EnvRestore(Vec<(&'static str, Option<OsString>)>);
+
+    impl EnvRestore {
+        fn capture(names: &[&'static str]) -> Self {
+            Self(
+                names
+                    .iter()
+                    .map(|name| (*name, std::env::var_os(name)))
+                    .collect(),
+            )
+        }
+    }
+
+    impl Drop for EnvRestore {
+        fn drop(&mut self) {
+            for (name, value) in &self.0 {
+                match value {
+                    Some(value) => std::env::set_var(name, value),
+                    None => std::env::remove_var(name),
+                }
+            }
+        }
+    }
+
+    async fn task_fixture(identifier: &str, loop_flow: &str) -> TaskFixture {
+        let repository =
+            std::fs::canonicalize(std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("../.."))
+                .unwrap();
+        let database = tempfile::tempdir().unwrap();
+        let database_path = database.path().join("registry.db");
+        let store = std::sync::Arc::new(
+            open_store(&StorageConfig::sqlite(database_path.clone()))
+                .await
+                .unwrap(),
+        );
+        let now = time::OffsetDateTime::now_utc();
+        let wave = Wave::new(
+            crate::id::WaveId::new(),
+            "task-recovery".to_string(),
+            repository.display().to_string(),
+        );
+        let project = Project {
+            id: ProjectId::new(),
+            plan: ProjectPlan {
+                id: LinearProjectId::new("task-recovery-project").unwrap(),
+                slug: "task-recovery".to_string(),
+                name: "Task recovery".to_string(),
+                prompt_context: "Keep automatic Task recovery bounded.".to_string(),
+                pm_snapshot_synced_at: now.unix_timestamp(),
+            },
+            wave_id: wave.id().clone(),
+            iteration: 0,
+            observation_cursor: 0,
+            last_state_fingerprint: None,
+            agent: "codex".to_string(),
+            provider: "codex".to_string(),
+            provider_session_id: None,
+            abandon_intent: None,
+            created_at: now,
+            updated_at: now,
+        };
+        let task = Task {
+            id: TaskId::new(),
+            plan: TaskPlan {
+                id: LinearIssueId::new(format!("{identifier}-issue")).unwrap(),
+                identifier: identifier.to_string(),
+                title: "Task recovery fixture".to_string(),
+                description: String::new(),
+                pm_snapshot_synced_at: now.unix_timestamp(),
+            },
+            pm_writeback: PmWritebackState::Current,
+            wave_id: wave.id().clone(),
+            project_id: project.id.clone(),
+            worktree: repository,
+            workspace_slug: "task-recovery-fixture".to_string(),
+            lifecycle: TaskLifecyclePlan::standard("task-design", loop_flow, "ship"),
+            lifecycle_phase: TaskLifecyclePhase::Loop,
+            phase_epoch: 4,
+            phase_cursor: 0,
+            phase_iteration: 0,
+            gate_cycle: 1,
+            gate_proposal: None,
+            agent: "codex".to_string(),
+            provider: "codex".to_string(),
+            provider_session_id: None,
+            abandon_intent: None,
+            created_at: now,
+            updated_at: now,
+            observation: Observation::NotRequired,
+        };
+        let pr = TaskPr {
+            id: TaskPrId::new(),
+            task_id: task.id.clone(),
+            sequence: 1,
+            slug: task.workspace_slug.clone(),
+            branch: format!("test/{}", task.workspace_slug),
+            base_commit: "deadbeef".to_string(),
+            parent_pr_id: None,
+            publication: None,
+            merge_commit: None,
+            abandoned_at: None,
+            ci_observation: None,
+            github_observation: None,
+            linear_attachment_id: None,
+            linear_comment_id: None,
+            linear_link_error: None,
+            created_at: now,
+            updated_at: now,
+        };
+        store.create_wave(&wave).await.unwrap();
+        store.create_project(&project).await.unwrap();
+        store.create_task(&task, &pr).await.unwrap();
+        let work = store
+            .work_for_child(&ChildRef::Task(task.id.clone()))
+            .await
+            .unwrap();
+        TaskFixture {
+            _database: database,
+            database_path,
+            store,
+            task,
+            work,
+        }
+    }
 
     #[test]
     fn piped_report_supplies_title_and_preserves_full_description() {
@@ -4826,6 +5181,202 @@ mod tests {
         assert!(error
             .to_string()
             .contains("Task INF-123 already pins loop flow \"slice\""));
+    }
+
+    #[tokio::test]
+    async fn unavailable_persisted_flow_is_rejected_before_every_run_reservation() {
+        let TaskFixture {
+            store,
+            mut task,
+            work,
+            ..
+        } = task_fixture("TEST-STALE", "retired-task-flow").await;
+
+        for _ in 0..2 {
+            let error = launch_task_process(&store, &mut task, None)
+                .await
+                .expect_err("the unavailable flow must fail startup validation");
+            assert!(error.to_string().contains(
+                "Task TEST-STALE cannot launch: pinned loop flow \"retired-task-flow\" is invalid: failed to load Task flow \"retired-task-flow\": flow not found: retired-task-flow"
+            ));
+            assert!(store.current_run(&work).await.unwrap().is_none());
+        }
+        assert!(store
+            .recent_task_events(&task.id, 10)
+            .await
+            .unwrap()
+            .is_empty());
+    }
+
+    #[cfg(unix)]
+    #[allow(clippy::await_holding_lock)]
+    #[tokio::test]
+    async fn repaired_persisted_task_flows_launch_through_the_generic_path() {
+        let _env_lock = crate::journal::test_env_lock();
+        let _restore = EnvRestore::capture(&["LF_BIN", "LF_HOME", "LF_DB_PATH", "PATH"]);
+        let environment = tempfile::tempdir().unwrap();
+        let bin = environment.path().join("bin");
+        std::fs::create_dir(&bin).unwrap();
+        let tmux = bin.join("tmux");
+        std::fs::write(&tmux, "#!/bin/sh\nexit 0\n").unwrap();
+        std::fs::set_permissions(&tmux, std::fs::Permissions::from_mode(0o755)).unwrap();
+        std::env::set_var("LF_BIN", std::env::current_exe().unwrap());
+        std::env::set_var("LF_HOME", environment.path());
+        std::env::remove_var("LF_DB_PATH");
+        std::env::set_var("PATH", &bin);
+
+        for identifier in ["LOO-167", "LOO-193", "LOO-195"] {
+            let TaskFixture {
+                _database,
+                database_path,
+                store,
+                task,
+                work,
+                ..
+            } = task_fixture(identifier, "task").await;
+            rusqlite::Connection::open(database_path)
+                .unwrap()
+                .execute_batch(&crate::store::migrations::migration_sql_for_test(
+                    "repair_legacy_task_flow",
+                ))
+                .unwrap();
+            let mut repaired = store.get_task(&task.id).await.unwrap().unwrap();
+
+            assert_eq!(repaired.lifecycle.loop_.flow, "slice");
+            launch_task_process(&store, &mut repaired, None)
+                .await
+                .expect("a repaired Task reaches the generic launch boundary");
+            let run = store.current_run(&work).await.unwrap().unwrap();
+            assert!(matches!(run.trigger, RunTrigger::Input { .. }));
+            assert!(store
+                .open_invocation_for_run(&run.id)
+                .await
+                .unwrap()
+                .is_some());
+        }
+    }
+
+    #[tokio::test]
+    async fn automatic_task_relaunch_exhausts_until_durable_progress_or_user_input() {
+        let TaskFixture {
+            store, task, work, ..
+        } = task_fixture("TEST-RECOVERY", "slice").await;
+        let basis = store.current_epoch(&work).await.unwrap().current_basis;
+        let (initial, initial_lease) = store
+            .reserve_run(
+                &work,
+                RunTrigger::Input {
+                    basis: basis.clone(),
+                },
+            )
+            .await
+            .unwrap();
+        store
+            .append_task_event_for_run(&task.id, &initial_lease, &TaskEventKind::Started)
+            .await
+            .unwrap();
+        store
+            .fail_task_run(&task.id, &initial_lease, "always fails")
+            .await
+            .unwrap();
+
+        let mut prior_run_id = initial.id;
+        for recovery in 1..=MAX_AUTOMATIC_TASK_RECOVERY_RUNS {
+            let trigger = prepare_automatic_task_relaunch(&store, &task)
+                .await
+                .unwrap()
+                .expect("automatic recovery remains within its budget");
+            assert_eq!(
+                trigger,
+                RunTrigger::Recovery {
+                    prior_run_id: prior_run_id.clone()
+                }
+            );
+            let (run, lease) = store.reserve_run(&work, trigger).await.unwrap();
+            assert_eq!(run.retry_of, Some(prior_run_id));
+            store
+                .append_task_event_for_run(&task.id, &lease, &TaskEventKind::Started)
+                .await
+                .unwrap();
+            store
+                .fail_task_run(
+                    &task.id,
+                    &lease,
+                    &format!("automatic recovery {recovery} failed"),
+                )
+                .await
+                .unwrap();
+            prior_run_id = run.id;
+        }
+
+        assert!(prepare_automatic_task_relaunch(&store, &task)
+            .await
+            .unwrap()
+            .is_none());
+        assert!(matches!(
+            store.work_status(&work).await.unwrap(),
+            WorkStatus::Waiting { .. }
+        ));
+        let parked_run = store.latest_run(&work).await.unwrap().unwrap();
+        for _ in 0..10 {
+            assert!(prepare_automatic_task_relaunch(&store, &task)
+                .await
+                .unwrap()
+                .is_none());
+            assert_eq!(
+                store.latest_run(&work).await.unwrap().unwrap().id,
+                parked_run.id
+            );
+        }
+
+        let (user_run, user_lease) = store
+            .reserve_run(&work, RunTrigger::User)
+            .await
+            .expect("explicit User input clears the exhausted wait");
+        store
+            .append_task_event_for_run(&task.id, &user_lease, &TaskEventKind::Started)
+            .await
+            .unwrap();
+        store
+            .fail_task_run(&task.id, &user_lease, "User-started Run failed")
+            .await
+            .unwrap();
+        let trigger = prepare_automatic_task_relaunch(&store, &task)
+            .await
+            .unwrap()
+            .expect("User input starts a fresh recovery budget");
+        assert_eq!(
+            trigger,
+            RunTrigger::Recovery {
+                prior_run_id: user_run.id
+            }
+        );
+
+        let (_, progress_lease) = store.reserve_run(&work, trigger).await.unwrap();
+        store
+            .append_task_event_for_run(&task.id, &progress_lease, &TaskEventKind::Started)
+            .await
+            .unwrap();
+        store
+            .append_task_event_for_run(
+                &task.id,
+                &progress_lease,
+                &TaskEventKind::Progress {
+                    summary: "durable progress".to_string(),
+                },
+            )
+            .await
+            .unwrap();
+        store
+            .fail_task_run(&task.id, &progress_lease, "failed after durable progress")
+            .await
+            .unwrap();
+        assert_eq!(
+            prepare_automatic_task_relaunch(&store, &task)
+                .await
+                .unwrap(),
+            Some(RunTrigger::Input { basis })
+        );
     }
 
     #[test]

--- a/rust/loopflow/src/store/children.rs
+++ b/rust/loopflow/src/store/children.rs
@@ -456,43 +456,7 @@ impl Store {
             store.append_task_event(&write_task_id, &write_kind)
         })
         .await?;
-        if kind.is_project_observable() {
-            if let Some(task) = self.get_task(&task_id).await? {
-                if let Err(error) = crate::ops::project::wake_task_project_route(self, &task).await
-                {
-                    tracing::debug!(
-                        %error,
-                        %task_id,
-                        project_id = %task.project_id,
-                        event_id = event.id,
-                        "Task observation wake failed; Project lifecycle touch will retry"
-                    );
-                }
-                if kind.is_root_wave_observable() {
-                    match self.get_wave(&task.wave_id).await? {
-                        Some(wave) => {
-                            if let Err(error) =
-                                crate::lf::commands::chat::nudge_child_observations(wave.name())
-                                    .await
-                            {
-                                tracing::debug!(
-                                    %error,
-                                    %task_id,
-                                    event_id = event.id,
-                                    "live Task observation delivery failed; Wave observer will retry"
-                                );
-                            }
-                        }
-                        None => tracing::error!(
-                            wave_id = %task.wave_id,
-                            %task_id,
-                            event_id = event.id,
-                            "Task observation cannot nudge its missing owning Wave"
-                        ),
-                    }
-                }
-            }
-        }
+        self.nudge_task_event(&task_id, &kind, &event).await?;
         Ok(event)
     }
 
@@ -511,8 +475,48 @@ impl Store {
             store.append_task_event_for_run(&write_task_id, &lease, &write_kind)
         })
         .await?;
+        self.nudge_task_event(&task_id, &kind, &event).await?;
+        Ok(event)
+    }
+
+    pub(crate) async fn fail_task_run(
+        &self,
+        task_id: &TaskId,
+        lease: &RunLease,
+        error: &str,
+    ) -> StoreResult<TaskEvent> {
+        let task_id = task_id.clone();
+        let lease = lease.clone();
+        let error = error.to_string();
+        let write_task_id = task_id.clone();
+        let write_error = error.clone();
+        let event = run_sqlite(&self.sqlite, move |store| {
+            store.fail_task_run(&write_task_id, &lease, &write_error)
+        })
+        .await?;
+        let kind = TaskEventKind::Failed {
+            error,
+            resumable: true,
+        };
+        if let Err(error) = self.nudge_task_event(&task_id, &kind, &event).await {
+            tracing::debug!(
+                %error,
+                %task_id,
+                event_id = event.id,
+                "terminal Task event persisted; live observer nudge will retry"
+            );
+        }
+        Ok(event)
+    }
+
+    async fn nudge_task_event(
+        &self,
+        task_id: &TaskId,
+        kind: &TaskEventKind,
+        event: &TaskEvent,
+    ) -> StoreResult<()> {
         if kind.is_project_observable() {
-            if let Some(task) = self.get_task(&task_id).await? {
+            if let Some(task) = self.get_task(task_id).await? {
                 if let Err(error) = crate::ops::project::wake_task_project_route(self, &task).await
                 {
                     tracing::debug!(
@@ -548,7 +552,7 @@ impl Store {
                 }
             }
         }
-        Ok(event)
+        Ok(())
     }
 
     pub async fn task_events_after(

--- a/rust/loopflow/src/store/durable.rs
+++ b/rust/loopflow/src/store/durable.rs
@@ -143,6 +143,11 @@ impl Store {
         run_sqlite(&self.sqlite, move |store| store.run_by_id(&run_id)).await
     }
 
+    pub(crate) async fn latest_run(&self, work: &WorkRef) -> StoreResult<Option<Run>> {
+        let work = work.clone();
+        run_sqlite(&self.sqlite, move |store| store.latest_run(&work)).await
+    }
+
     pub(crate) async fn resolve_run_lease(
         &self,
         token: crate::durable::RunLeaseToken,

--- a/rust/loopflow/src/store/migrations.rs
+++ b/rust/loopflow/src/store/migrations.rs
@@ -502,6 +502,31 @@ const MIGRATIONS: &[Migration] = &[
     },
 ];
 
+#[cfg(test)]
+pub(crate) fn migration_sql_for_test(name: &str) -> String {
+    let marker = format!("-- draft: {name}");
+    if let Some(migration) = MIGRATIONS
+        .iter()
+        .find(|migration| migration.sql.lines().any(|line| line == marker))
+    {
+        return migration.sql.to_string();
+    }
+
+    let drafts =
+        std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src/store/migrations/drafts");
+    let prefix = format!("{name}__");
+    let path = std::fs::read_dir(drafts)
+        .expect("migration draft directory")
+        .map(|entry| entry.expect("migration draft entry").path())
+        .find(|path| {
+            path.file_name()
+                .and_then(|name| name.to_str())
+                .is_some_and(|name| name.starts_with(&prefix) && name.ends_with(".sql"))
+        })
+        .expect("migration is canonical or present as an ordinal-free draft");
+    std::fs::read_to_string(path).expect("migration SQL")
+}
+
 /// The exact branch-local history that reached one production ledger before
 /// main established `0.11.008_interactive_handoffs`. These ids were never
 /// released. They remain here only long enough to recognize and converge that
@@ -1563,7 +1588,6 @@ fn incompatible() -> StoreError {
 
 #[cfg(test)]
 mod tests {
-    use std::fs;
     use std::sync::mpsc::sync_channel;
     use std::time::Duration;
 
@@ -1572,13 +1596,14 @@ mod tests {
     use super::{
         active_namespace, applied_versions, apply_set, apply_sqlite, apply_sqlite_transaction,
         apply_sqlite_with_backup, backup_before_migration, latest_applied_version_sqlite,
-        latest_known_version, latest_version_sqlite, migration_checksum, pending_migrations,
-        product_schema, validate_foreign_keys, validate_persisted_json, validate_set,
-        validate_sqlite, Migration, MigrationId, DIVERGENT_MIGRATIONS, MIGRATIONS,
+        latest_known_version, latest_version_sqlite, migration_checksum, migration_sql_for_test,
+        pending_migrations, product_schema, validate_foreign_keys, validate_persisted_json,
+        validate_set, validate_sqlite, Migration, MigrationId, DIVERGENT_MIGRATIONS, MIGRATIONS,
     };
 
     const REOPEN_REPAIR_NAME: &str = "retire_obsolete_pm_reopen_writebacks";
     const GATE_PROPOSAL_REPAIR_NAME: &str = "repair_legacy_task_gate_proposals";
+    const LEGACY_TASK_FLOW_REPAIR_NAME: &str = "repair_legacy_task_flow";
 
     fn _draft_is_canonical(name: &str) -> bool {
         let marker = format!("-- draft: {name}");
@@ -1632,22 +1657,6 @@ mod tests {
             )
             .unwrap();
         }
-    }
-
-    fn _repair_sql(name: &str) -> String {
-        let drafts =
-            std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src/store/migrations/drafts");
-        let prefix = format!("{name}__");
-        let repair = fs::read_dir(&drafts)
-            .unwrap()
-            .map(|entry| entry.unwrap().path())
-            .find(|path| {
-                path.file_name()
-                    .and_then(|name| name.to_str())
-                    .is_some_and(|name| name.starts_with(&prefix) && name.ends_with(".sql"))
-            })
-            .expect("repair is canonical or present as an ordinal-free draft");
-        fs::read_to_string(repair).unwrap()
     }
 
     fn apply_permuted_history(conn: &rusqlite::Connection) {
@@ -3010,11 +3019,11 @@ mod tests {
             .unwrap();
         if !_draft_is_canonical(REOPEN_REPAIR_NAME) {
             assert!(stale.contains("reopen_task"));
-            conn.execute_batch(&_repair_sql(REOPEN_REPAIR_NAME))
+            conn.execute_batch(&migration_sql_for_test(REOPEN_REPAIR_NAME))
                 .unwrap();
         }
         if !_draft_is_canonical(GATE_PROPOSAL_REPAIR_NAME) {
-            conn.execute_batch(&_repair_sql(GATE_PROPOSAL_REPAIR_NAME))
+            conn.execute_batch(&migration_sql_for_test(GATE_PROPOSAL_REPAIR_NAME))
                 .unwrap();
         }
         assert_eq!(
@@ -3773,6 +3782,152 @@ mod tests {
             [],
         )
         .unwrap();
+    }
+
+    #[test]
+    fn legacy_task_flow_repair_restores_existing_tasks_without_moving_their_work() {
+        let conn = open();
+        if _draft_is_canonical(LEGACY_TASK_FLOW_REPAIR_NAME) {
+            apply_before_draft(&conn, LEGACY_TASK_FLOW_REPAIR_NAME);
+        } else {
+            apply_set(&conn, MIGRATIONS).unwrap();
+        }
+        conn.execute_batch(
+            "INSERT INTO waves (id, name, repo, created_at)
+                 VALUES ('wave_restore', 'restore', '/repo', 100);
+             INSERT INTO projects (id, wave_id, external_project_id, created_at)
+                 VALUES ('proj_restore', 'wave_restore', 'linear_project', 100);
+             INSERT INTO tasks (
+                 id, project_id, external_issue_id, issue_identifier, created_at,
+                 issue_title, issue_description, pm_snapshot_synced_at,
+                 pm_writeback_json, worktree, workspace_slug, agent, provider,
+                 iterate_flow, phase_cursor, phase_iteration, kickoff_flow,
+                 gate_flow, lifecycle_phase, phase_epoch, gate_cycle, updated_at
+             ) VALUES
+                 ('task_legacy_a', 'proj_restore', 'issue_a', 'LOO-193', 101,
+                  'Legacy A', '', 101, '{\"state\":\"current\"}', '/repo.a',
+                  'legacy-a', 'codex', 'codex', 'task', 3, 4,
+                  'task-design', 'ship', 'iterate', 7, 2, 111),
+                 ('task_legacy_b', 'proj_restore', 'issue_b', 'LOO-195', 102,
+                  'Legacy B', '', 102, '{\"state\":\"current\"}', '/repo.b',
+                  'legacy-b', 'codex', 'codex', 'task', 5, 6,
+                  'incident', 'ship', 'iterate', 8, 3, 112),
+                 ('task_explicit', 'proj_restore', 'issue_c', 'LOO-206', 103,
+                  'Explicit', '', 103, '{\"state\":\"current\"}', '/repo.c',
+                  'explicit-c', 'codex', 'codex', 'ship-5whys', 1, 2,
+                  'incident', 'ship', 'iterate', 9, 4, 113);
+             INSERT INTO epochs (
+                 id, number, task_id, state, current_rev, created_at
+             ) VALUES
+                 ('epoch_a', 1, 'task_legacy_a', 'open', 0, 101),
+                 ('epoch_b', 1, 'task_legacy_b', 'open', 0, 102),
+                 ('epoch_c', 1, 'task_explicit', 'open', 0, 103);
+             INSERT INTO task_prs (
+                 id, task_id, sequence, slug, branch, base_commit,
+                 created_at, updated_at
+             ) VALUES
+                 ('pr_a', 'task_legacy_a', 1, 'legacy-a', 'jack/legacy-a', 'base-a', 101, 111),
+                 ('pr_b', 'task_legacy_b', 1, 'legacy-b', 'jack/legacy-b', 'base-b', 102, 112),
+                 ('pr_c', 'task_explicit', 1, 'explicit-c', 'jack/explicit-c', 'base-c', 103, 113);",
+        )
+        .unwrap();
+
+        if _draft_is_canonical(LEGACY_TASK_FLOW_REPAIR_NAME) {
+            apply_draft(&conn, LEGACY_TASK_FLOW_REPAIR_NAME);
+        } else {
+            conn.execute_batch(&migration_sql_for_test(LEGACY_TASK_FLOW_REPAIR_NAME))
+                .unwrap();
+        }
+
+        let tasks = conn
+            .prepare(
+                "SELECT id, iterate_flow, kickoff_flow, gate_flow, lifecycle_phase,
+                        phase_epoch, phase_cursor, phase_iteration, gate_cycle,
+                        worktree, updated_at
+                 FROM tasks ORDER BY id",
+            )
+            .unwrap()
+            .query_map([], |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, String>(2)?,
+                    row.get::<_, String>(3)?,
+                    row.get::<_, String>(4)?,
+                    row.get::<_, i64>(5)?,
+                    row.get::<_, i64>(6)?,
+                    row.get::<_, i64>(7)?,
+                    row.get::<_, i64>(8)?,
+                    row.get::<_, String>(9)?,
+                    row.get::<_, i64>(10)?,
+                ))
+            })
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+        assert_eq!(
+            tasks,
+            vec![
+                (
+                    "task_explicit".into(),
+                    "ship-5whys".into(),
+                    "incident".into(),
+                    "ship".into(),
+                    "iterate".into(),
+                    9,
+                    1,
+                    2,
+                    4,
+                    "/repo.c".into(),
+                    113,
+                ),
+                (
+                    "task_legacy_a".into(),
+                    "slice".into(),
+                    "task-design".into(),
+                    "ship".into(),
+                    "iterate".into(),
+                    7,
+                    3,
+                    4,
+                    2,
+                    "/repo.a".into(),
+                    111,
+                ),
+                (
+                    "task_legacy_b".into(),
+                    "slice".into(),
+                    "incident".into(),
+                    "ship".into(),
+                    "iterate".into(),
+                    8,
+                    5,
+                    6,
+                    3,
+                    "/repo.b".into(),
+                    112,
+                ),
+            ]
+        );
+        assert_eq!(
+            conn.query_row("SELECT COUNT(*) FROM epochs", [], |row| row
+                .get::<_, i64>(0))
+                .unwrap(),
+            3
+        );
+        assert_eq!(
+            conn.query_row("SELECT COUNT(*) FROM task_prs", [], |row| row
+                .get::<_, i64>(0))
+                .unwrap(),
+            3
+        );
+
+        let repo = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
+        for flow in ["slice", "slice", "ship-5whys"] {
+            let invocation = crate::wave::playhead::QueuedInvocation::load(&repo, flow)
+                .expect("every repaired persisted loop flow resolves");
+            assert_eq!(invocation.flow, flow);
+        }
     }
 
     #[test]

--- a/rust/loopflow/src/store/migrations/drafts/repair_legacy_task_flow__6e8fbbdbbfa6ef69991bac7f448c25f1.sql
+++ b/rust/loopflow/src/store/migrations/drafts/repair_legacy_task_flow__6e8fbbdbbfa6ef69991bac7f448c25f1.sql
@@ -1,0 +1,8 @@
+-- name: repair_legacy_task_flow
+-- id: 6e8fbbdbbfa6ef69991bac7f448c25f1
+-- depends_on:
+-- `task` was the historical default loop flow. `slice` is its current
+-- replacement; change only that retired default and preserve explicit flows.
+UPDATE tasks
+SET iterate_flow = 'slice'
+WHERE iterate_flow = 'task';

--- a/rust/loopflow/src/store/sqlite/children.rs
+++ b/rust/loopflow/src/store/sqlite/children.rs
@@ -801,6 +801,30 @@ impl SqliteStore {
         Ok(event)
     }
 
+    pub(crate) fn fail_task_run(
+        &self,
+        task_id: &TaskId,
+        lease: &RunLease,
+        error: &str,
+    ) -> StoreResult<TaskEvent> {
+        let mut conn = self.conn.lock().expect("store mutex poisoned");
+        let transaction = conn.transaction_with_behavior(TransactionBehavior::Immediate)?;
+        require_cleanup_run_owns_child(&transaction, &ChildRef::Task(task_id.clone()), lease)?;
+        let task = transaction.query_row(TASK_SELECT, params![task_id.as_str()], map_task_row)?;
+        validate_task(&task)?;
+        let event = insert_task_event_in(
+            &transaction,
+            &task,
+            &TaskEventKind::Failed {
+                error: error.to_string(),
+                resumable: true,
+            },
+        )?;
+        end_run_for_lease(&transaction, lease, crate::durable::BoundaryState::Failed)?;
+        transaction.commit()?;
+        Ok(event)
+    }
+
     pub fn task_events_after(&self, task_id: &TaskId, cursor: i64) -> StoreResult<Vec<TaskEvent>> {
         let conn = self.conn.lock().expect("store mutex poisoned");
         let mut statement = conn.prepare(

--- a/rust/loopflow/src/store/sqlite/durable.rs
+++ b/rust/loopflow/src/store/sqlite/durable.rs
@@ -278,6 +278,12 @@ impl SqliteStore {
         run_by_id_in(&conn, run_id)
     }
 
+    pub(crate) fn latest_run(&self, work: &WorkRef) -> StoreResult<Option<Run>> {
+        let conn = self.conn.lock().expect("store mutex poisoned");
+        let epoch = current_epoch_in(&conn, work)?;
+        latest_run_for_epoch_in(&conn, &epoch.id)
+    }
+
     pub(crate) fn resolve_run_lease(&self, token: &RunLeaseToken) -> StoreResult<RunLease> {
         let conn = self.conn.lock().expect("store mutex poisoned");
         let id = conn
@@ -1991,6 +1997,22 @@ fn run_for_epoch_in(conn: &Connection, epoch_id: &EpochId) -> StoreResult<Option
     let id = conn
         .query_row(
             "SELECT id FROM runs WHERE epoch_id=?1 AND state != 'ended'",
+            [epoch_id.as_str()],
+            |row| row.get::<_, String>(0),
+        )
+        .optional()?;
+    id.map(|id| {
+        RunId::parse(&id)
+            .map_err(invalid_durable)
+            .and_then(|id| run_by_id_in(conn, &id))
+    })
+    .transpose()
+}
+
+fn latest_run_for_epoch_in(conn: &Connection, epoch_id: &EpochId) -> StoreResult<Option<Run>> {
+    let id = conn
+        .query_row(
+            "SELECT id FROM runs WHERE epoch_id=?1 ORDER BY created_at DESC, rowid DESC LIMIT 1",
             [epoch_id.as_str()],
             |row| row.get::<_, String>(0),
         )

--- a/rust/loopflow/src/task/runner.rs
+++ b/rust/loopflow/src/task/runner.rs
@@ -1445,29 +1445,28 @@ async fn record_unhandled_failure(
     lease: &RunLease,
     error: &anyhow::Error,
 ) {
-    let Ok(Some(task)) = store.get_task(task_id).await else {
-        return;
-    };
-    let Ok(work) = store.work_for_child(&ChildRef::Task(task.id.clone())).await else {
-        return;
-    };
-    if lease.work != work {
-        return;
+    match store.current_run(&lease.work).await {
+        Ok(Some(run)) if run.id == lease.run_id => {}
+        Ok(_) => return,
+        Err(store_error) => {
+            tracing::error!(
+                task = %task_id,
+                run = %lease.run_id,
+                error = %store_error,
+                "cannot inspect Task Run before recording its failure receipt"
+            );
+            return;
+        }
     }
     let message = format!("task process failed: {error}");
-    let _ = store
-        .append_task_event_for_run(
-            &task.id,
-            lease,
-            &TaskEventKind::Failed {
-                error: message.clone(),
-                resumable: true,
-            },
-        )
-        .await;
-    let _ = store
-        .finish_task_run(&task, lease, crate::durable::BoundaryState::Failed)
-        .await;
+    if let Err(persist_error) = store.fail_task_run(task_id, lease, &message).await {
+        tracing::error!(
+            task = %task_id,
+            run = %lease.run_id,
+            error = %persist_error,
+            "Task failure receipt did not persist; Run remains recoverable"
+        );
+    }
 }
 
 async fn apply_input(
@@ -1496,19 +1495,8 @@ async fn finish_failed(
 ) -> Result<()> {
     finish_capture(capture, "failed");
     let _ = harness.stop().await;
-    store
-        .append_task_event_for_run(
-            &task.id,
-            lease,
-            &TaskEventKind::Failed {
-                error: error.to_string(),
-                resumable: true,
-            },
-        )
-        .await?;
-    store
-        .finish_task_run(task, lease, crate::durable::BoundaryState::Failed)
-        .await?;
+    store.update_task_for_run(task, lease).await?;
+    store.fail_task_run(&task.id, lease, error).await?;
     anyhow::bail!(error.to_string())
 }
 
@@ -1522,11 +1510,11 @@ fn infra_blocked_reason(capability: &str, detail: &str, pr_number: Option<u32>) 
     format!("ci-fix blocked by {capability}: {detail}.{pr_note}")
 }
 
-/// Stop the body and transition the Task to Blocked for an infrastructure
-/// failure (provider outage, GitHub observation failure), keeping the active PR
-/// attached so a resume after the capability recovers picks up the same PR.
-/// Returns `Ok(())` — a clean stop, not an error — so the runner does not also
-/// record an unhandled failure.
+/// Stop the body and record an infrastructure failure (provider outage, GitHub
+/// observation failure), keeping the active PR attached so a resume after the
+/// capability recovers picks up the same PR. Returns `Ok(())` after the atomic
+/// Task failure receipt settles the Run, so the outer boundary does not record
+/// the same failure twice.
 async fn finish_infra_blocked(
     store: &SharedStore,
     task: &mut Task,
@@ -1546,9 +1534,8 @@ async fn finish_infra_blocked(
             .mark_ci_incidents_blocked(&pr.id, time::OffsetDateTime::now_utc(), &reason)
             .await?;
     }
-    store
-        .finish_task_run(task, lease, crate::durable::BoundaryState::Failed)
-        .await?;
+    store.update_task_for_run(task, lease).await?;
+    store.fail_task_run(&task.id, lease, &reason).await?;
     Ok(())
 }
 
@@ -1987,7 +1974,8 @@ mod planning_tests {
     };
     use crate::chat::types::{ConversationEvent, Lifecycle};
     use crate::durable::{
-        AgentInvocationId, Basis, BoundarySeed, Containment, EpochId, RunAdvance, RunTrigger,
+        AgentInvocationId, Basis, BoundarySeed, Containment, EpochId, InvocationRoute, RunAdvance,
+        RunTrigger,
     };
     use crate::engine::agent::AgentConfig;
     use crate::harness::{Harness, SendCurrentOutcome};
@@ -1995,8 +1983,8 @@ mod planning_tests {
     use crate::project::{Project, ProjectId};
     use crate::store::{open_store, StorageConfig};
     use crate::task::{
-        Observation, PmWritebackState, Task, TaskGateProposal, TaskId, TaskLifecyclePhase,
-        TaskLifecyclePlan, TaskPr, TaskPrId,
+        Observation, PmWritebackState, Task, TaskEventKind, TaskGateProposal, TaskId,
+        TaskLifecyclePhase, TaskLifecyclePlan, TaskPr, TaskPrId,
     };
     use crate::wave::playhead::{BodyProvenance, Playhead, QueuedInvocation};
     use crate::wave::Wave;
@@ -2044,6 +2032,299 @@ mod planning_tests {
                 if turn_id == format!("interactive:{invocation_id}")
                     && status == Lifecycle::Completed
         ));
+    }
+
+    #[allow(clippy::await_holding_lock)]
+    #[tokio::test]
+    async fn pre_provider_failure_ends_prompt_only_invocation_and_records_task_failure() {
+        let repository =
+            std::fs::canonicalize(std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("../.."))
+                .unwrap();
+        let database = tempfile::tempdir().unwrap();
+        let database_path = database.path().join("registry.db");
+        let store = std::sync::Arc::new(
+            open_store(&StorageConfig::sqlite(database_path.clone()))
+                .await
+                .unwrap(),
+        );
+        let now = time::OffsetDateTime::now_utc();
+        let wave = Wave::new(
+            crate::id::WaveId::new(),
+            "prompt-only-failure".to_string(),
+            repository.display().to_string(),
+        );
+        let project = Project {
+            id: ProjectId::new(),
+            plan: ProjectPlan {
+                id: LinearProjectId::new("prompt-only-project").unwrap(),
+                slug: "prompt-only-failure".to_string(),
+                name: "Prompt-only failure".to_string(),
+                prompt_context: "Preserve the exact terminal failure.".to_string(),
+                pm_snapshot_synced_at: now.unix_timestamp(),
+            },
+            wave_id: wave.id().clone(),
+            iteration: 0,
+            observation_cursor: 0,
+            last_state_fingerprint: None,
+            agent: "unsupported".to_string(),
+            provider: "unsupported".to_string(),
+            provider_session_id: None,
+            abandon_intent: None,
+            created_at: now,
+            updated_at: now,
+        };
+        let mut task = Task {
+            id: TaskId::new(),
+            plan: TaskPlan {
+                id: LinearIssueId::new("prompt-only-issue").unwrap(),
+                identifier: "TEST-PROMPT".to_string(),
+                title: "Prompt-only failure".to_string(),
+                description: String::new(),
+                pm_snapshot_synced_at: now.unix_timestamp(),
+            },
+            pm_writeback: PmWritebackState::Current,
+            wave_id: wave.id().clone(),
+            project_id: project.id.clone(),
+            worktree: repository.clone(),
+            workspace_slug: "prompt-only-failure".to_string(),
+            lifecycle: TaskLifecyclePlan::defaults(),
+            lifecycle_phase: TaskLifecyclePhase::First,
+            phase_epoch: 1,
+            phase_cursor: 0,
+            phase_iteration: 0,
+            gate_cycle: 0,
+            gate_proposal: None,
+            agent: "unsupported".to_string(),
+            provider: "unsupported".to_string(),
+            provider_session_id: None,
+            abandon_intent: None,
+            created_at: now,
+            updated_at: now,
+            observation: Observation::NotRequired,
+        };
+        let pr = TaskPr {
+            id: TaskPrId::new(),
+            task_id: task.id.clone(),
+            sequence: 1,
+            slug: task.workspace_slug.clone(),
+            branch: "test/prompt-only-failure".to_string(),
+            base_commit: "deadbeef".to_string(),
+            parent_pr_id: None,
+            publication: None,
+            merge_commit: None,
+            abandoned_at: None,
+            ci_observation: None,
+            github_observation: None,
+            linear_attachment_id: None,
+            linear_comment_id: None,
+            linear_link_error: None,
+            created_at: now,
+            updated_at: now,
+        };
+        store.create_wave(&wave).await.unwrap();
+        store.create_project(&project).await.unwrap();
+        store.create_task(&task, &pr).await.unwrap();
+        let work = store
+            .work_for_child(&crate::child::ChildRef::Task(task.id.clone()))
+            .await
+            .unwrap();
+        let (run, lease) = store.reserve_run(&work, RunTrigger::User).await.unwrap();
+        store
+            .advance_run(
+                &lease,
+                RunAdvance::RunStarting {
+                    containment: Containment::Tmux {
+                        name: "prompt-only-failure".to_string(),
+                    },
+                    cwd: repository.clone(),
+                },
+            )
+            .await
+            .unwrap();
+        let invocation = store
+            .advance_run(
+                &lease,
+                RunAdvance::InvocationStarting {
+                    route: InvocationRoute {
+                        provider: "unsupported".to_string(),
+                        model: None,
+                        account_id: None,
+                    },
+                    surface: "headless".to_string(),
+                    resume_token: None,
+                    answer_ask_id: None,
+                },
+            )
+            .await
+            .unwrap();
+        let crate::durable::AdvanceReceipt::Invocation(invocation) = invocation else {
+            unreachable!("InvocationStarting returns an Invocation receipt")
+        };
+        let connection = rusqlite::Connection::open(&database_path).unwrap();
+        connection
+            .execute_batch(
+                "CREATE TRIGGER reject_test_task_failure
+                 BEFORE INSERT ON task_events
+                 WHEN json_extract(NEW.kind_json, '$.kind') = 'failed'
+                 BEGIN
+                     SELECT RAISE(ABORT, 'injected Task failure write');
+                 END;",
+            )
+            .unwrap();
+
+        let _env_lock = crate::journal::test_env_lock();
+        let inherited_invocation = std::env::var_os(crate::durable::AGENT_INVOCATION_ENV);
+        std::env::set_var(crate::durable::AGENT_INVOCATION_ENV, invocation.id.as_str());
+        let result = super::run(store.clone(), task.id.clone(), &lease).await;
+        match inherited_invocation {
+            Some(value) => std::env::set_var(crate::durable::AGENT_INVOCATION_ENV, value),
+            None => std::env::remove_var(crate::durable::AGENT_INVOCATION_ENV),
+        }
+        let error = result.expect_err("unsupported provider must fail before its first event");
+        assert!(
+            error
+                .to_string()
+                .contains("unsupported session harness: unsupported"),
+            "unexpected startup failure: {error:#}"
+        );
+
+        let events = store.recent_task_events(&task.id, 10).await.unwrap();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].kind, TaskEventKind::Started);
+        assert!(store.current_run(&work).await.unwrap().is_some());
+        let unsettled: (String, bool) = connection
+            .query_row(
+                "SELECT outcome, ended_at IS NOT NULL
+                 FROM agent_invocations WHERE supervising_run_id=?1",
+                [run.id.as_str()],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(unsettled, ("running".into(), false));
+
+        connection
+            .execute_batch("DROP TRIGGER reject_test_task_failure;")
+            .unwrap();
+        super::record_unhandled_failure(&store, &task.id, &lease, &error).await;
+
+        let events = store.recent_task_events(&task.id, 10).await.unwrap();
+        assert_eq!(events.len(), 2);
+        assert!(matches!(
+            &events[0].kind,
+            TaskEventKind::Failed { error, resumable: true }
+                if error.contains("task process failed: unsupported session harness: unsupported")
+        ));
+        assert_eq!(events[1].kind, TaskEventKind::Started);
+        assert!(store.current_run(&work).await.unwrap().is_none());
+
+        let invocation: (String, String, bool) = connection
+            .query_row(
+                "SELECT capture_status, outcome, ended_at IS NOT NULL
+                 FROM agent_invocations WHERE supervising_run_id=?1",
+                [run.id.as_str()],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .unwrap();
+        assert_eq!(invocation, ("prompt_only".into(), "failed".into(), true));
+
+        let (run, lease) = store.reserve_run(&work, RunTrigger::User).await.unwrap();
+        store
+            .advance_run(
+                &lease,
+                RunAdvance::RunStarting {
+                    containment: Containment::Tmux {
+                        name: "handled-provider-failure".to_string(),
+                    },
+                    cwd: repository.clone(),
+                },
+            )
+            .await
+            .unwrap();
+        store
+            .advance_run(
+                &lease,
+                RunAdvance::InvocationStarting {
+                    route: InvocationRoute {
+                        provider: "unsupported".to_string(),
+                        model: None,
+                        account_id: None,
+                    },
+                    surface: "headless".to_string(),
+                    resume_token: None,
+                    answer_ask_id: None,
+                },
+            )
+            .await
+            .unwrap();
+        store
+            .append_task_event_for_run(&task.id, &lease, &TaskEventKind::Started)
+            .await
+            .unwrap();
+        connection
+            .execute_batch(
+                "CREATE TRIGGER reject_test_task_failure
+                 BEFORE INSERT ON task_events
+                 WHEN json_extract(NEW.kind_json, '$.kind') = 'failed'
+                 BEGIN
+                     SELECT RAISE(ABORT, 'injected Task failure write');
+                 END;",
+            )
+            .unwrap();
+
+        let mut harness = UnusedHarness;
+        super::finish_failed(
+            &store,
+            &mut task,
+            &lease,
+            &mut harness,
+            "provider stream closed",
+            None,
+        )
+        .await
+        .expect_err("the rejected receipt keeps the handled failure recoverable");
+        assert!(store.current_run(&work).await.unwrap().is_some());
+        let unsettled: (String, bool) = connection
+            .query_row(
+                "SELECT outcome, ended_at IS NOT NULL
+                 FROM agent_invocations WHERE supervising_run_id=?1",
+                [run.id.as_str()],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(unsettled, ("running".into(), false));
+
+        connection
+            .execute_batch("DROP TRIGGER reject_test_task_failure;")
+            .unwrap();
+        let handled_error = super::finish_failed(
+            &store,
+            &mut task,
+            &lease,
+            &mut harness,
+            "provider stream closed",
+            None,
+        )
+        .await
+        .expect_err("a handled failure returns its reason after settlement");
+        let event_count = store.recent_task_events(&task.id, 10).await.unwrap().len();
+        super::record_unhandled_failure(&store, &task.id, &lease, &handled_error).await;
+        let events = store.recent_task_events(&task.id, 10).await.unwrap();
+        assert_eq!(events.len(), event_count);
+        assert!(matches!(
+            &events[0].kind,
+            TaskEventKind::Failed { error, resumable: true }
+                if error == "provider stream closed"
+        ));
+        assert!(store.current_run(&work).await.unwrap().is_none());
+        let invocation: (String, String, bool) = connection
+            .query_row(
+                "SELECT capture_status, outcome, ended_at IS NOT NULL
+                 FROM agent_invocations WHERE supervising_run_id=?1",
+                [run.id.as_str()],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .unwrap();
+        assert_eq!(invocation, ("prompt_only".into(), "failed".into(), true));
     }
 
     #[test]

--- a/wave/infrastructure/MEMORY.md
+++ b/wave/infrastructure/MEMORY.md
@@ -23,6 +23,12 @@ Renamed from `systems` in the 2026-07-08 wave/project/task restructure. Steers L
 - **Run `cargo test` to completion before trusting a green-looking suite.** A failing lib target makes cargo skip every later target, so lib failures mask bin failures — two `bin/lf.rs` tests naming a deleted command had never run at all.
 - **Rust compilation does not validate SQLite column names.** Runtime SQL whose shape depends on a released schema must be shared with a behavior test that prepares and executes it against the materialized migration head. Epoch Work ownership is three exclusive foreign keys (`wave_id`, `project_id`, `task_id`); generic kind/id belongs to explicit routes such as parent Asks, not to Epochs.
 - **Source history must reconstruct every applied release frontier** (learned 2026-07-20). One pre-schema-closure local promotion embedded a test-materialized `0.12.4` batch and advanced the shared store while git retained the ten source drafts and omitted the canonical file. Recovery preserved the database, extracted the canonical bytes from the retained immutable binary, matched their checksum to `schema_migrations`, registered the batch, and removed only byte-identical drafts. If a store is ahead by an unknown migration, retain state and old binary bytes; prove the checksum before ratifying history. Since #1123, draft-bearing candidates fail promotion even at an exact frontier, while a schema-complete exact-frontier CLI repair may safely activate with live Runs because it writes no migration.
+- **Tests must survive draft migration materialization** (learned 2026-07-21).
+  Release-equivalent Rust tests delete ordinal-free drafts and compile the
+  generated canonical batch. Test fixtures resolve migration SQL by its draft
+  marker through `migration_sql_for_test`; an `include_str!` pointing directly
+  at `migrations/drafts/` passes locally and fails the release tree at compile
+  time.
 - **Ordinary-PR integration tests inherit Task authority inside a worker.** Scrub `LF_RUN_CONTEXT` (plus its lease/invocation companions) when a fixture deliberately represents a non-Task repository. A missing registry while Run context is present is the intended fail-closed behavior, not a commit/push regression.
 - **Concurrent editing corrupts a file; concurrent rebasing corrupts history.** Two drivers sharing one worktree shared its `rebase-merge` state dir: conflicts resolved themselves between one command and the next, and `done` advanced 6→22 with no `--continue` from the losing session. Nothing was lost that time. Check for a live agent before working — or rebasing — a wave worktree; the driver that owns the worktree owns its `.git` sequencer.
 - **Linear Project names are identity-bearing under the native hierarchy.** The CLI slug derives deterministically from the Project name, and the slug is the cache filename (`projects/<slug>.md`) and the `--project` argument to task commands. Renaming a Linear Project changes its slug, so it moves the cache file and changes every task command's input — a rename is a migration, not a cosmetic edit.
@@ -67,6 +73,16 @@ Renamed from `systems` in the 2026-07-08 wave/project/task restructure. Steers L
   phase owns the Task worktree; providers without enforceable read-only mode
   fail closed. Launch failure ends the Invocation once, while a successful
   launch stays live until optional handback records its evidence.
+- **Persisted executable references are an installed-state invariant** (learned
+  2026-07-21). Removing or renaming a builtin flow requires a forward migration
+  for every surviving Task pin, plus catalog resolution before Run reservation.
+  A non-empty stored name is not proof that the installed binary and worktree
+  can execute it.
+- **One Task failure is one atomic durable fact** (learned 2026-07-21). The
+  failure event and Run/Invocation terminal state commit together; if the event
+  cannot persist, the Run stays open and recoverable. Automatic relaunch is
+  progress-relative and bounded, and only durable progress or explicit User
+  input resets its budget. An empty Run slot alone never authorizes retries.
 
 ## Planning model (settled, PR #852)
 
@@ -91,6 +107,12 @@ Renamed from `systems` in the 2026-07-08 wave/project/task restructure. Steers L
 - **Cadenza release parity** — same nightly/weekly cadence, one-command updater, tests, self-hosted assumptions; document any deliberate divergence.
 - **Cron host bootstrap** — bring up the first maintained `lf cron` host (Mac mini default), Doppler configured, with scheduled checks.
 - **Release feedback loop** — failed nightly/weekly runs surface as attention items or focused fix PRs, distinguishing verification vs publish vs host vs stale-local drift.
+- **Installed-upgrade semantic gate** — resolve every active placed Work's
+  persisted lifecycle through the candidate builtin and repo-local catalogs
+  after migrations, before that binary becomes the Home launcher.
+- **Project terminal-receipt parity** — make Project failure events and
+  Run/Invocation settlement share the atomic receipt boundary now used by
+  Tasks, with a fault-injection proof.
 - **Replicate intentionally** — apply the skeleton to Manabot/Hootro only when they need it.
 
 - **Deferred: "up/down 5ths"** (Jack, 2026-07-06) — referent unresolved. `lf wt` shipped up/down stack navigation this branch; candidates for the phrase are stack level-jumps ("fifth" = a level), circle-of-fifths name generation instead of random word pairs, or a chord-model transpose. Jack said "keep going" — deferred, not dropped.


### PR DESCRIPTION
## Usage

```bash
lf task resume INF-123
cargo test -p loopflow automatic_task_relaunch_exhausts_until_durable_progress_or_user_input
```

## Summary

Task relaunch now survives flow-catalog upgrades and repeated runtime failures without creating orphan Runs or retrying forever. Legacy Tasks pinned to the retired `task` flow migrate to `slice`, every lifecycle flow is validated before Run reservation, and automatic recovery waits for durable input after three no-progress attempts.

## Changes

- Preserve explicit Task flow overrides while repairing the historical default
- Distinguish user resumes, new input, and automatic recovery Runs so durable progress or explicit input starts a fresh recovery budget
- Persist failure events and Run/Invocation settlement atomically, leaving the Run recoverable if the failure receipt cannot be written
- Keep exhausted Tasks waiting instead of repeatedly relaunching them
- Make migration tests work both before and after draft migrations are materialized into a release