### PR TITLE
mac: restore live Podium evidence

### DIFF
--- a/rust/loopflow/src/lf/commands/activity.rs
+++ b/rust/loopflow/src/lf/commands/activity.rs
@@ -9,10 +9,11 @@ use time::OffsetDateTime;
 use crate::durable::{Author, Steer, SteerId, WorkRef};
 use crate::lf::commands::runs::{collect_run_activity_since, SkillRunEntry};
 use crate::lf::commands::util::parse_since;
+use crate::lf::commands::waves::PrMergeRequestSnapshot;
 use crate::lf::commands::WorkFilter;
 use crate::project::Project;
 use crate::store::sqlite::SqliteStore;
-use crate::task::{GithubPr, PrMergeRequest, Task, TaskPr, TaskPrId};
+use crate::task::{GithubPr, Task, TaskPr, TaskPrId};
 use crate::wave::Wave;
 
 const MAX_LIMIT: usize = 200;
@@ -61,7 +62,7 @@ pub enum WorkActivityFact {
     },
     PrMergeRequested {
         id: TaskPrId,
-        request: PrMergeRequest,
+        request: PrMergeRequestSnapshot,
         github: Option<GithubPr>,
     },
     PrMerged {
@@ -420,7 +421,7 @@ fn pr_entries(pr: &TaskPr, work: &WorkOwner, since: i64) -> Vec<WorkActivityEntr
             work,
             WorkActivityFact::PrMergeRequested {
                 id: pr.id.clone(),
-                request: request.clone(),
+                request: PrMergeRequestSnapshot::from(request),
                 github: github.cloned(),
             },
         ));
@@ -550,7 +551,7 @@ mod tests {
         let snapshot = serde_json::from_str::<WorkActivitySnapshot>(fixture).unwrap();
 
         assert_eq!(snapshot.limit, 50);
-        assert_eq!(snapshot.items.len(), 4);
+        assert_eq!(snapshot.items.len(), 5);
         assert!(matches!(
             snapshot.items[0].fact,
             WorkActivityFact::RunFinished { ref status, .. } if status == "ok"
@@ -559,6 +560,11 @@ mod tests {
             snapshot.items[1].fact,
             WorkActivityFact::PrMerged { ref github, .. }
                 if github.as_ref().map(|pr| pr.number) == Some(1144)
+        ));
+        assert!(matches!(
+            snapshot.items[2].fact,
+            WorkActivityFact::PrMergeRequested { ref request, .. }
+                if request.requested_at == "2026-07-21T18:35:51Z"
         ));
         assert_eq!(
             serde_json::from_str::<WorkActivitySnapshot>(
@@ -784,6 +790,11 @@ mod tests {
             entries[2].fact,
             WorkActivityFact::PrMergeRequested { .. }
         ));
+        let merge_request = serde_json::to_value(&entries[2]).unwrap();
+        assert_eq!(
+            merge_request["fact"]["request"]["requested_at"],
+            "1970-01-01T00:00:30Z"
+        );
         assert!(matches!(
             &entries[3].fact,
             WorkActivityFact::PrMerged {

--- a/rust/loopflow/src/lf/commands/waves.rs
+++ b/rust/loopflow/src/lf/commands/waves.rs
@@ -361,13 +361,26 @@ pub struct PrPublicationSnapshot {
     pub merge: Option<PrMergeRequestSnapshot>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PrMergeRequestSnapshot {
     pub mode: PrMergeMode,
     pub requested_at: String,
     pub head_sha: String,
     pub after_merge: AfterMerge,
     pub next_slug: Option<String>,
+}
+
+impl From<&PrMergeRequest> for PrMergeRequestSnapshot {
+    fn from(request: &PrMergeRequest) -> Self {
+        Self {
+            mode: request.mode,
+            requested_at: format_time(request.requested_at)
+                .expect("PR merge request timestamp formats as RFC 3339"),
+            head_sha: request.head_sha.clone(),
+            after_merge: request.after_merge,
+            next_slug: request.next_slug.clone(),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -396,17 +409,7 @@ impl PrSnapshot {
                         number: github.number,
                         url: github.url.clone(),
                     }),
-                    merge: publication
-                        .merge
-                        .as_ref()
-                        .map(|request| PrMergeRequestSnapshot {
-                            mode: request.mode,
-                            requested_at: format_time(request.requested_at)
-                                .expect("PR merge request timestamp formats as RFC 3339"),
-                            head_sha: request.head_sha.clone(),
-                            after_merge: request.after_merge,
-                            next_slug: request.next_slug.clone(),
-                        }),
+                    merge: publication.merge.as_ref().map(PrMergeRequestSnapshot::from),
                 }),
             merge_commit: pr.merge_commit.clone(),
             abandoned_at: pr.abandoned_at.and_then(format_time),
@@ -1247,7 +1250,12 @@ async fn validate_pm_portfolio(store: &SharedStore, waves: &[Wave]) -> Result<()
         else {
             continue;
         };
-        let planning = decode_pm_planning(wave, &row.payload)?;
+        let Ok(planning) = decode_pm_planning(wave, &row.payload) else {
+            // The Wave's own roadmap row reports its unreadable planning as
+            // unavailable. Keep validating every readable sibling so one stale
+            // snapshot cannot erase unrelated Work from the machine view.
+            continue;
+        };
         let expected_team = crate::ops::pm::repository_team_for_snapshot_validation(&repo)?;
         ownership.validate(
             wave.name(),

--- a/rust/loopflow/tests/repository_team_matrix.rs
+++ b/rust/loopflow/tests/repository_team_matrix.rs
@@ -232,6 +232,13 @@ fn repository_team_matrix() {
             true,
         ),
     );
+    put_snapshot(
+        &store,
+        foreign_repo.path(),
+        "intelligence",
+        "initiative-intelligence",
+        r#"{"projects":[],"items":[{"id":"stale"}]}"#.to_string(),
+    );
     drop(store);
 
     // Recursive discovery and durable ancestry make nested titles legible.
@@ -287,6 +294,8 @@ fn repository_team_matrix() {
     let status = assert_success(&run_lf(&home, &repo, &["pm", "status"]), "pm status");
     assert!(status.contains("survival"));
     assert!(status.contains("survival/infrastructure"));
+    // An unreadable snapshot remains visible as unavailable evidence for its
+    // Wave without blanking readable Work from another repository.
     let roadmap = assert_success(&run_lf(&home, &repo, &["roadmap", "--json"]), "roadmap");
     assert!(roadmap.contains("LOO-1"));
     assert!(roadmap.contains("LOO-2"));

--- a/scripts/loopflow-dev.py
+++ b/scripts/loopflow-dev.py
@@ -475,8 +475,26 @@ def _copy_bundled_tools(app_macos_dir: Path, profile: str) -> None:
         ]
         bin_dir = REPO_ROOT / "target" / "release"
     else:
-        cargo_cmd = ["cargo", "build", "--locked", "--bin", "lf", "--bin", "lfd"]
-        bin_dir = REPO_ROOT / "target" / "debug"
+        # The app is a live operator surface even when its Swift shell is a dev
+        # build. Compile its bundled control binary against the installed Home,
+        # but never grant it migration authority. Ordinary development binaries
+        # keep their isolated `.lf-dev` stores.
+        target_dir = REPO_ROOT / "target" / "dev-app-control"
+        cargo_cmd = [
+            "/usr/bin/env",
+            "LOOPFLOW_BUILD_PROVENANCE=release",
+            "LOOPFLOW_MIGRATION_AUTHORITY=validation_only",
+            "cargo",
+            "build",
+            "--locked",
+            "--bin",
+            "lf",
+            "--bin",
+            "lfd",
+            "--target-dir",
+            str(target_dir),
+        ]
+        bin_dir = target_dir / "debug"
 
     result = run(cargo_cmd, cwd=REPO_ROOT, check=False)
     if result.returncode != 0:

--- a/swift/Loopflow/Services/WaveOrigin.swift
+++ b/swift/Loopflow/Services/WaveOrigin.swift
@@ -31,6 +31,17 @@ public enum WaveOrigin {
         return origin
     }
 
+    /// Return a previously resolved origin without performing I/O.
+    ///
+    /// Render paths use this after their query boundary has called `resolve` on
+    /// a detached task. A cache miss stays at the supplied path; SwiftUI must
+    /// never run `git` while evaluating its attribute graph.
+    public static func cached(_ repoPath: String) -> String {
+        lock.lock()
+        defer { lock.unlock() }
+        return cache[repoPath] ?? repoPath
+    }
+
     #if os(macOS)
     private static func resolveUncached(_ repoPath: String) -> String {
         // Only a working-tree root resolves. A plain subdirectory inside a

--- a/swift/LoopflowMac/PodiumFixture.swift
+++ b/swift/LoopflowMac/PodiumFixture.swift
@@ -87,7 +87,7 @@ enum PodiumFixture {
         let waves = roadmap.waves.map { $0.wave.toWave() }
         var seen = Set<String>()
         let repos = roadmap.waves.compactMap { roadmap -> PortfolioRepo? in
-            let path = WaveOrigin.resolve(roadmap.wave.repo).normalizedFilePath
+            let path = roadmap.wave.repo.normalizedFilePath
             guard seen.insert(path).inserted else { return nil }
             return PortfolioRepo(path: path, lastOpened: .distantPast)
         }

--- a/swift/LoopflowMac/PodiumModel.swift
+++ b/swift/LoopflowMac/PodiumModel.swift
@@ -113,17 +113,17 @@ final class PodiumModel {
 
     var visibleRepos: [PortfolioRepo] {
         guard let repoPath else { return allRepos }
-        let target = WaveOrigin.resolve(repoPath).normalizedFilePath
-        return allRepos.filter { WaveOrigin.resolve($0.path).normalizedFilePath == target }
+        let target = repoIdentity(repoPath)
+        return allRepos.filter { repoIdentity($0.path) == target }
     }
 
     var allRepos: [PortfolioRepo] {
         var result = repos
-        var seen = Set(result.map { WaveOrigin.resolve($0.path).normalizedFilePath })
+        var seen = Set(result.map { repoIdentity($0.path) })
         for wave in waves.value ?? [] {
-            let path = WaveOrigin.resolve(wave.repo).normalizedFilePath
-            guard seen.insert(path).inserted else { continue }
-            result.append(PortfolioRepo(path: path, lastOpened: .distantPast))
+            let identity = repoIdentity(wave.repo)
+            guard seen.insert(identity).inserted else { continue }
+            result.append(PortfolioRepo(path: identity, lastOpened: .distantPast))
         }
         return result.sorted {
             $0.displayName.localizedCaseInsensitiveCompare($1.displayName) == .orderedAscending
@@ -166,6 +166,7 @@ final class PodiumModel {
             initialRepoPath: initialRepoPath,
             persistedRepos: persistedRepos
         )
+        await Self.resolveRepoOrigins(discovered.map(\.path))
         repos = discovered
         authoredWavesByRepo = await PortfolioDiscovery.authoredWaves(in: discovered)
         if repoPath == nil, let initialRepoPath {
@@ -318,12 +319,25 @@ final class PodiumModel {
         repo: (Value) -> String
     ) -> [Value] {
         guard let repoPath else { return values }
-        let target = WaveOrigin.resolve(repoPath).normalizedFilePath
-        return values.filter { WaveOrigin.resolve(repo($0)).normalizedFilePath == target }
+        let target = repoIdentity(repoPath)
+        return values.filter { repoIdentity(repo($0)) == target }
     }
 
     private func waveIdentity(repo: String, name: String) -> String {
-        "\(WaveOrigin.resolve(repo).normalizedFilePath)#\(name)"
+        "\(repoIdentity(repo))#\(name)"
+    }
+
+    func repoIdentity(_ path: String) -> String {
+        let path = path.normalizedFilePath
+        return WaveOrigin.cached(path).normalizedFilePath
+    }
+
+    private nonisolated static func resolveRepoOrigins(_ paths: [String]) async {
+        await Task.detached {
+            for path in Set(paths.map(\.normalizedFilePath)) {
+                _ = WaveOrigin.resolve(path)
+            }
+        }.value
     }
 
     private func activityScope(for selection: WorkReference?) -> WorkActivityScope? {
@@ -385,7 +399,9 @@ final class PodiumModel {
 
     private func readWaves() async -> Result<[Wave], Error> {
         do {
-            return .success(try await query.allWaves())
+            let waves = try await query.allWaves()
+            await Self.resolveRepoOrigins(waves.map(\.repo))
+            return .success(waves)
         } catch {
             return .failure(error)
         }
@@ -393,7 +409,9 @@ final class PodiumModel {
 
     private func readProcessActivity() async -> Result<ActivitySnapshot, Error> {
         do {
-            return .success(try await query.processActivity())
+            let snapshot = try await query.processActivity()
+            await Self.resolveRepoOrigins(snapshot.nodes.compactMap(\.repo))
+            return .success(snapshot)
         } catch {
             return .failure(error)
         }

--- a/swift/LoopflowMac/Views/PodiumView.swift
+++ b/swift/LoopflowMac/Views/PodiumView.swift
@@ -92,8 +92,7 @@ private struct PodiumBar: View {
     private var scopeTitle: String {
         guard let repoPath = model.repoPath else { return "All repositories" }
         return model.allRepos.first {
-            WaveOrigin.resolve($0.path).normalizedFilePath
-                == WaveOrigin.resolve(repoPath).normalizedFilePath
+            model.repoIdentity($0.path) == model.repoIdentity(repoPath)
         }?.displayName ?? URL(fileURLWithPath: repoPath).lastPathComponent
     }
 
@@ -589,7 +588,7 @@ private struct WaveScore: View {
     }
 
     private func normalized(_ path: String) -> String {
-        WaveOrigin.resolve(path).normalizedFilePath
+        model.repoIdentity(path)
     }
 
     private func toggle(_ id: String, in expanded: inout Set<String>) {

--- a/swift/LoopflowTests/DTOFixtureTests.swift
+++ b/swift/LoopflowTests/DTOFixtureTests.swift
@@ -77,17 +77,24 @@ struct DTOFixtureTests {
         let snapshot = try JSONDecoder().decode(WorkActivitySnapshot.self, from: data)
 
         #expect(snapshot.limit == 50)
-        #expect(snapshot.items.map(\.subject) == ["W2-144", "W2-144", "product", "mac-surface-ux"])
+        #expect(snapshot.items.map(\.subject) == [
+            "W2-144", "W2-144", "W2-144", "product", "mac-surface-ux",
+        ])
         #expect(snapshot.items[0].fact.invocationId == "invocation-product-run")
         #expect(snapshot.items[1].fact.github?.number == 1144)
         #expect(snapshot.items[1].fact.github?.url.host == "github.com")
-        #expect(snapshot.items[2].work.kind == .wave)
-        if case .steerIssued(_, .run(let id)) = snapshot.items[2].fact {
+        if case .prMergeRequested(_, let request, _) = snapshot.items[2].fact {
+            #expect(request.requestedAt == "2026-07-21T18:35:51Z")
+        } else {
+            Issue.record("expected a typed PR merge request")
+        }
+        #expect(snapshot.items[3].work.kind == .wave)
+        if case .steerIssued(_, .run(let id)) = snapshot.items[3].fact {
             #expect(id == "run_00000000000000000000000000000001")
         } else {
             Issue.record("expected a Run-authored Steer")
         }
-        #expect(snapshot.items[3].fact == .workCreated)
+        #expect(snapshot.items[4].fact == .workCreated)
     }
 
     @Test("Context Lab fixture preserves missing coverage and trace identity")

--- a/swift/LoopflowTests/WaveOriginTests.swift
+++ b/swift/LoopflowTests/WaveOriginTests.swift
@@ -50,7 +50,9 @@ struct WaveOriginTests {
             )
             try git(["worktree", "add", "-q", worktree.path], at: origin)
 
+            #expect(WaveOrigin.cached(worktree.path) == worktree.path)
             #expect(canonical(WaveOrigin.resolve(worktree.path)) == canonical(origin.path))
+            #expect(canonical(WaveOrigin.cached(worktree.path)) == canonical(origin.path))
             #expect(canonical(WaveOrigin.resolve(origin.path)) == canonical(origin.path))
         }
     }

--- a/swift/README.md
+++ b/swift/README.md
@@ -120,6 +120,12 @@ so macOS permissions survive rebuilds. The app queries `lf` directly and starts
 only the selected Wave's `lf wave` process; it has no machine-wide service or
 remote-connection mode.
 
+The dev app bundles the current source `lf` with release Home selection and
+validation-only migration authority. Its operator views therefore read the
+real Home without allowing an unpromoted build to advance the shared database
+frontier. Ordinary source-built `lf` commands keep their isolated `.lf-dev`
+Home.
+
 | Command | What it does |
 | --- | --- |
 | `./dev run` | Build and launch |

--- a/tests/fixtures/dto/work_activity_snapshot.json
+++ b/tests/fixtures/dto/work_activity_snapshot.json
@@ -42,6 +42,32 @@
       }
     },
     {
+      "id": "pr:pr_00000000000000000000000000000001:merge_requested",
+      "recorded_at": 1784654550,
+      "summary": "Merge requested for PR #1144",
+      "work": {
+        "kind": "task",
+        "id": "task_00000000000000000000000000000001"
+      },
+      "subject": "W2-144",
+      "fact": {
+        "kind": "pr_merge_requested",
+        "id": "pr_00000000000000000000000000000001",
+        "request": {
+          "mode": "auto",
+          "requested_at": "2026-07-21T18:35:51Z",
+          "head_sha": "3333333333333333333333333333333333333333",
+          "after_merge": "complete_task",
+          "next_slug": null
+        },
+        "github": {
+          "number": 1144,
+          "url": "https://github.com/loopflowstudio/loopflow/pull/1144",
+          "head_sha": "3333333333333333333333333333333333333333"
+        }
+      }
+    },
+    {
       "id": "steer:steer_00000000000000000000000000000001",
       "recorded_at": 1784654500,
       "summary": "Steered: Make The Podium primary",


### PR DESCRIPTION
## Try it!

```bash
uv run python scripts/loopflow-dev.py run-debug
```

The Podium opens against the real Home with Wave, Run, Work, and Activity evidence.

## Intent

Restore the configured live demo path without adding another Work tree, telemetry store, endpoint, or lifecycle model. Repo origins resolve off-main through the existing WaveOrigin cache; malformed PM snapshots remain per-Wave Evidence; Activity reuses PrMergeRequestSnapshot.

## Safety

The dev app control binary selects the installed Home but has validation-only migration authority. Ordinary source-built lf commands remain isolated under .lf-dev.

## Proof

The live app showed 5 Loopflow Waves, 4 Runs, active/stopped Tasks, and current Wave/PR Activity without a new crash report. Focused Rust and Swift tests plus cargo clippy passed.
