### PR TITLE
task shipping: close containment and publication seams

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -349,13 +349,20 @@ If vendor config is less permissive, Loopflow warns and supplies its default.
 `--dangerously-bypass-approvals-and-sandbox`, Gemini uses `--yolo`, and OpenCode
 uses `permission: "allow"` via `OPENCODE_CONFIG_CONTENT`.
 
+Durable Task provider turns are the exception. Their assigned worktree is a
+hard write boundary, so `yolo` and a more permissive vendor config cannot widen
+it. Codex runs with `workspace-write`, Claude uses its strict fail-closed Bash
+sandbox, and OpenCode denies external-directory tools.
+
 ### Worktree Sandboxes
 
 Claude and Codex CLI/TUI sessions launched from a Git worktree automatically add
 the main repo as an extra writable directory. This keeps normal agent
 permissions, but lets Git write the linked worktree index under
 `<main>/.git/worktrees/<worktree>/` when the agent stages, commits, rebases, or
-runs mechanical `lf` commands.
+runs mechanical `lf` commands. Durable Task provider turns do not add the main
+repo. Loopflow owns their Git mutations after the provider edits and tests the
+assigned files.
 
 ### Session Launch
 

--- a/docs/lf.md
+++ b/docs/lf.md
@@ -644,11 +644,13 @@ lf -m codex pr publish        # one-off agent override for copy generation
 
 When `-m` is omitted, copy generation uses `agent:` from `.lf/config.yaml` or
 `~/.lf/config.yaml`. Use the `pr` ops skill to generate `--title`/`--body`
-with agent judgment. Publication commits and pushes the current branch as-is;
-it never fetches to integrate, rebases, rewrites Task stack metadata, or
-launches conflict recovery. A PR may remain behind its base until `lf rebase`,
-`lf gate`, `lf pr submit`, or `lf pr land` owns integration. Push or GitHub
-failure returns an error and presents nothing.
+with agent judgment. When task gate has written cached PR copy, publication
+consumes it and removes the gate-owned copy/review files before its first
+commit or push. Other `scratch/` state remains untouched. Publication never
+fetches to integrate, rebases, rewrites Task stack metadata, or launches
+conflict recovery. A PR may remain behind its base until `lf rebase`, `lf gate`,
+`lf pr submit`, or `lf pr land` owns integration. Push or GitHub failure returns
+an error and presents nothing.
 
 ### lf pr open
 

--- a/rust/loopflow/src/engine/agent.rs
+++ b/rust/loopflow/src/engine/agent.rs
@@ -101,6 +101,16 @@ pub enum AgentAuthority {
     Detached,
 }
 
+/// Filesystem write boundary for a provider launch.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum AgentWriteScope {
+    /// Respect the provider's configured permissions and Loopflow's ordinary floor.
+    #[default]
+    Configured,
+    /// Permit writes only inside the assigned working directory.
+    Worktree,
+}
+
 #[derive(Clone, Default)]
 pub struct AgentConfig {
     /// System/context prompt content.
@@ -117,6 +127,8 @@ pub struct AgentConfig {
     pub cwd: Option<std::path::PathBuf>,
     /// Whether the provider process inherits ambient Work execution authority.
     pub authority: AgentAuthority,
+    /// Maximum filesystem write scope granted to the provider.
+    pub write_scope: AgentWriteScope,
     /// Skip permission prompts
     pub skip_permissions: bool,
     /// Engine-injected structured replies (rendered via harness prompt guidance).
@@ -153,6 +165,7 @@ impl std::fmt::Debug for AgentConfig {
             .field("max_turns", &self.max_turns)
             .field("resume_token", &self.resume_token)
             .field("authority", &self.authority)
+            .field("write_scope", &self.write_scope)
             .field("cwd", &self.cwd)
             .field("skip_permissions", &self.skip_permissions)
             .field("structured_replies", &self.structured_replies)
@@ -344,6 +357,23 @@ pub fn codex_permission_args(
     auto: bool,
     skip_permissions: bool,
 ) -> Vec<String> {
+    codex_permission_args_for_scope(cwd, auto, skip_permissions, AgentWriteScope::Configured)
+}
+
+fn codex_permission_args_for_scope(
+    cwd: Option<&Path>,
+    auto: bool,
+    skip_permissions: bool,
+    write_scope: AgentWriteScope,
+) -> Vec<String> {
+    if write_scope == AgentWriteScope::Worktree {
+        let mut args = vec!["--sandbox".to_string(), "workspace-write".to_string()];
+        if auto {
+            args.push("--ask-for-approval".to_string());
+            args.push("never".to_string());
+        }
+        return args;
+    }
     if skip_permissions {
         return vec!["--dangerously-bypass-approvals-and-sandbox".to_string()];
     }
@@ -462,6 +492,8 @@ pub struct ClaudeArgs {
     pub add_dirs: Vec<PathBuf>,
     /// Skip permission prompts.
     pub skip_permissions: bool,
+    /// Enforce the managed Task worktree boundary.
+    pub worktree_isolation: bool,
     /// Max turn budget.
     pub max_turns: Option<u32>,
     /// Enable streaming output (`--output-format stream-json --verbose`).
@@ -522,6 +554,24 @@ impl ClaudeArgs {
             args.push("--dangerously-skip-permissions".to_string());
         }
 
+        if self.worktree_isolation {
+            args.push("--permission-mode".to_string());
+            args.push("acceptEdits".to_string());
+            args.push("--setting-sources".to_string());
+            args.push(String::new());
+            args.push("--settings".to_string());
+            args.push(
+                serde_json::json!({
+                    "sandbox": {
+                        "enabled": true,
+                        "failIfUnavailable": true,
+                        "allowUnsandboxedCommands": false
+                    }
+                })
+                .to_string(),
+            );
+        }
+
         if let Some(max_turns) = self.max_turns {
             args.push("--max-turns".to_string());
             args.push(max_turns.to_string());
@@ -556,16 +606,13 @@ pub fn build_claude_session_turn_args(
         model: config.agent.as_deref().and_then(ClaudeArgs::resolve_model),
         system_prompt: Some(system_prompt_with_structured_replies(config)),
         system_prompt_file: None,
-        add_dirs: config
-            .cwd
-            .as_deref()
-            .map(workspace_add_dirs)
+        add_dirs: (config.write_scope == AgentWriteScope::Configured)
+            .then(|| config.cwd.as_deref().map(workspace_add_dirs))
+            .flatten()
             .unwrap_or_default(),
-        skip_permissions: claude_skip_permissions(
-            config.cwd.as_deref(),
-            true,
-            config.skip_permissions,
-        ),
+        skip_permissions: config.write_scope == AgentWriteScope::Configured
+            && claude_skip_permissions(config.cwd.as_deref(), true, config.skip_permissions),
+        worktree_isolation: config.write_scope == AgentWriteScope::Worktree,
         max_turns: config.max_turns,
         stream: true,
         chrome: false,
@@ -647,7 +694,16 @@ pub fn build_codex_thread_start_params(
         );
     }
 
-    if launch.skip_permissions {
+    if launch.write_scope == AgentWriteScope::Worktree {
+        params.insert(
+            "approvalPolicy".to_string(),
+            serde_json::Value::String("never".to_string()),
+        );
+        params.insert(
+            "sandbox".to_string(),
+            serde_json::Value::String("workspace-write".to_string()),
+        );
+    } else if launch.skip_permissions {
         params.insert(
             "approvalPolicy".to_string(),
             serde_json::Value::String("never".to_string()),
@@ -707,16 +763,17 @@ pub fn build_claude_command(
         model: model_variant.map(str::to_string),
         system_prompt: Some(system_prompt_with_structured_replies(launch)),
         system_prompt_file: process.context_file.clone(),
-        add_dirs: launch
-            .cwd
-            .as_deref()
-            .map(workspace_add_dirs)
+        add_dirs: (launch.write_scope == AgentWriteScope::Configured)
+            .then(|| launch.cwd.as_deref().map(workspace_add_dirs))
+            .flatten()
             .unwrap_or_default(),
-        skip_permissions: claude_skip_permissions(
-            launch.cwd.as_deref(),
-            process.auto,
-            launch.skip_permissions,
-        ),
+        skip_permissions: launch.write_scope == AgentWriteScope::Configured
+            && claude_skip_permissions(
+                launch.cwd.as_deref(),
+                process.auto,
+                launch.skip_permissions,
+            ),
+        worktree_isolation: launch.write_scope == AgentWriteScope::Worktree,
         max_turns: launch.max_turns,
         stream: process.auto && process.stream,
         chrome: capabilities.chrome,
@@ -770,7 +827,7 @@ pub fn build_codex_command(
         cmd.push(cwd.to_string_lossy().to_string());
     }
 
-    if !launch.skip_permissions {
+    if !launch.skip_permissions && launch.write_scope == AgentWriteScope::Configured {
         for dir in launch
             .cwd
             .as_deref()
@@ -786,10 +843,11 @@ pub fn build_codex_command(
         cmd.push("--json".to_string());
     }
 
-    cmd.extend(codex_permission_args(
+    cmd.extend(codex_permission_args_for_scope(
         launch.cwd.as_deref(),
         process.auto,
         launch.skip_permissions,
+        launch.write_scope,
     ));
 
     if process.auto {
@@ -852,8 +910,20 @@ pub fn build_opencode_command(process: &ProcessConfig, model_variant: Option<&st
 ///
 /// Returns `None` when no config overrides are needed (interactive mode, no context).
 pub fn build_opencode_env(process: &ProcessConfig) -> Option<String> {
+    build_opencode_env_for_scope(process, AgentWriteScope::Configured)
+}
+
+fn build_opencode_env_for_scope(
+    process: &ProcessConfig,
+    write_scope: AgentWriteScope,
+) -> Option<String> {
     let mut oc_config = serde_json::Map::new();
-    if process.auto {
+    if write_scope == AgentWriteScope::Worktree {
+        oc_config.insert(
+            "permission".into(),
+            serde_json::json!({"*": "allow", "external_directory": "deny"}),
+        );
+    } else if process.auto {
         oc_config.insert(
             "permission".into(),
             serde_json::Value::String("allow".into()),
@@ -872,6 +942,12 @@ pub fn build_opencode_env(process: &ProcessConfig) -> Option<String> {
     }
 }
 
+/// Highest-priority OpenCode configuration for a managed Task provider.
+pub fn opencode_worktree_config() -> String {
+    build_opencode_env_for_scope(&ProcessConfig::default(), AgentWriteScope::Worktree)
+        .expect("worktree scope always produces OpenCode configuration")
+}
+
 pub fn build_agent_env(launch: &AgentConfig, process: &ProcessConfig) -> BTreeMap<String, String> {
     let mut env = process.env.clone();
     let agent = launch.agent();
@@ -886,7 +962,7 @@ pub fn build_agent_env(launch: &AgentConfig, process: &ProcessConfig) -> BTreeMa
             }
         }
         "opencode" => {
-            if let Some(env_val) = build_opencode_env(process) {
+            if let Some(env_val) = build_opencode_env_for_scope(process, launch.write_scope) {
                 env.insert("OPENCODE_CONFIG_CONTENT".to_string(), env_val);
             }
         }
@@ -897,7 +973,12 @@ pub fn build_agent_env(launch: &AgentConfig, process: &ProcessConfig) -> BTreeMa
 }
 
 /// Apply harness-specific environment variables to a command.
-fn apply_harness_env(harness: &str, cmd: &mut Command, process: &ProcessConfig) {
+fn apply_harness_env(
+    harness: &str,
+    cmd: &mut Command,
+    launch: &AgentConfig,
+    process: &ProcessConfig,
+) {
     match harness {
         "gemini" => {
             if let Some(ref context_file) = process.context_file {
@@ -908,7 +989,7 @@ fn apply_harness_env(harness: &str, cmd: &mut Command, process: &ProcessConfig) 
             }
         }
         "opencode" => {
-            if let Some(env_val) = build_opencode_env(process) {
+            if let Some(env_val) = build_opencode_env_for_scope(process, launch.write_scope) {
                 cmd.env("OPENCODE_CONFIG_CONTENT", env_val);
             }
         }
@@ -1350,7 +1431,7 @@ fn _launch_agent_once(
                 .map_err(|error| CoreError::ExecutionFailed(error.to_string()))?;
         }
     }
-    apply_harness_env(&harness, &mut cmd, process);
+    apply_harness_env(&harness, &mut cmd, launch, process);
 
     // Callers that already assembled semantic assets supply a capture handle.
     // Small internal agent launches (PR copy, commit copy, ops fallback) still
@@ -2102,6 +2183,48 @@ trust_level = "trusted"
     }
 
     #[test]
+    fn managed_task_scope_cannot_be_widened_by_yolo_or_linked_main() {
+        let (_tmp, _main, worktree) = git_worktree_fixture();
+        let launch = AgentConfig {
+            agent: Some("codex".to_string()),
+            cwd: Some(worktree),
+            write_scope: AgentWriteScope::Worktree,
+            skip_permissions: true,
+            ..default_launch()
+        };
+        let process = auto_process();
+
+        let codex = build_codex_command(&launch, &process, None);
+        assert_arg_pair(&codex, "--sandbox", "workspace-write");
+        assert_arg_pair(&codex, "--ask-for-approval", "never");
+        assert!(!codex.contains(&"--add-dir".to_string()));
+        assert!(!codex.contains(&"--dangerously-bypass-approvals-and-sandbox".to_string()));
+        let thread = build_codex_thread_start_params(&launch);
+        assert_eq!(thread["sandbox"], "workspace-write");
+        assert_eq!(thread["approvalPolicy"], "never");
+
+        let claude = build_claude_command(&launch, &process, &AgentCapabilities::default(), None);
+        assert_arg_pair(&claude, "--permission-mode", "acceptEdits");
+        assert_arg_pair(&claude, "--setting-sources", "");
+        assert!(!claude.contains(&"--add-dir".to_string()));
+        assert!(!claude.contains(&"--dangerously-skip-permissions".to_string()));
+        let settings = claude
+            .windows(2)
+            .find_map(|pair| (pair[0] == "--settings").then_some(&pair[1]))
+            .expect("managed Claude settings");
+        let settings: serde_json::Value = serde_json::from_str(settings).unwrap();
+        assert_eq!(settings["sandbox"]["enabled"], true);
+        assert_eq!(settings["sandbox"]["failIfUnavailable"], true);
+        assert_eq!(settings["sandbox"]["allowUnsandboxedCommands"], false);
+
+        let opencode = build_opencode_env_for_scope(&process, AgentWriteScope::Worktree)
+            .expect("managed OpenCode settings");
+        let opencode: serde_json::Value = serde_json::from_str(&opencode).unwrap();
+        assert_eq!(opencode["permission"]["*"], "allow");
+        assert_eq!(opencode["permission"]["external_directory"], "deny");
+    }
+
+    #[test]
     fn build_codex_command_with_model() {
         let launch = default_launch();
         let process = auto_process();
@@ -2358,6 +2481,7 @@ trust_level = "trusted"
             system_prompt_file: None,
             add_dirs: vec!["/tmp/repo".into()],
             skip_permissions: true,
+            worktree_isolation: false,
             max_turns: Some(10),
             stream: true,
             chrome: true,
@@ -2477,6 +2601,7 @@ trust_level = "trusted"
             max_turns: None,
             resume_token: None,
             authority: AgentAuthority::Inherit,
+            write_scope: AgentWriteScope::Configured,
             skip_permissions: false,
             structured_replies: Vec::new(),
             directive_relay: None,
@@ -2503,6 +2628,7 @@ trust_level = "trusted"
             max_turns: Some(5),
             resume_token: None,
             authority: AgentAuthority::Inherit,
+            write_scope: AgentWriteScope::Configured,
             skip_permissions: true,
             structured_replies: Vec::new(),
             directive_relay: None,
@@ -2529,6 +2655,7 @@ trust_level = "trusted"
             max_turns: None,
             resume_token: None,
             authority: AgentAuthority::Inherit,
+            write_scope: AgentWriteScope::Configured,
             skip_permissions: false,
             structured_replies: vec![StructuredReply {
                 name: "suggest_actions".to_string(),

--- a/rust/loopflow/src/engine/builtins/task/skill/gate.md
+++ b/rust/loopflow/src/engine/builtins/task/skill/gate.md
@@ -116,7 +116,9 @@ Make the change easy to review.
    - `scratch/pr-body.md` — markdown PR body
    - `scratch/.pr-copy-ref` — current `HEAD` SHA (`git rev-parse HEAD`)
 
-   `lf pr land` consumes these files.
+   `lf pr publish`, `lf pr submit`, and `lf pr land` consume these files.
+   Publication removes these files and `scratch/<branch>-review.md` before its
+   first commit or push, so gate handoff state never becomes a PR head.
 
 4. **Update README and docs**
    - If user-facing behavior changed, docs must reflect it

--- a/rust/loopflow/src/engine/launch.rs
+++ b/rust/loopflow/src/engine/launch.rs
@@ -176,6 +176,7 @@ pub fn prepare_launch_prompt(
         resume_token: None,
         cwd: Some(cwd.unwrap_or(repo_root)),
         authority: crate::engine::agent::AgentAuthority::Inherit,
+        write_scope: crate::engine::agent::AgentWriteScope::Configured,
         skip_permissions: yolo_mode,
         structured_replies: structured_replies_for_context(&client_context, action_style),
         directive_relay: None,

--- a/rust/loopflow/src/engine/mod.rs
+++ b/rust/loopflow/src/engine/mod.rs
@@ -28,8 +28,8 @@ pub mod worktrees;
 pub use agent::{
     build_agent_command, build_claude_command, build_codex_command, build_gemini_command,
     build_model_command, build_opencode_command, check_cli_available, codex_permission_args,
-    launch_agent, workspace_add_dirs, AgentCapabilities, AgentConfig, AgentFailure, ClaudeArgs,
-    DefaultRunner, LaunchResult, ProcessConfig, Runner,
+    launch_agent, workspace_add_dirs, AgentCapabilities, AgentConfig, AgentFailure,
+    AgentWriteScope, ClaudeArgs, DefaultRunner, LaunchResult, ProcessConfig, Runner,
 };
 pub use command::{run_command, CommandError};
 pub use config::{

--- a/rust/loopflow/src/harness/claude.rs
+++ b/rust/loopflow/src/harness/claude.rs
@@ -390,6 +390,7 @@ mod tests {
             max_turns: None,
             resume_token: None,
             authority: crate::engine::agent::AgentAuthority::Inherit,
+            write_scope: crate::engine::agent::AgentWriteScope::Configured,
             skip_permissions: false,
             structured_replies: Vec::new(),
             directive_relay: None,

--- a/rust/loopflow/src/harness/opencode.rs
+++ b/rust/loopflow/src/harness/opencode.rs
@@ -11,7 +11,9 @@ use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
 
 use crate::chat::types::{ConversationEvent, FailureEvidence, Lifecycle};
-use crate::engine::agent::{register_interrupt_cleanup, AgentConfig};
+use crate::engine::agent::{
+    opencode_worktree_config, register_interrupt_cleanup, AgentConfig, AgentWriteScope,
+};
 use crate::engine::config::parse_agent;
 use crate::harness::common::{spawn_stderr_logger, TurnInProgressGuard};
 use crate::harness::{
@@ -103,6 +105,9 @@ impl OpenCodeHarness {
             .kill_on_drop(true);
         if let Some(cwd) = &config.cwd {
             command.current_dir(cwd);
+        }
+        if config.write_scope == AgentWriteScope::Worktree {
+            command.env("OPENCODE_CONFIG_CONTENT", opencode_worktree_config());
         }
         // Own process group so `stop()` and the interrupt hook can kill the
         // whole tree — `opencode serve` spawns descendants (MCP servers, model

--- a/rust/loopflow/src/harness/opencode_runtime.rs
+++ b/rust/loopflow/src/harness/opencode_runtime.rs
@@ -4,6 +4,7 @@ use std::process::Command;
 use std::time::{Duration, Instant};
 
 use anyhow::{Context, Result};
+use fs2::FileExt;
 use serde::{Deserialize, Serialize};
 
 const OPENCODE_REGISTRY_FILE: &str = "runtime/opencode-servers.json";
@@ -26,7 +27,9 @@ pub(crate) struct OpenCodeServerEntry {
 }
 
 pub(crate) fn registered_opencode_servers_at(lf_home: &Path) -> Result<Vec<OpenCodeServerEntry>> {
-    read_registry_entries(&lf_home.join(OPENCODE_REGISTRY_FILE))
+    let path = lf_home.join(OPENCODE_REGISTRY_FILE);
+    let _lock = lock_registry_for_read(&path)?;
+    read_registry_entries(&path)
 }
 
 pub(crate) fn register_opencode_server(opencode_pid: u32) -> Result<()> {
@@ -38,8 +41,12 @@ pub(crate) fn unregister_opencode_server(opencode_pid: u32) -> Result<()> {
 }
 
 pub fn reap_orphaned_opencode_servers() -> OpenCodeReapReport {
+    reap_orphaned_opencode_servers_at(&crate::store::lf_home_dir())
+}
+
+pub(crate) fn reap_orphaned_opencode_servers_at(lf_home: &Path) -> OpenCodeReapReport {
     reap_orphaned_opencode_servers_at_path(
-        &registry_path(),
+        &lf_home.join(OPENCODE_REGISTRY_FILE),
         |_| true,
         pid_is_alive,
         classify_leader,
@@ -71,6 +78,7 @@ fn register_opencode_server_at_path(
     opencode_pid: u32,
     owner_loopflow_pid: u32,
 ) -> Result<()> {
+    let _lock = lock_registry(path)?;
     let mut entries = read_registry_entries(path)?;
     entries.retain(|entry| entry.opencode_pid != opencode_pid);
     entries.push(OpenCodeServerEntry {
@@ -81,6 +89,7 @@ fn register_opencode_server_at_path(
 }
 
 fn unregister_opencode_server_at_path(path: &Path, opencode_pid: u32) -> Result<()> {
+    let _lock = lock_registry(path)?;
     let mut entries = read_registry_entries(path)?;
     let original_len = entries.len();
     entries.retain(|entry| entry.opencode_pid != opencode_pid);
@@ -113,6 +122,14 @@ fn reap_orphaned_opencode_servers_at_path(
     terminate_group: impl Fn(u32) -> bool,
 ) -> OpenCodeReapReport {
     let mut report = OpenCodeReapReport::default();
+    let _lock = match lock_registry(path) {
+        Ok(lock) => lock,
+        Err(err) => {
+            tracing::warn!(path = %path.display(), error = %err, "failed to lock OpenCode registry");
+            report.errors += 1;
+            return report;
+        }
+    };
     let entries = match read_registry_entries(path) {
         Ok(entries) => entries,
         Err(err) => {
@@ -176,6 +193,48 @@ fn reap_orphaned_opencode_servers_at_path(
     }
 
     report
+}
+
+fn lock_registry(path: &Path) -> Result<std::fs::File> {
+    let lock_path = path.with_extension("json.lock");
+    if let Some(parent) = lock_path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("failed creating runtime dir {}", parent.display()))?;
+    }
+    let lock = std::fs::OpenOptions::new()
+        .create(true)
+        .read(true)
+        .write(true)
+        .truncate(false)
+        .open(&lock_path)
+        .with_context(|| {
+            format!(
+                "failed opening OpenCode registry lock {}",
+                lock_path.display()
+            )
+        })?;
+    FileExt::lock_exclusive(&lock)
+        .with_context(|| format!("failed locking OpenCode registry {}", lock_path.display()))?;
+    Ok(lock)
+}
+
+fn lock_registry_for_read(path: &Path) -> Result<Option<std::fs::File>> {
+    let lock_path = path.with_extension("json.lock");
+    let lock = match std::fs::OpenOptions::new().read(true).open(&lock_path) {
+        Ok(lock) => lock,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => {
+            return Err(error).with_context(|| {
+                format!(
+                    "failed opening OpenCode registry lock {}",
+                    lock_path.display()
+                )
+            })
+        }
+    };
+    FileExt::lock_shared(&lock)
+        .with_context(|| format!("failed locking OpenCode registry {}", lock_path.display()))?;
+    Ok(Some(lock))
 }
 
 fn read_registry_entries(path: &Path) -> Result<Vec<OpenCodeServerEntry>> {
@@ -379,6 +438,16 @@ mod tests {
         unregister_opencode_server_at_path(&path, 111).expect("unregister pid");
         let entries = read_registry_entries(&path).expect("read entries");
         assert!(entries.is_empty());
+    }
+
+    #[test]
+    fn reading_an_absent_registry_creates_no_runtime_state() {
+        let tmp = tempdir().expect("tempdir");
+
+        assert!(registered_opencode_servers_at(tmp.path())
+            .expect("read absent registry")
+            .is_empty());
+        assert!(!tmp.path().join("runtime").exists());
     }
 
     #[test]

--- a/rust/loopflow/src/lfd/mod.rs
+++ b/rust/loopflow/src/lfd/mod.rs
@@ -56,6 +56,7 @@ use crate::engine::worktrees::{
     main_repo_root, prune_abandoned_prompt_logs, prune_branch_worktree, prune_terminal_worktree,
     prune_worktrees, TargetedPruneOutcome, WorktreePrunePolicy, WorktreePruneReason,
 };
+use crate::harness::opencode_runtime::reap_orphaned_opencode_servers_at;
 use crate::id::WaveId;
 use crate::repository::RepoId;
 use crate::store::provider_deliveries::{DeliveryCompletion, DeliveryEventKind, DeliveryStatus};
@@ -623,6 +624,25 @@ async fn prune_github_event(state: &LfdState, event: GithubPruneEvent) -> anyhow
 }
 
 async fn maintenance_sweep(state: &LfdState) {
+    let lf_home = crate::store::lf_home_dir();
+    match tokio::task::spawn_blocking(move || reap_orphaned_opencode_servers_at(&lf_home)).await {
+        Ok(report) => {
+            if report.reaped > 0 {
+                tracing::info!(
+                    reaped = report.reaped,
+                    "OpenCode orphan maintenance complete"
+                );
+            }
+            if report.errors > 0 {
+                tracing::warn!(
+                    errors = report.errors,
+                    "OpenCode orphan maintenance incomplete"
+                );
+            }
+        }
+        Err(error) => tracing::warn!(%error, "OpenCode orphan maintenance task failed"),
+    }
+
     let protected_paths = match protected_worktree_paths(state).await {
         Ok(paths) => paths,
         Err(error) => {

--- a/rust/loopflow/src/ops/land.rs
+++ b/rust/loopflow/src/ops/land.rs
@@ -9,7 +9,7 @@ use crate::engine::worktrees::{main_repo_root, worktree_path};
 use crate::engine::command::run_command;
 use crate::ops::commit::{commit_workflow, CommitOptions};
 use crate::ops::error::{OpsError, OpsResult};
-use crate::ops::pr::{generate_pr_copy, PrInfo};
+use crate::ops::pr::{generate_pr_copy, read_cached_pr_copy, PrInfo};
 
 use crate::ops::progress::Progress;
 
@@ -329,11 +329,11 @@ fn resolve_pr_copy(
         return Ok((pr_title, pr_body));
     }
 
-    if let Some((title, body)) = read_cached_pr_copy(repo_root, progress)? {
+    if let Some(copy) = read_cached_pr_copy(repo_root, progress)? {
         progress.status("Using cached PR copy from scratch/");
-        pr_title = Some(title);
+        pr_title = Some(copy.title);
         if pr_body.is_none() {
-            pr_body = Some(body);
+            pr_body = Some(copy.body);
         }
         return Ok((pr_title, pr_body));
     }
@@ -344,57 +344,6 @@ fn resolve_pr_copy(
         pr_body = Some(generated.body);
     }
     Ok((pr_title, pr_body))
-}
-
-fn read_cached_pr_copy(
-    repo_root: &Path,
-    progress: &impl Progress,
-) -> OpsResult<Option<(String, String)>> {
-    let title_path = repo_root.join("scratch/pr-title.txt");
-    let body_path = repo_root.join("scratch/pr-body.md");
-    let ref_path = repo_root.join("scratch/.pr-copy-ref");
-
-    if !title_path.exists() || !body_path.exists() {
-        return Ok(None);
-    }
-
-    let title = std::fs::read_to_string(&title_path)?.trim().to_string();
-    if title.is_empty() {
-        return Ok(None);
-    }
-
-    let copied_for = match std::fs::read_to_string(&ref_path) {
-        Ok(value) => value.trim().to_string(),
-        Err(_) => {
-            progress.status("Ignoring cached PR copy: scratch/.pr-copy-ref is missing");
-            return Ok(None);
-        }
-    };
-    if !is_recent_ancestor(repo_root, &copied_for, 1)? {
-        progress.status("Ignoring cached PR copy: branch changed since gate output");
-        return Ok(None);
-    }
-
-    let body = std::fs::read_to_string(body_path)?;
-    Ok(Some((title, body)))
-}
-
-/// Check if HEAD is no more than `max_ahead` commits ahead of `commit`.
-/// This tolerates one bookkeeping commit after gate output while still
-/// forcing regeneration if substantive commits were added later.
-fn is_recent_ancestor(repo_root: &Path, commit: &str, max_ahead: u32) -> OpsResult<bool> {
-    let output = Command::new("git")
-        .args(["rev-list", "--count", &format!("{commit}..HEAD")])
-        .current_dir(repo_root)
-        .output()?;
-    if !output.status.success() {
-        return Ok(false);
-    }
-    let ahead = String::from_utf8_lossy(&output.stdout)
-        .trim()
-        .parse::<u32>()
-        .unwrap_or(u32::MAX);
-    Ok(ahead <= max_ahead)
 }
 
 fn prepare_land(

--- a/rust/loopflow/src/ops/pr.rs
+++ b/rust/loopflow/src/ops/pr.rs
@@ -85,6 +85,11 @@ pub fn create_or_update_pr(
     // first remote side effect. No-op for non-Task worktrees.
     crate::ops::task::verify_task_pr_range_without_healing(repo)?;
 
+    // Gate output is an in-worktree handoff, never published content. Consume
+    // valid cached copy before deleting the gate-owned files so the commit and
+    // push below can only expose the reviewed implementation tree.
+    let cached_copy = consume_gate_artifacts(repo, progress)?;
+
     // Publication owns no integration. Commit locally, prove the resulting
     // range, then push exactly the branch the user has now. A PR may honestly
     // remain behind its base until an explicit integration boundary.
@@ -103,7 +108,7 @@ pub fn create_or_update_pr(
     let published_head = rev_parse(repo, "HEAD")?;
     crate::ops::commit::push_with_upstream_if_needed(repo)?;
 
-    let copy = resolve_pr_copy(repo, options, progress)?;
+    let copy = resolve_pr_copy(repo, options, cached_copy, progress)?;
     let current_branch_state = current_branch(repo)?;
     let current_head = rev_parse(repo, "HEAD")?;
     if current_branch_state.as_deref() != Some(branch.as_str()) || current_head != published_head {
@@ -204,6 +209,7 @@ pub(crate) fn reject_control_plane_pr(repo: &Path) -> OpsResult<()> {
 fn resolve_pr_copy(
     repo: &Path,
     options: &PrOptions,
+    cached: Option<PrCopy>,
     progress: &impl Progress,
 ) -> OpsResult<PrCopy> {
     if let Some(title) = options
@@ -218,11 +224,99 @@ fn resolve_pr_copy(
         });
     }
 
-    let mut generated = generate_pr_copy(repo, progress, options.agent.as_deref())?;
+    let mut copy = match cached {
+        Some(copy) => {
+            progress.status("Using cached PR copy from task gate");
+            copy
+        }
+        None => generate_pr_copy(repo, progress, options.agent.as_deref())?,
+    };
     if let Some(body_override) = options.body.as_deref() {
-        generated.body = body_override.to_string();
+        copy.body = body_override.to_string();
     }
-    Ok(generated)
+    Ok(copy)
+}
+
+fn consume_gate_artifacts(repo: &Path, progress: &impl Progress) -> OpsResult<Option<PrCopy>> {
+    let cached = read_cached_pr_copy(repo, progress)?;
+    let scratch = repo.join("scratch");
+    if !scratch.exists() {
+        return Ok(cached);
+    }
+
+    let mut removed = false;
+    for entry in std::fs::read_dir(&scratch)? {
+        let entry = entry?;
+        let path = entry.path();
+        if !path.is_file() {
+            continue;
+        }
+        let name = entry.file_name();
+        let name = name.to_string_lossy();
+        let gate_owned = matches!(
+            name.as_ref(),
+            ".pr-copy-ref" | "pr-title.txt" | "pr-body.md"
+        ) || name.ends_with("-review.md");
+        if gate_owned {
+            std::fs::remove_file(path)?;
+            removed = true;
+        }
+    }
+    if removed {
+        progress.status("Removing task-gate artifacts before publication");
+    }
+    Ok(cached)
+}
+
+pub(crate) fn read_cached_pr_copy(
+    repo: &Path,
+    progress: &impl Progress,
+) -> OpsResult<Option<PrCopy>> {
+    let title_path = repo.join("scratch/pr-title.txt");
+    let body_path = repo.join("scratch/pr-body.md");
+    let ref_path = repo.join("scratch/.pr-copy-ref");
+
+    if !title_path.exists() || !body_path.exists() {
+        return Ok(None);
+    }
+
+    let title = std::fs::read_to_string(&title_path)?.trim().to_string();
+    if title.is_empty() {
+        return Ok(None);
+    }
+
+    let copied_for = match std::fs::read_to_string(&ref_path) {
+        Ok(value) => value.trim().to_string(),
+        Err(_) => {
+            progress.status("Ignoring cached PR copy: scratch/.pr-copy-ref is missing");
+            return Ok(None);
+        }
+    };
+    if !is_recent_ancestor(repo, &copied_for, 1)? {
+        progress.status("Ignoring cached PR copy: branch changed since gate output");
+        return Ok(None);
+    }
+
+    let body = std::fs::read_to_string(body_path)?;
+    Ok(Some(PrCopy { title, body }))
+}
+
+/// Check if HEAD is no more than `max_ahead` commits ahead of `commit`.
+/// This tolerates one bookkeeping commit after gate output while still
+/// forcing regeneration if substantive commits were added later.
+fn is_recent_ancestor(repo: &Path, commit: &str, max_ahead: u32) -> OpsResult<bool> {
+    let output = Command::new("git")
+        .args(["rev-list", "--count", &format!("{commit}..HEAD")])
+        .current_dir(repo)
+        .output()?;
+    if !output.status.success() {
+        return Ok(false);
+    }
+    let ahead = String::from_utf8_lossy(&output.stdout)
+        .trim()
+        .parse::<u32>()
+        .unwrap_or(u32::MAX);
+    Ok(ahead <= max_ahead)
 }
 
 pub fn generate_pr_copy(

--- a/rust/loopflow/src/ops/task.rs
+++ b/rust/loopflow/src/ops/task.rs
@@ -1704,7 +1704,7 @@ async fn resolve_verifier_upstream(
 
 /// Core parity proof. Takes the store + task explicitly so it can be
 /// exercised in tests without a live LF_HOME (mirrors `ensure_working_pr`).
-async fn verify_task_pr_range_with_authority(
+pub(crate) async fn verify_task_pr_range_with_authority(
     store: &SharedStore,
     task: &Task,
     lease: Option<&RunLease>,

--- a/rust/loopflow/src/task/runner.rs
+++ b/rust/loopflow/src/task/runner.rs
@@ -952,6 +952,8 @@ async fn prepare_task_flow_step(
         crate::lf::commands::run::prepare_harness_turn(&step.step, &seed, wave_name, None)?
     };
     prepared.config.agent = Some(task.agent.clone());
+    prepared.config.write_scope = crate::engine::agent::AgentWriteScope::Worktree;
+    prepared.config.skip_permissions = false;
     let position = FlowPosition {
         work,
         epoch_id: boundary.basis.epoch_id.clone(),
@@ -1967,6 +1969,9 @@ fn progress_summary(text: &str) -> String {
 }
 
 #[cfg(test)]
+mod shipping_lifecycle_tests;
+
+#[cfg(test)]
 mod planning_tests {
     use super::{
         complete_interactive_step, finish_task_flow_turn, interactive_step_prompt, sync_task_state,
@@ -2550,6 +2555,11 @@ mod planning_tests {
         .await
         .unwrap();
         assert!(prepared.interactive);
+        assert_eq!(
+            prepared.turn.config.write_scope,
+            crate::engine::agent::AgentWriteScope::Worktree
+        );
+        assert!(!prepared.turn.config.skip_permissions);
         let (event_tx, mut event_rx) = tokio::sync::mpsc::unbounded_channel();
         let mut harness = UnusedHarness;
 

--- a/rust/loopflow/src/task/runner/shipping_lifecycle_tests.rs
+++ b/rust/loopflow/src/task/runner/shipping_lifecycle_tests.rs
@@ -1,0 +1,468 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::Arc;
+
+use time::OffsetDateTime;
+
+use super::{arm_ci_fix_wake, prepare_task_flow_step, resume_task_phase, settle_ci_fix_turn};
+use crate::chat::types::Lifecycle;
+use crate::child::ChildRef;
+use crate::durable::{
+    BoundaryState, Containment, InvocationRoute, RunAdvance, RunTrigger, WorkStatus,
+};
+use crate::engine::agent::{
+    build_claude_session_turn_args, build_codex_command, opencode_worktree_config, AgentWriteScope,
+    ProcessConfig,
+};
+use crate::id::WaveId;
+use crate::planning::{LinearIssueId, LinearProjectId, ProjectPlan, TaskPlan};
+use crate::project::{Project, ProjectId};
+use crate::store::{open_store, SharedStore, StorageConfig};
+use crate::task::{
+    AfterMerge, CiCheck, CiObservation, CiState, GithubPr, Observation, PmWritebackState,
+    PrMergeMode, PrMergeRequest, PrPublication, Task, TaskEventKind, TaskGateProposal,
+    TaskLifecyclePhase, TaskLifecyclePlan, TaskPr, TaskPrId,
+};
+use crate::wave::Wave;
+
+struct GitFixture {
+    _root: tempfile::TempDir,
+    main: PathBuf,
+    worktree: PathBuf,
+    base: String,
+    upstream: String,
+    failed_head: String,
+}
+
+impl GitFixture {
+    fn new() -> Self {
+        let root = tempfile::tempdir().unwrap();
+        let main = root.path().join("repo");
+        let remote = root.path().join("origin.git");
+        let worktree = root.path().join("repo.task");
+        fs::create_dir(&main).unwrap();
+        git(&main, &["init", "-b", "main"]);
+        git(&main, &["config", "user.email", "test@example.com"]);
+        git(&main, &["config", "user.name", "Loopflow Test"]);
+        fs::write(main.join("base.txt"), "base\n").unwrap();
+        git(&main, &["add", "."]);
+        git(&main, &["commit", "-m", "base"]);
+        let base = git(&main, &["rev-parse", "HEAD"]);
+
+        let output = Command::new("git")
+            .args(["clone", "--bare"])
+            .arg(&main)
+            .arg(&remote)
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "git clone --bare failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        git(
+            &main,
+            &["remote", "add", "origin", remote.to_str().unwrap()],
+        );
+        git(&main, &["push", "-u", "origin", "main"]);
+        git(
+            &main,
+            &[
+                "worktree",
+                "add",
+                "-b",
+                "task/shipping-proof",
+                worktree.to_str().unwrap(),
+            ],
+        );
+        git(&worktree, &["config", "user.email", "test@example.com"]);
+        git(&worktree, &["config", "user.name", "Loopflow Test"]);
+        fs::write(worktree.join("task.txt"), "task\n").unwrap();
+        git(&worktree, &["add", "."]);
+        git(&worktree, &["commit", "-m", "task change"]);
+
+        fs::write(main.join("upstream.txt"), "upstream\n").unwrap();
+        git(&main, &["add", "."]);
+        git(&main, &["commit", "-m", "upstream change"]);
+        git(&main, &["push", "origin", "main"]);
+        let upstream = git(&main, &["rev-parse", "HEAD"]);
+
+        git(&worktree, &["fetch", "origin", "main"]);
+        git(&worktree, &["rebase", "origin/main"]);
+        let failed_head = git(&worktree, &["rev-parse", "HEAD"]);
+
+        Self {
+            _root: root,
+            main,
+            worktree,
+            base,
+            upstream,
+            failed_head,
+        }
+    }
+
+    fn commit_repair(&self) -> String {
+        fs::write(self.worktree.join("repair.txt"), "repair\n").unwrap();
+        git(&self.worktree, &["add", "."]);
+        git(&self.worktree, &["commit", "-m", "repair CI"]);
+        git(&self.worktree, &["rev-parse", "HEAD"])
+    }
+}
+
+fn git(cwd: &Path, args: &[&str]) -> String {
+    let output = Command::new("git")
+        .current_dir(cwd)
+        .args(args)
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "git {} failed: {}",
+        args.join(" "),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8_lossy(&output.stdout).trim().to_string()
+}
+
+async fn registry(
+    fixture: &GitFixture,
+) -> (SharedStore, tempfile::TempDir, Wave, Project, Task, TaskPr) {
+    let database = tempfile::tempdir().unwrap();
+    let store = Arc::new(
+        open_store(&StorageConfig::sqlite(database.path().join("registry.db")))
+            .await
+            .unwrap(),
+    );
+    let now = OffsetDateTime::now_utc();
+    let wave = Wave::new(
+        WaveId::new(),
+        "shipping-proof".to_string(),
+        fixture.main.display().to_string(),
+    );
+    let project = Project {
+        id: ProjectId::new(),
+        plan: ProjectPlan {
+            id: LinearProjectId::new("shipping-proof-project").unwrap(),
+            slug: "shipping-proof".to_string(),
+            name: "Shipping proof".to_string(),
+            prompt_context: "A Task ships without manual repair.".to_string(),
+            pm_snapshot_synced_at: now.unix_timestamp(),
+        },
+        wave_id: wave.id().clone(),
+        iteration: 0,
+        observation_cursor: 0,
+        last_state_fingerprint: None,
+        agent: "codex".to_string(),
+        provider: "codex".to_string(),
+        provider_session_id: None,
+        abandon_intent: None,
+        created_at: now,
+        updated_at: now,
+    };
+    let task = Task {
+        id: crate::task::TaskId::new(),
+        plan: TaskPlan {
+            id: LinearIssueId::new("shipping-proof-issue").unwrap(),
+            identifier: "TEST-55".to_string(),
+            title: "Ship without repair".to_string(),
+            description: "Exercise the complete authority chain.".to_string(),
+            pm_snapshot_synced_at: now.unix_timestamp(),
+        },
+        pm_writeback: PmWritebackState::Current,
+        wave_id: wave.id().clone(),
+        project_id: project.id.clone(),
+        worktree: fixture.worktree.clone(),
+        workspace_slug: "shipping-proof".to_string(),
+        lifecycle: TaskLifecyclePlan::standard("task-kickoff", "slice", "ship"),
+        lifecycle_phase: TaskLifecyclePhase::First,
+        phase_epoch: 1,
+        phase_cursor: 0,
+        phase_iteration: 0,
+        gate_cycle: 0,
+        gate_proposal: None,
+        agent: "codex".to_string(),
+        provider: "codex".to_string(),
+        provider_session_id: None,
+        abandon_intent: None,
+        created_at: now,
+        updated_at: now,
+        observation: Observation::NotRequired,
+    };
+    let mut pr = TaskPr {
+        id: TaskPrId::new(),
+        task_id: task.id.clone(),
+        sequence: 1,
+        slug: task.workspace_slug.clone(),
+        branch: "task/shipping-proof".to_string(),
+        base_commit: fixture.base.clone(),
+        parent_pr_id: None,
+        publication: None,
+        merge_commit: None,
+        abandoned_at: None,
+        ci_observation: None,
+        github_observation: None,
+        linear_attachment_id: None,
+        linear_comment_id: None,
+        linear_link_error: None,
+        created_at: now,
+        updated_at: now,
+    };
+    store.create_wave(&wave).await.unwrap();
+    store.create_project(&project).await.unwrap();
+    store.create_task(&task, &pr).await.unwrap();
+    pr.publication = Some(PrPublication {
+        requested_at: now,
+        github: Some(GithubPr {
+            number: 55,
+            url: "https://github.com/loopflowstudio/loopflow/pull/55".to_string(),
+            head_sha: Some(fixture.failed_head.clone()),
+        }),
+        merge: None,
+    });
+    pr.ci_observation = Some(CiObservation {
+        head_sha: fixture.failed_head.clone(),
+        state: CiState::Failing,
+        failing_checks: vec![CiCheck {
+            name: "task-shipping".to_string(),
+            url: Some("https://example.com/check/55".to_string()),
+        }],
+        observed_at: now,
+    });
+    store.update_task_pr(&pr).await.unwrap();
+    (store, database, wave, project, task, pr)
+}
+
+#[tokio::test]
+async fn task_ships_on_one_authority_chain_without_manual_repair() {
+    let fixture = GitFixture::new();
+    let (store, _database, _wave, project, mut task, _pr) = registry(&fixture).await;
+    let work = store
+        .work_for_child(&ChildRef::Task(task.id.clone()))
+        .await
+        .unwrap();
+    let (_run, lease) = store.reserve_run(&work, RunTrigger::User).await.unwrap();
+    store
+        .advance_run(
+            &lease,
+            RunAdvance::RunStarting {
+                containment: Containment::Tmux {
+                    name: "shipping-proof".to_string(),
+                },
+                cwd: fixture.worktree.clone(),
+            },
+        )
+        .await
+        .unwrap();
+    store
+        .advance_run(
+            &lease,
+            RunAdvance::InvocationStarting {
+                route: InvocationRoute {
+                    provider: "codex".to_string(),
+                    model: None,
+                    account_id: None,
+                },
+                surface: "headless".to_string(),
+                resume_token: None,
+                answer_ask_id: None,
+            },
+        )
+        .await
+        .unwrap();
+
+    let flow = resume_task_phase(&task).unwrap();
+    let prepared = prepare_task_flow_step(&store, &mut task, &lease, "shipping-proof", &flow, None)
+        .await
+        .unwrap();
+    assert_eq!(prepared.turn.config.write_scope, AgentWriteScope::Worktree);
+    assert!(!prepared.turn.config.skip_permissions);
+    let codex = build_codex_command(
+        &prepared.turn.config,
+        &ProcessConfig {
+            auto: true,
+            ..Default::default()
+        },
+        None,
+    );
+    assert!(
+        codex
+            .windows(2)
+            .any(|pair| pair == ["--sandbox", "workspace-write"]),
+        "managed Codex must keep writes inside the Task worktree"
+    );
+    assert!(!codex.iter().any(|arg| arg == "--add-dir"));
+    assert!(!codex
+        .iter()
+        .any(|arg| arg == "--dangerously-bypass-approvals-and-sandbox"));
+    let claude = build_claude_session_turn_args("ship", &prepared.turn.config, None);
+    assert!(!claude.iter().any(|arg| arg == "--add-dir"));
+    assert!(!claude
+        .iter()
+        .any(|arg| arg == "--dangerously-skip-permissions"));
+    let opencode: serde_json::Value = serde_json::from_str(&opencode_worktree_config()).unwrap();
+    assert_eq!(opencode["permission"]["external_directory"], "deny");
+
+    crate::ops::task::verify_task_pr_range_with_authority(
+        &store,
+        &task,
+        Some(&lease),
+        &fixture.worktree,
+    )
+    .await
+    .unwrap();
+    let pr = store.active_task_pr(&task.id).await.unwrap().unwrap();
+    assert_eq!(pr.base_commit, fixture.upstream);
+    assert_eq!(
+        git(&fixture.worktree, &["merge-base", "origin/main", "HEAD"]),
+        fixture.upstream,
+        "origin/main advancement is the authoritative base, not contamination"
+    );
+
+    let incident = crate::ops::task::current_ci_incident(&pr).unwrap();
+    store.observe_ci_incident(&incident).await.unwrap();
+    let wake = arm_ci_fix_wake(&store, &task, &lease)
+        .await
+        .unwrap()
+        .expect("failed authoritative head wakes ci-fix");
+    assert_eq!(wake.head_sha, fixture.failed_head);
+    assert_eq!(wake.failing_checks[0].name, "task-shipping");
+
+    let project_work = store
+        .work_for_child(&ChildRef::Project(project.id.clone()))
+        .await
+        .unwrap();
+    let (_project_run, project_lease) = store
+        .reserve_run(&project_work, RunTrigger::User)
+        .await
+        .unwrap();
+    assert!(
+        !store
+            .claim_ci_incident(
+                &wake.incident_identity,
+                &project_lease.run_id,
+                OffsetDateTime::now_utc(),
+            )
+            .await
+            .unwrap(),
+        "a second live Run cannot steal the bounded repair"
+    );
+    store
+        .finish_project_run(&project, &project_lease, BoundaryState::Succeeded)
+        .await
+        .unwrap();
+
+    let repaired_head = fixture.commit_repair();
+    let mut repaired_pr = pr.clone();
+    repaired_pr
+        .publication
+        .as_mut()
+        .unwrap()
+        .github
+        .as_mut()
+        .unwrap()
+        .head_sha = Some(repaired_head.clone());
+    repaired_pr.ci_observation = Some(CiObservation {
+        head_sha: repaired_head.clone(),
+        state: CiState::Pending,
+        failing_checks: Vec::new(),
+        observed_at: OffsetDateTime::now_utc(),
+    });
+    repaired_pr.updated_at = OffsetDateTime::now_utc();
+    store
+        .update_task_pr_for_run(&repaired_pr, &lease)
+        .await
+        .unwrap();
+    settle_ci_fix_turn(
+        &store,
+        &mut task,
+        &lease,
+        &wake,
+        Some(&repaired_pr),
+        Some(&wake.head_sha),
+        Lifecycle::Completed,
+        None,
+    )
+    .await
+    .unwrap();
+    assert!(store.current_run(&work).await.unwrap().is_none());
+
+    let reports = store
+        .ci_incidents_since(
+            OffsetDateTime::now_utc() - time::Duration::hours(1),
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+    assert_eq!(reports.len(), 1);
+    assert_eq!(
+        reports[0].incident.claimed_run_id.as_ref(),
+        Some(&lease.run_id)
+    );
+    assert_eq!(
+        reports[0].incident.repaired_head_sha.as_deref(),
+        Some(repaired_head.as_str())
+    );
+
+    let now = OffsetDateTime::now_utc();
+    repaired_pr.ci_observation = Some(CiObservation {
+        head_sha: repaired_head.clone(),
+        state: CiState::Passing,
+        failing_checks: Vec::new(),
+        observed_at: now,
+    });
+    repaired_pr.publication.as_mut().unwrap().merge = Some(PrMergeRequest {
+        mode: PrMergeMode::Auto,
+        requested_at: now,
+        head_sha: repaired_head.clone(),
+        after_merge: AfterMerge::CompleteTask,
+        next_slug: None,
+    });
+    repaired_pr.updated_at = now;
+    store.update_task_pr(&repaired_pr).await.unwrap();
+    store
+        .mark_ci_incidents_green(&repaired_pr.id, now)
+        .await
+        .unwrap();
+
+    let mut merged_pr = repaired_pr;
+    merged_pr.merge_commit = Some(repaired_head);
+    merged_pr.ci_observation = None;
+    merged_pr.updated_at = now;
+    store
+        .mark_ci_incidents_merged(&merged_pr.id, now)
+        .await
+        .unwrap();
+    task.enter_loop().unwrap();
+    task.enter_finally(TaskGateProposal {
+        done: true,
+        reason: "pull request #55 merged and completed the Task".to_string(),
+    })
+    .unwrap();
+    store
+        .complete_task_after_pr(&task, &merged_pr)
+        .await
+        .unwrap();
+
+    assert_eq!(store.work_status(&work).await.unwrap(), WorkStatus::Done);
+    assert!(store.current_run(&work).await.unwrap().is_none());
+    let reports = store
+        .ci_incidents_since(
+            OffsetDateTime::now_utc() - time::Duration::hours(1),
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+    assert!(reports[0].incident.green_at.is_some());
+    assert!(reports[0].incident.merged_at.is_some());
+    let events = store.recent_task_events(&task.id, 20).await.unwrap();
+    assert_eq!(
+        events
+            .iter()
+            .filter(|event| matches!(event.kind, TaskEventKind::Completed { .. }))
+            .count(),
+        1
+    );
+}

--- a/rust/loopflow/tests/pr_tests.rs
+++ b/rust/loopflow/tests/pr_tests.rs
@@ -276,6 +276,82 @@ fn publish_makes_no_presentation_attempt() {
 }
 
 #[test]
+fn task_gate_artifacts_never_reach_the_published_head() {
+    let gh_script = write_gh_script("[]", None);
+    let marker_dir = tempfile::TempDir::new().expect("marker dir");
+    let agent_marker = marker_dir.path().join("agent-called");
+    let codex = format!(
+        "#!/bin/sh\nprintf called > '{}'\nexit 1\n",
+        agent_marker.display()
+    );
+    let home = tempfile::TempDir::new().expect("temp home");
+    let _env = EnvGuard::with_home(
+        &[("gh", gh_script.as_str()), ("codex", codex.as_str())],
+        Some(home.path()),
+    );
+    let repo = TestRepo::new();
+    create_changed_branch(&repo, "feature");
+    push_branch(&repo, "feature");
+    let implementation_head = repo.head_sha();
+
+    let scratch = repo.path().join("scratch");
+    fs::create_dir_all(&scratch).expect("create scratch");
+    fs::write(scratch.join(".pr-copy-ref"), &implementation_head).expect("write copy ref");
+    fs::write(scratch.join("pr-title.txt"), "cached gate title").expect("write title");
+    fs::write(scratch.join("pr-body.md"), "cached gate body").expect("write body");
+    fs::write(scratch.join("feature-review.md"), "temporary review").expect("write review");
+
+    create_or_update_pr(
+        repo.path(),
+        &PrOptions {
+            title: None,
+            body: None,
+            agent: Some("codex".to_string()),
+        },
+        &NullProgress,
+    )
+    .expect("publish cached gate output");
+
+    assert_eq!(
+        repo.head_sha(),
+        implementation_head,
+        "gate handoff must not manufacture an artifact-only prepare commit"
+    );
+    let remote_head = Command::new("git")
+        .arg("--git-dir")
+        .arg(repo.bare_path())
+        .args(["rev-parse", "refs/heads/feature"])
+        .output()
+        .map(|output| String::from_utf8_lossy(&output.stdout).trim().to_string())
+        .expect("read remote feature");
+    assert_eq!(remote_head, implementation_head);
+    for artifact in [
+        ".pr-copy-ref",
+        "pr-title.txt",
+        "pr-body.md",
+        "feature-review.md",
+    ] {
+        assert!(
+            !scratch.join(artifact).exists(),
+            "task-gate artifact survived publication: {artifact}"
+        );
+    }
+    assert!(
+        !agent_marker.exists(),
+        "valid task-gate copy must be consumed without launching another provider"
+    );
+    let status = Command::new("git")
+        .args(["status", "--porcelain"])
+        .current_dir(repo.path())
+        .output()
+        .expect("read worktree status");
+    assert!(
+        status.stdout.is_empty(),
+        "publication must leave a clean tree"
+    );
+}
+
+#[test]
 fn publication_refuses_if_copy_generation_changes_the_pushed_head() {
     let gh_script = write_gh_script("[]", None);
     let _env = EnvGuard::new(&[


### PR DESCRIPTION
## Usage

```bash
lf task run INF-123

cargo test -p loopflow task_ships_on_one_authority_chain_without_manual_repair
cargo test -p loopflow task_gate_artifacts_never_reach_the_published_head
```

## Summary

Closes the remaining manual-repair seams in durable Task delivery. Provider turns now stay inside their assigned worktree, OpenCode orphan cleanup is coordinated safely, and PR publication consumes gate output before committing or pushing so temporary review artifacts never become the published head.

## Changes

- Enforced worktree-scoped permissions for durable Codex, Claude, and OpenCode turns, regardless of configured yolo settings
- Serialized OpenCode registry access and added `lfd` maintenance for registry-proven orphan process groups
- Reused validated gate PR copy while removing only gate-owned copy and review files before publication
- Added lifecycle coverage for authoritative range validation, exclusive exact-head CI repair, publication, merge settlement, and terminal Task completion