### PR TITLE
release: finish safely when notes automation degrades

### DIFF
--- a/docs/lf.md
+++ b/docs/lf.md
@@ -897,10 +897,13 @@ unreleased ledger; headless runs do not. The release workflow promotes
 intent source, the exact git range as shipped-behavior truth, and merged PRs as
 narrative context, then archives the generated notes. If the ledger is absent,
 notes fall back to commits and PR history. Headless release automation needs no
-runner-local agent CLI — if no harness can start, Loopflow writes deterministic
-notes from the same context. Configure repository-specific verification,
-preparation, and completion evidence under `release.targets`; see
-[Configuration](config.md).
+healthy notes provider. Missing CLIs, cooldowns, rate limits, quota or
+authentication failures, and provider outages write deterministic notes from
+bounded context. Unknown skill failures and missing, stale-version, or
+oversized output keep the release gate red. `lf release status` reports note
+quality and gate safety separately from workflow and GitHub Release completion.
+Configure repository-specific verification, preparation, and completion
+evidence under `release.targets`; see [Configuration](config.md).
 
 ## See Also
 

--- a/release/README.md
+++ b/release/README.md
@@ -88,7 +88,14 @@ writes the final notes to both `RELEASE_NOTES.md` and
 the shipped-behavior ledger; matching PRs add narrative context. If the
 decisions directory is absent, the same commit evidence still produces notes.
 
-Scheduled releases prefer the same agent-backed `release-notes` skill. When
-the runner has no Claude, Codex, or OpenCode CLI, `lf release run` writes
-deterministic notes from the exact commits, matching PRs, and archived
-decisions instead of blocking the patch release.
+Scheduled releases prefer the same agent-backed `release-notes` skill. Missing
+CLIs, provider cooldowns, rate limits, quota exhaustion, authentication loss,
+and provider outages select concise deterministic notes instead of stranding a
+verified patch release. Release-note source context is capped at 128 KiB and
+the resulting notes/merge-queue body at 60 KiB; omission counts travel with the
+agent context. Unknown skill failures, stale-version output, missing output,
+and oversized notes still block the release gate.
+
+`lf release status` reports narrative notes, degraded-but-safe deterministic
+notes, missing unsafe notes, or an unmarked legacy archive separately from the
+workflow and GitHub Release status.

--- a/rust/loopflow/src/engine/builtins/ops/skill/release-notes.md
+++ b/rust/loopflow/src/engine/builtins/ops/skill/release-notes.md
@@ -7,18 +7,23 @@ Write release notes that fuse release intent with shipped behavior.
 
 ## Workflow
 
-1. Read `LF_RELEASE_NOTES_CONTEXT` and parse the JSON.
+1. Read `LF_RELEASE_NOTES_CONTEXT` and parse the JSON. `source_limits` states
+   the hard context/output bounds; `omissions` records source material that did
+   not fit. Never infer behavior from omitted source.
 2. Treat `decisions` as the intent ledger: what changed in product direction, release policy, operations, and user experience during this cycle.
-3. Treat `commits` as the behavior ledger: the exact first-parent git range in
-   the target area. Use `merged_prs` to recover intent and discussion. When
-   `prev_tag` exists, use `git diff <prev_tag>..HEAD` only to inspect details.
+3. Treat `commits` as the bounded behavior ledger for the exact first-parent
+   git range in the target area. Use `merged_prs` to recover intent and
+   discussion. Do not expand the source with git or GitHub queries; the bounded
+   JSON is the complete notes input.
 4. Fuse them. The release notes should explain what users, operators, and contributors can do differently now. Use commits/PRs to ground every claim.
 5. Keep the previous release-note voice if `previous_release_notes` exists, but improve structure when the previous notes were too raw.
 6. Write `RELEASE_NOTES.md`.
 
 ## Output
 
-Raw markdown only. No JSON. No code fence wrapping the output.
+Raw markdown only. No JSON. No code fence wrapping the output. Keep the
+complete file below `source_limits.release_notes_bytes`; Loopflow rejects
+oversized notes because this file also becomes release-queue metadata.
 
 First line must be exactly:
 
@@ -39,6 +44,9 @@ Structure:
 - PR titles are source material, not release notes. Do not dump them chronologically.
 - If decisions and commits disagree, trust the commits for what shipped and use decisions to explain why.
 - If decisions mention future work that did not ship, either omit it or mark it clearly as “not included.”
+- If `omissions` contains non-zero counts, synthesize only from the included
+  evidence. Mention the bounded sample only when it materially limits a claim;
+  do not dump the omission ledger into the notes.
 - If there are no decisions, build the narrative from commits, merged PRs, and
   diffs.
 - If there are decisions but no matching shipped behavior, keep the note cautious: describe the policy/intent change, not an implementation that is absent.

--- a/rust/loopflow/src/lf/commands/ops/mod.rs
+++ b/rust/loopflow/src/lf/commands/ops/mod.rs
@@ -1297,6 +1297,22 @@ fn release_status_cmd(target_name: Option<&str>) -> Result<()> {
         println!("Workflow URL: {url}");
     }
 
+    match status.notes_status {
+        Some(crate::ops::ReleaseNotesStatus::Narrative) => {
+            println!("Release notes: narrative / gate safe");
+        }
+        Some(crate::ops::ReleaseNotesStatus::Degraded(reason)) => {
+            println!("Release notes: degraded ({reason}) / gate safe");
+        }
+        Some(crate::ops::ReleaseNotesStatus::Missing) => {
+            println!("Release notes: missing / gate unsafe");
+        }
+        Some(crate::ops::ReleaseNotesStatus::Legacy) => {
+            println!("Release notes: legacy / gate status unknown");
+        }
+        None => println!("Release notes: (no release tag)"),
+    }
+
     println!(
         "GitHub Release: {}",
         if status.release_exists { "yes" } else { "no" }

--- a/rust/loopflow/src/ops/mod.rs
+++ b/rust/loopflow/src/ops/mod.rs
@@ -46,8 +46,8 @@ pub use rebase::{
 };
 pub use release::{
     bump_version, generate_release, release_bump, release_check, release_notes, release_publish,
-    release_run, release_status, release_tag, MergedPr, ReleaseReceipt, ReleaseRunOutcome,
-    ReleaseStatusResult,
+    release_run, release_status, release_tag, MergedPr, ReleaseNotesDegradation,
+    ReleaseNotesStatus, ReleaseReceipt, ReleaseRunOutcome, ReleaseStatusResult,
 };
 pub(crate) use run::{launch_in_run, RunLaunch};
 pub use trace::{hash_prompt, trace_enabled, MockResponses, OpTrace, Tracer};

--- a/rust/loopflow/src/ops/release.rs
+++ b/rust/loopflow/src/ops/release.rs
@@ -1,5 +1,6 @@
 use std::collections::HashSet;
 use std::fs;
+use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output};
 use std::thread;
@@ -21,6 +22,23 @@ use crate::ops::land::{land, LandOptions};
 use crate::ops::pr::PrCopy;
 use crate::ops::progress::Progress;
 use crate::ops::util::command_exists;
+
+const RELEASE_QUEUE_PR_LIMIT: usize = 200;
+const RELEASE_CONTEXT_MAX_BYTES: usize = 128 * 1024;
+const RELEASE_CONTEXT_MAX_COMMITS: usize = 256;
+const RELEASE_CONTEXT_MAX_PRS: usize = RELEASE_QUEUE_PR_LIMIT;
+const RELEASE_CONTEXT_MAX_FILES_PER_CHANGE: usize = 100;
+const RELEASE_CONTEXT_MAX_AREA_SCOPES: usize = 32;
+const RELEASE_CONTEXT_MAX_NAME_BYTES: usize = 256;
+const RELEASE_CONTEXT_MAX_TITLE_BYTES: usize = 300;
+const RELEASE_CONTEXT_MAX_PATH_BYTES: usize = 512;
+const RELEASE_CONTEXT_MAX_PR_BODY_BYTES: usize = 4 * 1024;
+const RELEASE_CONTEXT_MAX_DECISIONS_BYTES: usize = 16 * 1024;
+const RELEASE_CONTEXT_MAX_PREVIOUS_NOTES_BYTES: usize = 16 * 1024;
+const RELEASE_NOTES_MAX_BYTES: usize = 60 * 1024;
+const FALLBACK_NOTES_MAX_COMMITS: usize = 50;
+const FALLBACK_NOTES_MAX_PRS: usize = 50;
+const RELEASE_NOTES_STATUS_PREFIX: &str = "<!-- loopflow:release-notes=";
 
 /// A merged PR with enough context for release notes.
 #[derive(Debug, Clone, Serialize)]
@@ -161,10 +179,62 @@ struct ReleaseTarget {
 pub struct ReleaseStatusResult {
     pub target: String,
     pub latest_tag: Option<String>,
+    pub notes_status: Option<ReleaseNotesStatus>,
     pub workflow_status: Option<String>,
     pub workflow_conclusion: Option<String>,
     pub workflow_url: Option<String>,
     pub release_exists: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum ReleaseNotesDegradation {
+    MissingCli,
+    Cooldown,
+    Quota,
+    Authentication,
+    RateLimit,
+    ProviderUnavailable,
+}
+
+impl ReleaseNotesDegradation {
+    fn slug(self) -> &'static str {
+        match self {
+            Self::MissingCli => "missing-cli",
+            Self::Cooldown => "cooldown",
+            Self::Quota => "quota",
+            Self::Authentication => "authentication",
+            Self::RateLimit => "rate-limit",
+            Self::ProviderUnavailable => "provider-unavailable",
+        }
+    }
+
+    fn from_slug(value: &str) -> Option<Self> {
+        match value {
+            "missing-cli" => Some(Self::MissingCli),
+            "cooldown" => Some(Self::Cooldown),
+            "quota" => Some(Self::Quota),
+            "authentication" => Some(Self::Authentication),
+            "rate-limit" => Some(Self::RateLimit),
+            "provider-unavailable" => Some(Self::ProviderUnavailable),
+            _ => None,
+        }
+    }
+}
+
+impl std::fmt::Display for ReleaseNotesDegradation {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(self.slug())
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum ReleaseNotesStatus {
+    Narrative,
+    Degraded(ReleaseNotesDegradation),
+    Missing,
+    Legacy,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -261,17 +331,19 @@ pub fn release_status(repo: &Path, target_name: Option<&str>) -> OpsResult<Relea
     let (main_repo, target) = resolve_repo_and_target(repo, target_name)?;
 
     let latest_tag = latest_tag_optional(&main_repo, &target)?;
-    let (workflow, release_exists) = match latest_tag.as_deref() {
+    let (notes_status, workflow, release_exists) = match latest_tag.as_deref() {
         Some(tag) => (
+            Some(release_notes_status(&main_repo, tag, &target)?),
             find_workflow_run(&main_repo, tag, &target)?,
             github_release_exists(&main_repo, tag)?,
         ),
-        None => (None, false),
+        None => (None, None, false),
     };
 
     Ok(ReleaseStatusResult {
         target: target.name,
         latest_tag,
+        notes_status,
         workflow_status: workflow.as_ref().map(|run| run.status.clone()),
         workflow_conclusion: workflow.as_ref().and_then(|run| run.conclusion.clone()),
         workflow_url: workflow.and_then(|run| run.url),
@@ -328,6 +400,7 @@ pub fn release_notes(
         &commits,
         &prs,
         &target,
+        progress,
     )?;
 
     let notes = fs::read_to_string(main_repo.join("RELEASE_NOTES.md"))?;
@@ -786,7 +859,9 @@ fn prepare_release_in_worktree(
         "Generating release notes for {}...",
         target_tag(target, version)
     ));
-    run_release_notes_stage(wt_path, version, prev_tag, commits, merged_prs, target)?;
+    run_release_notes_stage(
+        wt_path, version, prev_tag, commits, merged_prs, target, progress,
+    )?;
 
     progress.status("Committing release changes...");
     let _ = commit_workflow(
@@ -838,6 +913,36 @@ struct ReleaseNotesContext {
     merged_prs: Vec<MergedPr>,
     decisions: Option<String>,
     previous_release_notes: Option<String>,
+    source_limits: ReleaseNotesSourceLimits,
+    omissions: ReleaseNotesOmissions,
+}
+
+#[derive(Debug, Serialize)]
+struct ReleaseNotesSourceLimits {
+    context_bytes: usize,
+    commits: usize,
+    merged_prs: usize,
+    files_per_change: usize,
+    area_scopes: usize,
+    name_bytes: usize,
+    title_bytes: usize,
+    path_bytes: usize,
+    pr_body_bytes: usize,
+    decisions_bytes: usize,
+    previous_release_notes_bytes: usize,
+    release_notes_bytes: usize,
+}
+
+#[derive(Debug, Serialize)]
+struct ReleaseNotesOmissions {
+    commits: usize,
+    merged_prs: usize,
+    commit_files: usize,
+    pr_files: usize,
+    area_scopes: usize,
+    text_bytes: usize,
+    decisions_bytes: usize,
+    previous_release_notes_bytes: usize,
 }
 
 fn run_release_notes_stage(
@@ -847,66 +952,322 @@ fn run_release_notes_stage(
     commits: &[ReleaseCommit],
     merged_prs: &[MergedPr],
     target: &ReleaseTarget,
+    progress: &impl Progress,
 ) -> OpsResult<()> {
-    let previous_notes = fs::read_to_string(repo.join("RELEASE_NOTES.md")).ok();
-    promote_unreleased_dir(repo, version)?;
-    let decisions = fs::read_to_string(
-        repo.join("release")
+    let notes_path = repo.join("RELEASE_NOTES.md");
+    let (previous_notes, previous_notes_omitted) =
+        read_bounded_text(&notes_path, RELEASE_CONTEXT_MAX_PREVIOUS_NOTES_BYTES)?;
+    let previous_notes_file = move_release_notes_aside(repo, &notes_path)?;
+
+    let result = (|| -> OpsResult<()> {
+        promote_unreleased_dir(repo, version)?;
+        let decisions_path = repo
+            .join("release")
             .join(format!("v{version}"))
-            .join("DECISIONS.md"),
-    )
-    .ok();
+            .join("DECISIONS.md");
+        let (decisions, decisions_omitted) =
+            read_bounded_text(&decisions_path, RELEASE_CONTEXT_MAX_DECISIONS_BYTES)?;
+        let (context, context_json) = build_release_notes_context(
+            version,
+            prev_tag,
+            commits,
+            merged_prs,
+            target,
+            decisions,
+            decisions_omitted,
+            previous_notes,
+            previous_notes_omitted,
+        )?;
 
-    let context = ReleaseNotesContext {
-        version: version.to_string(),
-        prev_tag: prev_tag.map(str::to_string),
-        target: target.name.clone(),
-        tag_prefix: target.tag_prefix.clone(),
-        area_scope: target.area.clone(),
-        commits: commits.to_vec(),
-        merged_prs: merged_prs.to_vec(),
-        decisions,
-        previous_release_notes: previous_notes,
-    };
+        let mut context_file = tempfile::NamedTempFile::new_in(repo)?;
+        context_file.write_all(&context_json)?;
+        let context_path = context_file.path().to_string_lossy().to_string();
 
-    let mut context_file = tempfile::NamedTempFile::new_in(repo)?;
-    serde_json::to_writer_pretty(&mut context_file, &context)
-        .map_err(|err| OpsError::Parse(format!("failed to encode release-notes context: {err}")))?;
-    let context_path = context_file.path().to_string_lossy().to_string();
+        let mut cmd = Command::new("lf");
+        cmd.arg("--batch")
+            .arg("release-notes")
+            .current_dir(repo)
+            .env("LF_RELEASE_NOTES_CONTEXT", &context_path);
+        let degradation = match run_command(&mut cmd) {
+            Ok(_) => None,
+            Err(err) => match classify_release_notes_degradation(&err) {
+                Some(degradation) => {
+                    let notes = generate_release_notes(&context)?;
+                    write_release_notes(repo, &notes, version)?;
+                    Some(degradation)
+                }
+                None => {
+                    return Err(OpsError::Message(format!(
+                        "release gate blocked: release-notes agent failed outside the supported provider-degradation policy: {err}"
+                    )));
+                }
+            },
+        };
 
-    let mut cmd = Command::new("lf");
-    cmd.arg("--batch")
-        .arg("release-notes")
-        .current_dir(repo)
-        .env("LF_RELEASE_NOTES_CONTEXT", &context_path);
-    match run_command(&mut cmd) {
-        Ok(_) => {}
-        Err(err) if is_missing_release_notes_agent_cli(&err) => {
-            eprintln!(
-                "release-notes agent unavailable; writing deterministic fallback release notes"
-            );
-            let notes = generate_release_notes(commits, merged_prs, version, prev_tag, target)?;
-            write_release_notes(repo, &notes, version)?;
+        finalize_release_notes(repo, version, degradation)?;
+        archive_release_notes(repo, version)?;
+        match degradation {
+            None => progress.status("Release notes: narrative; release gate safe."),
+            Some(reason) => progress.warning(&format!(
+                "Release notes: degraded ({reason}); deterministic fallback keeps the release gate safe."
+            )),
         }
-        Err(err) => {
-            return Err(OpsError::CommandFailed {
-                command: err.command_line(),
-                stderr: err.stderr,
-            });
-        }
-    }
+        Ok(())
+    })();
 
-    if !repo.join("RELEASE_NOTES.md").exists() {
-        return Err(OpsError::Message(
-            "release-notes skill did not write RELEASE_NOTES.md".to_string(),
-        ));
+    if result.is_err() {
+        restore_release_notes(&notes_path, previous_notes_file.as_ref())?;
     }
+    result
+}
 
-    archive_release_notes(repo, version)?;
+fn move_release_notes_aside(
+    repo: &Path,
+    notes_path: &Path,
+) -> OpsResult<Option<tempfile::TempPath>> {
+    if !notes_path.exists() {
+        return Ok(None);
+    }
+    let backup = tempfile::NamedTempFile::new_in(repo)?.into_temp_path();
+    fs::remove_file(&backup)?;
+    fs::rename(notes_path, &backup)?;
+    Ok(Some(backup))
+}
+
+fn restore_release_notes(
+    notes_path: &Path,
+    previous_notes: Option<&tempfile::TempPath>,
+) -> OpsResult<()> {
+    match fs::remove_file(notes_path) {
+        Ok(()) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => return Err(error.into()),
+    }
+    if let Some(previous_notes) = previous_notes {
+        fs::rename(previous_notes, notes_path)?;
+    }
     Ok(())
 }
 
-fn is_missing_release_notes_agent_cli(err: &CommandError) -> bool {
+#[allow(clippy::too_many_arguments)]
+fn build_release_notes_context(
+    version: &str,
+    prev_tag: Option<&str>,
+    commits: &[ReleaseCommit],
+    merged_prs: &[MergedPr],
+    target: &ReleaseTarget,
+    decisions: Option<String>,
+    decisions_omitted: usize,
+    previous_release_notes: Option<String>,
+    previous_release_notes_omitted: usize,
+) -> OpsResult<(ReleaseNotesContext, Vec<u8>)> {
+    let mut omissions = ReleaseNotesOmissions {
+        commits: commits.len().saturating_sub(RELEASE_CONTEXT_MAX_COMMITS),
+        merged_prs: merged_prs.len().saturating_sub(RELEASE_CONTEXT_MAX_PRS),
+        commit_files: 0,
+        pr_files: 0,
+        area_scopes: target
+            .area
+            .len()
+            .saturating_sub(RELEASE_CONTEXT_MAX_AREA_SCOPES),
+        text_bytes: 0,
+        decisions_bytes: decisions_omitted,
+        previous_release_notes_bytes: previous_release_notes_omitted,
+    };
+    let mut context = ReleaseNotesContext {
+        version: bound_text(
+            version,
+            RELEASE_CONTEXT_MAX_NAME_BYTES,
+            &mut omissions.text_bytes,
+        ),
+        prev_tag: prev_tag.map(|tag| {
+            bound_text(
+                tag,
+                RELEASE_CONTEXT_MAX_NAME_BYTES,
+                &mut omissions.text_bytes,
+            )
+        }),
+        target: bound_text(
+            &target.name,
+            RELEASE_CONTEXT_MAX_NAME_BYTES,
+            &mut omissions.text_bytes,
+        ),
+        tag_prefix: bound_text(
+            &target.tag_prefix,
+            RELEASE_CONTEXT_MAX_NAME_BYTES,
+            &mut omissions.text_bytes,
+        ),
+        area_scope: target
+            .area
+            .iter()
+            .take(RELEASE_CONTEXT_MAX_AREA_SCOPES)
+            .map(|scope| {
+                bound_text(
+                    scope,
+                    RELEASE_CONTEXT_MAX_PATH_BYTES,
+                    &mut omissions.text_bytes,
+                )
+            })
+            .collect(),
+        commits: commits
+            .iter()
+            .take(RELEASE_CONTEXT_MAX_COMMITS)
+            .map(|commit| bound_release_commit(commit, &mut omissions))
+            .collect(),
+        merged_prs: merged_prs
+            .iter()
+            .take(RELEASE_CONTEXT_MAX_PRS)
+            .map(|pr| bound_merged_pr(pr, &mut omissions))
+            .collect(),
+        decisions,
+        previous_release_notes,
+        source_limits: ReleaseNotesSourceLimits {
+            context_bytes: RELEASE_CONTEXT_MAX_BYTES,
+            commits: RELEASE_CONTEXT_MAX_COMMITS,
+            merged_prs: RELEASE_CONTEXT_MAX_PRS,
+            files_per_change: RELEASE_CONTEXT_MAX_FILES_PER_CHANGE,
+            area_scopes: RELEASE_CONTEXT_MAX_AREA_SCOPES,
+            name_bytes: RELEASE_CONTEXT_MAX_NAME_BYTES,
+            title_bytes: RELEASE_CONTEXT_MAX_TITLE_BYTES,
+            path_bytes: RELEASE_CONTEXT_MAX_PATH_BYTES,
+            pr_body_bytes: RELEASE_CONTEXT_MAX_PR_BODY_BYTES,
+            decisions_bytes: RELEASE_CONTEXT_MAX_DECISIONS_BYTES,
+            previous_release_notes_bytes: RELEASE_CONTEXT_MAX_PREVIOUS_NOTES_BYTES,
+            release_notes_bytes: RELEASE_NOTES_MAX_BYTES,
+        },
+        omissions,
+    };
+
+    loop {
+        let json = serde_json::to_vec(&context).map_err(|err| {
+            OpsError::Parse(format!("failed to encode release-notes context: {err}"))
+        })?;
+        if json.len() <= RELEASE_CONTEXT_MAX_BYTES {
+            return Ok((context, json));
+        }
+        if context.merged_prs.len() >= context.commits.len() && !context.merged_prs.is_empty() {
+            context.merged_prs.pop();
+            context.omissions.merged_prs += 1;
+        } else if !context.commits.is_empty() {
+            context.commits.pop();
+            context.omissions.commits += 1;
+        } else if !context.merged_prs.is_empty() {
+            context.merged_prs.pop();
+            context.omissions.merged_prs += 1;
+        } else {
+            return Err(OpsError::Message(format!(
+                "release gate blocked: bounded release-notes metadata exceeds {RELEASE_CONTEXT_MAX_BYTES} bytes"
+            )));
+        }
+    }
+}
+
+fn bound_release_commit(
+    commit: &ReleaseCommit,
+    omissions: &mut ReleaseNotesOmissions,
+) -> ReleaseCommit {
+    omissions.commit_files += commit
+        .files
+        .len()
+        .saturating_sub(RELEASE_CONTEXT_MAX_FILES_PER_CHANGE);
+    ReleaseCommit {
+        sha: bound_text(
+            &commit.sha,
+            RELEASE_CONTEXT_MAX_NAME_BYTES,
+            &mut omissions.text_bytes,
+        ),
+        title: bound_text(
+            &commit.title,
+            RELEASE_CONTEXT_MAX_TITLE_BYTES,
+            &mut omissions.text_bytes,
+        ),
+        files: commit
+            .files
+            .iter()
+            .take(RELEASE_CONTEXT_MAX_FILES_PER_CHANGE)
+            .map(|path| {
+                bound_text(
+                    path,
+                    RELEASE_CONTEXT_MAX_PATH_BYTES,
+                    &mut omissions.text_bytes,
+                )
+            })
+            .collect(),
+    }
+}
+
+fn bound_merged_pr(pr: &MergedPr, omissions: &mut ReleaseNotesOmissions) -> MergedPr {
+    omissions.pr_files += pr
+        .files
+        .len()
+        .saturating_sub(RELEASE_CONTEXT_MAX_FILES_PER_CHANGE);
+    MergedPr {
+        number: pr.number,
+        title: bound_text(
+            &pr.title,
+            RELEASE_CONTEXT_MAX_TITLE_BYTES,
+            &mut omissions.text_bytes,
+        ),
+        body: pr.body.as_deref().map(|body| {
+            bound_text(
+                body,
+                RELEASE_CONTEXT_MAX_PR_BODY_BYTES,
+                &mut omissions.text_bytes,
+            )
+        }),
+        files: pr
+            .files
+            .iter()
+            .take(RELEASE_CONTEXT_MAX_FILES_PER_CHANGE)
+            .map(|path| {
+                bound_text(
+                    path,
+                    RELEASE_CONTEXT_MAX_PATH_BYTES,
+                    &mut omissions.text_bytes,
+                )
+            })
+            .collect(),
+        additions: pr.additions,
+        deletions: pr.deletions,
+        changed_files: pr.changed_files,
+        merge_commit: pr.merge_commit.as_deref().map(|commit| {
+            bound_text(
+                commit,
+                RELEASE_CONTEXT_MAX_NAME_BYTES,
+                &mut omissions.text_bytes,
+            )
+        }),
+    }
+}
+
+fn bound_text(value: &str, max_bytes: usize, omitted: &mut usize) -> String {
+    if value.len() <= max_bytes {
+        return value.to_string();
+    }
+    let mut end = max_bytes;
+    while !value.is_char_boundary(end) {
+        end -= 1;
+    }
+    *omitted += value.len() - end;
+    value[..end].to_string()
+}
+
+fn read_bounded_text(path: &Path, max_bytes: usize) -> OpsResult<(Option<String>, usize)> {
+    let file = match fs::File::open(path) {
+        Ok(file) => file,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok((None, 0)),
+        Err(error) => return Err(error.into()),
+    };
+    let total_bytes = file.metadata()?.len().min(usize::MAX as u64) as usize;
+    let mut bytes = Vec::with_capacity(total_bytes.min(max_bytes));
+    file.take(max_bytes as u64).read_to_end(&mut bytes)?;
+    let mut omitted = total_bytes.saturating_sub(bytes.len());
+    let decoded = String::from_utf8_lossy(&bytes);
+    let value = bound_text(&decoded, max_bytes, &mut omitted);
+    Ok((Some(value), omitted))
+}
+
+fn classify_release_notes_degradation(err: &CommandError) -> Option<ReleaseNotesDegradation> {
     let stderr = err.stderr.to_lowercase();
     let message = err.message.to_lowercase();
     let combined = format!("{stderr}\n{message}");
@@ -919,8 +1280,142 @@ fn is_missing_release_notes_agent_cli(err: &CommandError) -> bool {
         || combined.contains("not found on path")
         || combined.contains("no such file or directory")
         || combined.contains("failed to spawn");
+    if mentions_agent_cli && missing_binary {
+        return Some(ReleaseNotesDegradation::MissingCli);
+    }
+    if combined.contains("account subscription limit")
+        || combined.contains("usage limit reached")
+        || combined.contains("usage limit has been reached")
+        || combined.contains("you've hit your usage limit")
+        || combined.contains("subscription quota")
+        || combined.contains("quota exceeded")
+        || combined.contains("insufficient_quota")
+    {
+        return Some(ReleaseNotesDegradation::Quota);
+    }
+    if combined.contains("account credential invalidated")
+        || combined.contains("no authenticated")
+        || combined.contains("not authenticated")
+        || combined.contains("not logged in")
+        || combined.contains("please sign in")
+        || combined.contains("log in again")
+        || combined.contains("login required")
+        || combined.contains("unauthorized")
+        || combined.contains("status 401")
+    {
+        return Some(ReleaseNotesDegradation::Authentication);
+    }
+    if combined.contains("no eligible managed")
+        || combined.contains("cooling down")
+        || combined.contains("cooldown")
+    {
+        return Some(ReleaseNotesDegradation::Cooldown);
+    }
+    if combined.contains("provider rate limit")
+        || combined.contains("too many requests")
+        || combined.contains("status 429")
+        || combined.contains("status code 429")
+    {
+        return Some(ReleaseNotesDegradation::RateLimit);
+    }
+    if combined.contains("provider capacity")
+        || combined.contains("provider unavailable")
+        || combined.contains("provider transport")
+        || combined.contains("temporarily unavailable")
+        || combined.contains("service unavailable")
+        || combined.contains("server is busy")
+        || combined.contains("server overloaded")
+        || combined.contains("try again later")
+        || combined.contains("internal server error")
+        || combined.contains("status 502")
+        || combined.contains("status 503")
+        || combined.contains("status 504")
+        || combined.contains("connection reset")
+        || combined.contains("connection closed")
+        || combined.contains("connection refused")
+        || combined.contains("network error")
+        || combined.contains("request timed out")
+        || combined.contains("request timeout")
+    {
+        return Some(ReleaseNotesDegradation::ProviderUnavailable);
+    }
+    None
+}
 
-    mentions_agent_cli && missing_binary
+fn finalize_release_notes(
+    repo: &Path,
+    version: &str,
+    degradation: Option<ReleaseNotesDegradation>,
+) -> OpsResult<()> {
+    let path = repo.join("RELEASE_NOTES.md");
+    let file = fs::File::open(&path).map_err(|error| {
+        if error.kind() == std::io::ErrorKind::NotFound {
+            OpsError::Message(
+                "release gate blocked: release-notes skill did not write fresh RELEASE_NOTES.md"
+                    .to_string(),
+            )
+        } else {
+            error.into()
+        }
+    })?;
+    let reported_bytes = file.metadata()?.len();
+    let mut raw =
+        String::with_capacity(reported_bytes.min((RELEASE_NOTES_MAX_BYTES + 1) as u64) as usize);
+    file.take((RELEASE_NOTES_MAX_BYTES + 1) as u64)
+        .read_to_string(&mut raw)?;
+    if reported_bytes > RELEASE_NOTES_MAX_BYTES as u64 || raw.len() > RELEASE_NOTES_MAX_BYTES {
+        return Err(OpsError::Message(format!(
+            "release gate blocked: release notes are at least {} bytes; maximum queue metadata is {RELEASE_NOTES_MAX_BYTES} bytes",
+            reported_bytes.max(raw.len() as u64)
+        )));
+    }
+    let expected_header = format!("# v{version}");
+    let mut lines = raw.trim().lines();
+    let actual_header = lines.next().map(str::trim);
+    if actual_header != Some(expected_header.as_str()) {
+        return Err(OpsError::Message(format!(
+            "release gate blocked: release notes must start with '{expected_header}'"
+        )));
+    }
+
+    let body = lines
+        .filter(|line| !line.trim().starts_with(RELEASE_NOTES_STATUS_PREFIX))
+        .collect::<Vec<_>>()
+        .join("\n")
+        .trim()
+        .to_string();
+    if body.is_empty() {
+        return Err(OpsError::Message(
+            "release gate blocked: release notes contain no release content".to_string(),
+        ));
+    }
+    let marker = match degradation {
+        None => "<!-- loopflow:release-notes=narrative;gate=safe -->".to_string(),
+        Some(reason) => format!(
+            "<!-- loopflow:release-notes=degraded;reason={};gate=safe -->",
+            reason.slug()
+        ),
+    };
+    let content = format!("{expected_header}\n\n{marker}\n\n{body}");
+    if content.len() > RELEASE_NOTES_MAX_BYTES {
+        return Err(OpsError::Message(format!(
+            "release gate blocked: release notes are {} bytes; maximum queue metadata is {RELEASE_NOTES_MAX_BYTES} bytes",
+            content.len()
+        )));
+    }
+    write_atomic(&path, content.as_bytes())
+}
+
+fn write_atomic(path: &Path, content: &[u8]) -> OpsResult<()> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| OpsError::Message(format!("path has no parent: {}", path.display())))?;
+    fs::create_dir_all(parent)?;
+    let mut file = tempfile::NamedTempFile::new_in(parent)?;
+    file.write_all(content)?;
+    file.persist(path)
+        .map_err(|error| OpsError::Io(error.error))?;
+    Ok(())
 }
 
 /// Rename `release/unreleased/` to `release/v<version>/` at tag time.
@@ -962,9 +1457,44 @@ fn promote_unreleased_dir(repo: &Path, version: &str) -> OpsResult<()> {
 fn archive_release_notes(repo: &Path, version: &str) -> OpsResult<()> {
     let src = repo.join("RELEASE_NOTES.md");
     let dir = repo.join("release").join(format!("v{version}"));
-    fs::create_dir_all(&dir)?;
-    fs::copy(&src, dir.join("NOTES.md"))?;
-    Ok(())
+    let notes = fs::read(&src)?;
+    write_atomic(&dir.join("NOTES.md"), &notes)
+}
+
+fn release_notes_status(
+    repo: &Path,
+    tag: &str,
+    target: &ReleaseTarget,
+) -> OpsResult<ReleaseNotesStatus> {
+    let version = version_from_tag(tag, target)?;
+    let archive = format!("release/v{version}/NOTES.md");
+    let reference = format!("{tag}:{archive}");
+    let output = run_output(repo, "git", &["show", &reference])?;
+    if !output.status.success() {
+        return Ok(ReleaseNotesStatus::Missing);
+    }
+    let notes = String::from_utf8_lossy(&output.stdout);
+    Ok(parse_release_notes_status(&notes))
+}
+
+fn parse_release_notes_status(notes: &str) -> ReleaseNotesStatus {
+    let marker = notes
+        .lines()
+        .find_map(|line| line.trim().strip_prefix(RELEASE_NOTES_STATUS_PREFIX));
+    let Some(marker) = marker else {
+        return ReleaseNotesStatus::Legacy;
+    };
+    if marker == "narrative;gate=safe -->" {
+        return ReleaseNotesStatus::Narrative;
+    }
+    let reason = marker
+        .strip_prefix("degraded;reason=")
+        .and_then(|value| value.strip_suffix(";gate=safe -->"))
+        .and_then(ReleaseNotesDegradation::from_slug);
+    if let Some(reason) = reason {
+        return ReleaseNotesStatus::Degraded(reason);
+    }
+    ReleaseNotesStatus::Legacy
 }
 
 fn cleanup_release_worktree(
@@ -1222,7 +1752,18 @@ fn generate_release_with_target(
     let prs = merged_prs_since(repo, prev_tag.as_deref(), target, &commit_shas)?;
 
     progress.status("Generating release notes...");
-    let notes = generate_release_notes(&commits, &prs, &version, prev_tag.as_deref(), target)?;
+    let (context, _) = build_release_notes_context(
+        &version,
+        prev_tag.as_deref(),
+        &commits,
+        &prs,
+        target,
+        None,
+        0,
+        None,
+        0,
+    )?;
+    let notes = generate_release_notes(&context)?;
 
     progress.status("Writing RELEASE_NOTES.md...");
     write_release_notes(repo, &notes, &version)?;
@@ -1489,22 +2030,6 @@ fn target_tag(target: &ReleaseTarget, version: &str) -> String {
     format!("{}v{version}", target.tag_prefix)
 }
 
-fn display_tag_prefix(target: &ReleaseTarget) -> &str {
-    if target.tag_prefix.is_empty() {
-        "(none)"
-    } else {
-        target.tag_prefix.as_str()
-    }
-}
-
-fn display_area_scope(target: &ReleaseTarget) -> String {
-    if target.area.is_empty() {
-        "(entire repository)".to_string()
-    } else {
-        target.area.join(", ")
-    }
-}
-
 fn latest_tag(repo: &Path, target: &ReleaseTarget) -> OpsResult<String> {
     latest_tag_optional(repo, target)?.ok_or_else(|| {
         OpsError::Message(format!(
@@ -1700,13 +2225,18 @@ fn list_merged_prs(
     if let Some(search) = search {
         args.extend(["--search", search]);
     }
-    args.extend(["--json", fields, "--limit", "200"]);
+    let limit = RELEASE_QUEUE_PR_LIMIT.to_string();
+    args.extend(["--json", fields, "--limit", &limit]);
     let output = run_stdout(repo, "gh", &args)?;
 
     let prs: Vec<GhMergedPr> = serde_json::from_str(&output)
         .map_err(|err| OpsError::Parse(format!("failed to parse merged PR list: {err}")))?;
 
-    Ok(prs.into_iter().map(Into::into).collect())
+    Ok(prs
+        .into_iter()
+        .take(RELEASE_QUEUE_PR_LIMIT)
+        .map(Into::into)
+        .collect())
 }
 
 fn should_fallback_for_pr_files(err: &OpsError) -> bool {
@@ -1803,57 +2333,87 @@ fn glob_to_regex(pattern: &str) -> String {
     regex
 }
 
-fn generate_release_notes(
-    commits: &[ReleaseCommit],
-    prs: &[MergedPr],
-    version: &str,
-    prev_tag: Option<&str>,
-    target: &ReleaseTarget,
-) -> OpsResult<String> {
-    let previous = prev_tag.unwrap_or("repository start");
+fn generate_release_notes(context: &ReleaseNotesContext) -> OpsResult<String> {
+    let previous = context.prev_tag.as_deref().unwrap_or("repository start");
+    let tag_prefix = if context.tag_prefix.is_empty() {
+        "v".to_string()
+    } else {
+        format!("{}v", context.tag_prefix)
+    };
+    let area_scope = if context.area_scope.is_empty() {
+        "all files".to_string()
+    } else {
+        context.area_scope.join(", ")
+    };
     let mut lines = vec![
         format!("## Changes since {previous}"),
         String::new(),
-        format!("- Target: {}", target.name),
-        format!("- Tag prefix: {}", display_tag_prefix(target)),
-        format!("- Area scope: {}", display_area_scope(target)),
+        format!("- Target: {}", context.target),
+        format!("- Tag prefix: {tag_prefix}"),
+        format!("- Area scope: {area_scope}"),
         String::new(),
     ];
 
     lines.push("## Commits".to_string());
     lines.push(String::new());
 
-    for commit in commits {
+    for commit in context.commits.iter().take(FALLBACK_NOTES_MAX_COMMITS) {
         let short_sha = commit.sha.get(..7).unwrap_or(&commit.sha);
         lines.push(format!("- `{short_sha}` {}", commit.title));
+    }
+    let omitted_commits = context.omissions.commits
+        + context
+            .commits
+            .len()
+            .saturating_sub(FALLBACK_NOTES_MAX_COMMITS);
+    if omitted_commits > 0 {
+        lines.push(format!(
+            "- … {omitted_commits} more commit(s) in the release range."
+        ));
     }
 
     lines.push(String::new());
     lines.push("## Merged PRs".to_string());
     lines.push(String::new());
 
-    if prs.is_empty() {
+    if context.merged_prs.is_empty() {
         lines.push("- No merged PRs found in this window.".to_string());
     } else {
-        for pr in prs {
+        for pr in context.merged_prs.iter().take(FALLBACK_NOTES_MAX_PRS) {
             lines.push(format!(
                 "- #{} {} (+{} -{}, {} files)",
                 pr.number, pr.title, pr.additions, pr.deletions, pr.changed_files
             ));
-            if let Some(body) = pr
-                .body
-                .as_deref()
-                .map(str::trim)
-                .filter(|body| !body.is_empty())
-            {
-                let single_line = body.replace('\n', " ");
-                lines.push(format!("  - {}", single_line));
-            }
+        }
+        let omitted_prs = context.omissions.merged_prs
+            + context
+                .merged_prs
+                .len()
+                .saturating_sub(FALLBACK_NOTES_MAX_PRS);
+        if omitted_prs > 0 {
+            lines.push(format!(
+                "- … {omitted_prs} more merged PR(s) in the release range."
+            ));
         }
     }
 
     lines.push(String::new());
-    lines.push(format!("_Generated mechanically for v{version}._"));
+    if context.omissions.text_bytes > 0
+        || context.omissions.commit_files > 0
+        || context.omissions.pr_files > 0
+        || context.omissions.decisions_bytes > 0
+        || context.omissions.previous_release_notes_bytes > 0
+        || context.omissions.area_scopes > 0
+    {
+        lines.push(
+            "_Some narrative source was omitted to keep release context bounded._".to_string(),
+        );
+        lines.push(String::new());
+    }
+    lines.push(format!(
+        "_Generated mechanically for v{}._",
+        context.version
+    ));
     Ok(lines.join("\n"))
 }
 

--- a/rust/loopflow/tests/release_tests.rs
+++ b/rust/loopflow/tests/release_tests.rs
@@ -5,7 +5,8 @@ use std::process::Command;
 
 use loopflow::ops::{
     bump_version, generate_release, release_bump, release_check, release_notes, release_run,
-    release_status, release_tag, NullProgress, ReleaseRunOutcome,
+    release_status, release_tag, NullProgress, ReleaseNotesDegradation, ReleaseNotesStatus,
+    ReleaseRunOutcome,
 };
 use loopflow_test_support::TestRepo;
 use support::EnvGuard;
@@ -153,6 +154,7 @@ fn release_notes_falls_back_when_agent_cli_is_missing() {
         .expect("release notes should fall back");
 
     assert!(notes.starts_with("# v0.9.1\n\n"));
+    assert!(notes.contains("loopflow:release-notes=degraded;reason=missing-cli;gate=safe"));
     assert!(notes.contains("_Generated mechanically for v0.9.1._"));
     // Notes synthesize from the merged PRs, not a central ledger.
     assert!(notes.contains("Make weekly release self-contained"));
@@ -164,6 +166,242 @@ fn release_notes_falls_back_when_agent_cli_is_missing() {
     // The unreleased dir was promoted to the version dir.
     assert!(!repo.path().join("release/unreleased").exists());
     assert!(repo.path().join("release/v0.9.1/CHANGES.md").exists());
+}
+
+#[test]
+fn release_notes_falls_back_for_every_provider_degradation_class() {
+    let gh_script = write_gh_script("[]");
+    let lf_script = "#!/bin/sh\ncat .provider-failure >&2\nexit 1\n";
+    let _env = EnvGuard::new(&[("gh", gh_script.as_str()), ("lf", lf_script)]);
+    let cases = [
+        (
+            "failed to select provider account: no eligible managed codex account: 'primary'",
+            ReleaseNotesDegradation::Cooldown,
+        ),
+        (
+            "agent stopped after account subscription limit",
+            ReleaseNotesDegradation::Quota,
+        ),
+        (
+            "agent stopped after account credential invalidated",
+            ReleaseNotesDegradation::Authentication,
+        ),
+        (
+            "agent stopped after provider rate limit",
+            ReleaseNotesDegradation::RateLimit,
+        ),
+        (
+            "agent stopped after provider unavailable",
+            ReleaseNotesDegradation::ProviderUnavailable,
+        ),
+        (
+            "agent stopped after provider capacity",
+            ReleaseNotesDegradation::ProviderUnavailable,
+        ),
+        (
+            "agent stopped after provider transport",
+            ReleaseNotesDegradation::ProviderUnavailable,
+        ),
+    ];
+
+    for (failure, degradation) in cases {
+        let repo = TestRepo::new();
+        git(&repo, &["tag", "v0.9.0"]);
+        fs::write(repo.path().join(".provider-failure"), failure).unwrap();
+
+        let notes = release_notes(repo.path(), "0.9.1", Some("v0.9.0"), None, &NullProgress)
+            .expect("provider degradation should select deterministic notes");
+
+        assert!(notes.contains(&format!(
+            "loopflow:release-notes=degraded;reason={degradation};gate=safe"
+        )));
+        assert!(notes.contains("_Generated mechanically for v0.9.1._"));
+        assert!(notes.len() < 60 * 1024);
+    }
+}
+
+#[test]
+fn release_notes_bounds_oversized_pr_bodies_and_queue_metadata() {
+    let repo = TestRepo::new();
+    git(&repo, &["tag", "v0.9.0"]);
+    fs::write(
+        repo.path().join("RELEASE_NOTES.md"),
+        "previous voice ".repeat(4_000),
+    )
+    .unwrap();
+    fs::create_dir_all(repo.path().join("release/unreleased")).unwrap();
+    fs::write(
+        repo.path().join("release/unreleased/DECISIONS.md"),
+        "bounded decision ".repeat(4_000),
+    )
+    .unwrap();
+    fs::write(repo.path().join("bounded.txt"), "bounded\n").unwrap();
+    git(&repo, &["add", "bounded.txt"]);
+    git(&repo, &["commit", "-m", "Bound release context"]);
+    let sha = git_output(&repo, &["rev-parse", "HEAD"]);
+    let pr_list = serde_json::to_string(&vec![serde_json::json!({
+        "number": 202,
+        "title": "Bound release context",
+        "body": "x".repeat(100_000),
+        "additions": 8,
+        "deletions": 2,
+        "changedFiles": 1,
+        "mergeCommit": {"oid": sha},
+    })])
+    .unwrap();
+    let gh_script = write_gh_script(&pr_list);
+    let lf_script = "#!/bin/sh\ncp \"$LF_RELEASE_NOTES_CONTEXT\" RELEASE_CONTEXT.json\nprintf '# v0.9.1\\n\\nBounded narrative notes.\\n' > RELEASE_NOTES.md\n";
+    let _env = EnvGuard::new(&[("gh", gh_script.as_str()), ("lf", lf_script)]);
+
+    let notes = release_notes(repo.path(), "0.9.1", Some("v0.9.0"), None, &NullProgress)
+        .expect("bounded narrative notes should succeed");
+
+    let context_path = repo.path().join("RELEASE_CONTEXT.json");
+    assert!(fs::metadata(&context_path).unwrap().len() <= 128 * 1024);
+    let context: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(context_path).unwrap()).unwrap();
+    assert!(context["merged_prs"][0]["body"].as_str().unwrap().len() <= 4 * 1024);
+    assert!(context["omissions"]["text_bytes"].as_u64().unwrap() >= 95_000);
+    assert!(context["decisions"].as_str().unwrap().len() <= 16 * 1024);
+    assert!(context["previous_release_notes"].as_str().unwrap().len() <= 16 * 1024);
+    assert!(context["omissions"]["decisions_bytes"].as_u64().unwrap() > 0);
+    assert!(
+        context["omissions"]["previous_release_notes_bytes"]
+            .as_u64()
+            .unwrap()
+            > 0
+    );
+    assert!(notes.len() < 60 * 1024);
+    assert!(!notes.contains(&"x".repeat(1_000)));
+}
+
+#[test]
+fn interrupted_release_notes_retry_replaces_partial_state_once() {
+    let gh_script = write_gh_script("[]");
+    let lf_script = r#"#!/bin/sh
+attempt=1
+if [ -f .notes-attempt ]; then
+  attempt=2
+fi
+printf '%s' "$attempt" > .notes-attempt
+cp "$LF_RELEASE_NOTES_CONTEXT" "RELEASE_CONTEXT.$attempt.json"
+if [ "$attempt" = "1" ]; then
+  printf '# v0.9.1\n\nPartial notes that must not ship.\n' > RELEASE_NOTES.md
+  echo 'operator interrupted release-notes generation' >&2
+  exit 130
+fi
+printf '# v0.9.1\n\nConcise resumed release notes.\n' > RELEASE_NOTES.md
+"#;
+    let _env = EnvGuard::new(&[("gh", gh_script.as_str()), ("lf", lf_script)]);
+    let repo = TestRepo::new();
+    git(&repo, &["tag", "v0.9.0"]);
+    let previous_notes = "# v0.9.0\n\nPrevious safe notes.\n";
+    fs::write(repo.path().join("RELEASE_NOTES.md"), previous_notes).unwrap();
+
+    let error = release_notes(repo.path(), "0.9.1", Some("v0.9.0"), None, &NullProgress)
+        .expect_err("an unclassified interruption must keep the gate red");
+    assert!(error.to_string().contains("release gate blocked"));
+    assert_eq!(
+        fs::read_to_string(repo.path().join("RELEASE_NOTES.md")).unwrap(),
+        previous_notes
+    );
+
+    let notes = release_notes(repo.path(), "0.9.1", Some("v0.9.0"), None, &NullProgress)
+        .expect("retry should replace partial state");
+
+    assert!(
+        fs::metadata(repo.path().join("RELEASE_CONTEXT.1.json"))
+            .unwrap()
+            .len()
+            <= 128 * 1024
+    );
+    assert!(
+        fs::metadata(repo.path().join("RELEASE_CONTEXT.2.json"))
+            .unwrap()
+            .len()
+            <= 128 * 1024
+    );
+    assert!(notes.contains("Concise resumed release notes."));
+    assert!(!notes.contains("Partial notes that must not ship."));
+    assert_eq!(notes.matches("loopflow:release-notes=").count(), 1);
+    let archived = fs::read_to_string(repo.path().join("release/v0.9.1/NOTES.md")).unwrap();
+    assert_eq!(archived, notes);
+    assert_eq!(
+        fs::read_dir(repo.path().join("release/v0.9.1"))
+            .unwrap()
+            .filter_map(Result::ok)
+            .filter(|entry| entry.file_name() == "NOTES.md")
+            .count(),
+        1
+    );
+}
+
+#[test]
+fn successful_agent_without_fresh_notes_keeps_release_gate_unsafe() {
+    let gh_script = write_gh_script("[]");
+    let lf_script = "#!/bin/sh\nexit 0\n";
+    let _env = EnvGuard::new(&[("gh", gh_script.as_str()), ("lf", lf_script)]);
+    let repo = TestRepo::new();
+    git(&repo, &["tag", "v0.9.0"]);
+    let previous_notes = "# v0.9.0\n\nPrevious safe notes.\n";
+    fs::write(repo.path().join("RELEASE_NOTES.md"), previous_notes).unwrap();
+
+    let error = release_notes(repo.path(), "0.9.1", Some("v0.9.0"), None, &NullProgress)
+        .expect_err("missing fresh notes must stop the gate");
+
+    assert!(error.to_string().contains("release gate blocked"));
+    assert!(error.to_string().contains("fresh RELEASE_NOTES.md"));
+    assert_eq!(
+        fs::read_to_string(repo.path().join("RELEASE_NOTES.md")).unwrap(),
+        previous_notes
+    );
+}
+
+#[test]
+fn release_notes_rejects_a_successful_agent_with_stale_version() {
+    let gh_script = write_gh_script("[]");
+    let lf_script =
+        "#!/bin/sh\nprintf '# v0.9.0\\n\\nWrong generated release.\\n' > RELEASE_NOTES.md\n";
+    let _env = EnvGuard::new(&[("gh", gh_script.as_str()), ("lf", lf_script)]);
+    let repo = TestRepo::new();
+    git(&repo, &["tag", "v0.9.0"]);
+    let previous_notes = "# v0.9.0\n\nPrevious safe notes.\n";
+    fs::write(repo.path().join("RELEASE_NOTES.md"), previous_notes).unwrap();
+
+    let error = release_notes(repo.path(), "0.9.1", Some("v0.9.0"), None, &NullProgress)
+        .expect_err("stale-version notes must stop the gate");
+
+    assert!(error.to_string().contains("release gate blocked"));
+    assert!(error.to_string().contains("must start with '# v0.9.1'"));
+    assert_eq!(
+        fs::read_to_string(repo.path().join("RELEASE_NOTES.md")).unwrap(),
+        previous_notes
+    );
+}
+
+#[test]
+fn oversized_agent_notes_keep_queue_metadata_unsafe() {
+    let gh_script = write_gh_script("[]");
+    let lf_script = r#"#!/bin/sh
+{
+  printf '# v0.9.1\n\n'
+  i=0
+  while [ "$i" -lt 7000 ]; do
+    printf '0123456789'
+    i=$((i + 1))
+  done
+} > RELEASE_NOTES.md
+"#;
+    let _env = EnvGuard::new(&[("gh", gh_script.as_str()), ("lf", lf_script)]);
+    let repo = TestRepo::new();
+    git(&repo, &["tag", "v0.9.0"]);
+
+    let error = release_notes(repo.path(), "0.9.1", Some("v0.9.0"), None, &NullProgress)
+        .expect_err("oversized queue metadata must stop the gate");
+
+    assert!(error.to_string().contains("release gate blocked"));
+    assert!(error.to_string().contains("maximum queue metadata"));
+    assert!(!repo.path().join("RELEASE_NOTES.md").exists());
 }
 
 #[test]
@@ -401,7 +639,84 @@ fn release_status_reports_latest_tag_and_release() {
     assert_eq!(status.latest_tag.as_deref(), Some("v0.9.1"));
     assert_eq!(status.workflow_status.as_deref(), Some("completed"));
     assert_eq!(status.workflow_conclusion.as_deref(), Some("success"));
+    assert_eq!(status.notes_status, Some(ReleaseNotesStatus::Missing));
     assert!(status.release_exists);
+}
+
+#[test]
+fn release_status_reports_degraded_notes_as_gate_safe() {
+    let gh_script = write_gh_status_script(
+        r#"[{"databaseId":42,"headBranch":"v0.9.1","status":"completed","conclusion":"success"}]"#,
+        r#"{"isDraft":false}"#,
+    );
+    let _env = EnvGuard::new(&[("gh", gh_script.as_str())]);
+    let repo = TestRepo::new();
+    fs::create_dir_all(repo.path().join("release/v0.9.1")).unwrap();
+    fs::write(
+        repo.path().join("release/v0.9.1/NOTES.md"),
+        "# v0.9.1\n\n<!-- loopflow:release-notes=degraded;reason=quota;gate=safe -->\n\nConcise fallback notes.\n",
+    )
+    .unwrap();
+    git(&repo, &["add", "release/v0.9.1/NOTES.md"]);
+    git(&repo, &["commit", "-m", "Archive degraded release notes"]);
+    git(&repo, &["tag", "v0.9.1"]);
+
+    let status = release_status(repo.path(), None).expect("status should read tagged notes");
+
+    assert_eq!(
+        status.notes_status,
+        Some(ReleaseNotesStatus::Degraded(ReleaseNotesDegradation::Quota))
+    );
+    assert!(status.release_exists);
+}
+
+#[test]
+fn release_status_reports_unmarked_notes_as_legacy() {
+    let gh_script = write_gh_status_script("[]", r#"{"isDraft":false}"#);
+    let _env = EnvGuard::new(&[("gh", gh_script.as_str())]);
+    let repo = TestRepo::new();
+    fs::create_dir_all(repo.path().join("release/v0.9.1")).unwrap();
+    fs::write(
+        repo.path().join("release/v0.9.1/NOTES.md"),
+        "# v0.9.1\n\nNotes from before status markers.\n",
+    )
+    .unwrap();
+    git(&repo, &["add", "release/v0.9.1/NOTES.md"]);
+    git(&repo, &["commit", "-m", "Archive legacy release notes"]);
+    git(&repo, &["tag", "v0.9.1"]);
+
+    let status = release_status(repo.path(), None).expect("status should read legacy notes");
+
+    assert_eq!(status.notes_status, Some(ReleaseNotesStatus::Legacy));
+    assert!(status.release_exists);
+}
+
+#[test]
+fn release_status_does_not_trust_malformed_safe_markers() {
+    let gh_script = write_gh_status_script("[]", r#"{"isDraft":false}"#);
+    let _env = EnvGuard::new(&[("gh", gh_script.as_str())]);
+    let markers = [
+        "narrative;gate=unsafe -->",
+        "degraded;reason=quota -->",
+        "degraded;reason=unknown;gate=safe -->",
+    ];
+
+    for marker in markers {
+        let repo = TestRepo::new();
+        fs::create_dir_all(repo.path().join("release/v0.9.1")).unwrap();
+        fs::write(
+            repo.path().join("release/v0.9.1/NOTES.md"),
+            format!("# v0.9.1\n\n<!-- loopflow:release-notes={marker}\n\nNotes.\n"),
+        )
+        .unwrap();
+        git(&repo, &["add", "release/v0.9.1/NOTES.md"]);
+        git(&repo, &["commit", "-m", "Archive malformed release notes"]);
+        git(&repo, &["tag", "v0.9.1"]);
+
+        let status = release_status(repo.path(), None).expect("status should fail closed");
+
+        assert_eq!(status.notes_status, Some(ReleaseNotesStatus::Legacy));
+    }
 }
 
 #[test]
@@ -468,6 +783,11 @@ fn release_run_resumes_an_existing_explicit_tag() {
     let gh_script = write_gh_status_script("[]", r#"{"isDraft":false}"#);
     let _env = EnvGuard::new(&[("gh", gh_script.as_str())]);
     let repo = TestRepo::new();
+    let intended_notes = "# v0.9.1\n\n<!-- loopflow:release-notes=narrative;gate=safe -->\n\nConcise intended artifact.\n";
+    fs::create_dir_all(repo.path().join("release/v0.9.1")).unwrap();
+    fs::write(repo.path().join("release/v0.9.1/NOTES.md"), intended_notes).unwrap();
+    git(&repo, &["add", "release/v0.9.1/NOTES.md"]);
+    git(&repo, &["commit", "-m", "Prepare exact release artifact"]);
     release_tag(repo.path(), "0.9.1", None).expect("tag should succeed");
 
     let result = release_run(repo.path(), "0.9.1", None, &NullProgress)
@@ -479,6 +799,21 @@ fn release_run_resumes_an_existing_explicit_tag() {
     assert_eq!(receipt.version, "0.9.1");
     assert_eq!(receipt.tag, "v0.9.1");
     assert!(receipt.release_exists);
+    let status = release_status(repo.path(), None).expect("status should preserve narrative notes");
+    assert_eq!(status.notes_status, Some(ReleaseNotesStatus::Narrative));
+    assert_eq!(
+        git_output_bare(&repo, &["show", "v0.9.1:release/v0.9.1/NOTES.md",],),
+        intended_notes.trim()
+    );
+    assert_eq!(
+        git_output_bare(
+            &repo,
+            &["for-each-ref", "--format=%(refname)", "refs/tags/v0.9.1"],
+        )
+        .lines()
+        .count(),
+        1
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Try it!

```bash
cargo test -p loopflow --test release_tests release_notes
cargo test -p loopflow --test release_tests release_status
cargo test -p loopflow --test release_tests oversized_agent_notes_keep_queue_metadata_unsafe -- --exact
```

The first command exercises bounded narrative context, missing CLI fallback,
every supported provider-degradation class, stale output, and interrupted
retry. The second shows narrative, degraded-safe, missing-unsafe, legacy, and
malformed-marker status. The last demonstrates that oversized agent output
stops before becoming release-queue metadata.

Full affected-suite result: 33 release integration tests passed. Agent context
is bounded at 128 KiB; final notes and the PR body are bounded at 60 KiB.

## Intent

Keep releases useful and safely resumable when narrative-note automation is
missing, cooling down, rate-limited, quota-exhausted, unauthenticated, or
unavailable. Provider degradation lowers prose quality without bypassing
verification, merge, tag, workflow, publisher, or GitHub Release gates.

## Assumptions

- Loopflow's typed `AgentFailure` terminal phrases are the stable provider
  boundary; unrecognized failures must remain red.
- The exact first-parent git range is shipped-behavior truth. PR bodies,
  decisions, and previous notes are bounded narrative aids.
- A tagged notes artifact without the exact safe marker cannot establish gate
  safety and must report legacy/unknown.
- The existing deterministic branch, PR, tag, and workflow evidence remains the
  exact-once release authority.

## Key decisions

- Build one private bounded context for both the agent and deterministic
  fallback, carrying source limits and omission counts in the JSON.
- Cap the queue query at 200 PRs, serialized context at 128 KiB, and final notes
  at 60 KiB. Read agent output through the same bound before parsing.
- Fall back only for explicit provider-unavailability classes. Unknown skill
  failures and missing, stale-version, malformed, or oversized output fail
  closed.
- Remove prior root notes before launch, restore them after unsafe attempts,
  atomically replace the intended archive, and reuse existing release
  authorities for retry and resume.
- Keep generation state to an optional degradation reason; reserve narrative,
  degraded, missing, and legacy for tagged status evidence.

## Not included

- Changes to repository verification, merge queue, tags, hosted builds,
  publishers, credentials, or cadence.
- Product-specific Cadenza release work or a generic deployment platform.
- Automatic retries for unknown skill failures or rewriting historical legacy
  notes.
