### PR TITLE
Project completion settles Work atomically

### DIFF
--- a/rust/loopflow/src/project/runner.rs
+++ b/rust/loopflow/src/project/runner.rs
@@ -692,14 +692,15 @@ async fn finish_project_outcome(
     summary: String,
 ) -> Result<()> {
     if disposition == ProjectDisposition::Done {
-        store
-            .append_project_event_for_run(
-                &project.id,
-                lease,
-                &ProjectEventKind::Completed { summary },
-            )
+        let work = store
+            .work_for_child(&ChildRef::Project(project.id.clone()))
             .await?;
-        store.done(lease, basis).await?;
+        if store.work_status(&work).await? == WorkStatus::Done {
+            return Ok(());
+        }
+        store
+            .complete_project_run(project, lease, basis, &summary)
+            .await?;
     } else {
         store
             .finish_project_run(project, lease, crate::durable::BoundaryState::Succeeded)
@@ -1004,19 +1005,7 @@ async fn finish_failed(
 ) -> Result<()> {
     finish_capture(capture, "failed");
     let _ = harness.stop().await;
-    store
-        .append_project_event_for_run(
-            &project.id,
-            lease,
-            &ProjectEventKind::Failed {
-                error: error.to_string(),
-                resumable: true,
-            },
-        )
-        .await?;
-    store
-        .finish_project_run(project, lease, crate::durable::BoundaryState::Failed)
-        .await?;
+    store.fail_project_run(project, lease, error).await?;
     anyhow::bail!(error.to_string())
 }
 
@@ -1229,19 +1218,7 @@ async fn record_unhandled_failure(
         return;
     }
     let message = format!("project runner failed: {error}");
-    let _ = store
-        .append_project_event_for_run(
-            &project.id,
-            lease,
-            &ProjectEventKind::Failed {
-                error: message.clone(),
-                resumable: true,
-            },
-        )
-        .await;
-    let _ = store
-        .finish_project_run(&project, lease, crate::durable::BoundaryState::Failed)
-        .await;
+    let _ = store.fail_project_run(&project, lease, &message).await;
 }
 
 fn project_seed(
@@ -1281,11 +1258,305 @@ fn bounded_summary(text: &str) -> String {
 
 #[cfg(test)]
 mod tests {
+    use std::path::PathBuf;
+
+    use anyhow::anyhow;
+    use time::OffsetDateTime;
+
+    use crate::child::ChildRef;
+    use crate::durable::{BoundaryState, RunAdvance, RunLease, WorkStatus};
+    use crate::id::WaveId;
+    use crate::planning::{LinearProjectId, ProjectPlan};
+    use crate::project::{Project, ProjectEventKind, ProjectId};
+    use crate::store::{open_store, SharedStore, StorageConfig};
+    use crate::wave::Wave;
+
+    async fn project_fixture() -> (
+        tempfile::TempDir,
+        PathBuf,
+        SharedStore,
+        Project,
+        RunLease,
+        crate::durable::AgentInvocation,
+    ) {
+        let directory = tempfile::tempdir().unwrap();
+        let database = directory.path().join("registry.db");
+        let store = std::sync::Arc::new(
+            open_store(&StorageConfig::sqlite(database.clone()))
+                .await
+                .unwrap(),
+        );
+        let wave = Wave::new(
+            WaveId::new(),
+            "incident-management".to_string(),
+            directory.path().display().to_string(),
+        );
+        store.create_wave(&wave).await.unwrap();
+        let now = OffsetDateTime::now_utc();
+        let project = Project {
+            id: ProjectId::new(),
+            plan: ProjectPlan {
+                id: LinearProjectId::new("incident-management-project").unwrap(),
+                slug: "incident-management".to_string(),
+                name: "Incident Management".to_string(),
+                prompt_context: "Restore incidents before prevention.".to_string(),
+                pm_snapshot_synced_at: now.unix_timestamp(),
+            },
+            wave_id: wave.id().clone(),
+            iteration: 0,
+            observation_cursor: 0,
+            last_state_fingerprint: None,
+            agent: "codex".to_string(),
+            provider: "codex".to_string(),
+            provider_session_id: None,
+            abandon_intent: None,
+            created_at: now,
+            updated_at: now,
+        };
+        store.create_project(&project).await.unwrap();
+        let reservation = store
+            .reserve_project_process(&project, WorkStatus::Ready)
+            .await
+            .unwrap()
+            .unwrap();
+        let lease = store
+            .resolve_run_lease(reservation.run_token.clone())
+            .await
+            .unwrap();
+        let invocation = store
+            .open_invocation_for_run(&lease.run_id)
+            .await
+            .unwrap()
+            .unwrap();
+        (directory, database, store, project, lease, invocation)
+    }
+
     #[test]
     fn project_summary_is_bounded() {
         assert_eq!(
             super::bounded_summary(&"x".repeat(2_500)).chars().count(),
             2_000
         );
+    }
+
+    #[tokio::test]
+    async fn successful_project_flow_boundary_settles_once_without_turn_capture() {
+        let (_directory, database, store, mut project, lease, invocation) = project_fixture().await;
+        let work = store
+            .work_for_child(&ChildRef::Project(project.id.clone()))
+            .await
+            .unwrap();
+        let basis = store.boundary_seed(&work).await.unwrap().basis;
+        project.iteration = 1;
+        store
+            .append_project_event_for_run(
+                &project.id,
+                &lease,
+                &ProjectEventKind::IterationCompleted {
+                    iteration: project.iteration,
+                    summary: "restored the reported surface".to_string(),
+                },
+            )
+            .await
+            .unwrap();
+        store
+            .advance_run(
+                &lease,
+                RunAdvance::InvocationEnded {
+                    invocation_id: invocation.id,
+                    outcome: BoundaryState::Succeeded,
+                },
+            )
+            .await
+            .unwrap();
+
+        super::finish_project_outcome(
+            &store,
+            &project,
+            &lease,
+            &basis,
+            super::ProjectDisposition::Done,
+            "restored the reported surface".to_string(),
+        )
+        .await
+        .unwrap();
+        super::finish_project_outcome(
+            &store,
+            &project,
+            &lease,
+            &basis,
+            super::ProjectDisposition::Done,
+            "restored the reported surface".to_string(),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(store.work_status(&work).await.unwrap(), WorkStatus::Done);
+        let events = store.project_events_after(&project.id, 0).await.unwrap();
+        assert_eq!(events.len(), 2);
+        assert!(matches!(
+            events[0].kind,
+            ProjectEventKind::IterationCompleted { iteration: 1, .. }
+        ));
+        assert!(matches!(events[1].kind, ProjectEventKind::Completed { .. }));
+        assert!(!events
+            .iter()
+            .any(|event| matches!(event.kind, ProjectEventKind::Failed { .. })));
+
+        let connection = rusqlite::Connection::open(database).unwrap();
+        let run_count: i64 = connection
+            .query_row(
+                "SELECT COUNT(*) FROM runs WHERE epoch_id=?1",
+                [basis.epoch_id.as_str()],
+                |row| row.get(0),
+            )
+            .unwrap();
+        let turn_count: i64 = connection
+            .query_row(
+                "SELECT COUNT(*) FROM agent_turns WHERE epoch_id=?1",
+                [basis.epoch_id.as_str()],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(run_count, 1);
+        assert_eq!(turn_count, 0);
+    }
+
+    #[tokio::test]
+    async fn project_failure_before_success_remains_resumable_and_exact() {
+        let (_directory, database, store, project, lease, invocation) = project_fixture().await;
+        let work = store
+            .work_for_child(&ChildRef::Project(project.id.clone()))
+            .await
+            .unwrap();
+
+        super::record_unhandled_failure(
+            &store,
+            &project.id,
+            &lease,
+            &anyhow!("Linear project snapshot is unavailable"),
+        )
+        .await;
+
+        assert_eq!(store.work_status(&work).await.unwrap(), WorkStatus::Ready);
+        let events = store.project_events_after(&project.id, 0).await.unwrap();
+        assert_eq!(events.len(), 1);
+        assert!(matches!(
+            &events[0].kind,
+            ProjectEventKind::Failed { error, resumable: true }
+                if error == "project runner failed: Linear project snapshot is unavailable"
+        ));
+
+        let connection = rusqlite::Connection::open(database).unwrap();
+        let run_state: String = connection
+            .query_row(
+                "SELECT state FROM runs WHERE id=?1",
+                [lease.run_id.as_str()],
+                |row| row.get(0),
+            )
+            .unwrap();
+        let (invocation_ended, invocation_outcome): (bool, String) = connection
+            .query_row(
+                "SELECT ended_at IS NOT NULL, outcome FROM agent_invocations WHERE id=?1",
+                [invocation.id.as_str()],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(run_state, "ended");
+        assert!(invocation_ended);
+        assert_eq!(invocation_outcome, "failed");
+    }
+
+    #[tokio::test]
+    async fn project_failure_cannot_bypass_its_atomic_receipt() {
+        let (_directory, _database, store, project, lease, _invocation) = project_fixture().await;
+        let work = store
+            .work_for_child(&ChildRef::Project(project.id.clone()))
+            .await
+            .unwrap();
+
+        let error = store
+            .finish_project_run(&project, &lease, BoundaryState::Failed)
+            .await
+            .unwrap_err();
+
+        assert!(error.to_string().contains("must use fail_project_run"));
+        assert!(matches!(
+            store.work_status(&work).await.unwrap(),
+            WorkStatus::Running { .. }
+        ));
+        assert!(store
+            .project_events_after(&project.id, 0)
+            .await
+            .unwrap()
+            .is_empty());
+        assert!(store
+            .open_invocation_for_run(&lease.run_id)
+            .await
+            .unwrap()
+            .is_some());
+    }
+
+    #[tokio::test]
+    async fn project_failure_receipt_rolls_back_together() {
+        let (_directory, database, store, project, lease, invocation) = project_fixture().await;
+        let work = store
+            .work_for_child(&ChildRef::Project(project.id.clone()))
+            .await
+            .unwrap();
+        let connection = rusqlite::Connection::open(&database).unwrap();
+        connection
+            .execute_batch(
+                "CREATE TRIGGER inject_project_failure_receipt_error
+                 BEFORE UPDATE OF state ON runs
+                 WHEN NEW.state='ended'
+                 BEGIN
+                    SELECT RAISE(ABORT, 'injected Project failure receipt error');
+                 END;",
+            )
+            .unwrap();
+        drop(connection);
+
+        let error = store
+            .fail_project_run(&project, &lease, "provider event stream closed")
+            .await
+            .unwrap_err();
+
+        assert!(error
+            .to_string()
+            .contains("injected Project failure receipt error"));
+        assert!(matches!(
+            store.work_status(&work).await.unwrap(),
+            WorkStatus::Running { .. }
+        ));
+        assert!(store
+            .project_events_after(&project.id, 0)
+            .await
+            .unwrap()
+            .is_empty());
+        let connection = rusqlite::Connection::open(database).unwrap();
+        let run_state: String = connection
+            .query_row(
+                "SELECT state FROM runs WHERE id=?1",
+                [lease.run_id.as_str()],
+                |row| row.get(0),
+            )
+            .unwrap();
+        let (invocation_ended, invocation_outcome): (bool, String) = connection
+            .query_row(
+                "SELECT ended_at IS NOT NULL, outcome FROM agent_invocations WHERE id=?1",
+                [invocation.id.as_str()],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .unwrap();
+        let observation_count: i64 = connection
+            .query_row("SELECT COUNT(*) FROM observation_outbox", [], |row| {
+                row.get(0)
+            })
+            .unwrap();
+        assert_eq!(run_state, "active");
+        assert!(!invocation_ended);
+        assert_eq!(invocation_outcome, "running");
+        assert_eq!(observation_count, 0);
     }
 }

--- a/rust/loopflow/src/store/children.rs
+++ b/rust/loopflow/src/store/children.rs
@@ -1,7 +1,7 @@
 //! Durable Project and Task compatibility rows and their observation outbox.
 
 use crate::child::{ChildBodyHandoffRequest, ObservationRecipient};
-use crate::durable::{Author, RunLease};
+use crate::durable::{Author, Basis, RunLease};
 use crate::id::WaveId;
 use crate::project::{ObservationOutboxRow, Project, ProjectEvent, ProjectEventKind, ProjectId};
 use crate::task::{
@@ -651,6 +651,72 @@ impl Store {
             store.finish_project_run(&project, &lease, outcome)
         })
         .await
+    }
+
+    pub(crate) async fn fail_project_run(
+        &self,
+        project: &Project,
+        lease: &RunLease,
+        error: &str,
+    ) -> StoreResult<ProjectEvent> {
+        let project_id = project.id.clone();
+        let wave_id = project.wave_id.clone();
+        let project = project.clone();
+        let lease = lease.clone();
+        let error = error.to_string();
+        let event = run_sqlite(&self.sqlite, move |store| {
+            store.fail_project_run(&project, &lease, &error)
+        })
+        .await?;
+        self.nudge_project_terminal_observation(&project_id, &wave_id, event.id, "failed")
+            .await;
+        Ok(event)
+    }
+
+    pub(crate) async fn complete_project_run(
+        &self,
+        project: &Project,
+        lease: &RunLease,
+        basis: &Basis,
+        summary: &str,
+    ) -> StoreResult<ProjectEvent> {
+        let project_id = project.id.clone();
+        let wave_id = project.wave_id.clone();
+        let project = project.clone();
+        let lease = lease.clone();
+        let basis = basis.clone();
+        let summary = summary.to_string();
+        let event = run_sqlite(&self.sqlite, move |store| {
+            store.complete_project_run(&project, &lease, &basis, &summary)
+        })
+        .await?;
+        self.nudge_project_terminal_observation(&project_id, &wave_id, event.id, "completed")
+            .await;
+        Ok(event)
+    }
+
+    async fn nudge_project_terminal_observation(
+        &self,
+        project_id: &ProjectId,
+        wave_id: &WaveId,
+        event_id: i64,
+        outcome: &'static str,
+    ) {
+        match self.get_wave(wave_id).await {
+            Ok(Some(wave)) => {
+                if let Err(error) =
+                    crate::lf::commands::chat::nudge_child_observations(wave.name()).await
+                {
+                    tracing::debug!(%error, %project_id, event_id, outcome, "live Project terminal observation delivery failed; Wave observer will retry");
+                }
+            }
+            Ok(None) => {
+                tracing::error!(%wave_id, %project_id, event_id, outcome, "Project terminal event cannot nudge its missing owning Wave")
+            }
+            Err(error) => {
+                tracing::debug!(%error, %wave_id, %project_id, event_id, outcome, "Project terminal observation lookup failed; Wave observer will retry")
+            }
+        }
     }
 
     #[cfg(test)]

--- a/rust/loopflow/src/store/sqlite/children.rs
+++ b/rust/loopflow/src/store/sqlite/children.rs
@@ -15,7 +15,7 @@ use time::OffsetDateTime;
 use crate::child::{
     AbandonIntent, ChildBodyHandoff, ChildBodyHandoffRequest, ChildRef, ObservationRecipient,
 };
-use crate::durable::{Author, RunLease};
+use crate::durable::{Author, Basis, RunLease};
 use crate::id::WaveId;
 use crate::planning::{LinearIssueId, LinearProjectId, ProjectPlan, TaskPlan};
 use crate::project::{
@@ -31,8 +31,9 @@ use crate::task::{
 };
 
 use super::durable::{
-    create_project_spine, create_task_spine, end_run_for_lease, validate_run_lease,
-    validate_stop_lease, work_for_child_in, work_status_in,
+    create_project_spine, create_task_spine, current_epoch_in, end_run_for_lease, validate_basis,
+    validate_completion_readiness_in, validate_run_lease, validate_stop_lease, work_for_child_in,
+    work_status_in,
 };
 use super::SqliteStore;
 
@@ -1002,6 +1003,12 @@ impl SqliteStore {
         outcome: crate::durable::BoundaryState,
     ) -> StoreResult<()> {
         validate_project(project)?;
+        if outcome == crate::durable::BoundaryState::Failed {
+            return Err(StoreError::InvalidData(
+                "Project failure must use fail_project_run so its event and Run settle atomically"
+                    .to_string(),
+            ));
+        }
         let mut conn = self.conn.lock().expect("store mutex poisoned");
         let transaction = conn.transaction_with_behavior(TransactionBehavior::Immediate)?;
         require_cleanup_run_owns_child(
@@ -1023,6 +1030,98 @@ impl SqliteStore {
         end_run_for_lease(&transaction, lease, outcome)?;
         transaction.commit()?;
         Ok(())
+    }
+
+    pub(crate) fn fail_project_run(
+        &self,
+        project: &Project,
+        lease: &RunLease,
+        error: &str,
+    ) -> StoreResult<ProjectEvent> {
+        validate_project(project)?;
+        let mut conn = self.conn.lock().expect("store mutex poisoned");
+        let transaction = conn.transaction_with_behavior(TransactionBehavior::Immediate)?;
+        require_cleanup_run_owns_child(
+            &transaction,
+            &ChildRef::Project(project.id.clone()),
+            lease,
+        )?;
+        let parameters = project_params(project);
+        if transaction.execute(
+            PROJECT_RUN_UPDATE,
+            rusqlite::params_from_iter(parameters.iter().map(|value| value.as_ref())),
+        )? == 0
+        {
+            return Err(StoreError::InvalidAuthority(format!(
+                "Run {} cannot fail Project {}",
+                lease.run_id, project.id
+            )));
+        }
+        let event = insert_project_event_in(
+            &transaction,
+            project,
+            &ProjectEventKind::Failed {
+                error: error.to_string(),
+                resumable: true,
+            },
+        )?;
+        end_run_for_lease(&transaction, lease, crate::durable::BoundaryState::Failed)?;
+        transaction.commit()?;
+        Ok(event)
+    }
+
+    pub(crate) fn complete_project_run(
+        &self,
+        project: &Project,
+        lease: &RunLease,
+        basis: &Basis,
+        summary: &str,
+    ) -> StoreResult<ProjectEvent> {
+        validate_project(project)?;
+        let mut conn = self.conn.lock().expect("store mutex poisoned");
+        let transaction = conn.transaction_with_behavior(TransactionBehavior::Immediate)?;
+        require_run_owns_child(&transaction, &ChildRef::Project(project.id.clone()), lease)?;
+        let run = validate_run_lease(&transaction, lease)?;
+        let epoch = current_epoch_in(&transaction, &run.work)?;
+        if epoch.id != run.epoch_id {
+            return Err(StoreError::InvalidAuthority(format!(
+                "Run {} does not own the current Project Epoch {}",
+                run.id, epoch.id
+            )));
+        }
+        validate_basis(&epoch.current_basis, basis)?;
+        validate_completion_readiness_in(&transaction, &run)?;
+        if update_project_for_run_in(&transaction, project, lease)? == 0 {
+            return Err(StoreError::InvalidAuthority(format!(
+                "Run {} cannot complete Project {}",
+                lease.run_id, project.id
+            )));
+        }
+        let event = insert_project_event_in(
+            &transaction,
+            project,
+            &ProjectEventKind::Completed {
+                summary: summary.to_string(),
+            },
+        )?;
+        if transaction.execute(
+            "UPDATE epochs SET state='done', terminal_at=?2
+             WHERE id=?1 AND state='open' AND current_rev=?3",
+            params![epoch.id.as_str(), now_unix(), basis.revision as i64,],
+        )? != 1
+        {
+            return Err(StoreError::InvalidData(format!(
+                "Project {} Work changed while completion was being recorded",
+                project.id
+            )));
+        }
+        end_run_for_lease(
+            &transaction,
+            lease,
+            crate::durable::BoundaryState::Succeeded,
+        )?;
+        transaction.commit()?;
+        Ok(event)
     }
 
     pub fn handoff_project_body(

--- a/rust/loopflow/src/store/sqlite/durable.rs
+++ b/rust/loopflow/src/store/sqlite/durable.rs
@@ -1271,37 +1271,7 @@ impl SqliteStore {
             StoreError::InvalidData("no successful boundary can complete Work".to_string())
         })?;
         validate_basis(&applied, basis)?;
-        let open: bool = tx.query_row(
-            "SELECT EXISTS(
-                SELECT 1 FROM agent_invocations
-                WHERE supervising_run_id=?1 AND ended_at IS NULL
-             )",
-            [run.id.as_str()],
-            |row| row.get(0),
-        )?;
-        if open {
-            return Err(StoreError::InvalidData(
-                "Run has an open Invocation".to_string(),
-            ));
-        }
-        let child_ask_open: bool = tx.query_row(
-            "SELECT EXISTS(
-                SELECT 1 FROM ask_exchanges a
-                JOIN agent_turns t ON t.id=a.turn_id
-                JOIN epochs child_epoch ON child_epoch.id=t.epoch_id
-                WHERE a.answered_at IS NULL AND child_epoch.state='open'
-                  AND t.status NOT IN ('completed', 'interrupted')
-                  AND a.route_kind='parent' AND a.route_work_kind=?1
-                  AND a.route_work_id=?2
-             )",
-            params![run.work.kind(), run.work.id()],
-            |row| row.get(0),
-        )?;
-        if child_ask_open {
-            return Err(StoreError::InvalidData(
-                "Run cannot complete while a child Ask is unanswered".to_string(),
-            ));
-        }
+        validate_completion_readiness_in(&tx, &run)?;
         let proposal = DoneProposal {
             id: DoneProposalId::new(),
             run_id: run.id.clone(),
@@ -3318,7 +3288,7 @@ fn insert_truth(
     Ok(())
 }
 
-fn validate_basis(current: &Basis, expected: &Basis) -> StoreResult<()> {
+pub(crate) fn validate_basis(current: &Basis, expected: &Basis) -> StoreResult<()> {
     if current == expected {
         return Ok(());
     }
@@ -3326,6 +3296,41 @@ fn validate_basis(current: &Basis, expected: &Basis) -> StoreResult<()> {
         expected: format!("{}:{}", expected.epoch_id, expected.revision),
         current: format!("{}:{}", current.epoch_id, current.revision),
     })
+}
+
+pub(crate) fn validate_completion_readiness_in(conn: &Connection, run: &Run) -> StoreResult<()> {
+    let invocation_open: bool = conn.query_row(
+        "SELECT EXISTS(
+            SELECT 1 FROM agent_invocations
+            WHERE supervising_run_id=?1 AND ended_at IS NULL
+         )",
+        [run.id.as_str()],
+        |row| row.get(0),
+    )?;
+    if invocation_open {
+        return Err(StoreError::InvalidData(
+            "Run has an open Invocation".to_string(),
+        ));
+    }
+    let child_ask_open: bool = conn.query_row(
+        "SELECT EXISTS(
+            SELECT 1 FROM ask_exchanges a
+            JOIN agent_turns t ON t.id=a.turn_id
+            JOIN epochs child_epoch ON child_epoch.id=t.epoch_id
+            WHERE a.answered_at IS NULL AND child_epoch.state='open'
+              AND t.status NOT IN ('completed', 'interrupted')
+              AND a.route_kind='parent' AND a.route_work_kind=?1
+              AND a.route_work_id=?2
+         )",
+        params![run.work.kind(), run.work.id()],
+        |row| row.get(0),
+    )?;
+    if child_ask_open {
+        return Err(StoreError::InvalidData(
+            "Run cannot complete while a child Ask is unanswered".to_string(),
+        ));
+    }
+    Ok(())
 }
 
 fn validate_author(tx: &Transaction<'_>, target: &WorkRef, author: &Author) -> StoreResult<()> {
@@ -3399,7 +3404,7 @@ pub(crate) fn work_for_child_in(conn: &Connection, target: &ChildRef) -> StoreRe
     }
 }
 
-fn current_epoch_in(conn: &Connection, work: &WorkRef) -> StoreResult<Epoch> {
+pub(crate) fn current_epoch_in(conn: &Connection, work: &WorkRef) -> StoreResult<Epoch> {
     let (column, id) = match work {
         WorkRef::Wave(id) => ("wave_id", id.as_str()),
         WorkRef::Project(id) => ("project_id", id.as_str()),


### PR DESCRIPTION
## Try it!

```bash
cargo test -p loopflow project::runner::tests::
```

Five Project runner fixtures pass. The terminal fixture uses the production
shape of one supervised Invocation and zero durable agent Turns, then replays
reconciliation and proves one completion event, one Run, zero synthetic Turns,
and no following failure.

On the configured Home, inspect the restored Incident Management supervisor:

```bash
lf status infrastructure --json \
  | jq '.projects[] | select(.project.slug == "incident-management") | .runtime'
```

The installed path reached iteration 12 and returned to `ready` without
`no successful boundary can complete Work`. The candidate's terminal receipt is
proved by the deterministic SQLite fixture until this binary is installed.

## Intent

Incident Management recorded `iteration_completed` and `completed`, then the
generic Work transition rejected the same boundary because Project Runs do not
own durable agent Turns. This change gives Project controller evidence its own
atomic settlement: the Project, event and outbox, Work Epoch, Run, and open
Invocation now agree or roll back together. Reconciliation observes terminal
Work and cannot repeat the boundary.

## Assumptions

- A successful structured Project disposition plus authoritative PM state is
  controller evidence; an `agent_turns` row is not required or manufactured.
- Terminal settlement still requires the current Run lease, exact Work Basis,
  a closed Invocation, and no blocking child Ask.
- The durable outbox is notification correctness. A live Wave nudge is only a
  best-effort latency optimization after commit.

## Key decisions

- Add authority-specific Project completion rather than weaken generic agent
  `done()`.
- Commit the terminal Project result as one receipt instead of sequential
  event, Work, and Run writes.
- Treat already-done Work as a successful replay with no new event or Run.
- Reject the older generic `finish_project_run(..., Failed)` path so failure
  cannot bypass its atomic event receipt.

Changed-aware validation passed formatting, clippy, release-equivalent draft
migration materialization, and 1,766 Rust tests. Two tests were skipped; one
unrelated Wave cron test passed with a leaky-process classification.

## Not included

- The remaining Task runner audit and generic completion API narrowing.
- Turning nonterminal route-recovery observations into terminal failures.
- Installing the candidate binary merely to manufacture a production terminal
  boundary.
