### PR TITLE
podium: make waves the work navigator

### DIFF
--- a/swift/LoopflowMac/Views/PodiumView.swift
+++ b/swift/LoopflowMac/Views/PodiumView.swift
@@ -8,7 +8,7 @@ struct PodiumView: View {
 
     @Environment(\.palette) private var palette
     @State private var model: PodiumModel
-    @AppStorage("podiumShowsWaveScore") private var showsWaveScore = true
+    @AppStorage("podiumShowsWaves") private var showsWaves = true
 
     init(
         portfolioService: PortfolioService,
@@ -17,7 +17,10 @@ struct PodiumView: View {
     ) {
         self.portfolioService = portfolioService
         self.initialRepoPath = initialRepoPath
-        let model = PodiumModel(query: query)
+        let restoredRepoPath = initialRepoPath == nil && !AppTestMode.shouldBypassRegistry
+            ? loadLoopflowState()?.selectedRepoPath
+            : nil
+        let model = PodiumModel(query: query, repoPath: restoredRepoPath)
         PodiumFixture.applyIfRequested(to: model)
         _model = State(initialValue: model)
     }
@@ -25,11 +28,11 @@ struct PodiumView: View {
     var body: some View {
         @Bindable var model = model
         VStack(spacing: 0) {
-            PodiumBar(model: model, showsWaveScore: $showsWaveScore)
+            PodiumBar(model: model, showsWaves: $showsWaves)
             Divider()
             HStack(spacing: 0) {
-                if showsWaveScore {
-                    WaveScore(model: model)
+                if showsWaves {
+                    WavesSidebar(model: model)
                         .frame(width: 224)
                     Divider()
                 }
@@ -87,19 +90,12 @@ struct PodiumView: View {
 
 private struct PodiumBar: View {
     @Bindable var model: PodiumModel
-    @Binding var showsWaveScore: Bool
-
-    private var scopeTitle: String {
-        guard let repoPath = model.repoPath else { return "All repositories" }
-        return model.allRepos.first {
-            model.repoIdentity($0.path) == model.repoIdentity(repoPath)
-        }?.displayName ?? URL(fileURLWithPath: repoPath).lastPathComponent
-    }
+    @Binding var showsWaves: Bool
 
     var body: some View {
         HStack(spacing: Spacing.lg) {
             Button {
-                showsWaveScore.toggle()
+                showsWaves.toggle()
             } label: {
                 Image(systemName: "sidebar.left")
                     .font(.system(size: 13, weight: .semibold))
@@ -107,10 +103,10 @@ private struct PodiumBar: View {
             .buttonStyle(.plain)
             .foregroundStyle(.white.opacity(0.84))
             .frame(width: HitTarget.comfortable, height: HitTarget.comfortable)
-            .background(Color.white.opacity(showsWaveScore ? 0.12 : 0.06), in: Circle())
-            .help(showsWaveScore ? "Close Wave score" : "Open Wave score")
-            .accessibilityLabel(showsWaveScore ? "Close Wave score" : "Open Wave score")
-            .accessibilityIdentifier("podium-wave-score-toggle")
+            .background(Color.white.opacity(showsWaves ? 0.12 : 0.06), in: Circle())
+            .help(showsWaves ? "Close Waves" : "Open Waves")
+            .accessibilityLabel(showsWaves ? "Close Waves" : "Open Waves")
+            .accessibilityIdentifier("podium-waves-toggle")
 
             VStack(alignment: .leading, spacing: 0) {
                 Text("CONDUCTING WAVES")
@@ -125,30 +121,6 @@ private struct PodiumBar: View {
             Rectangle()
                 .fill(Color.white.opacity(0.18))
                 .frame(width: 1, height: 30)
-
-            Menu {
-                Button("All repositories") { model.setRepoPath(nil) }
-                if !model.allRepos.isEmpty { Divider() }
-                ForEach(model.allRepos) { repo in
-                    Button(repo.displayName) { model.setRepoPath(repo.path) }
-                }
-            } label: {
-                HStack(spacing: Spacing.xs) {
-                    Text(scopeTitle)
-                        .font(Typography.body(11).weight(.semibold))
-                        .lineLimit(1)
-                    Image(systemName: "chevron.down")
-                        .font(.system(size: 8, weight: .bold))
-                }
-                .foregroundStyle(.white.opacity(0.86))
-                .padding(.horizontal, Spacing.sm)
-                .padding(.vertical, Spacing.xs)
-                .background(Color.black.opacity(0.13), in: Capsule())
-            }
-            .menuStyle(.button)
-            .buttonStyle(.plain)
-            .fixedSize()
-            .accessibilityIdentifier("podium-repo-scope")
 
             if let summary = model.waveSummary {
                 HStack(spacing: Spacing.md) {
@@ -373,7 +345,7 @@ private struct TokenOutputMeter: View {
     }
 }
 
-private struct WaveScore: View {
+private struct WavesSidebar: View {
     @Bindable var model: PodiumModel
     @State private var expandedWaves = Set<String>()
     @State private var expandedProjects = Set<String>()
@@ -383,15 +355,27 @@ private struct WaveScore: View {
         waveOutline(model.visibleWaves)
     }
 
+    private var repoTitle: String {
+        guard let repoPath = model.repoPath else { return "All repositories" }
+        return model.allRepos.first {
+            model.repoIdentity($0.path) == model.repoIdentity(repoPath)
+        }?.displayName ?? URL(fileURLWithPath: repoPath).lastPathComponent
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
+            repoSelector
+
+            Divider()
+                .overlay(Color.white.opacity(0.12))
+
             HStack {
-                Text("SCORE")
+                Text("WAVES")
                     .font(Typography.caption(9).weight(.bold))
                     .tracking(1.5)
                     .foregroundStyle(.white.opacity(0.68))
                 Spacer()
-                Text("\(model.visibleWaves.count.formatted()) WAVES")
+                Text(model.visibleWaves.count.formatted())
                     .font(Typography.code(9))
                     .foregroundStyle(.white.opacity(0.68))
             }
@@ -406,7 +390,7 @@ private struct WaveScore: View {
                     .padding(Spacing.md)
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .background(Color.white.opacity(0.08))
-                    .accessibilityIdentifier("podium-wave-score-error")
+                    .accessibilityIdentifier("podium-waves-error")
             }
 
             if model.waves.isLoading {
@@ -414,13 +398,13 @@ private struct WaveScore: View {
                     .controlSize(.small)
                     .foregroundStyle(.white.opacity(0.65))
                     .padding(Spacing.lg)
-                    .accessibilityIdentifier("podium-wave-score-loading")
+                    .accessibilityIdentifier("podium-waves-loading")
             } else if outlinedWaves.isEmpty {
                 Text(model.repoPath == nil ? "No Waves found." : "No Waves in this repository.")
                     .font(Typography.caption())
                     .foregroundStyle(.white.opacity(0.58))
                     .padding(Spacing.lg)
-                    .accessibilityIdentifier("podium-wave-score-empty")
+                    .accessibilityIdentifier("podium-waves-empty")
             } else {
                 ScrollView {
                     LazyVStack(alignment: .leading, spacing: 1) {
@@ -438,8 +422,62 @@ private struct WaveScore: View {
         .frame(maxHeight: .infinity, alignment: .top)
         .background(Color.loopflowBurgundy)
         .accessibilityElement(children: .contain)
-        .accessibilityLabel("Work score")
-        .accessibilityIdentifier("podium-wave-score")
+        .accessibilityLabel("Waves")
+        .accessibilityIdentifier("podium-waves")
+    }
+
+    private var repoSelector: some View {
+        VStack(alignment: .leading, spacing: Spacing.xxs) {
+            Text("REPOSITORY")
+                .font(Typography.caption(8).weight(.bold))
+                .tracking(1.4)
+                .foregroundStyle(.white.opacity(0.55))
+
+            Menu {
+                Button {
+                    selectRepo(nil)
+                } label: {
+                    Label("All repositories", systemImage: "square.stack.3d.up")
+                }
+                if !model.allRepos.isEmpty { Divider() }
+                ForEach(model.allRepos) { repo in
+                    Button {
+                        selectRepo(repo.path)
+                    } label: {
+                        Label(repo.displayName, systemImage: "folder")
+                    }
+                }
+            } label: {
+                HStack(spacing: Spacing.xs) {
+                    Image(systemName: "folder")
+                        .font(.system(size: 11, weight: .semibold))
+                        .foregroundStyle(.white.opacity(0.62))
+                    Text(repoTitle)
+                        .font(Typography.sectionTitle(15))
+                        .foregroundStyle(.white)
+                        .lineLimit(1)
+                        .truncationMode(.tail)
+                    Spacer(minLength: 0)
+                    Image(systemName: "chevron.down")
+                        .font(.system(size: 8, weight: .bold))
+                        .foregroundStyle(.white.opacity(0.55))
+                }
+                .contentShape(Rectangle())
+            }
+            .menuStyle(.borderlessButton)
+            .menuIndicator(.hidden)
+        }
+        .padding(.horizontal, Spacing.lg)
+        .padding(.vertical, Spacing.md)
+        .accessibilityIdentifier("podium-repo-scope")
+        .accessibilityLabel("Repository: \(repoTitle)")
+    }
+
+    private func selectRepo(_ path: String?) {
+        model.setRepoPath(path)
+        Task.detached {
+            try? saveLoopflowState(LoopflowState(selectedRepoPath: path?.normalizedFilePath))
+        }
     }
 
     @ViewBuilder
@@ -447,7 +485,7 @@ private struct WaveScore: View {
         let roadmap = roadmap(for: wave)
         let projects = roadmap?.projects.items ?? []
         let nodes = outputNodes(wave: wave)
-        ScoreRow(
+        WaveTreeRow(
             identifier: "wave-\(wave.id)",
             kind: .wave,
             title: wave.displayName,
@@ -476,7 +514,7 @@ private struct WaveScore: View {
     ) -> some View {
         let key = "\(wave.id):\(project.id)"
         let nodes = outputNodes(wave: wave, project: project)
-        ScoreRow(
+        WaveTreeRow(
             identifier: "project-\(project.id)",
             kind: .project,
             title: project.project.name,
@@ -509,7 +547,7 @@ private struct WaveScore: View {
         let key = "\(wave.id):\(task.id)"
         let nodes = outputNodes(wave: wave, project: project, task: task)
         let execs = execNodes(for: nodes)
-        ScoreRow(
+        WaveTreeRow(
             identifier: "task-\(task.id)",
             kind: .task,
             title: task.task.name,
@@ -526,7 +564,7 @@ private struct WaveScore: View {
         if expandedTasks.contains(key) {
             ForEach(execs) { exec in
                 let providers = nodes.filter { $0.parentId == exec.id }
-                ScoreRow(
+                WaveTreeRow(
                     identifier: "exec-\(exec.id)",
                     kind: .exec,
                     title: exec.label,
@@ -600,7 +638,7 @@ private struct WaveScore: View {
     }
 }
 
-private enum ScoreRowKind: Equatable {
+private enum WaveTreeRowKind: Equatable {
     case wave
     case project
     case task
@@ -633,9 +671,9 @@ private enum ScoreRowKind: Equatable {
     }
 }
 
-private struct ScoreRow: View {
+private struct WaveTreeRow: View {
     let identifier: String
-    let kind: ScoreRowKind
+    let kind: WaveTreeRowKind
     let title: String
     let level: Int
     let outputNodes: [ActivityNode]
@@ -670,7 +708,7 @@ private struct ScoreRow: View {
                     .buttonStyle(.plain)
                     .help(isExpanded ? "Collapse \(kind.label)" : "Expand \(kind.label)")
                     .accessibilityLabel(isExpanded ? "Collapse \(title)" : "Expand \(title)")
-                    .accessibilityIdentifier("podium-score-\(identifier)-disclosure")
+                    .accessibilityIdentifier("podium-waves-\(identifier)-disclosure")
                 } else {
                     Color.clear
                 }
@@ -714,7 +752,7 @@ private struct ScoreRow: View {
             .onHover { isHovering = $0 }
             .help(title)
             .accessibilityLabel("\(kind.label): \(title)")
-            .accessibilityIdentifier("podium-score-\(identifier)")
+            .accessibilityIdentifier("podium-waves-\(identifier)")
             .accessibilityValue(
                 "\(fastRate.formatted(.number.precision(.fractionLength(1)))) tokens per second, \(state.label)"
             )

--- a/swift/LoopflowMac/Views/RoadmapView.swift
+++ b/swift/LoopflowMac/Views/RoadmapView.swift
@@ -122,11 +122,39 @@ struct RoadmapView: View {
     private var isRefreshing: Bool { model.isRefreshing }
 
     private var visibleWaves: [WaveRoadmap] {
-        guard let repoPath else { return snapshot?.waves ?? [] }
-        let target = WaveOrigin.resolve(repoPath).normalizedFilePath
-        return (snapshot?.waves ?? []).filter {
-            WaveOrigin.resolve($0.wave.repo).normalizedFilePath == target
+        model.visibleRoadmaps
+    }
+
+    private var selectedWaveRoadmap: WaveRoadmap? {
+        guard let selection, let waveId = model.waveId(for: selection) else { return nil }
+        return model.wave(id: waveId)
+    }
+
+    private var selectedRosterWave: Wave? {
+        guard let selection, selection.kind == .wave else { return nil }
+        return model.rosterWave(id: selection.id)?.api
+    }
+
+    private var selectedProject: (wave: WaveRoadmap, project: RoadmapProject)? {
+        guard let selection else { return nil }
+        switch selection.kind {
+        case .project:
+            return model.project(id: selection.id)
+        case .task:
+            guard let task = model.task(id: selection.id) else { return nil }
+            return (task.wave, task.project)
+        case .wave:
+            return nil
         }
+    }
+
+    private var selectedTask: (
+        wave: WaveRoadmap,
+        project: RoadmapProject,
+        task: RoadmapTask
+    )? {
+        guard let selection, selection.kind == .task else { return nil }
+        return model.task(id: selection.id)
     }
 
     var body: some View {
@@ -184,25 +212,31 @@ struct RoadmapView: View {
     }
 
     private var header: some View {
-        HStack(alignment: .firstTextBaseline, spacing: Spacing.md) {
+        HStack(alignment: .center, spacing: Spacing.md) {
             VStack(alignment: .leading, spacing: Spacing.xxs) {
-                Text("Work")
+                if selection != nil {
+                    workBreadcrumb
+                }
+                Text(workTitle)
                     .font(Typography.sectionTitle(20))
                     .foregroundStyle(palette.text)
-                Text(repoPath == nil ? "All planned Work" : "Planned Work in this repository")
+                Text(workSubtitle)
                     .font(Typography.caption(11))
                     .foregroundStyle(palette.textSecondary)
+                    .lineLimit(1)
             }
             Spacer()
-            Picker("Lens", selection: $lens) {
-                ForEach(WorkLens.allCases) { lens in
-                    Text(lens.title).tag(lens)
+            if selection == nil {
+                Picker("Lens", selection: $lens) {
+                    ForEach(WorkLens.allCases) { lens in
+                        Text(lens.title).tag(lens)
+                    }
                 }
+                .pickerStyle(.segmented)
+                .labelsHidden()
+                .fixedSize()
+                .accessibilityIdentifier("work-lens")
             }
-            .pickerStyle(.segmented)
-            .labelsHidden()
-            .fixedSize()
-            .accessibilityIdentifier("work-lens")
             if isRefreshing {
                 ProgressView()
                     .controlSize(.small)
@@ -222,6 +256,72 @@ struct RoadmapView: View {
     }
 
     @ViewBuilder
+    private var workBreadcrumb: some View {
+        HStack(spacing: Spacing.xs) {
+            Button("Work") { selection = nil }
+                .buttonStyle(.plain)
+            if let waveId = selectedWaveRoadmap?.wave.id ?? selectedRosterWave?.id,
+               let waveName = selectedWaveRoadmap?.wave.name ?? selectedRosterWave?.name {
+                breadcrumbSeparator
+                Button(waveName) { selection = .wave(id: waveId) }
+                    .buttonStyle(.plain)
+                    .disabled(selection == .wave(id: waveId))
+            }
+            if let project = selectedProject?.project {
+                breadcrumbSeparator
+                Button(project.project.name) { selection = .project(id: project.id) }
+                    .buttonStyle(.plain)
+                    .disabled(selection == .project(id: project.id))
+            }
+            if let task = selectedTask?.task {
+                breadcrumbSeparator
+                Text(task.task.identifier)
+            }
+        }
+        .font(Typography.caption(9).weight(.semibold))
+        .foregroundStyle(palette.textSecondary)
+        .accessibilityIdentifier("podium-work-breadcrumb")
+    }
+
+    private var breadcrumbSeparator: some View {
+        Image(systemName: "chevron.right")
+            .font(.system(size: 7, weight: .bold))
+            .foregroundStyle(palette.textSecondary.opacity(0.7))
+    }
+
+    private var workTitle: String {
+        switch selection {
+        case nil:
+            "Work"
+        case .some(let work):
+            switch work.kind {
+            case .wave:
+                selectedWaveRoadmap?.wave.name ?? selectedRosterWave?.name ?? "Wave"
+            case .project:
+                selectedProject?.project.project.name ?? "Project"
+            case .task:
+                selectedTask?.task.task.name ?? "Task"
+            }
+        }
+    }
+
+    private var workSubtitle: String {
+        switch selection {
+        case nil:
+            repoPath == nil ? "All planned Work" : "Planned Work in this repository"
+        case .some(let work):
+            switch work.kind {
+            case .wave:
+                selectedWaveRoadmap?.wave.goal ?? "No readable plan for this Wave"
+            case .project:
+                selectedProject?.project.project.definition ?? "Project unavailable"
+            case .task:
+                selectedTask?.task.attention.reason ?? "Task unavailable"
+            }
+        }
+    }
+
+    @ViewBuilder
     private var content: some View {
         if snapshot == nil, queryError == nil {
             ProgressView("Reading roadmap…")
@@ -238,15 +338,70 @@ struct RoadmapView: View {
             ContentUnavailableView(
                 repoPath == nil ? "No planned Work yet" : "No planned Work in this repository",
                 systemImage: "map",
-                description: Text("Waves without readable Projects remain in the score.")
+                description: Text("Waves without readable Projects remain in the Waves sidebar.")
             )
             .accessibilityIdentifier("podium-work-empty")
         } else {
-            switch lens {
-            case .now: nowContent
-            case .roadmap: roadmapContent
+            if selection != nil {
+                focusedContent
+            } else {
+                switch lens {
+                case .now: nowContent
+                case .roadmap: roadmapContent
+                }
             }
         }
+    }
+
+    @ViewBuilder
+    private var focusedContent: some View {
+        switch selection?.kind {
+        case .wave:
+            if let roadmap = selectedWaveRoadmap {
+                focusedScroll {
+                    waveCard(roadmap)
+                }
+            } else {
+                missingFocus("No planned Work for this Wave")
+            }
+        case .project:
+            if let selectedProject {
+                focusedScroll {
+                    projectCard(selectedProject.project, wave: selectedProject.wave.wave)
+                }
+            } else {
+                missingFocus("Project unavailable")
+            }
+        case .task:
+            if let selectedTask {
+                focusedScroll {
+                    taskCard(selectedTask.task, wave: selectedTask.wave.wave)
+                }
+            } else {
+                missingFocus("Task unavailable")
+            }
+        case nil:
+            EmptyView()
+        }
+    }
+
+    private func focusedScroll<Content: View>(
+        @ViewBuilder content: () -> Content
+    ) -> some View {
+        ScrollView {
+            content()
+                .padding(Spacing.xl)
+                .frame(maxWidth: 920, alignment: .leading)
+                .frame(maxWidth: .infinity, alignment: .center)
+        }
+    }
+
+    private func missingFocus(_ title: String) -> some View {
+        ContentUnavailableView(
+            title,
+            systemImage: "map",
+            description: Text("Return to Work or refresh the latest roadmap.")
+        )
     }
 
     private var nowSectionsList: [NowSection] {
@@ -295,31 +450,7 @@ struct RoadmapView: View {
         ScrollView {
             LazyVStack(alignment: .leading, spacing: Spacing.lg) {
                 ForEach(visibleWaves, id: \.wave.id) { roadmap in
-                    RoadmapWaveCard(
-                        roadmap: roadmap,
-                        selection: selection,
-                        activeControlId: activeControlId,
-                        onSelect: { selected in selection = selected },
-                        onOpen: {
-                            selection = .wave(id: roadmap.wave.id)
-                            openWave(roadmap.wave)
-                        },
-                        onRefresh: { await refresh() },
-                        onSetPaused: { paused in
-                            try await model.setWavePaused(
-                                waveId: roadmap.wave.id,
-                                paused: paused
-                            )
-                        },
-                        onError: { controlError = $0 },
-                        onTaskAction: { task, action in
-                            perform(action, on: RoadmapTaskSelection(wave: roadmap.wave, task: task))
-                        },
-                        onInterrupt: { task in
-                            interruptSelection = RoadmapTaskSelection(wave: roadmap.wave, task: task)
-                        },
-                        onOpenWorktree: openWorktree
-                    )
+                    waveCard(roadmap)
                 }
             }
             .padding(Spacing.xl)
@@ -327,6 +458,73 @@ struct RoadmapView: View {
             .frame(maxWidth: .infinity, alignment: .center)
         }
         .accessibilityIdentifier("wave-roadmap")
+    }
+
+    private func waveCard(_ roadmap: WaveRoadmap) -> some View {
+        RoadmapWaveCard(
+            roadmap: roadmap,
+            selection: selection,
+            activeControlId: activeControlId,
+            onSelect: { selected in selection = selected },
+            onOpen: {
+                selection = .wave(id: roadmap.wave.id)
+                openWave(roadmap.wave)
+            },
+            onRefresh: { await refresh() },
+            onSetPaused: { paused in
+                try await model.setWavePaused(
+                    waveId: roadmap.wave.id,
+                    paused: paused
+                )
+            },
+            onError: { controlError = $0 },
+            onTaskAction: { task, action in
+                perform(action, on: RoadmapTaskSelection(wave: roadmap.wave, task: task))
+            },
+            onInterrupt: { task in
+                interruptSelection = RoadmapTaskSelection(wave: roadmap.wave, task: task)
+            },
+            onOpenWorktree: openWorktree
+        )
+    }
+
+    private func projectCard(_ project: RoadmapProject, wave: WaveSnapshot) -> some View {
+        RoadmapProjectCard(
+            project: project,
+            selection: selection,
+            activeControlId: activeControlId,
+            onSelect: { selected in selection = selected },
+            onTaskAction: { task, action in
+                perform(action, on: RoadmapTaskSelection(wave: wave, task: task))
+            },
+            onInterrupt: { task in
+                interruptSelection = RoadmapTaskSelection(wave: wave, task: task)
+            },
+            onOpenWorktree: openWorktree
+        )
+    }
+
+    private func taskCard(_ task: RoadmapTask, wave: WaveSnapshot) -> some View {
+        RoadmapTaskRow(
+            task: task,
+            isSelected: true,
+            activeControlId: activeControlId,
+            onSelect: {},
+            onAction: { action in
+                perform(action, on: RoadmapTaskSelection(wave: wave, task: task))
+            },
+            onInterrupt: {
+                interruptSelection = RoadmapTaskSelection(wave: wave, task: task)
+            },
+            onOpenWorktree: openWorktree
+        )
+        .padding(Spacing.lg)
+        .background(palette.surface)
+        .clipShape(RoundedRectangle(cornerRadius: CornerRadius.lg))
+        .overlay {
+            RoundedRectangle(cornerRadius: CornerRadius.lg)
+                .stroke(palette.border, lineWidth: 1)
+        }
     }
 
     private func evidenceBanner(title: String, detail: String) -> some View {

--- a/swift/LoopflowUITests/PodiumStateTests.swift
+++ b/swift/LoopflowUITests/PodiumStateTests.swift
@@ -59,41 +59,66 @@ final class PodiumStateTests: XCTestCase {
     }
 
     @MainActor
-    func testScoreDisclosesWorkHierarchyWithOneOutputLanguage() {
+    func testWavesDiscloseWorkHierarchyWithOneOutputLanguage() {
         forEachWidth { app in
-            let wave = app.descendants(matching: .any)["podium-score-wave-wave-1"]
+            let wave = app.descendants(matching: .any)["podium-waves-wave-wave-1"]
             XCTAssertTrue(wave.waitForExistence(timeout: 8))
             XCTAssertTrue(String(describing: wave.value).contains("tokens per second"))
 
-            app.descendants(matching: .any)["podium-score-wave-wave-1-disclosure"].click()
-            let project = app.descendants(matching: .any)["podium-score-project-project-1"]
+            app.descendants(matching: .any)["podium-waves-wave-wave-1-disclosure"].click()
+            let project = app.descendants(matching: .any)["podium-waves-project-project-1"]
             XCTAssertTrue(project.waitForExistence(timeout: 8))
             XCTAssertTrue(String(describing: project.value).contains("tokens per second"))
 
-            app.descendants(matching: .any)["podium-score-project-project-1-disclosure"].click()
-            let task = app.descendants(matching: .any)["podium-score-task-issue-now"]
+            app.descendants(matching: .any)["podium-waves-project-project-1-disclosure"].click()
+            let task = app.descendants(matching: .any)["podium-waves-task-issue-now"]
             XCTAssertTrue(task.waitForExistence(timeout: 8))
             XCTAssertTrue(String(describing: task.value).contains("tokens per second"))
 
-            app.descendants(matching: .any)["podium-score-task-issue-now-disclosure"].click()
-            let exec = app.descendants(matching: .any)["podium-score-exec-exec:exec-podium"]
+            app.descendants(matching: .any)["podium-waves-task-issue-now-disclosure"].click()
+            let exec = app.descendants(matching: .any)["podium-waves-exec-exec:exec-podium"]
             XCTAssertTrue(exec.waitForExistence(timeout: 8))
             XCTAssertTrue(String(describing: exec.value).contains("tokens per second"))
         }
     }
 
     @MainActor
-    func testWaveScoreClosesWithoutRemovingTheLiveSurface() {
+    func testWavesCloseWithoutRemovingTheLiveSurface() {
         forEachWidth { app in
-            ensureWaveScoreOpen(app)
-            app.descendants(matching: .any)["podium-wave-score-toggle"].click()
+            ensureWavesOpen(app)
+            app.descendants(matching: .any)["podium-waves-toggle"].click()
 
-            XCTAssertFalse(exists(app, id: "podium-wave-score"))
+            XCTAssertFalse(exists(app, id: "podium-waves"))
             XCTAssertTrue(exists(app, id: "podium-work"))
             XCTAssertTrue(exists(app, id: "podium-activity"))
 
-            app.descendants(matching: .any)["podium-wave-score-toggle"].click()
-            XCTAssertTrue(waitFor(app, id: "podium-wave-score"))
+            app.descendants(matching: .any)["podium-waves-toggle"].click()
+            XCTAssertTrue(waitFor(app, id: "podium-waves"))
+        }
+    }
+
+    @MainActor
+    func testWaveProjectAndTaskSelectionsZoomTheWorkPane() {
+        forEachWidth { app in
+            let wave = app.descendants(matching: .any)["podium-waves-wave-wave-1"]
+            XCTAssertTrue(wave.waitForExistence(timeout: 8))
+            wave.click()
+            XCTAssertTrue(waitFor(app, id: "podium-wave-wave-1"))
+            XCTAssertFalse(exists(app, id: "podium-wave-wave-2"))
+
+            app.descendants(matching: .any)["podium-waves-wave-wave-1-disclosure"].click()
+            let project = app.descendants(matching: .any)["podium-waves-project-project-1"]
+            XCTAssertTrue(project.waitForExistence(timeout: 8))
+            project.click()
+            XCTAssertTrue(waitFor(app, id: "podium-project-project-1"))
+            XCTAssertFalse(exists(app, id: "podium-wave-wave-1"))
+
+            app.descendants(matching: .any)["podium-waves-project-project-1-disclosure"].click()
+            let task = app.descendants(matching: .any)["podium-waves-task-issue-now"]
+            XCTAssertTrue(task.waitForExistence(timeout: 8))
+            task.click()
+            XCTAssertTrue(waitFor(app, id: "podium-task-issue-now"))
+            XCTAssertFalse(exists(app, id: "podium-project-project-1"))
         }
     }
 
@@ -120,7 +145,7 @@ final class PodiumStateTests: XCTestCase {
     @MainActor
     func testEmptyPodiumKeepsDistinctWaveWorkAndActivityStates() {
         forEachWidth(mode: "empty-workspaces") { app in
-            XCTAssertTrue(waitFor(app, id: "podium-wave-score-empty"))
+            XCTAssertTrue(waitFor(app, id: "podium-waves-empty"))
             XCTAssertTrue(waitFor(app, id: "podium-work-empty"))
             XCTAssertTrue(waitFor(app, id: "podium-activity-empty"))
             XCTAssertTrue(
@@ -144,20 +169,20 @@ final class PodiumStateTests: XCTestCase {
             let app = launch.makeApp()
             app.launch()
             XCTAssertTrue(app.windows.element(boundBy: 0).waitForExistence(timeout: 10))
-            ensureWaveScoreOpen(app)
+            ensureWavesOpen(app)
             assertions(app)
             app.terminate()
         }
     }
 
     @MainActor
-    private func ensureWaveScoreOpen(_ app: XCUIApplication) {
-        let score = app.descendants(matching: .any)["podium-wave-score"]
-        if !score.waitForExistence(timeout: 1) {
-            let toggle = app.descendants(matching: .any)["podium-wave-score-toggle"]
+    private func ensureWavesOpen(_ app: XCUIApplication) {
+        let waves = app.descendants(matching: .any)["podium-waves"]
+        if !waves.waitForExistence(timeout: 1) {
+            let toggle = app.descendants(matching: .any)["podium-waves-toggle"]
             XCTAssertTrue(toggle.waitForExistence(timeout: 8))
             toggle.click()
-            XCTAssertTrue(score.waitForExistence(timeout: 8))
+            XCTAssertTrue(waves.waitForExistence(timeout: 8))
         }
     }
 
@@ -165,7 +190,8 @@ final class PodiumStateTests: XCTestCase {
     private func assertPodiumRegions(_ app: XCUIApplication) {
         let podium = app.descendants(matching: .any)["podium"]
         XCTAssertTrue(podium.waitForExistence(timeout: 8))
-        XCTAssertTrue(waitFor(app, id: "podium-wave-score"))
+        XCTAssertTrue(waitFor(app, id: "podium-waves"))
+        XCTAssertTrue(waitFor(app, id: "podium-repo-scope"))
         XCTAssertTrue(waitFor(app, id: "podium-work"))
         XCTAssertTrue(waitFor(app, id: "podium-activity"))
         XCTAssertGreaterThan(


### PR DESCRIPTION
## Try it

```bash
cd swift
./dev run
```

Open The Podium, choose a repository from the Waves sidebar, then expand and select a Wave, Project, or Task. The Work pane focuses on that selection; use the breadcrumb to navigate back out.

## Summary

Turns the left-hand Wave score into a Waves navigation sidebar so repository scope, work hierarchy, and selection live together. Selecting work now zooms the central pane into the chosen Wave, Project, or Task without losing the surrounding Activity surface, making the path from portfolio overview to focused work more direct.

## Changes

- Renamed the score surface and its accessibility identifiers around the clearer Waves concept
- Moved repository selection into the sidebar and restored the selected repository across launches
- Added focused Work views with contextual titles, descriptions, and breadcrumb navigation
- Expanded UI coverage for hierarchy disclosure, sidebar toggling, repository scope, and focused selections