### PR TITLE
wave start: reach live or roll back

### DIFF
--- a/rust/loopflow/src/bin/lfd.rs
+++ b/rust/loopflow/src/bin/lfd.rs
@@ -151,6 +151,18 @@ enum Commands {
         /// Defaults to the Loopflow repo root of this checkout.
         #[arg(long)]
         repo: Option<String>,
+
+        /// Internal one-shot id used by `lf start` to correlate daemon startup.
+        #[arg(long, hide = true, requires_all = ["startup_receipt", "startup_socket"])]
+        startup_attempt: Option<String>,
+
+        /// Internal durable startup receipt written before signaling the caller.
+        #[arg(long, hide = true, requires_all = ["startup_attempt", "startup_socket"])]
+        startup_receipt: Option<PathBuf>,
+
+        /// Internal Unix socket used to signal the waiting `lf start` process.
+        #[arg(long, hide = true, requires_all = ["startup_attempt", "startup_receipt"])]
+        startup_socket: Option<PathBuf>,
     },
     /// Render and load the launchd (macOS) or systemd user (Linux) service so
     /// the daemon stays up across reboots. Service files never carry secrets —
@@ -178,34 +190,33 @@ fn main() -> anyhow::Result<()> {
     let rt = tokio::runtime::Runtime::new()?;
 
     match cli.command {
-        Commands::Serve { addr, repo } => {
-            let repo_root = match repo {
-                Some(path) => std::path::PathBuf::from(path),
-                None => loopflow::lf::commands::util::find_repo_root()
-                    .map_err(|e| anyhow::anyhow!("cannot find repo root: {e}"))?,
+        Commands::Serve {
+            addr,
+            repo,
+            startup_attempt,
+            startup_receipt,
+            startup_socket,
+        } => {
+            let startup = match (startup_attempt, startup_receipt, startup_socket) {
+                (Some(attempt_id), Some(receipt_path), Some(socket_path)) => {
+                    Some(lfd::StartupSignal {
+                        attempt_id,
+                        receipt_path,
+                        socket_path,
+                    })
+                }
+                (None, None, None) => None,
+                _ => unreachable!("clap requires the complete startup signal"),
             };
-
-            let socket: std::net::SocketAddr = addr
-                .parse()
-                .map_err(|error| anyhow::anyhow!("invalid --addr {addr:?}: {error}"))?;
-
-            // The store is always open: the delivery inbox lives there. A
-            // machine with no registry yet cannot host the daemon.
-            let store = rt.block_on(async {
-                store::open_existing_store().await.ok_or_else(|| {
-                    anyhow::anyhow!(
-                        "no Loopflow registry on this machine; run `lf` once to create it"
-                    )
-                })
-            })?;
-            let store = std::sync::Arc::new(store);
-
-            // Linear config is optional: the daemon runs without it, but
-            // /linear/webhook returns 503 until LF_LINEAR_WEBHOOK_SECRET and
-            // LF_LINEAR_VIEWER_ID are both set.
-            let linear = read_linear_config();
-
-            rt.block_on(lfd::serve(repo_root, socket, store, linear))
+            let result = run_serve(&rt, addr, repo, startup.clone());
+            if let (Err(error), Some(startup)) = (&result, startup) {
+                if let Err(report_error) = rt.block_on(startup.report(lfd::StartupState::Failed {
+                    reason: error.to_string(),
+                })) {
+                    tracing::warn!(%report_error, "could not publish failed lfd startup receipt");
+                }
+            }
+            result
         }
         Commands::Install { addr, repo } => {
             let lfd_path = std::env::current_exe()
@@ -244,6 +255,37 @@ fn main() -> anyhow::Result<()> {
             Ok(())
         }
     }
+}
+
+fn run_serve(
+    rt: &tokio::runtime::Runtime,
+    addr: String,
+    repo: Option<String>,
+    startup: Option<lfd::StartupSignal>,
+) -> anyhow::Result<()> {
+    let repo_root = match repo {
+        Some(path) => std::path::PathBuf::from(path),
+        None => loopflow::lf::commands::util::find_repo_root()
+            .map_err(|e| anyhow::anyhow!("cannot find repo root: {e}"))?,
+    };
+
+    let socket: std::net::SocketAddr = addr
+        .parse()
+        .map_err(|error| anyhow::anyhow!("invalid --addr {addr:?}: {error}"))?;
+
+    // The store is always open: the delivery inbox lives there. A machine with
+    // no registry yet cannot host the daemon.
+    let store = rt.block_on(async {
+        store::open_existing_store().await.ok_or_else(|| {
+            anyhow::anyhow!("no Loopflow registry on this machine; run `lf` once to create it")
+        })
+    })?;
+    let store = std::sync::Arc::new(store);
+
+    // Linear config is optional: the daemon runs without it, but
+    // /linear/webhook returns 503 until both variables are configured.
+    let linear = read_linear_config();
+    rt.block_on(lfd::serve(repo_root, socket, store, linear, startup))
 }
 
 /// Read Linear webhook config from env. `None` when either the secret or the

--- a/rust/loopflow/src/engine/process.rs
+++ b/rust/loopflow/src/engine/process.rs
@@ -111,6 +111,26 @@ pub(crate) fn resolve_lfd_binary() -> PathBuf {
     )
 }
 
+pub(crate) fn resolve_lfd_binary_checked() -> Result<PathBuf> {
+    let candidate = resolve_lfd_binary();
+    if candidate.is_absolute() {
+        return if candidate.is_file() {
+            Ok(candidate)
+        } else {
+            Err(anyhow!(
+                "lfd binary {} does not exist; install the current Home control pair",
+                candidate.display()
+            ))
+        };
+    }
+    which_on_path(&candidate).ok_or_else(|| {
+        anyhow!(
+            "cannot resolve an absolute path for `{}`; install lfd beside the current Home lf",
+            candidate.display()
+        )
+    })
+}
+
 fn select_lfd_binary(
     provenance: crate::build_info::BuildProvenance,
     cargo_override: Option<PathBuf>,
@@ -221,7 +241,7 @@ pub(crate) fn pinned_execution_context() -> Result<crate::child::ChildExecutionC
 /// that is exactly the stranding this resolver exists to prevent, so the
 /// control override is deliberately skipped: `LF_BIN` (the current Home), then
 /// the installed `lf` on `PATH`, then this executable, then the bare name.
-fn resolve_current_home_lf_binary() -> PathBuf {
+pub(crate) fn resolve_current_home_lf_binary() -> PathBuf {
     if let Some(bin) = select_current_home_binary(std::env::var_os("LF_BIN")) {
         return bin;
     }
@@ -353,6 +373,14 @@ pub(crate) async fn start_lf_session(session: &str, cwd: &Path, argv: &[String])
     start_lf_session_with_env(session, cwd, argv, &[]).await
 }
 
+/// Start a machine-Home process through the current installed/dev control pair,
+/// ignoring a historical body's `LF_CONTROL_*` pins.
+pub(crate) async fn start_home_session(session: &str, cwd: &Path, argv: &[String]) -> Result<()> {
+    let context = current_home_execution_context()?;
+    let lf_bin = context.lf_bin.to_string_lossy().to_string();
+    start_session_with_context(session, cwd, argv, &[("LF_BIN", &lf_bin)], context).await
+}
+
 pub(crate) async fn start_lf_session_with_env(
     session: &str,
     cwd: &Path,
@@ -360,6 +388,16 @@ pub(crate) async fn start_lf_session_with_env(
     env: &[(&str, &str)],
 ) -> Result<()> {
     let context = pinned_execution_context()?;
+    start_session_with_context(session, cwd, argv, env, context).await
+}
+
+async fn start_session_with_context(
+    session: &str,
+    cwd: &Path,
+    argv: &[String],
+    env: &[(&str, &str)],
+    context: crate::child::ChildExecutionContext,
+) -> Result<()> {
     let inherited_context = ["LF_TRACE_ID", "LF_PROCESS_ID"]
         .into_iter()
         .filter(|key| !env.iter().any(|(explicit, _)| explicit == key))

--- a/rust/loopflow/src/lf/commands/ask.rs
+++ b/rust/loopflow/src/lf/commands/ask.rs
@@ -126,7 +126,19 @@ async fn wake_parent(store: &Store, route: &AnswerRoute) -> anyhow::Result<()> {
                 .ok_or_else(|| anyhow!("parent Wave {wave_id} is not registered"))?;
             let placement = store.placement(parent).await?;
             crate::lfd::ensure(&placement.home_id, Path::new(wave.repo())).await?;
-            crate::lfd::start_waves(&placement.home_id, vec![wave_id.clone()]).await
+            let outcomes =
+                crate::lfd::start_waves(&placement.home_id, vec![wave_id.clone()]).await?;
+            match outcomes.as_slice() {
+                [crate::wave_host::WaveStartOutcome {
+                    state: crate::wave_host::WaveStartState::Live { .. },
+                    ..
+                }] => Ok(()),
+                [crate::wave_host::WaveStartOutcome {
+                    state: crate::wave_host::WaveStartState::Failed { reason },
+                    ..
+                }] => Err(anyhow!(reason.clone())),
+                _ => Err(anyhow!("lfd returned no outcome for parent Wave {wave_id}")),
+            }
         }
         WorkRef::Task(task_id) => Err(anyhow!(
             "Task {task_id} cannot own child Work and is not an Ask parent"

--- a/rust/loopflow/src/lf/commands/home.rs
+++ b/rust/loopflow/src/lf/commands/home.rs
@@ -142,15 +142,34 @@ async fn start_inner(
     repo: &Path,
 ) -> anyhow::Result<Vec<crate::lf::commands::waves::WaveSnapshot>> {
     let store = std::sync::Arc::new(
-        crate::store::open_existing_store()
+        crate::store::open_store(&crate::store::storage_config_from_env()?)
             .await
-            .ok_or_else(|| anyhow!("lf start needs an initialized local store"))?,
+            .map_err(|error| anyhow!("lf start cannot open this Home registry: {error}"))?,
     );
     let local = store.local_home().await?;
     validate_expected_home(&local.id)?;
     let repo =
         crate::engine::worktrees::main_repo_root(repo).unwrap_or_else(|_| repo.to_path_buf());
     let wave_ids = parse_wave_ids(raw_wave_ids)?;
+    let normalized_names = names
+        .iter()
+        .map(|raw| {
+            crate::ops::util::normalize_wave_name(raw)
+                .ok_or_else(|| anyhow!("invalid wave name: '{raw}'"))
+        })
+        .collect::<anyhow::Result<Vec<_>>>()?;
+    let unique_names = normalized_names
+        .iter()
+        .collect::<std::collections::BTreeSet<_>>();
+    if unique_names.len() != normalized_names.len() {
+        return Err(anyhow!("duplicate Wave name in start request"));
+    }
+    for name in wave_ids.keys() {
+        if !normalized_names.contains(name) {
+            return Err(anyhow!("--wave-id names unselected Wave '{name}'"));
+        }
+    }
+    crate::lfd::ensure(&local.id, &repo).await?;
     let selected = if names.is_empty() {
         if !wave_ids.is_empty() {
             return Err(anyhow!("--wave-id requires explicit Wave names"));
@@ -163,24 +182,56 @@ async fn start_inner(
                 repo.display()
             ));
         }
-        crate::wave_host::waves_for_home(&store, &local.id, Some(&repo_name)).await?
+        crate::wave_host::waves_for_home(&store, &local.id, Some(&repo_name))
+            .await?
+            .into_iter()
+            .map(|wave| StartSelection {
+                wave,
+                created: false,
+                prior_home: Some(local.id.clone()),
+            })
+            .collect()
     } else {
-        let mut selected = Vec::with_capacity(names.len());
-        for raw in names {
-            let name = crate::ops::util::normalize_wave_name(raw)
-                .ok_or_else(|| anyhow!("invalid wave name: '{raw}'"))?;
-            let wave = match wave_ids.get(&name) {
-                Some(id) => {
-                    crate::wave::registry::ensure_wave_row_with_id(&store, &repo, &name, id).await?
-                }
-                None => crate::wave::registry::ensure_wave_row(&store, &repo, &name).await?,
+        let mut candidates = Vec::with_capacity(normalized_names.len());
+        for name in &normalized_names {
+            let existing_wave = store.get_wave_by_name(name).await?;
+            let prior_home = match existing_wave.as_ref() {
+                Some(wave) => Some(
+                    store
+                        .placement(&crate::durable::WorkRef::Wave(wave.id().clone()))
+                        .await?
+                        .home_id,
+                ),
+                None => None,
             };
-            selected.push(wave);
+            candidates.push((name.clone(), existing_wave, prior_home));
         }
-        for name in wave_ids.keys() {
-            if !selected.iter().any(|wave| wave.name() == name) {
-                return Err(anyhow!("--wave-id names unselected Wave '{name}'"));
-            }
+        let mut selected = Vec::with_capacity(candidates.len());
+        for (name, existing_wave, prior_home) in candidates {
+            let created = existing_wave.is_none();
+            let wave_result = match wave_ids.get(&name) {
+                Some(id) => {
+                    crate::wave::registry::ensure_wave_row_with_id(&store, &repo, &name, id).await
+                }
+                None => crate::wave::registry::ensure_wave_row(&store, &repo, &name).await,
+            };
+            let wave = match wave_result {
+                Ok(wave) => wave,
+                Err(error) => {
+                    let rollback = rollback_selections(&store, &selected).await;
+                    return match rollback {
+                        Ok(()) => Err(error.into()),
+                        Err(rollback) => Err(anyhow!(
+                            "Wave registration failed: {error}; registry rollback failed: {rollback}"
+                        )),
+                    };
+                }
+            };
+            selected.push(StartSelection {
+                wave,
+                created,
+                prior_home,
+            });
         }
         selected
     };
@@ -190,25 +241,141 @@ async fn start_inner(
 
     let wave_ids = selected
         .iter()
-        .map(|wave| wave.id().clone())
+        .map(|selection| selection.wave.id().clone())
         .collect::<Vec<_>>();
-    for wave in &selected {
-        store
-            .place_work(&crate::durable::WorkRef::Wave(wave.id().clone()), &local.id)
-            .await?;
+    for selection in &selected {
+        if let Err(error) = store
+            .place_work(
+                &crate::durable::WorkRef::Wave(selection.wave.id().clone()),
+                &local.id,
+            )
+            .await
+        {
+            let rollback = rollback_selections(&store, &selected).await;
+            return match rollback {
+                Ok(()) => Err(error.into()),
+                Err(rollback) => Err(anyhow!(
+                    "Wave placement failed: {error}; registry rollback failed: {rollback}"
+                )),
+            };
+        }
     }
-    crate::lfd::ensure(&local.id, &repo).await?;
-    crate::lfd::start_waves(&local.id, wave_ids).await?;
+    let outcomes = match crate::lfd::start_waves(&local.id, wave_ids).await {
+        Ok(outcomes) => outcomes,
+        Err(error) => {
+            let mut outcomes = Vec::with_capacity(selected.len());
+            for selection in &selected {
+                let state = match crate::wave::server::live_endpoint(
+                    Path::new(selection.wave.repo()),
+                    selection.wave.name(),
+                )
+                .await
+                {
+                    Some(endpoint) => crate::wave_host::WaveStartState::Live { endpoint },
+                    None => crate::wave_host::WaveStartState::Failed {
+                        reason: error.to_string(),
+                    },
+                };
+                outcomes.push(crate::wave_host::WaveStartOutcome {
+                    wave_id: selection.wave.id().clone(),
+                    state,
+                });
+            }
+            outcomes
+        }
+    };
+
+    let mut failures = Vec::new();
+    for selection in &selected {
+        let outcome = outcomes
+            .iter()
+            .find(|outcome| outcome.wave_id == *selection.wave.id());
+        let reason = match outcome.map(|outcome| &outcome.state) {
+            Some(crate::wave_host::WaveStartState::Live { .. }) => continue,
+            Some(crate::wave_host::WaveStartState::Failed { reason }) => reason.clone(),
+            None => "lfd returned no startup outcome".to_string(),
+        };
+        if let Err(rollback) = rollback_selection(&store, selection).await {
+            failures.push(format!(
+                "Wave {} failed to start: {reason}; registry rollback failed: {rollback}",
+                selection.wave.name()
+            ));
+        } else {
+            failures.push(format!(
+                "Wave {} failed to start: {reason}",
+                selection.wave.name()
+            ));
+        }
+    }
+    if !failures.is_empty() {
+        return Err(anyhow!(failures.join("; ")));
+    }
 
     let mut responses = Vec::with_capacity(selected.len());
-    for selected_wave in selected {
+    for selection in &selected {
         let wave = store
-            .get_wave_by_name(selected_wave.name())
+            .get_wave_by_name(selection.wave.name())
             .await?
-            .ok_or_else(|| anyhow!("Wave '{}' disappeared after start", selected_wave.name()))?;
-        responses.push(crate::lf::commands::waves::snapshot_wave(&store, &wave).await?);
+            .ok_or_else(|| anyhow!("Wave '{}' disappeared after start", selection.wave.name()))?;
+        let snapshot = crate::lf::commands::waves::snapshot_wave(&store, &wave).await?;
+        if !snapshot.live {
+            let reason = format!(
+                "Wave {} reported a live startup outcome but its endpoint is not answering",
+                wave.name()
+            );
+            if let Err(rollback) = rollback_selection(&store, selection).await {
+                failures.push(format!("{reason}; registry rollback failed: {rollback}"));
+            } else {
+                failures.push(reason);
+            }
+            continue;
+        }
+        responses.push(snapshot);
+    }
+    if !failures.is_empty() {
+        return Err(anyhow!(failures.join("; ")));
     }
     Ok(responses)
+}
+
+struct StartSelection {
+    wave: crate::wave::Wave,
+    created: bool,
+    prior_home: Option<crate::durable::HomeId>,
+}
+
+async fn rollback_selection(
+    store: &crate::store::Store,
+    selection: &StartSelection,
+) -> anyhow::Result<()> {
+    if selection.created {
+        store.delete_wave(selection.wave.id()).await?;
+    } else if let Some(home_id) = &selection.prior_home {
+        store
+            .place_work(
+                &crate::durable::WorkRef::Wave(selection.wave.id().clone()),
+                home_id,
+            )
+            .await?;
+    }
+    Ok(())
+}
+
+async fn rollback_selections(
+    store: &crate::store::Store,
+    selections: &[StartSelection],
+) -> anyhow::Result<()> {
+    let mut failures = Vec::new();
+    for selection in selections.iter().rev() {
+        if let Err(error) = rollback_selection(store, selection).await {
+            failures.push(format!("{}: {error}", selection.wave.name()));
+        }
+    }
+    if failures.is_empty() {
+        Ok(())
+    } else {
+        Err(anyhow!(failures.join("; ")))
+    }
 }
 
 fn parse_wave_ids(

--- a/rust/loopflow/src/lfd/mod.rs
+++ b/rust/loopflow/src/lfd/mod.rs
@@ -61,6 +61,7 @@ use crate::repository::RepoId;
 use crate::store::provider_deliveries::{DeliveryCompletion, DeliveryEventKind, DeliveryStatus};
 use crate::store::Store;
 use crate::wave_host::WaveHost;
+use crate::wave_host::WaveStartOutcome;
 use crate::webhook::{self, WebhookEvent, WebhookOutcome, SIGNATURE_HEADER};
 
 /// Body limit on webhook routes. Linear deliveries are small; a hard cap keeps
@@ -69,6 +70,53 @@ const WEBHOOK_BODY_LIMIT: usize = 256 * 1024;
 const GITHUB_SIGNATURE_HEADER: &str = "x-hub-signature-256";
 const GITHUB_EVENT_HEADER: &str = "x-github-event";
 const ABANDONED_LOG_AGE: Duration = Duration::from_secs(24 * 60 * 60);
+const STARTUP_TIMEOUT: Duration = Duration::from_secs(10);
+
+#[derive(Debug, Clone)]
+pub struct StartupSignal {
+    pub attempt_id: String,
+    pub receipt_path: PathBuf,
+    pub socket_path: PathBuf,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "state", rename_all = "snake_case")]
+pub enum StartupState {
+    Live { endpoint: String, home_id: HomeId },
+    Failed { reason: String },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct StartupReceipt {
+    pub attempt_id: String,
+    #[serde(flatten)]
+    pub state: StartupState,
+}
+
+#[derive(Debug)]
+struct StartupSocket {
+    path: PathBuf,
+    directory: PathBuf,
+}
+
+impl Drop for StartupSocket {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.path);
+        let _ = std::fs::remove_dir(&self.directory);
+    }
+}
+
+impl StartupSignal {
+    pub async fn report(&self, state: StartupState) -> anyhow::Result<()> {
+        let receipt = StartupReceipt {
+            attempt_id: self.attempt_id.clone(),
+            state,
+        };
+        write_startup_receipt(&self.receipt_path, &receipt)?;
+        tokio::net::UnixStream::connect(&self.socket_path).await?;
+        Ok(())
+    }
+}
 
 /// Everything the `lfd` receiver needs, shared across requests.
 #[derive(Clone)]
@@ -172,14 +220,9 @@ async fn start_waves_handler(
     State(state): State<LfdState>,
     headers: HeaderMap,
     Json(request): Json<StartWavesRequest>,
-) -> Result<StatusCode, (StatusCode, String)> {
+) -> Result<Json<Vec<WaveStartOutcome>>, (StatusCode, String)> {
     authorize_wave_control(&state, &headers)?;
-    state
-        .wave_host
-        .start_waves(request.wave_ids)
-        .await
-        .map(|()| StatusCode::NO_CONTENT)
-        .map_err(|error| (StatusCode::INTERNAL_SERVER_ERROR, error.to_string()))
+    Ok(Json(state.wave_host.start_waves(request.wave_ids).await))
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -839,6 +882,7 @@ pub async fn serve(
     addr: SocketAddr,
     store: Arc<Store>,
     linear: Option<LinearConfig>,
+    startup: Option<StartupSignal>,
 ) -> anyhow::Result<()> {
     ensure_bind_allowed(
         addr,
@@ -882,6 +926,17 @@ pub async fn serve(
         token: state.control_token.as_ref().clone(),
     };
     write_endpoint(wave_host.home_id(), &client)?;
+    if let Some(startup) = startup {
+        if let Err(error) = startup
+            .report(StartupState::Live {
+                endpoint: client.endpoint.clone(),
+                home_id: wave_host.home_id().clone(),
+            })
+            .await
+        {
+            tracing::warn!(%error, "could not publish lfd startup receipt");
+        }
+    }
     tracing::info!(addr = %bound, home_id = %wave_host.home_id(), "lfd serving");
     let result = axum::serve(listener, router(state).into_make_service())
         .with_graceful_shutdown(shutdown_signal())
@@ -927,17 +982,45 @@ pub(crate) async fn ensure(home_id: &HomeId, repo: &Path) -> anyhow::Result<()> 
     if live_endpoint(home_id).await.is_some() {
         return Ok(());
     }
+    let _launch_lock = lock_start(home_id).await?;
+    if live_endpoint(home_id).await.is_some() {
+        return Ok(());
+    }
+    let lfd = crate::engine::process::resolve_lfd_binary_checked()?;
+    let attempt_id = uuid::Uuid::new_v4().simple().to_string();
+    let startup_dir = endpoint_dir().join("startup");
+    std::fs::create_dir_all(&startup_dir)?;
+    let socket_id = &attempt_id[..12];
+    let socket_dir = std::env::temp_dir().join(format!("lfd-{socket_id}"));
+    std::fs::create_dir(&socket_dir)?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+
+        std::fs::set_permissions(&socket_dir, std::fs::Permissions::from_mode(0o700))?;
+    }
+    let socket_path = socket_dir.join("startup.sock");
+    let _socket_cleanup = StartupSocket {
+        path: socket_path.clone(),
+        directory: socket_dir,
+    };
+    let receipt_path = startup_dir.join(format!("{attempt_id}.json"));
+    let listener = tokio::net::UnixListener::bind(&socket_path)?;
     let argv = vec![
-        crate::engine::process::resolve_lfd_binary()
-            .to_string_lossy()
-            .to_string(),
+        lfd.to_string_lossy().to_string(),
         "serve".to_string(),
         "--addr".to_string(),
         "127.0.0.1:0".to_string(),
         "--repo".to_string(),
         repo.display().to_string(),
+        "--startup-attempt".to_string(),
+        attempt_id.clone(),
+        "--startup-receipt".to_string(),
+        receipt_path.display().to_string(),
+        "--startup-socket".to_string(),
+        socket_path.display().to_string(),
     ];
-    let launch = crate::engine::process::start_lf_session(
+    let launch = crate::engine::process::start_home_session(
         &format!(
             "lfd-{}",
             crate::engine::process::tmux_session_slug(home_id.as_str())
@@ -946,23 +1029,51 @@ pub(crate) async fn ensure(home_id: &HomeId, repo: &Path) -> anyhow::Result<()> 
         &argv,
     )
     .await;
-    for _ in 0..40 {
-        tokio::time::sleep(Duration::from_millis(100)).await;
-        if live_endpoint(home_id).await.is_some() {
-            return Ok(());
-        }
-    }
-    match launch {
-        Ok(()) => Err(anyhow::anyhow!(
-            "lfd started for Home {home_id} but did not publish a live endpoint"
-        )),
-        Err(error) => Err(anyhow::anyhow!(
+    if let Err(error) = launch {
+        return Err(anyhow::anyhow!(
             "failed to start lfd for Home {home_id}: {error}"
+        ));
+    }
+    let receipt = tokio::time::timeout(
+        STARTUP_TIMEOUT,
+        read_startup_signal(listener, &receipt_path, &attempt_id),
+    )
+    .await
+    .map_err(|_| {
+        anyhow::anyhow!(
+            "lfd did not publish a live or failed startup receipt for Home {home_id} within 10s; inspect {}",
+            crate::store::lf_home_dir().join("logs/lfd.log").display()
+        )
+    })??;
+    match receipt.state {
+        StartupState::Live {
+            home_id: reported, ..
+        } if reported == *home_id => live_endpoint(home_id).await.map(|_| ()).ok_or_else(|| {
+            anyhow::anyhow!(
+                "lfd reported live for Home {home_id}, but its endpoint is not answering"
+            )
+        }),
+        StartupState::Live {
+            home_id: reported, ..
+        } => Err(anyhow::anyhow!(
+            "lfd startup reached Home {reported}, not requested Home {home_id}"
         )),
+        StartupState::Failed { reason } => {
+            if live_endpoint(home_id).await.is_some() {
+                Ok(())
+            } else {
+                Err(anyhow::anyhow!(
+                    "failed to start lfd for Home {home_id}: {reason}"
+                ))
+            }
+        }
     }
 }
 
-pub(crate) async fn start_waves(home_id: &HomeId, wave_ids: Vec<WaveId>) -> anyhow::Result<()> {
+pub(crate) async fn start_waves(
+    home_id: &HomeId,
+    wave_ids: Vec<WaveId>,
+) -> anyhow::Result<Vec<WaveStartOutcome>> {
     let client = live_endpoint(home_id)
         .await
         .ok_or_else(|| anyhow::anyhow!("lfd is not running for Home {home_id}"))?;
@@ -974,7 +1085,10 @@ pub(crate) async fn start_waves(home_id: &HomeId, wave_ids: Vec<WaveId>) -> anyh
         .await?;
     let status = response.status();
     if status.is_success() {
-        Ok(())
+        response
+            .json::<Vec<WaveStartOutcome>>()
+            .await
+            .map_err(anyhow::Error::from)
     } else {
         Err(anyhow::anyhow!(
             "lfd refused Wave start with HTTP {status}: {}",
@@ -1046,6 +1160,63 @@ fn lock_home(home_id: &HomeId) -> anyhow::Result<File> {
         anyhow::anyhow!("another lfd process already owns Home {home_id}: {error}")
     })?;
     Ok(file)
+}
+
+async fn lock_start(home_id: &HomeId) -> anyhow::Result<File> {
+    let path = endpoint_dir().join(format!("{}.start.lock", home_id.as_str()));
+    tokio::task::spawn_blocking(move || {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let file = OpenOptions::new()
+            .create(true)
+            .truncate(false)
+            .read(true)
+            .write(true)
+            .open(&path)?;
+        file.lock_exclusive()?;
+        Ok::<_, anyhow::Error>(file)
+    })
+    .await
+    .map_err(|error| anyhow::anyhow!("lfd launch lock task failed: {error}"))?
+}
+
+async fn read_startup_signal(
+    listener: tokio::net::UnixListener,
+    receipt_path: &Path,
+    attempt_id: &str,
+) -> anyhow::Result<StartupReceipt> {
+    listener.accept().await?;
+    let bytes = std::fs::read(receipt_path)?;
+    let receipt: StartupReceipt = serde_json::from_slice(&bytes)?;
+    if receipt.attempt_id != attempt_id {
+        anyhow::bail!(
+            "lfd startup receipt belongs to attempt {}, not {attempt_id}",
+            receipt.attempt_id
+        );
+    }
+    Ok(receipt)
+}
+
+fn write_startup_receipt(path: &Path, receipt: &StartupReceipt) -> anyhow::Result<()> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| anyhow::anyhow!("startup receipt path has no parent"))?;
+    std::fs::create_dir_all(parent)?;
+    let temporary = path.with_extension("json.tmp");
+    let mut options = OpenOptions::new();
+    options.create(true).truncate(true).write(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+
+        options.mode(0o600);
+    }
+    let mut file = options.open(&temporary)?;
+    file.write_all(&serde_json::to_vec(receipt)?)?;
+    file.sync_all()?;
+    std::fs::rename(temporary, path)?;
+    Ok(())
 }
 
 fn read_endpoint(home_id: &HomeId) -> Option<LfdClientEndpoint> {
@@ -1175,10 +1346,19 @@ mod tests {
             .send()
             .await
             .unwrap();
-        assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
-        let message = response.text().await.unwrap();
-        assert!(message.contains(first.as_str()));
-        assert!(message.contains(second.as_str()));
+        assert_eq!(response.status(), StatusCode::OK);
+        let outcomes = response.json::<Vec<WaveStartOutcome>>().await.unwrap();
+        assert_eq!(outcomes.len(), 2);
+        assert_eq!(outcomes[0].wave_id, first);
+        assert!(matches!(
+            outcomes[0].state,
+            crate::wave_host::WaveStartState::Failed { .. }
+        ));
+        assert_eq!(outcomes[1].wave_id, second);
+        assert!(matches!(
+            outcomes[1].state,
+            crate::wave_host::WaveStartState::Failed { .. }
+        ));
     }
 
     #[tokio::test]

--- a/rust/loopflow/src/wave/mod.rs
+++ b/rust/loopflow/src/wave/mod.rs
@@ -86,6 +86,18 @@ use crate::wave::runtime::WaveRuntime;
 pub(crate) const RESIDENT_SUBCOMMAND: &str = "__resident";
 pub(crate) const WAVE_SERVER_ENDPOINT_ENV: &str = "LF_WAVE_SERVER_ENDPOINT";
 
+#[derive(Debug)]
+pub(crate) struct ListenerSignals<F> {
+    startup: Option<tokio::sync::oneshot::Sender<String>>,
+    shutdown: F,
+}
+
+impl<F> ListenerSignals<F> {
+    pub(crate) fn new(startup: Option<tokio::sync::oneshot::Sender<String>>, shutdown: F) -> Self {
+        Self { startup, shutdown }
+    }
+}
+
 /// `lf wave <name>` — boot the named mind's listener and supervise its
 /// resident. The steerable half: an endpoint, a thread, a cadence.
 ///
@@ -299,6 +311,34 @@ pub(crate) async fn run_listener(
     discord_token: Option<SecretString>,
     shutdown: impl Future<Output = ()> + Send + 'static,
 ) -> Result<()> {
+    run_listener_with_startup(
+        repo_root,
+        wave,
+        registry_config,
+        force,
+        spawn_resident,
+        discord_token,
+        ListenerSignals::new(None, shutdown),
+    )
+    .await
+}
+
+/// Run a listener and publish the exact point at which its endpoint becomes
+/// attachable. The Home host uses this instead of polling the discovery file;
+/// direct `lf wave` callers need no startup receiver.
+pub(crate) async fn run_listener_with_startup<F>(
+    repo_root: PathBuf,
+    wave: String,
+    registry_config: Option<registry::RegistryConfig>,
+    force: bool,
+    spawn_resident: bool,
+    discord_token: Option<SecretString>,
+    signals: ListenerSignals<F>,
+) -> Result<()>
+where
+    F: Future<Output = ()> + Send + 'static,
+{
+    let ListenerSignals { startup, shutdown } = signals;
     // File-level one-brain floor, before anything else: an existing pointer
     // that answers /health for this wave is a live server — refuse (unless
     // --force takes over and overwrites); a dead pointer is stale and gets
@@ -455,6 +495,9 @@ pub(crate) async fn run_listener(
     let supervisor_task = tokio::spawn(supervisor.run());
 
     server::write_endpoint(&repo_root, &wave, addr)?;
+    if let Some(startup) = startup {
+        let _ = startup.send(addr.to_string());
+    }
     // Ctrl+C exits the process before graceful shutdown runs, so clean up
     // from the interrupt handler too: SIGTERM the resident (its hooks stop
     // the vendor process group) and remove the discovery files — only while

--- a/rust/loopflow/src/wave_host.rs
+++ b/rust/loopflow/src/wave_host.rs
@@ -8,7 +8,8 @@ use std::time::Duration;
 
 use anyhow::{anyhow, Result};
 use secrecy::SecretString;
-use tokio::sync::Mutex;
+use serde::{Deserialize, Serialize};
+use tokio::sync::{watch, Mutex};
 
 use crate::durable::{Containment, ContainmentObservation, HomeId, RunState, WorkRef};
 use crate::id::WaveId;
@@ -16,12 +17,40 @@ use crate::store::SharedStore;
 use crate::wave::{self, registry, Wave};
 
 pub(crate) const RECONCILE_INTERVAL: Duration = Duration::from_secs(30);
+const STARTUP_TIMEOUT: Duration = Duration::from_secs(10);
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum WaveStartup {
+    Starting,
+    Live(String),
+    Failed(String),
+}
+
+#[derive(Debug)]
+struct HostedWave {
+    task: tokio::task::JoinHandle<()>,
+    startup: watch::Receiver<WaveStartup>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "state", rename_all = "snake_case")]
+pub(crate) enum WaveStartState {
+    Live { endpoint: String },
+    Failed { reason: String },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct WaveStartOutcome {
+    pub wave_id: WaveId,
+    #[serde(flatten)]
+    pub state: WaveStartState,
+}
 
 #[derive(Debug, Clone)]
 pub(crate) struct WaveHost {
     home_id: HomeId,
     store: SharedStore,
-    waves: Arc<Mutex<HashMap<WaveId, tokio::task::JoinHandle<Result<()>>>>>,
+    waves: Arc<Mutex<HashMap<WaveId, HostedWave>>>,
     suppressed: Arc<Mutex<HashSet<WaveId>>>,
     discord_token: Option<SecretString>,
 }
@@ -50,7 +79,7 @@ impl WaveHost {
             .lock()
             .await
             .values()
-            .filter(|task| !task.is_finished())
+            .filter(|wave| !wave.task.is_finished())
             .count()
     }
 
@@ -79,24 +108,24 @@ impl WaveHost {
         }
     }
 
-    pub(crate) async fn start_waves(&self, wave_ids: Vec<WaveId>) -> Result<()> {
+    pub(crate) async fn start_waves(&self, wave_ids: Vec<WaveId>) -> Vec<WaveStartOutcome> {
         {
             let mut suppressed = self.suppressed.lock().await;
             for wave_id in &wave_ids {
                 suppressed.remove(wave_id);
             }
         }
-        let mut errors = Vec::new();
+        let mut outcomes = Vec::with_capacity(wave_ids.len());
         for wave_id in wave_ids {
-            if let Err(error) = self.start_wave(&wave_id).await {
-                errors.push(error.to_string());
-            }
+            let state = match self.start_wave(&wave_id).await {
+                Ok(endpoint) => WaveStartState::Live { endpoint },
+                Err(error) => WaveStartState::Failed {
+                    reason: error.to_string(),
+                },
+            };
+            outcomes.push(WaveStartOutcome { wave_id, state });
         }
-        if errors.is_empty() {
-            Ok(())
-        } else {
-            Err(anyhow!(errors.join("; ")))
-        }
+        outcomes
     }
 
     pub(crate) async fn stop_wave(&self, wave_id: &WaveId) -> Result<bool> {
@@ -107,19 +136,19 @@ impl WaveHost {
             .await?
             .ok_or_else(|| anyhow!("Wave {wave_id} was not found"))?;
         let requested = wave::request_stop(Path::new(wave.repo()), wave.name()).await?;
-        let task = self.waves.lock().await.remove(wave_id);
-        if let Some(mut task) = task {
-            if tokio::time::timeout(Duration::from_secs(1), &mut task)
+        let hosted = self.waves.lock().await.remove(wave_id);
+        if let Some(mut hosted) = hosted {
+            if tokio::time::timeout(Duration::from_secs(1), &mut hosted.task)
                 .await
                 .is_err()
             {
-                task.abort();
+                hosted.task.abort();
             }
         }
         Ok(requested)
     }
 
-    async fn start_wave(&self, wave_id: &WaveId) -> Result<()> {
+    async fn start_wave(&self, wave_id: &WaveId) -> Result<String> {
         let wave = self
             .store
             .get_wave(wave_id)
@@ -139,35 +168,33 @@ impl WaveHost {
         }
 
         let repo = PathBuf::from(wave.repo());
-        if wave::server::live_endpoint(&repo, wave.name())
-            .await
-            .is_some()
-        {
-            return Ok(());
+        if let Some(endpoint) = wave::server::live_endpoint(&repo, wave.name()).await {
+            drain_observations(&endpoint, wave.name()).await?;
+            return Ok(endpoint);
         }
+        crate::engine::process::resolve_current_home_lf_binary_checked().map_err(|error| {
+            anyhow!(
+                "Wave {} cannot start its resident on this Home: {error}",
+                wave.name()
+            )
+        })?;
 
         let mut tasks = self.waves.lock().await;
-        if tasks.get(wave_id).is_some_and(|task| !task.is_finished()) {
+        if let Some(hosted) = tasks
+            .get(wave_id)
+            .filter(|hosted| !hosted.task.is_finished())
+        {
+            let startup = hosted.startup.clone();
             drop(tasks);
-            if self
-                .wait_for_wave(wave_id, &repo, wave.name())
-                .await
-                .is_some()
-            {
-                return Ok(());
+            let endpoint = wait_for_startup(startup, wave.name()).await?;
+            if let Err(error) = drain_observations(&endpoint, wave.name()).await {
+                self.abort_failed_start(wave_id, &wave).await;
+                return Err(error);
             }
-            return Err(self
-                .startup_failure(wave_id, wave.name())
-                .await
-                .unwrap_or_else(|| {
-                    anyhow!(
-                        "Wave {} is starting but did not publish a live endpoint",
-                        wave.name()
-                    )
-                }));
+            return Ok(endpoint);
         }
-        if let Some(task) = tasks.remove(wave_id) {
-            task.abort();
+        if let Some(hosted) = tasks.remove(wave_id) {
+            hosted.task.abort();
         }
         self.reconcile_run_slot(&wave).await?;
         let config = registry::RegistryConfig {
@@ -178,31 +205,86 @@ impl WaveHost {
         let task_name = name.clone();
         let listener_repo = repo.clone();
         let discord_token = self.discord_token.clone();
+        let (published, published_rx) = tokio::sync::oneshot::channel();
+        let (startup_tx, startup_rx) = watch::channel(WaveStartup::Starting);
         let task = tokio::spawn(async move {
-            let result = wave::run_listener(
+            let listener = wave::run_listener_with_startup(
                 listener_repo,
                 task_name.clone(),
                 Some(config),
                 false,
                 true,
                 discord_token,
-                pending(),
-            )
-            .await;
-            if let Err(error) = &result {
-                tracing::error!(wave = task_name, %error, "Wave listener stopped");
+                wave::ListenerSignals::new(Some(published), pending()),
+            );
+            tokio::pin!(listener);
+            tokio::select! {
+                result = &mut listener => {
+                    let reason = match result {
+                        Ok(()) => format!("Wave {task_name} stopped before publishing a live endpoint"),
+                        Err(error) => format!("Wave {task_name} failed preflight: {error}"),
+                    };
+                    startup_tx.send_replace(WaveStartup::Failed(reason.clone()));
+                    tracing::error!(wave = task_name, error = reason, "Wave listener stopped during startup");
+                }
+                published = published_rx => {
+                    match published {
+                        Ok(endpoint) => {
+                            startup_tx.send_replace(WaveStartup::Live(endpoint));
+                            if let Err(error) = listener.await {
+                                tracing::error!(wave = task_name, %error, "Wave listener stopped");
+                            }
+                        }
+                        Err(_) => {
+                            startup_tx.send_replace(WaveStartup::Failed(format!(
+                                "Wave {task_name} stopped before publishing a live endpoint"
+                            )));
+                        }
+                    }
+                }
             }
-            result
         });
-        tasks.insert(wave_id.clone(), task);
+        tasks.insert(
+            wave_id.clone(),
+            HostedWave {
+                task,
+                startup: startup_rx.clone(),
+            },
+        );
         drop(tasks);
-        if self.wait_for_wave(wave_id, &repo, &name).await.is_some() {
-            return Ok(());
+        let endpoint = match wait_for_startup(startup_rx, &name).await {
+            Ok(endpoint) => endpoint,
+            Err(error) => {
+                self.remove_failed_wave(wave_id).await;
+                return Err(error);
+            }
+        };
+        if let Err(error) = drain_observations(&endpoint, &name).await {
+            self.abort_failed_start(wave_id, &wave).await;
+            return Err(error);
         }
-        Err(self
-            .startup_failure(wave_id, &name)
-            .await
-            .unwrap_or_else(|| anyhow!("Wave {name} did not publish a live endpoint")))
+        Ok(endpoint)
+    }
+
+    async fn abort_failed_start(&self, wave_id: &WaveId, wave: &Wave) {
+        if let Err(error) = wave::request_stop(Path::new(wave.repo()), wave.name()).await {
+            tracing::warn!(wave = wave.name(), %error, "could not stop Wave after failed wake");
+        }
+        if let Some(hosted) = self.waves.lock().await.remove(wave_id) {
+            hosted.task.abort();
+        }
+    }
+
+    async fn remove_failed_wave(&self, wave_id: &WaveId) {
+        let mut waves = self.waves.lock().await;
+        let failed = waves.get(wave_id).is_some_and(|hosted| {
+            hosted.task.is_finished() || matches!(&*hosted.startup.borrow(), WaveStartup::Failed(_))
+        });
+        if failed {
+            if let Some(hosted) = waves.remove(wave_id) {
+                hosted.task.abort();
+            }
+        }
     }
 
     async fn reconcile_run_slot(&self, wave: &Wave) -> Result<()> {
@@ -243,41 +325,6 @@ impl WaveHost {
         Ok(())
     }
 
-    async fn startup_failure(&self, wave_id: &WaveId, name: &str) -> Option<anyhow::Error> {
-        let task = {
-            let mut tasks = self.waves.lock().await;
-            if tasks.get(wave_id).is_some_and(|task| task.is_finished()) {
-                tasks.remove(wave_id)
-            } else {
-                None
-            }
-        }?;
-        Some(match task.await {
-            Ok(Ok(())) => anyhow!("Wave {name} stopped before publishing a live endpoint"),
-            Ok(Err(error)) => anyhow!("Wave {name} failed to start: {error}"),
-            Err(error) => anyhow!("Wave {name} listener task failed: {error}"),
-        })
-    }
-
-    async fn wait_for_wave(&self, wave_id: &WaveId, repo: &Path, name: &str) -> Option<String> {
-        for _ in 0..40 {
-            if let Some(endpoint) = wave::server::live_endpoint(repo, name).await {
-                return Some(endpoint);
-            }
-            if self
-                .waves
-                .lock()
-                .await
-                .get(wave_id)
-                .is_some_and(|task| task.is_finished())
-            {
-                return None;
-            }
-            tokio::time::sleep(Duration::from_millis(100)).await;
-        }
-        None
-    }
-
     pub(crate) async fn shutdown(&self) {
         let wave_ids = self.waves.lock().await.keys().cloned().collect::<Vec<_>>();
         for wave_id in wave_ids {
@@ -289,12 +336,47 @@ impl WaveHost {
             }
         }
         let mut waves = self.waves.lock().await;
-        for task in waves.values_mut() {
-            if !task.is_finished() {
-                task.abort();
+        for hosted in waves.values_mut() {
+            if !hosted.task.is_finished() {
+                hosted.task.abort();
             }
         }
         waves.clear();
+    }
+}
+
+async fn wait_for_startup(mut startup: watch::Receiver<WaveStartup>, name: &str) -> Result<String> {
+    tokio::time::timeout(STARTUP_TIMEOUT, async {
+        loop {
+            let state = startup.borrow().clone();
+            match state {
+                WaveStartup::Starting => startup.changed().await.map_err(|_| {
+                    anyhow!("Wave {name} stopped before publishing a live endpoint")
+                })?,
+                WaveStartup::Live(endpoint) => return Ok(endpoint),
+                WaveStartup::Failed(reason) => return Err(anyhow!(reason)),
+            }
+        }
+    })
+    .await
+    .map_err(|_| anyhow!("Wave {name} did not publish a live endpoint within 10s"))?
+}
+
+async fn drain_observations(endpoint: &str, name: &str) -> Result<()> {
+    let response = reqwest::Client::new()
+        .post(format!("http://{endpoint}/observations"))
+        .json(&serde_json::json!({}))
+        .send()
+        .await
+        .map_err(|error| anyhow!("Wave {name} became live but its durable wake failed: {error}"))?;
+    if response.status() == reqwest::StatusCode::NO_CONTENT {
+        Ok(())
+    } else {
+        Err(anyhow!(
+            "Wave {name} became live but its durable wake was refused with HTTP {}: {}",
+            response.status(),
+            response.text().await.unwrap_or_default()
+        ))
     }
 }
 
@@ -344,7 +426,7 @@ mod tests {
     use crate::store::{open_store, StorageConfig};
     use crate::wave::Wave;
 
-    use super::{waves_for_home, WaveHost};
+    use super::{waves_for_home, WaveHost, WaveStartState};
 
     struct EnvRestore(Vec<(&'static str, Option<OsString>)>);
 
@@ -541,14 +623,14 @@ mod tests {
         store.create_wave(&wave).await.expect("create Wave");
         let host = WaveHost::new(local.id, store, None);
 
-        let error = host
-            .start_waves(vec![wave.id().clone()])
-            .await
-            .expect_err("Discord Wave without a token must fail");
+        let outcomes = host.start_waves(vec![wave.id().clone()]).await;
+        let WaveStartState::Failed { reason } = &outcomes[0].state else {
+            panic!("Discord Wave without a token must fail")
+        };
 
         assert!(
-            error.to_string().contains(crate::wave::discord::TOKEN_ENV),
-            "startup should preserve the actionable listener error: {error}"
+            reason.contains(crate::wave::discord::TOKEN_ENV),
+            "startup should preserve the actionable listener error: {reason}"
         );
     }
 

--- a/rust/loopflow/tests/wave_start_tests.rs
+++ b/rust/loopflow/tests/wave_start_tests.rs
@@ -1,0 +1,312 @@
+//! End-to-end proof for the supported Wave startup contract.
+
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::process::Stdio;
+use std::time::Duration;
+
+use futures_util::future::join_all;
+use loopflow::child::ObservationRecipient;
+use loopflow::planning::{LinearProjectId, ProjectPlan};
+use loopflow::project::{Project, ProjectEventKind, ProjectId};
+use loopflow::store::{open_store, StorageConfig};
+use time::OffsetDateTime;
+
+const COMMAND_TIMEOUT: Duration = Duration::from_secs(10);
+
+struct HomeDaemon {
+    pid_path: PathBuf,
+}
+
+impl HomeDaemon {
+    fn stop(&self) {
+        let Ok(pid) = std::fs::read_to_string(&self.pid_path) else {
+            return;
+        };
+        let _ = std::process::Command::new("kill")
+            .args(["-TERM", pid.trim()])
+            .status();
+    }
+}
+
+impl Drop for HomeDaemon {
+    fn drop(&mut self) {
+        self.stop();
+    }
+}
+
+fn git(repo: &Path, args: &[&str]) {
+    let status = std::process::Command::new("git")
+        .args(args)
+        .current_dir(repo)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .expect("run git");
+    assert!(status.success(), "git {args:?} failed");
+}
+
+fn write_fake_tmux(directory: &Path) -> PathBuf {
+    let bin = directory.join("bin");
+    let pid_dir = directory.join("sessions");
+    std::fs::create_dir_all(&bin).expect("create fake binary directory");
+    std::fs::create_dir_all(&pid_dir).expect("create fake session directory");
+    let tmux = bin.join("tmux");
+    std::fs::write(
+        &tmux,
+        r#"#!/bin/sh
+if [ "$1" != "new-session" ]; then
+  exit 0
+fi
+session="$4"
+cwd="$6"
+command="$9"
+printf '%s\n' "$command" > "$FAKE_TMUX_PID_DIR/$session.command"
+(
+  cd "$cwd" || exit 1
+  exec /bin/sh -c "$command"
+) </dev/null >> "$FAKE_TMUX_PID_DIR/$session.log" 2>&1 &
+printf '%s\n' "$!" > "$FAKE_TMUX_PID_DIR/$session.pid"
+"#,
+    )
+    .expect("write fake tmux");
+    let mut permissions = std::fs::metadata(&tmux)
+        .expect("read fake tmux metadata")
+        .permissions();
+    permissions.set_mode(0o755);
+    std::fs::set_permissions(&tmux, permissions).expect("make fake tmux executable");
+    bin
+}
+
+fn lf_command(repo: &Path, home: &Path, fake_bin: &Path, args: &[&str]) -> tokio::process::Command {
+    let path = std::env::var("PATH").unwrap_or_default();
+    let mut command = tokio::process::Command::new(env!("CARGO_BIN_EXE_lf"));
+    command
+        .args(args)
+        .current_dir(repo)
+        .env("LF_HOME", home)
+        .env("LF_DB_PATH", home.join("loopflow.db"))
+        .env("LF_BIN", env!("CARGO_BIN_EXE_lf"))
+        .env("CARGO_BIN_EXE_lf", env!("CARGO_BIN_EXE_lf"))
+        .env("CARGO_BIN_EXE_lfd", env!("CARGO_BIN_EXE_lfd"))
+        .env("FAKE_TMUX_PID_DIR", home.join("sessions"))
+        .env("PATH", format!("{}:{path}", fake_bin.display()))
+        .env_remove("LF_CONTROL_BIN")
+        .env_remove("LF_CONTROL_HOME")
+        .env_remove("LF_CONTROL_DB_PATH")
+        .env_remove("LF_WAVE_ID")
+        .env_remove("LF_RUN_CONTEXT")
+        .env_remove("LF_RUN_LEASE")
+        .env_remove("LF_AGENT_INVOCATION_ID")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .kill_on_drop(true);
+    command
+}
+
+async fn run_lf(repo: &Path, home: &Path, fake_bin: &Path, args: &[&str]) -> std::process::Output {
+    tokio::time::timeout(
+        COMMAND_TIMEOUT,
+        lf_command(repo, home, fake_bin, args).output(),
+    )
+    .await
+    .unwrap_or_else(|_| panic!("lf {args:?} exceeded {COMMAND_TIMEOUT:?}"))
+    .expect("run lf")
+}
+
+fn live_snapshot(output: &std::process::Output, name: &str) -> serde_json::Value {
+    assert!(
+        output.status.success(),
+        "lf start {name} failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let body: serde_json::Value = serde_json::from_slice(&output.stdout).expect("parse start JSON");
+    let snapshot = &body[0];
+    assert_eq!(snapshot["name"], name);
+    assert_eq!(snapshot["live"], true);
+    assert!(snapshot["endpoint"].as_str().is_some());
+    snapshot.clone()
+}
+
+#[tokio::test]
+async fn supported_wave_starts_reach_bounded_live_or_rolled_back_states() {
+    let temporary = tempfile::tempdir().expect("create temp directory");
+    let repo = temporary.path().join("repo");
+    let home = temporary.path().join("home");
+    std::fs::create_dir_all(repo.join("wave/good")).expect("create good Wave");
+    std::fs::create_dir_all(repo.join("wave/broken")).expect("create broken Wave");
+    std::fs::write(repo.join("wave/good/GOAL.md"), "A local test Wave.\n")
+        .expect("write good goal");
+    std::fs::write(
+        repo.join("wave/broken/GOAL.md"),
+        "---\nchat:\n  provider: [\n---\nBroken on purpose.\n",
+    )
+    .expect("write broken goal");
+    git(&repo, &["init", "-q", "-b", "main", "."]);
+    git(&repo, &["config", "user.name", "wave-start-test"]);
+    git(&repo, &["config", "user.email", "wave-start@test.invalid"]);
+    git(&repo, &["add", "-A"]);
+    git(&repo, &["commit", "-qm", "seed"]);
+    let fake_bin = write_fake_tmux(&home);
+
+    // A fresh Home starts its exact lfd/lf control pair. The valid sibling
+    // stays live even though malformed Wave policy fails preflight, and the
+    // failed first registration is removed.
+    let mixed = run_lf(
+        &repo,
+        &home,
+        &fake_bin,
+        &["start", "good", "broken", "--json"],
+    )
+    .await;
+    assert!(!mixed.status.success());
+    let failure = String::from_utf8_lossy(&mixed.stderr);
+    assert!(failure.contains("broken"), "unexpected failure: {failure}");
+    assert!(
+        failure.contains("failed preflight"),
+        "unexpected failure: {failure}"
+    );
+
+    let store = open_store(&StorageConfig::sqlite(home.join("loopflow.db")))
+        .await
+        .expect("open fresh Home registry");
+    let local = store.local_home().await.expect("read Home");
+    let good = store
+        .get_wave_by_name("good")
+        .await
+        .expect("read good Wave")
+        .expect("good Wave is registered");
+    assert!(store
+        .get_wave_by_name("broken")
+        .await
+        .expect("read broken Wave")
+        .is_none());
+    assert!(!repo.join("wave/broken/.wave-endpoint").exists());
+
+    let endpoint_path = home
+        .join("lfd")
+        .join(format!("{}.endpoint", local.id.as_str()));
+    assert!(endpoint_path.exists(), "fresh Home published lfd endpoint");
+    let session = format!("lfd-{}", local.id.as_str());
+    let _daemon = HomeDaemon {
+        pid_path: home.join("sessions").join(format!("{session}.pid")),
+    };
+    let launch = std::fs::read_to_string(home.join("sessions").join(format!("{session}.command")))
+        .expect("read lfd launch command");
+    assert!(launch.contains(env!("CARGO_BIN_EXE_lfd")));
+    assert!(launch.contains(env!("CARGO_BIN_EXE_lf")));
+    let receipts = std::fs::read_dir(home.join("lfd/startup"))
+        .expect("read startup receipts")
+        .filter_map(Result::ok)
+        .filter(|entry| {
+            entry
+                .path()
+                .extension()
+                .is_some_and(|value| value == "json")
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(receipts.len(), 1);
+    let receipt: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(receipts[0].path()).expect("read startup receipt"))
+            .expect("parse startup receipt");
+    assert_eq!(receipt["state"], "live");
+
+    // An installed/live lfd handles an already-registered Wave without
+    // launching a replacement daemon.
+    let existing = run_lf(&repo, &home, &fake_bin, &["start", "good", "--json"]).await;
+    let first = live_snapshot(&existing, "good");
+    let receipt_count = std::fs::read_dir(home.join("lfd/startup"))
+        .expect("read startup receipts")
+        .filter_map(Result::ok)
+        .filter(|entry| {
+            entry
+                .path()
+                .extension()
+                .is_some_and(|value| value == "json")
+        })
+        .count();
+    assert_eq!(receipt_count, 1, "live lfd was not replaced");
+
+    let stopped = run_lf(&repo, &home, &fake_bin, &["stop", "good"]).await;
+    assert!(
+        stopped.status.success(),
+        "stop failed: {}",
+        String::from_utf8_lossy(&stopped.stderr)
+    );
+
+    // A child event committed while the Wave is stopped remains durable until
+    // the next start synchronously drains it.
+    let now = OffsetDateTime::now_utc();
+    let project = Project {
+        id: ProjectId::new(),
+        plan: ProjectPlan {
+            id: LinearProjectId::new("wave-start-observation-proof")
+                .expect("valid Linear project id"),
+            slug: "observation-proof".to_owned(),
+            name: "Observation proof".to_owned(),
+            prompt_context: "Prove wake drains durable child observations.".to_owned(),
+            pm_snapshot_synced_at: now.unix_timestamp(),
+        },
+        wave_id: good.id().clone(),
+        iteration: 1,
+        observation_cursor: 0,
+        last_state_fingerprint: None,
+        agent: "codex".to_owned(),
+        provider: "codex".to_owned(),
+        provider_session_id: None,
+        abandon_intent: None,
+        created_at: now,
+        updated_at: now,
+    };
+    store
+        .create_project(&project)
+        .await
+        .expect("create child Project");
+    store
+        .append_project_event(
+            &project.id,
+            &ProjectEventKind::Failed {
+                error: "durable wake proof".to_owned(),
+                resumable: true,
+            },
+        )
+        .await
+        .expect("append observable Project event");
+    let recipient = ObservationRecipient::Wave {
+        wave_id: good.id().clone(),
+    };
+    assert_eq!(
+        store
+            .pending_observations(&recipient)
+            .await
+            .expect("read pending observations")
+            .len(),
+        1
+    );
+
+    // Concurrent wake callers share the listener's startup event. All return
+    // the same truthful live endpoint within the command bound.
+    let outputs =
+        join_all((0..20).map(|_| run_lf(&repo, &home, &fake_bin, &["start", "good", "--json"])))
+            .await;
+    let snapshots = outputs
+        .iter()
+        .map(|output| live_snapshot(output, "good"))
+        .collect::<Vec<_>>();
+    let endpoint = snapshots[0]["endpoint"].clone();
+    for snapshot in snapshots {
+        assert_eq!(snapshot["id"], first["id"]);
+        assert_eq!(snapshot["endpoint"], endpoint);
+    }
+    assert!(
+        store
+            .pending_observations(&recipient)
+            .await
+            .expect("read drained observations")
+            .is_empty(),
+        "start returned before the durable observation was drained"
+    );
+
+    let stopped = run_lf(&repo, &home, &fake_bin, &["stop", "good"]).await;
+    assert!(stopped.status.success());
+}

--- a/swift/Loopflow/Services/RegistryQuery.swift
+++ b/swift/Loopflow/Services/RegistryQuery.swift
@@ -72,7 +72,16 @@ public struct RegistryQuery: Sendable {
     /// Idempotently start a Wave on its placed Home and return its status row.
     public func start(wave: String, cwd: String?) async throws -> [WaveSnapshot] {
         let stdout = try await run(["start", wave, "--json"], cwd)
-        return try Self.decode([WaveSnapshot].self, from: stdout)
+        let snapshots = try Self.decode([WaveSnapshot].self, from: stdout)
+        guard snapshots.count == 1,
+              let snapshot = snapshots.first,
+              snapshot.name == wave,
+              snapshot.live,
+              snapshot.endpoint != nil
+        else {
+            throw RegistryQueryError("lf start \(wave) returned no live Wave receipt")
+        }
+        return snapshots
     }
 
     /// Pause or resume new Wave turns without changing listener residency.

--- a/swift/Loopflow/Services/WaveChatClient.swift
+++ b/swift/Loopflow/Services/WaveChatClient.swift
@@ -618,6 +618,14 @@ public final class WaveChatConnection {
         loop = nil
     }
 
+    /// Rediscover immediately after `lf start` has published a live endpoint.
+    public func reconnect() {
+        stop()
+        currentEndpoint = nil
+        phase = .idle
+        start()
+    }
+
     /// POST a message with an explicit op; a created user turn is applied
     /// immediately and also arrives over the stream (deduped by id). The
     /// assistant reply streams later. Text may be empty only for `.interrupt`

--- a/swift/LoopflowMac/MacLocalWaveAgentLauncher.swift
+++ b/swift/LoopflowMac/MacLocalWaveAgentLauncher.swift
@@ -1,23 +1,18 @@
-// Launches and probes the local `lf wave <name>` process backing a WaveChat pane.
+// Starts and controls the local Wave backing a WaveChat pane.
 //
-// Loopflow is a viewer, never a participant: launching a wave is the human's act
-// through the same door as a terminal — a detached tmux session running
-// `lf wave <name>` with the wave's repo as cwd. The session belongs to tmux, not
-// to Loopflow; quitting the app never kills a wave.
+// Loopflow uses the same `lf start <name>` lifecycle as the CLI. lfd owns the
+// detached listener; quitting the app never kills a wave.
 
 #if os(macOS)
 import Foundation
 import Loopflow
 
 enum WaveLaunchError: LocalizedError, Equatable {
-    case alreadyRunning(String)
     case noUsableLf(String)
     case launchFailed(String)
 
     var errorDescription: String? {
         switch self {
-        case .alreadyRunning(let reason):
-            return reason
         case .noUsableLf(let detail):
             return detail
         case .launchFailed(let detail):
@@ -34,50 +29,6 @@ struct TaskStartReceipt: Decodable, Sendable, Equatable {
 
 enum LocalWaveAgentLauncher {
     private static let resolutionCache = ResolvedLfCache()
-
-    static func sessionExists(repoPath: String, waveName: String) -> Bool {
-        runCommandSync(
-            [
-                "tmux",
-                "has-session",
-                "-t",
-                PortfolioRepoState.waveAgentSessionName(repoPath: repoPath, waveName: waveName),
-            ],
-            logFailure: false
-        ) != nil
-    }
-
-    /// Start `lf wave <name>` in a detached tmux session so it outlives Loopflow.
-    /// Refuses when the wave already has a tmux session or a live endpoint —
-    /// the server enforces one brain per wave; we just avoid the doomed spawn.
-    ///
-    /// Wave state lives at the wave's ORIGIN repo (`WaveOrigin`), so a worktree
-    /// `repoPath` resolves once up front and that one path feeds everything:
-    /// the session name, the endpoint guard, the launch cwd, and the dev-tree
-    /// lf candidate. Guard and discovery read the same file by construction.
-    static func launchWave(repoPath: String, waveName: String) throws {
-        let origin = WaveOrigin.resolve(repoPath)
-        let sessionName = PortfolioRepoState.waveAgentSessionName(repoPath: origin, waveName: waveName)
-        if let reason = launchBlockReason(
-            sessionName: sessionName,
-            sessionExists: sessionExists(repoPath: origin, waveName: waveName),
-            endpoint: liveEndpoint(
-                recorded: WaveEndpoint.read(repoPath: origin, waveName: waveName),
-                waveName: waveName
-            )
-        ) {
-            throw WaveLaunchError.alreadyRunning(reason)
-        }
-        let lfPath = try resolveWaveCapableLf(originRepo: origin)
-        let args = waveLaunchCommand(
-            lfPath: lfPath,
-            sessionName: sessionName,
-            repoPath: origin,
-            waveName: waveName,
-            environment: ProcessInfo.processInfo.environment
-        )
-        try runChecked(args, cwd: origin)
-    }
 
     /// Stop the listener through the same `lf` lifecycle surface the CLI uses.
     /// The server performs resident, registry, and discovery-file cleanup.
@@ -189,79 +140,6 @@ enum LocalWaveAgentLauncher {
         [lfPath, "task", "interrupt", issue]
     }
 
-    /// Why a launch must not happen, or nil when the way is clear. `endpoint`
-    /// must be a PROBED address (`liveEndpoint`), never the raw pointer file:
-    /// a SIGKILL or power loss leaves the file behind, and blocking on its
-    /// mere existence would refuse the Start button forever.
-    static func launchBlockReason(sessionName: String, sessionExists: Bool, endpoint: String?) -> String? {
-        if let endpoint {
-            return "Wave already has a live server at \(endpoint)."
-        }
-        if sessionExists {
-            return "tmux session '\(sessionName)' already exists — the wave may still be starting."
-        }
-        return nil
-    }
-
-    /// The recorded endpoint, but only when a live wave server for `waveName`
-    /// answers there. Mirrors Rust `server::live_endpoint`: a missing pointer,
-    /// a dead address, or an answer for a different wave is stale — nil, clear
-    /// to launch (the new server's own boot floor overwrites the file). Runs
-    /// only on the launch click path, never on the 1s status poll.
-    static func liveEndpoint(
-        recorded: String?,
-        waveName: String,
-        probe: (String) -> String? = healthWaveName
-    ) -> String? {
-        guard let recorded else { return nil }
-        return probe(recorded) == waveName ? recorded : nil
-    }
-
-    /// The `wave` a server at `endpoint` reports on `GET /health`, or nil when
-    /// nothing answers within 2s (mirrors Rust `ENDPOINT_PROBE_TIMEOUT`).
-    /// Probe contract: the guard keys on the `wave` field only. `/health`'s
-    /// `status` is listener liveness (`serving`) and `loop_state` is the resident's
-    /// state — a wave whose loop failed still answers here and still blocks a
-    /// second launch, which is correct: the listener is live.
-    static func healthWaveName(endpoint: String) -> String? {
-        guard let url = URL(string: "http://\(endpoint)/health") else { return nil }
-        var request = URLRequest(url: url)
-        request.timeoutInterval = 2
-        let semaphore = DispatchSemaphore(value: 0)
-        nonisolated(unsafe) var name: String?
-        URLSession.shared.dataTask(with: request) { data, response, _ in
-            defer { semaphore.signal() }
-            guard let http = response as? HTTPURLResponse, http.statusCode == 200,
-                  let data,
-                  let body = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
-            else { return }
-            name = body["wave"] as? String
-        }.resume()
-        semaphore.wait()
-        return name
-    }
-
-    /// The detached tmux invocation: session named after the wave, cwd at the
-    /// wave's repo, running `lf wave <name>`.
-    static func waveLaunchCommand(
-        lfPath: String,
-        sessionName: String,
-        repoPath: String,
-        waveName: String,
-        environment: [String: String]
-    ) -> [String] {
-        var command = ["tmux", "new-session", "-d", "-s", sessionName, "-c", repoPath]
-        let registryEnvironment = ["LF_HOME", "LF_DB_PATH"].compactMap { key in
-            environment[key].map { "\(key)=\($0)" }
-        }
-        if !registryEnvironment.isEmpty {
-            command.append("/usr/bin/env")
-            command.append(contentsOf: registryEnvironment)
-        }
-        command.append(contentsOf: [lfPath, "wave", waveName])
-        return command
-    }
-
     /// Candidate lf binaries in trust order: the lf bundled inside Loopflow.app,
     /// each `lf` on the enriched PATH, then
     /// `<origin>/target/release/lf` — the dev-tree build, for a Loopflow pointed
@@ -294,11 +172,9 @@ enum LocalWaveAgentLauncher {
     /// unknown lifecycle verb as a skill would launch the wrong work, so every
     /// candidate is capability-probed before it's trusted.
     ///
-    /// The probe is `lf help wave`, NOT `lf wave --help`: lf's arg reorderer
-    /// treats an unknown `wave` as a skill name, so `lf wave --help` prints the
-    /// root help and exits 0 even on a build without the subcommand. `lf help
-    /// wave` exits 0 only when the subcommand exists, and clap answers it without touching
-    /// any wave state. The same holds for the other probed verbs.
+    /// The probes use `lf help <verb>`, not `<verb> --help`: lf's arg reorderer
+    /// may treat an unknown lifecycle verb as a skill name. Clap's help command
+    /// answers without touching wave state.
     static func resolveWaveCapableLf(
         originRepo: String,
         bundled: URL? = Bundle.main.url(forAuxiliaryExecutable: "lf"),
@@ -333,14 +209,14 @@ enum LocalWaveAgentLauncher {
         }
         throw WaveLaunchError.noUsableLf(
             "No lf with the Wave control commands. Rejected (each failed at least one of "
-                + "`lf help wave`, `lf help stop`, `lf help pause`, or `lf help resume`): "
+                + "`lf help start`, `lf help stop`, `lf help pause`, or `lf help resume`): "
                 + candidates.joined(separator: ", ")
         )
     }
 
     /// Help probes parse without touching wave state.
     static func hasWaveCommands(lfPath: String) -> Bool {
-        run([lfPath, "help", "wave"])?.status == 0
+        run([lfPath, "help", "start"])?.status == 0
             && run([lfPath, "help", "stop"])?.status == 0
             && run([lfPath, "help", "pause"])?.status == 0
             && run([lfPath, "help", "resume"])?.status == 0
@@ -350,7 +226,7 @@ enum LocalWaveAgentLauncher {
     /// stdout. Backs `RegistryQuery` on macOS: the wave dashboard reads durable
     /// facts by shelling the daemonless `lf` over the local store, not by streaming
     /// a center. Resolves the same wave-capable `lf` the launcher trusts (a build
-    /// old enough to lack `lf wave` also lacks these verbs), then execs it with
+    /// old enough to lack `lf start` also lacks these verbs), then execs it with
     /// the enriched GUI PATH. Throws on a spawn failure or a non-zero exit.
     static func queryLf(_ subargs: [String], cwd: String?) throws -> String {
         let origin = cwd.map(WaveOrigin.resolve) ?? FileManager.default.currentDirectoryPath
@@ -389,22 +265,6 @@ enum LocalWaveAgentLauncher {
             throw WaveLaunchError.launchFailed(
                 detail.isEmpty ? "Command failed (\(result.status)): \(args.joined(separator: " "))" : detail
             )
-        }
-        return result.stdout
-    }
-
-    private static func runCommandSync(
-        _ args: [String],
-        cwd: String? = nil,
-        logFailure: Bool = true
-    ) -> String? {
-        guard let result = run(args, cwd: cwd) else { return nil }
-        guard result.status == 0 else {
-            guard logFailure else { return nil }
-            LoggingService.wave(
-                "command failed: \(args.joined(separator: " ")) \(result.stderr.trimmingCharacters(in: .whitespacesAndNewlines))"
-            )
-            return nil
         }
         return result.stdout
     }

--- a/swift/LoopflowMac/PortfolioRepoState.swift
+++ b/swift/LoopflowMac/PortfolioRepoState.swift
@@ -44,7 +44,7 @@ final class PortfolioRepoState {
         self.registryQuery = registryQuery
     }
 
-    /// Author a Wave before it is served. `lf wave` later registers the
+    /// Author a Wave before it is served. `lf start` later registers the
     /// coordination row; GOAL.md and MEMORY.md remain the authored objective
     /// and durable learning.
     ///
@@ -130,38 +130,6 @@ final class PortfolioRepoState {
         waves.sorted {
             $0.displayName.localizedCaseInsensitiveCompare($1.displayName) == .orderedAscending
         }
-    }
-
-    /// The tmux session name for a wave. Named after the wave's ORIGIN repo
-    /// (`WaveOrigin.resolve`, memoized): the launcher launches at the origin,
-    /// so launch guards and attach hints must derive the same name from a
-    /// worktree path.
-    nonisolated static func waveAgentSessionName(repoPath: String, waveName: String) -> String {
-        let repoName = URL(fileURLWithPath: WaveOrigin.resolve(repoPath)).lastPathComponent
-        return "lf-\(repoName)-\(sanitizeWavePathComponent(waveName))"
-            .replacingOccurrences(of: ".", with: "-")
-            .replacingOccurrences(of: ":", with: "-")
-    }
-
-    nonisolated static func waveAgentSessionExists(repoPath: String, waveName: String) -> Bool {
-        LocalWaveAgentLauncher.sessionExists(repoPath: repoPath, waveName: waveName)
-    }
-
-    private nonisolated static func sanitizeWavePathComponent(_ value: String) -> String {
-        var sanitized = ""
-        var pendingDash = false
-        for char in value {
-            if char.isASCII && (char.isLetter || char.isNumber || char == "_" || char == "-") {
-                if pendingDash && !sanitized.isEmpty {
-                    sanitized.append("-")
-                }
-                pendingDash = false
-                sanitized.append(char)
-            } else {
-                pendingDash = true
-            }
-        }
-        return sanitized.isEmpty ? "wave" : sanitized
     }
 
 }

--- a/swift/LoopflowMac/Views/WaveChatView.swift
+++ b/swift/LoopflowMac/Views/WaveChatView.swift
@@ -456,10 +456,9 @@ struct WaveChatView: View {
 
     // MARK: - Not running (start the wave)
     //
-    // The wave is a detached tmux session, launched here through the same door
-    // as a terminal: `lf wave <name>` at the wave's repo. Quitting Loopflow
-    // never touches it. After a launch, the connection's 1s endpoint poll picks
-    // the wave up on its own — this view just waits for the phase to move.
+    // The app and terminal share `lf start <name>`. lfd owns the detached
+    // listener, so quitting Loopflow never touches it. A successful command is
+    // the startup receipt; reconnecting only attaches the already-live chat.
 
     private var notRunningState: some View {
         VStack(spacing: Spacing.md) {
@@ -506,9 +505,7 @@ struct WaveChatView: View {
         .padding()
     }
 
-    /// Launch `lf wave` detached, then wait for the endpoint poll to attach.
-    /// The launch itself is quick (tmux returns immediately); the wave server
-    /// takes a few seconds to publish its endpoint.
+    /// Start through the synchronous Home lifecycle, then attach immediately.
     private func startWave() {
         guard startState != .starting else { return }
         startState = .starting
@@ -516,31 +513,14 @@ struct WaveChatView: View {
         let waveName = waveName
         Task {
             do {
-                try await Task.detached {
-                    try LocalWaveAgentLauncher.launchWave(repoPath: repoPath, waveName: waveName)
-                }.value
+                _ = try await RegistryQueryLocal.shared.start(wave: waveName, cwd: repoPath)
             } catch {
                 startState = .failed(error.localizedDescription)
                 return
             }
-            // The connection polls the endpoint pointer every second; give the
-            // wave server up to 20s to come up before calling it failed.
-            let deadline = Date().addingTimeInterval(20)
-            while Date() < deadline {
-                // Bail if the pane moved to a different wave mid-wait.
-                guard let conn = connection, conn.repoPath == repoPath, conn.waveName == waveName else { return }
-                let phase = conn.phase
-                if phase != .notRunning && phase != .idle {
-                    startState = .idle
-                    return
-                }
-                try? await Task.sleep(nanoseconds: 500_000_000)
-            }
             guard let conn = connection, conn.repoPath == repoPath, conn.waveName == waveName else { return }
-            startState = .failed(
-                "Wave didn't come up. Check the tmux session for what went wrong: "
-                    + "tmux attach -r -t \(PortfolioRepoState.waveAgentSessionName(repoPath: repoPath, waveName: waveName))"
-            )
+            conn.reconnect()
+            startState = .idle
         }
     }
 
@@ -842,7 +822,7 @@ private struct ChildControlActivityCard: View {
 /// The not-running hint, with the launch command as inline code so `lf` can't
 /// be misread as "If". Plain-string fallback only if markdown parsing fails.
 func waveStartHint(waveName: String) -> AttributedString {
-    let markdown = "Start it here, or run `lf wave \(waveName)` in a terminal — "
+    let markdown = "Start it here, or run `lf start \(waveName)` in a terminal — "
         + "its conversation appears here live."
     return (try? AttributedString(markdown: markdown))
         ?? AttributedString(markdown.replacingOccurrences(of: "`", with: ""))

--- a/swift/LoopflowTests/LocalWaveAgentLauncherTests.swift
+++ b/swift/LoopflowTests/LocalWaveAgentLauncherTests.swift
@@ -1,5 +1,5 @@
-// The wave launcher's pure parts: how the `lf` binary resolves, the exact
-// detached-tmux invocation, the double-launch guard, and the not-running copy.
+// The wave launcher's pure parts: how the `lf` binary resolves, how the
+// development registry environment survives launch, and the not-running copy.
 
 #if os(macOS)
 import Foundation
@@ -17,44 +17,16 @@ struct LocalWaveAgentLauncherTests {
         #expect(LaunchTargetLauncher.isRemoteHome("ssh://jack@builder.example:22"))
     }
 
-    @Test("launch command is a detached tmux session at the wave's repo")
-    func launchCommandShape() {
-        let args = LocalWaveAgentLauncher.waveLaunchCommand(
-            lfPath: "/Applications/Loopflow.app/Contents/MacOS/lf",
-            sessionName: "lf-loopflow-goals",
-            repoPath: "/Users/jack/src/loopflow",
-            waveName: "goals",
-            environment: [:]
-        )
-
-        #expect(args == [
-            "tmux", "new-session", "-d",
-            "-s", "lf-loopflow-goals",
-            "-c", "/Users/jack/src/loopflow",
-            "/Applications/Loopflow.app/Contents/MacOS/lf", "wave", "goals",
+    @Test("development launcher preserves the selected Home registry")
+    func launchEnvironmentPreservesRegistry() {
+        let environment = GUIProcessEnvironment.enriched([
+            "PATH": "/usr/bin:/bin",
+            "LF_HOME": "/tmp/loopflow-development-home",
+            "LF_DB_PATH": "/tmp/loopflow-development-home/loopflow.db",
         ])
-    }
 
-    @Test("launch carries an explicit registry through tmux")
-    func launchCommandForwardsRegistryEnvironment() {
-        let args = LocalWaveAgentLauncher.waveLaunchCommand(
-            lfPath: "/Applications/Loopflow.app/Contents/MacOS/lf",
-            sessionName: "lf-loopflow-goals",
-            repoPath: "/Users/jack/src/loopflow",
-            waveName: "goals",
-            environment: [
-                "LF_DB_PATH": "/Users/jack/.lf/demo.db",
-                "UNRELATED": "ignored",
-            ]
-        )
-
-        #expect(args == [
-            "tmux", "new-session", "-d",
-            "-s", "lf-loopflow-goals",
-            "-c", "/Users/jack/src/loopflow",
-            "/usr/bin/env", "LF_DB_PATH=/Users/jack/.lf/demo.db",
-            "/Applications/Loopflow.app/Contents/MacOS/lf", "wave", "goals",
-        ])
+        #expect(environment["LF_HOME"] == "/tmp/loopflow-development-home")
+        #expect(environment["LF_DB_PATH"] == "/tmp/loopflow-development-home/loopflow.db")
     }
 
     @Test("stop command uses the single-wave lifecycle verb")
@@ -202,7 +174,7 @@ struct LocalWaveAgentLauncherTests {
             guard case let WaveLaunchError.noUsableLf(detail) = error else { return false }
             return detail.contains("/Users/jack/.local/bin/lf")
                 && detail.contains("/Users/jack/src/loopflow/target/release/lf")
-                && detail.contains("lf help wave")
+                && detail.contains("lf help start")
                 && detail.contains("lf help stop")
                 && detail.contains("lf help pause")
                 && detail.contains("lf help resume")
@@ -226,100 +198,6 @@ struct LocalWaveAgentLauncherTests {
         }
     }
 
-    // MARK: - Double-launch guard
-
-    @Test("a live endpoint blocks the launch")
-    func endpointBlocksLaunch() {
-        let reason = LocalWaveAgentLauncher.launchBlockReason(
-            sessionName: "lf-loopflow-goals",
-            sessionExists: false,
-            endpoint: "127.0.0.1:52340"
-        )
-
-        #expect(reason == "Wave already has a live server at 127.0.0.1:52340.")
-    }
-
-    // MARK: - Endpoint liveness probe
-
-    @Test("a probed endpoint answering for this wave is live")
-    func probedEndpointIsLive() {
-        let live = LocalWaveAgentLauncher.liveEndpoint(
-            recorded: "127.0.0.1:52340",
-            waveName: "goals",
-            probe: { endpoint in
-                #expect(endpoint == "127.0.0.1:52340")
-                return "goals"
-            }
-        )
-
-        #expect(live == "127.0.0.1:52340")
-    }
-
-    @Test("a dead endpoint is stale: the pointer file alone never blocks")
-    func deadEndpointIsStale() {
-        // SIGKILL / power loss leaves `.wave-endpoint` behind; a probe that
-        // gets no answer must clear the launch, mirroring Rust live_endpoint.
-        let live = LocalWaveAgentLauncher.liveEndpoint(
-            recorded: "127.0.0.1:52340",
-            waveName: "goals",
-            probe: { _ in nil }
-        )
-
-        #expect(live == nil)
-        #expect(LocalWaveAgentLauncher.launchBlockReason(
-            sessionName: "lf-loopflow-goals",
-            sessionExists: false,
-            endpoint: live
-        ) == nil, "stale pointer: clear to launch")
-    }
-
-    @Test("a server answering for a different wave is stale")
-    func mismatchedWaveIsStale() {
-        let live = LocalWaveAgentLauncher.liveEndpoint(
-            recorded: "127.0.0.1:52340",
-            waveName: "goals",
-            probe: { _ in "ship" }
-        )
-
-        #expect(live == nil)
-    }
-
-    @Test("no pointer file: nothing to probe, clear to launch")
-    func missingPointerNeverProbes() {
-        let live = LocalWaveAgentLauncher.liveEndpoint(
-            recorded: nil,
-            waveName: "goals",
-            probe: { _ in
-                Issue.record("must not probe without a recorded endpoint")
-                return nil
-            }
-        )
-
-        #expect(live == nil)
-    }
-
-    @Test("an existing tmux session blocks the launch")
-    func tmuxSessionBlocksLaunch() {
-        let reason = LocalWaveAgentLauncher.launchBlockReason(
-            sessionName: "lf-loopflow-goals",
-            sessionExists: true,
-            endpoint: nil
-        )
-
-        #expect(reason?.contains("lf-loopflow-goals") == true)
-    }
-
-    @Test("no session and no endpoint: clear to launch")
-    func clearToLaunch() {
-        let reason = LocalWaveAgentLauncher.launchBlockReason(
-            sessionName: "lf-loopflow-goals",
-            sessionExists: false,
-            endpoint: nil
-        )
-
-        #expect(reason == nil)
-    }
-
     // MARK: - Not-running copy
 
     @Test("start hint keeps the launch command intact as inline code")
@@ -328,11 +206,11 @@ struct LocalWaveAgentLauncherTests {
 
         #expect(
             String(hint.characters)
-                == "Start it here, or run lf wave goals in a terminal — its conversation appears here live."
+                == "Start it here, or run lf start goals in a terminal — its conversation appears here live."
         )
 
         let codeRuns = hint.runs.filter { $0.inlinePresentationIntent == .code }
-        #expect(codeRuns.map { String(hint.characters[$0.range]) } == ["lf wave goals"])
+        #expect(codeRuns.map { String(hint.characters[$0.range]) } == ["lf start goals"])
     }
 }
 #endif

--- a/swift/LoopflowTests/PortfolioRepoStateTests.swift
+++ b/swift/LoopflowTests/PortfolioRepoStateTests.swift
@@ -45,24 +45,11 @@ struct PortfolioRepoStateTests {
         #expect(state.waves.map(\.id) == ["idle", "paused", "running-a", "running-b"])
     }
 
-    @Test("wave agent session name mirrors lf tmux handle")
-    func waveAgentSessionNameMirrorsLfTmuxHandle() {
-        let name = PortfolioRepoState.waveAgentSessionName(
-            repoPath: "/Users/jack/src/loopflow",
-            waveName: "loopflow"
-        )
-
-        #expect(name == "lf-loopflow-loopflow")
-    }
-
-    @Test("a worktree path names the same tmux session the launcher creates")
-    func worktreePathUsesLaunchSessionName() throws {
-        // The launcher resolves a worktree to its origin before naming the
-        // session; launch guards and attach hints must land on that same name
-        // from the raw worktree path. Real git, like WaveOriginTests: the whole
-        // point is the origin resolution.
+    @Test("a development worktree sees the origin registry rows")
+    func worktreeSeesOriginRegistryRows() throws {
+        // Real git, like WaveOriginTests: the origin resolution is the point.
         let root = FileManager.default.temporaryDirectory
-            .appendingPathComponent("session-name-\(UUID().uuidString)", isDirectory: true)
+            .appendingPathComponent("registry-origin-\(UUID().uuidString)", isDirectory: true)
         let origin = root.appendingPathComponent("repo", isDirectory: true)
         let worktree = root.appendingPathComponent("repo.wt", isDirectory: true)
         try FileManager.default.createDirectory(at: origin, withIntermediateDirectories: true)
@@ -85,15 +72,6 @@ struct PortfolioRepoStateTests {
             at: origin
         )
         try git(["worktree", "add", "-q", worktree.path], at: origin)
-
-        let sessionName = PortfolioRepoState.waveAgentSessionName(
-            repoPath: worktree.path, waveName: "goals"
-        )
-        let launchName = PortfolioRepoState.waveAgentSessionName(
-            repoPath: WaveOrigin.resolve(worktree.path), waveName: "goals"
-        )
-        #expect(sessionName == launchName)
-        #expect(sessionName == "lf-repo-goals", "named after the origin, not the worktree")
 
         let repo = PortfolioRepo(path: worktree.path.normalizedFilePath, lastOpened: Date())
         let state = PortfolioRepoState(repo: repo)

--- a/swift/LoopflowTests/RegistryQueryTests.swift
+++ b/swift/LoopflowTests/RegistryQueryTests.swift
@@ -199,6 +199,37 @@ struct RegistryQueryTests {
         #expect(result[0].home.id == "home_00000000000000000000000000000001")
     }
 
+    @Test("lf start rejects a non-live receipt")
+    func startRejectsNonLiveReceipt() async {
+        let json = #"""
+        [{"id":"wave-1","name":"product","status":"ready","goal":"Ship product",
+          "repo":"/tmp/repo","active_tasks":1,"active_projects":1,"live":false,"paused":false,
+          "endpoint":null,"created_at":"2026-07-17T00:00:00Z","parent_wave_id":null,
+          "home":{"id":"home_00000000000000000000000000000001","route":"local",
+          "created_at":"2026-07-17T00:00:00Z","observed_at":"2026-07-17T00:00:00Z"}}]
+        """#
+        let query = RegistryQuery { _, _ in json }
+
+        await #expect(throws: RegistryQueryError.self) {
+            try await query.start(wave: "product", cwd: "/tmp/repo")
+        }
+    }
+
+    @Test("lf start surfaces an actionable preflight failure")
+    func startSurfacesPreflightFailure() async {
+        let query = RegistryQuery { _, _ in
+            throw RegistryQueryError("Wave broken failed preflight: invalid chat policy")
+        }
+
+        do {
+            _ = try await query.start(wave: "broken", cwd: "/tmp/repo")
+            Issue.record("expected the preflight failure")
+        } catch {
+            #expect(error.localizedDescription.contains("failed preflight"))
+            #expect(error.localizedDescription.contains("invalid chat policy"))
+        }
+    }
+
     @Test("lf pause and resume return the authored turn intent")
     func setWavePausedUsesIntentVerbs() async throws {
         let query = RegistryQuery { args, cwd in

--- a/wave/infrastructure/MEMORY.md
+++ b/wave/infrastructure/MEMORY.md
@@ -52,6 +52,17 @@ Renamed from `systems` in the 2026-07-08 wave/project/task restructure. Steers L
   deleted. Authored input is a durable Work Steer. Best-effort process nudges may
   reduce latency, but the server follow-up must make Home-owned Ready scanning
   the correctness path so a stopped Project cannot miss child Feedback.
+- **Supported Wave startup is one event-driven Home lifecycle** (decided
+  2026-07-21). `lf start` opens the selected Home registry and uses its current
+  `lf`/`lfd` control pair without promoting or replacing binaries. Daemon boot
+  publishes one attempt-scoped durable `live | failed` receipt and uses a
+  private socket only as the wake edge; `lfd` owns listeners and shares each
+  listener's `starting | live | failed` transition with concurrent callers.
+  Success drains the durable observation outbox before returning. Failure
+  compensates only registry state introduced by that attempt, and one failed
+  Wave never terminates successful siblings. The Mac app uses the same
+  `RegistryQuery.start` receipt path. Reconciliation polling remains recovery,
+  never startup acknowledgement.
 - **Controller evidence is not an agent Run** (learned 2026-07-20). When a
   merged PR or another controller fact completes a Task, persist the Task
   lifecycle, Work Epoch, and completion event in one transaction. Never mint a


### PR DESCRIPTION
## Usage

```bash
lf start infrastructure
lf start infrastructure developer-efficiency --json
```

The Mac app’s **Start wave** action now uses the same lifecycle.

## Summary

Makes Wave startup a synchronous Home operation: `lf start` returns live snapshots only after the daemon and listeners are reachable and durable observations have been drained. Failed starts report concrete reasons and restore registry state introduced by that attempt, while successful sibling Waves remain live.

## Changes

- Added attempt-scoped durable receipts and event-driven signaling for `lfd` startup
- Serialized concurrent daemon launches and shared in-flight listener startup between callers
- Returned per-Wave `live` or `failed` outcomes from `lfd`
- Rolled back failed Wave registrations and placements without undoing successful starts
- Started Waves with the current Home `lf`/`lfd` control pair and validated resolved binaries
- Routed Mac Wave Chat startup through `lf start`, removing its separate tmux launch and polling path
- Added integration coverage for fresh Homes, mixed success and failure, concurrent callers, and durable wake delivery