### PR TITLE
Release: bind publisher to explicit release authority

### DIFF
--- a/.lf/config.yaml
+++ b/.lf/config.yaml
@@ -19,6 +19,10 @@ release:
       publisher:
       - doppler
       - run
+      - --project
+      - loopflow
+      - --config
+      - prd
       - --
       - uv
       - run

--- a/python/tests/test_release_automation.py
+++ b/python/tests/test_release_automation.py
@@ -45,9 +45,7 @@ def test_nightly_packages_workflow_builds_and_smokes_without_deploying():
     assert not any(term in commands for term in forbidden)
 
     acceptance = workflow["jobs"]["release-acceptance"]
-    acceptance_commands = "\n".join(
-        step.get("run", "") for step in acceptance["steps"]
-    )
+    acceptance_commands = "\n".join(step.get("run", "") for step in acceptance["steps"])
     assert "release_acceptance_recovers_from_a_revoked_selected_account" in acceptance_commands
 
 
@@ -189,9 +187,7 @@ def test_release_build_workflow_is_credential_free():
         Loader=yaml.BaseLoader,
     )
 
-    assert release["jobs"] == {
-        "packages": {"uses": "./.github/workflows/nightly-packages.yml"}
-    }
+    assert release["jobs"] == {"packages": {"uses": "./.github/workflows/nightly-packages.yml"}}
     assert "schedule" not in release["on"]
 
     workflow_text = (ROOT / ".github/workflows/release.yml").read_text()
@@ -239,6 +235,10 @@ def test_infrastructure_cron_runs_the_host_release_after_telemetry():
     assert config["release"]["targets"]["default"]["publisher"] == [
         "doppler",
         "run",
+        "--project",
+        "loopflow",
+        "--config",
+        "prd",
         "--",
         "uv",
         "run",
@@ -282,9 +282,7 @@ def test_loopflow_ui_gate_keeps_mac_test_runners_signed():
 
 
 def test_rust_ci_materializes_drafts_before_running_tests():
-    ci = yaml.load(
-        (ROOT / ".github/workflows/ci.yml").read_text(), Loader=yaml.BaseLoader
-    )
+    ci = yaml.load((ROOT / ".github/workflows/ci.yml").read_text(), Loader=yaml.BaseLoader)
     steps = ci["jobs"]["rust-test"]["steps"]
     names = [step.get("name") for step in steps]
 


### PR DESCRIPTION
## Verification

Run the focused publisher-contract proof:

    uv run pytest python/tests/test_release_automation.py

The read-only publisher preflight checks that the release host has the required signing, repository, deployment, and artifact authority. It does not publish a release.

## Intent

A scheduled release inherited an authority scope that could not satisfy the publisher contract and stopped before mutation. This change made release authority explicit at the release target so preflight remained fail-closed.

## Public/private boundary

The repository owns the logical publisher contract, preflight, and failure behavior. Maintainer-specific provider selectors, account topology, Home identifiers, and credential placement are private runtime configuration. A follow-up removes the original provider-specific binding from tracked source while preserving the explicit authority contract.

## Key decisions

- Scope release authority to the release target rather than changing daemon-wide authority.
- Preserve the generic publisher command model: Loopflow runs the read-only check before mutation and invokes publish only at the established release stage.
- Keep actual provider bindings and credential values outside the public repository.

## Not included

- No release or deployment was run by this PR.
- No credential value was committed.
- No Git history rewrite or credential rotation is required without evidence of an exposed credential.