### PR TITLE
task: fence child work behind current project direction

### DIFF
--- a/docs/agent-api.md
+++ b/docs/agent-api.md
@@ -95,8 +95,15 @@ later successful boundary's Basis is the proof that the direction was applied.
 
 Work survives its provider process. `lf task resume INF-123 --model codex`
 selects another provider without losing durable direction, the worktree, or
-the PR chain; `lf task recover` restarts abandoned Task pursuit on the same
-worktree.
+the PR chain. `lf task run` never reopens terminal Work: a person can use
+`lf task recover` to restart an abandoned Task on the same worktree, while a
+completed Task requires a new Linear task.
+
+Automated Task commit, PR, and completion commands also re-check current PM
+ownership. If Linear moved the issue to another Project, the historical Task
+Run fails closed before a commit, push, publication, merge request, rotation,
+or completion; a person retains explicit authority to inspect and remediate the
+preserved Work.
 
 `lf project` carries the same control verbs one level up: `steer`, `interrupt`,
 `wait`, `resume`, and `attach`.

--- a/rust/loopflow/src/lf/mod.rs
+++ b/rust/loopflow/src/lf/mod.rs
@@ -1027,7 +1027,7 @@ pub enum TaskCommand {
         #[arg(long)]
         json: bool,
     },
-    /// Recover an abandoned Task as a linked successor on the same worktree
+    /// Explicitly recover an abandoned Task on the same worktree (User only)
     Recover {
         issue: String,
         #[arg(long)]

--- a/rust/loopflow/src/ops/flow.rs
+++ b/rust/loopflow/src/ops/flow.rs
@@ -56,6 +56,7 @@ pub fn execute_flow_ops(repo: &Path, item: &Op, progress: &impl Progress) -> Ops
             push,
             no_add,
         }) => {
+            crate::ops::task::guard_task_mutation_authority(repo)?;
             commit_workflow(
                 repo,
                 &CommitOptions {

--- a/rust/loopflow/src/ops/task.rs
+++ b/rust/loopflow/src/ops/task.rs
@@ -19,7 +19,7 @@ use crate::engine::git::{
 use crate::engine::naming::sanitize_for_branch;
 use crate::engine::process::{tmux_session_exists, tmux_session_slug};
 use crate::engine::worktrees::{
-    create_from_placement_plan, plan_placement, PlacementStrategy, WorktreeSegment,
+    create_from_placement_plan, main_repo_root, plan_placement, PlacementStrategy, WorktreeSegment,
 };
 use crate::engine::{expand_flow, load_flow, ConcreteStep};
 use crate::ops::error::{OpsError, OpsResult};
@@ -32,8 +32,7 @@ use crate::task::actions::{derive_task_actions, TaskActionEvidence, TaskActionMo
 use crate::task::{
     AfterMerge, CiCheck, CiIncident, CiObservation, CiState, GithubObservation,
     GithubObservationResult, GithubPr, Observation, PmWritebackOperation, PmWritebackState,
-    PrMergeMode, PrMergeRequest, PrPhase, PrPublication, Task, TaskEventKind, TaskId, TaskPr,
-    TaskPrId,
+    PrMergeMode, PrMergeRequest, PrPhase, PrPublication, Task, TaskEventKind, TaskPr, TaskPrId,
 };
 use crate::wave::Wave;
 use fs2::FileExt;
@@ -347,7 +346,7 @@ pub fn task_run(repo: &Path, issue: &str, options: TaskLaunchOptions) -> OpsResu
             }
         })
         .transpose()?;
-    let (existing, terminal_predecessor_id) = block_on_task(async {
+    let existing = block_on_task(async {
         let store = task_store().await?;
         let mut existing = store
             .get_task_by_issue(issue)
@@ -355,14 +354,20 @@ pub fn task_run(repo: &Path, issue: &str, options: TaskLaunchOptions) -> OpsResu
             .map_err(|error| task_error(format!("failed to read task registry: {error}")))?;
         if let Some(task) = &mut existing {
             let status = task_work_status(&store, task).await?;
-            if matches!(status, WorkStatus::Done | WorkStatus::Abandoned) {
-                // A terminal Task leaves its direction to a successor
-                // created below; do not return its status here. The placement
-                // path re-resolves the issue, derives a distinct worktree slug
-                // from this predecessor's id, and carries the cursor and comment
-                // ledger onto the reopened Task Work.
-                let predecessor_id = task.id.clone();
-                return Ok((None, Some(predecessor_id)));
+            match status {
+                WorkStatus::Done => {
+                    return Err(task_error(format!(
+                        "Task {} is completed; start a new Linear task",
+                        task.plan.identifier
+                    )))
+                }
+                WorkStatus::Abandoned => {
+                    return Err(task_error(format!(
+                    "Task {} is abandoned; explicit User recovery requires `lf task recover {}`",
+                    task.plan.identifier, task.plan.identifier
+                )))
+                }
+                WorkStatus::Ready | WorkStatus::Running { .. } | WorkStatus::Waiting { .. } => {}
             }
             if let Some(requested) = name.as_deref() {
                 let requested = parse_workspace_slug(requested)?;
@@ -432,7 +437,7 @@ pub fn task_run(repo: &Path, issue: &str, options: TaskLaunchOptions) -> OpsResu
                 )));
             }
         }
-        Ok((existing, None))
+        Ok(existing)
     })?;
     if let Some(existing) = existing {
         return task_status(existing.plan.id.as_str());
@@ -449,13 +454,7 @@ pub fn task_run(repo: &Path, issue: &str, options: TaskLaunchOptions) -> OpsResu
     let lifecycle = resolve_task_lifecycle(&main_repo, &project_flows, &flows)?;
     let segment = match name.as_deref() {
         Some(name) => parse_workspace_slug(name)?,
-        None => match &terminal_predecessor_id {
-            // A terminal predecessor may still occupy its worktree and branch on
-            // disk (e.g. after `lf task complete`), so the successor places a
-            // fresh worktree under a slug derived from the predecessor's id.
-            Some(predecessor_id) => succession_workspace_slug(&resolved.item.name, predecessor_id)?,
-            None => derive_workspace_slug(&resolved.item.name)?,
-        },
+        None => derive_workspace_slug(&resolved.item.name)?,
     };
     let workspace_slug = segment.as_str().to_string();
     let mut plan = plan_placement(&main_repo, segment)
@@ -549,42 +548,34 @@ pub fn task_run(repo: &Path, issue: &str, options: TaskLaunchOptions) -> OpsResu
     block_on_task(async move {
         let store = task_store().await?;
         // Re-resolve after worktree planning: a concurrent run may have created
-        // the Task in the gap. Non-terminal Work wins — return it. A
-        // terminal one is the predecessor whose direction the successor carries;
-        // None means this is the first Task for the issue.
-        let predecessor = match store
+        // the Task in the gap. Non-terminal Work wins. Terminal Work remains
+        // authoritative and requires an explicit recovery transition.
+        if let Some(existing) = store
             .get_task_by_issue(&resolved.item.id)
             .await
             .map_err(|error| task_error(format!("failed to read task registry: {error}")))?
         {
-            Some(existing)
-                if !matches!(
-                    task_work_status(&store, &existing).await?,
-                    WorkStatus::Done | WorkStatus::Abandoned
-                ) =>
-            {
-                return Ok(existing)
+            match task_work_status(&store, &existing).await? {
+                WorkStatus::Done => {
+                    return Err(task_error(format!(
+                        "Task {} is completed; start a new Linear task",
+                        existing.plan.identifier
+                    )))
+                }
+                WorkStatus::Abandoned => {
+                    return Err(task_error(format!(
+                    "Task {} is abandoned; explicit User recovery requires `lf task recover {}`",
+                    existing.plan.identifier, existing.plan.identifier
+                )))
+                }
+                WorkStatus::Ready | WorkStatus::Running { .. } | WorkStatus::Waiting { .. } => {
+                    return Ok(existing)
+                }
             }
-            Some(terminal) => Some(terminal),
-            None => None,
-        };
+        }
         let now = time::OffsetDateTime::now_utc();
-        let task_id = predecessor
-            .as_ref()
-            .map(|task| task.id.clone())
-            .unwrap_or_else(crate::task::TaskId::new);
-        let sequence = if let Some(predecessor) = &predecessor {
-            store
-                .task_prs(&predecessor.id)
-                .await
-                .map_err(|error| task_error(format!("failed to read Task PR history: {error}")))?
-                .last()
-                .map_or(1, |pr| pr.sequence + 1)
-        } else {
-            1
-        };
         let mut task = Task {
-            id: task_id,
+            id: crate::task::TaskId::new(),
             plan: TaskPlan {
                 id: LinearIssueId::new(resolved.item.id.clone())
                     .map_err(|error| task_error(error.to_string()))?,
@@ -609,14 +600,14 @@ pub fn task_run(repo: &Path, issue: &str, options: TaskLaunchOptions) -> OpsResu
             provider,
             provider_session_id: None,
             abandon_intent: None,
-            created_at: predecessor.as_ref().map_or(now, |task| task.created_at),
+            created_at: now,
             updated_at: now,
             observation: crate::task::Observation::NotRequired,
         };
         let pr = TaskPr {
             id: TaskPrId::new(),
             task_id: task.id.clone(),
-            sequence,
+            sequence: 1,
             slug: workspace_slug,
             branch: plan.branch.clone(),
             base_commit,
@@ -633,41 +624,46 @@ pub fn task_run(repo: &Path, issue: &str, options: TaskLaunchOptions) -> OpsResu
             updated_at: now,
         };
 
-        if predecessor.is_some() {
-            store
-                .reopen_task(&task, Some(&pr), crate::durable::Author::User, &directive)
-                .await
-                .map_err(|error| task_error(format!("failed to reopen Task: {error}")))?;
-        } else {
-            match store
-                .create_task_with_steer(&task, &pr, crate::durable::Author::User, &directive)
-                .await
-            {
-                Ok(()) => {}
-                Err(StoreError::Sqlite(_)) => {
-                    if let Some(existing) = store
+        let caller = crate::ops::ambient_run_lease(&store).await?;
+        let reservation = match caller.as_ref() {
+            Some(caller) => {
+                store
+                    .create_task_run(&ControlCtx::Run(caller), &task, &pr, &directive)
+                    .await
+            }
+            None => {
+                let request = AuthenticatedRequest::cli();
+                store
+                    .create_task_run(&ControlCtx::User(&request), &task, &pr, &directive)
+                    .await
+            }
+        };
+        let (run, lease) = match reservation {
+            Ok(reservation) => reservation,
+            Err(StoreError::Sqlite(_)) => {
+                if let Some(existing) =
+                    store
                         .get_task_by_issue(&resolved.item.id)
                         .await
                         .map_err(|error| {
                             task_error(format!("failed to recover task reservation: {error}"))
                         })?
-                    {
-                        if !matches!(
-                            task_work_status(&store, &existing).await?,
-                            WorkStatus::Done | WorkStatus::Abandoned
-                        ) {
-                            return Ok(existing);
-                        }
+                {
+                    if !matches!(
+                        task_work_status(&store, &existing).await?,
+                        WorkStatus::Done | WorkStatus::Abandoned
+                    ) {
+                        return Ok(existing);
                     }
-                    return Err(task_error(
-                        "task reservation collided with another task placement",
-                    ));
                 }
-                Err(error) => return Err(task_error(format!("failed to reserve task: {error}"))),
+                return Err(task_error(
+                    "task reservation collided with another task placement",
+                ));
             }
-        }
+            Err(error) => return Err(task_error(format!("failed to reserve task: {error}"))),
+        };
 
-        store
+        if let Err(error) = store
             .append_task_event(
                 &task.id,
                 &TaskEventKind::PrStarted {
@@ -678,22 +674,33 @@ pub fn task_run(repo: &Path, issue: &str, options: TaskLaunchOptions) -> OpsResu
                 },
             )
             .await
-            .map_err(|error| task_error(error.to_string()))?;
+        {
+            store
+                .fail_task_run(&task.id, &lease, &error.to_string())
+                .await
+                .map_err(|settle_error| {
+                    task_error(format!(
+                        "failed to record initial Task PR ({error}); failed to settle reserved Run: {settle_error}"
+                    ))
+                })?;
+            return Err(task_error(error.to_string()));
+        }
 
         if let Err(error) = create_from_placement_plan(&main_repo, &plan) {
-            record_task_failure(
-                &store,
-                &mut task,
-                format!("worktree creation failed: {error}"),
-                error.to_string(),
-            )
-            .await?;
+            store
+                .fail_task_run(&task.id, &lease, &error.to_string())
+                .await
+                .map_err(|settle_error| {
+                    task_error(format!(
+                        "worktree creation failed ({error}); failed to settle reserved Run: {settle_error}"
+                    ))
+                })?;
             return Err(task_error(format!(
                 "failed to create task worktree: {error}"
             )));
         }
 
-        launch_task_process(&store, &mut task, None).await?;
+        launch_reserved_task_process(&store, &mut task, &run, &lease).await?;
         wait_until_running(&store, &task.id).await
     })
 }
@@ -935,19 +942,6 @@ fn derive_workspace_slug_with_cap(title: &str, max_words: usize) -> OpsResult<Wo
     parse_workspace_slug(&words.join("-"))
 }
 
-/// A successor's worktree and branch must differ from its terminal
-/// predecessor's, which may still occupy its checkout and branch on disk (for
-/// example after `lf task complete`). Append a short, per-predecessor suffix
-/// derived from the predecessor's id so the successor places a fresh worktree
-/// without colliding. The base is capped at four words so the suffix word keeps
-/// the segment within the 2-5 word limit.
-fn succession_workspace_slug(title: &str, predecessor_id: &TaskId) -> OpsResult<WorktreeSegment> {
-    let base = derive_workspace_slug_with_cap(title, 4)?;
-    let id = predecessor_id.as_str();
-    let tail = &id[id.len().saturating_sub(8)..];
-    parse_workspace_slug(&format!("{}-s{}", base.as_str(), tail))
-}
-
 fn parse_pr_slug(value: &str) -> OpsResult<String> {
     let value = value.trim();
     let words = value.split('-').filter(|word| !word.is_empty()).count();
@@ -1184,13 +1178,49 @@ async fn resolve_task_authority(repo: &Path) -> OpsResult<TaskAuthority> {
         Err(err) => return Err(registry_authority_error(err)),
     };
     match task_for_worktree(&store, repo).await? {
-        Some((task, lease)) => Ok(TaskAuthority::Authority {
-            store,
-            task: Box::new(task),
-            lease,
-        }),
+        Some((task, lease)) => {
+            if let Some(lease) = lease.as_ref() {
+                validate_automated_task_authority(repo, &store, &task, lease).await?;
+            }
+            Ok(TaskAuthority::Authority {
+                store,
+                task: Box::new(task),
+                lease,
+            })
+        }
         None => Ok(TaskAuthority::NotATaskWorktree),
     }
+}
+
+pub(crate) fn guard_task_mutation_authority(repo: &Path) -> OpsResult<()> {
+    block_on_task(async move {
+        let _ = resolve_task_authority(repo).await?;
+        Ok(())
+    })
+}
+
+async fn validate_automated_task_authority(
+    repo: &Path,
+    store: &SharedStore,
+    task: &Task,
+    lease: &RunLease,
+) -> OpsResult<()> {
+    let main_repo = main_repo_root(repo)?;
+    let current = crate::ops::task_pm::resolve_task(
+        &main_repo,
+        task.plan.id.as_str(),
+        crate::ops::pm::PmRefresh::Never,
+    )
+    .map_err(|error| {
+        task_error(format!(
+            "Task {} current PM authority refused: {error}",
+            task.plan.identifier
+        ))
+    })?;
+    store
+        .validate_task_run_route(task, lease, &current.project.id)
+        .await
+        .map_err(|error| task_error(format!("Task body lost Project authority: {error}")))
 }
 
 pub(crate) fn request_task_pr_publication(repo: &Path) -> OpsResult<bool> {
@@ -2040,10 +2070,7 @@ pub(crate) fn abandon_task_pr(
             return Err(task_error("uncommitted changes; use --force"));
         }
         if let Some(lease) = lease.as_ref() {
-            store
-                .validate_run_lease(lease)
-                .await
-                .map_err(|error| task_error(format!("Task body lost write authority: {error}")))?;
+            validate_automated_task_authority(&task.worktree, &store, &task, lease).await?;
         }
         if dirty {
             progress.status("Discarding uncommitted Task PR changes...");
@@ -2352,23 +2379,42 @@ async fn launch_task_process(
                 .current_basis,
         },
     };
-    let (run, lease) = store
-        .reserve_run(&work, trigger)
-        .await
-        .map_err(|error| task_error(format!("failed to reserve Task Run: {error}")))?;
+    let caller = crate::ops::ambient_run_lease(store).await?;
+    let reservation = match caller.as_ref() {
+        Some(caller) => store.reserve_child_run(caller, &work, trigger).await,
+        None => store.reserve_run(&work, trigger).await,
+    };
+    let (run, lease) =
+        reservation.map_err(|error| task_error(format!("failed to reserve Task Run: {error}")))?;
+    launch_reserved_task_process(store, task, &run, &lease).await
+}
+
+async fn launch_reserved_task_process(
+    store: &SharedStore,
+    task: &mut Task,
+    run: &Run,
+    lease: &RunLease,
+) -> OpsResult<()> {
     let tmux_name = format!(
         "lf-task-{}-{}-{}",
         tmux_session_slug(&task.plan.identifier),
         &task.id.as_str()[3..11],
         &run.id.as_str()[4..12]
     );
-    store
-        .update_task_for_run(task, &lease)
-        .await
-        .map_err(|error| task_error(error.to_string()))?;
+    if let Err(error) = store.update_task_for_run(task, lease).await {
+        store
+            .fail_task_run(&task.id, lease, &error.to_string())
+            .await
+            .map_err(|settle_error| {
+                task_error(format!(
+                    "failed to prepare reserved Task Run ({error}); failed to settle it: {settle_error}"
+                ))
+            })?;
+        return Err(task_error(error.to_string()));
+    }
     crate::ops::launch_in_run(
         store,
-        &lease,
+        lease,
         crate::ops::RunLaunch {
             work: WorkRef::Task(task.id.clone()),
             wave_id: task.wave_id.clone(),
@@ -2900,6 +2946,9 @@ async fn reconcile_task_pr_with_authority(
     lease: Option<&RunLease>,
     freshness: crate::ops::pr::PrReadFreshness,
 ) -> OpsResult<Option<TaskPr>> {
+    if let Some(lease) = lease {
+        validate_automated_task_authority(&task.worktree, store, task, lease).await?;
+    }
     // Reconciliation updates the same projection as publication/finalization.
     // Refuse overlap so a remote read begun before a push cannot overwrite the
     // request or head recorded by the command that completed after it.
@@ -3597,10 +3646,7 @@ async fn ensure_working_pr_with_authority(
         return Ok(None);
     }
     if let Some(lease) = lease {
-        store
-            .validate_run_lease(lease)
-            .await
-            .map_err(|error| task_error(format!("Task body lost write authority: {error}")))?;
+        validate_automated_task_authority(&task.worktree, store, task, lease).await?;
     }
     let sequence = settled.sequence + 1;
     let slug = next_pr_slug(&settled, rotate.slug_override.as_deref());
@@ -3878,14 +3924,14 @@ pub fn task_complete(issue: &str, summary: String) -> OpsResult<Task> {
             .await
             .map_err(|error| task_error(format!("failed to read Task: {error}")))?
             .ok_or_else(|| task_error(format!("no Task exists for {issue:?}")))?;
-        reconcile_task_pr(&store, &mut task).await?;
         let lease = ambient_task_run_lease(&store, &task).await?;
-        if let Some(lease) = lease.as_ref() {
-            store
-                .validate_run_lease(lease)
-                .await
-                .map_err(|error| task_error(format!("Task body lost write authority: {error}")))?;
-        }
+        reconcile_task_pr_with_authority(
+            &store,
+            &mut task,
+            lease.as_ref(),
+            crate::ops::pr::PrReadFreshness::Cached,
+        )
+        .await?;
         let work = store
             .work_for_child(&ChildRef::Task(task.id.clone()))
             .await
@@ -4260,6 +4306,9 @@ async fn advance_completion_after_gate(
     task: &mut Task,
     lease: Option<&RunLease>,
 ) -> OpsResult<bool> {
+    if let Some(lease) = lease {
+        validate_automated_task_authority(&task.worktree, store, task, lease).await?;
+    }
     let work = store
         .work_for_child(&ChildRef::Task(task.id.clone()))
         .await
@@ -4771,6 +4820,7 @@ async fn _recover_abandoned_task(
     issue: &str,
     reason: Option<String>,
 ) -> OpsResult<Task> {
+    let caller = crate::ops::ambient_run_lease(store).await?;
     let reason = reason
         .map(|value| value.trim().to_string())
         .map(|value| {
@@ -4827,10 +4877,20 @@ async fn _recover_abandoned_task(
     task.abandon_intent = None;
     task.updated_at = now;
     task.observation = Observation::NotRequired;
-    store
-        .reopen_task(&task, None, crate::durable::Author::User, &carried)
-        .await
-        .map_err(|error| task_error(format!("failed to recover Task: {error}")))?;
+    match caller.as_ref() {
+        Some(caller) => {
+            store
+                .reopen_task(&ControlCtx::Run(caller), &task, None, &carried)
+                .await
+        }
+        None => {
+            let request = AuthenticatedRequest::cli();
+            store
+                .reopen_task(&ControlCtx::User(&request), &task, None, &carried)
+                .await
+        }
+    }
+    .map_err(|error| task_error(format!("failed to recover Task: {error}")))?;
     Ok(task)
 }
 
@@ -5213,7 +5273,16 @@ mod tests {
     #[tokio::test]
     async fn repaired_persisted_task_flows_launch_through_the_generic_path() {
         let _env_lock = crate::journal::test_env_lock();
-        let _restore = EnvRestore::capture(&["LF_BIN", "LF_HOME", "LF_DB_PATH", "PATH"]);
+        let _restore = EnvRestore::capture(&[
+            "LF_BIN",
+            "LF_HOME",
+            "LF_DB_PATH",
+            "LF_RUN_CONTEXT",
+            "LF_RUN_ID",
+            "LF_RUN_LEASE",
+            "LF_AGENT_INVOCATION_ID",
+            "PATH",
+        ]);
         let environment = tempfile::tempdir().unwrap();
         let bin = environment.path().join("bin");
         std::fs::create_dir(&bin).unwrap();
@@ -5223,6 +5292,10 @@ mod tests {
         std::env::set_var("LF_BIN", std::env::current_exe().unwrap());
         std::env::set_var("LF_HOME", environment.path());
         std::env::remove_var("LF_DB_PATH");
+        std::env::remove_var("LF_RUN_CONTEXT");
+        std::env::remove_var("LF_RUN_ID");
+        std::env::remove_var("LF_RUN_LEASE");
+        std::env::remove_var("LF_AGENT_INVOCATION_ID");
         std::env::set_var("PATH", &bin);
 
         for identifier in ["LOO-167", "LOO-193", "LOO-195"] {

--- a/rust/loopflow/src/store/children.rs
+++ b/rust/loopflow/src/store/children.rs
@@ -1,7 +1,7 @@
 //! Durable Project and Task compatibility rows and their observation outbox.
 
 use crate::child::{ChildBodyHandoffRequest, ObservationRecipient};
-use crate::durable::{Author, Basis, RunLease};
+use crate::durable::{Author, Basis, Run, RunLease};
 use crate::id::WaveId;
 use crate::project::{ObservationOutboxRow, Project, ProjectEvent, ProjectEventKind, ProjectId};
 use crate::task::{
@@ -10,7 +10,7 @@ use crate::task::{
 };
 use time::OffsetDateTime;
 
-use super::{run_sqlite, Store, StoreResult};
+use super::{run_sqlite, Store, StoreError, StoreResult};
 
 #[cfg(test)]
 #[derive(Debug, Clone)]
@@ -35,34 +35,49 @@ impl Store {
         run_sqlite(&self.sqlite, move |store| store.insert_task(&task, &pr)).await
     }
 
-    pub async fn create_task_with_steer(
+    pub async fn create_task_run(
         &self,
+        context: &crate::durable::ControlCtx<'_>,
         task: &Task,
         pr: &TaskPr,
-        author: Author,
         text: &str,
-    ) -> StoreResult<()> {
+    ) -> StoreResult<(Run, RunLease)> {
+        let _promotion_lock = crate::promotion_lock::acquire_shared()
+            .await
+            .map_err(|error| {
+                StoreError::InvalidData(format!(
+                    "acquire shared promotion lock before Task Run reservation: {error}"
+                ))
+            })?;
+        let caller = match context {
+            crate::durable::ControlCtx::User(_) => None,
+            crate::durable::ControlCtx::Run(lease) => Some((*lease).clone()),
+        };
         let task = task.clone();
         let pr = pr.clone();
         let text = text.to_string();
         run_sqlite(&self.sqlite, move |store| {
-            store.insert_task_with_steer(&task, &pr, &author, &text)
+            store.insert_task_run(&task, &pr, caller.as_ref(), &text)
         })
         .await
     }
 
     pub async fn reopen_task(
         &self,
+        context: &crate::durable::ControlCtx<'_>,
         task: &Task,
         pr: Option<&TaskPr>,
-        author: Author,
         text: &str,
     ) -> StoreResult<()> {
+        let caller = match context {
+            crate::durable::ControlCtx::User(_) => None,
+            crate::durable::ControlCtx::Run(lease) => Some((*lease).clone()),
+        };
         let task = task.clone();
         let pr = pr.cloned();
         let text = text.to_string();
         run_sqlite(&self.sqlite, move |store| {
-            store.reopen_task(&task, pr.as_ref(), &author, &text)
+            store.reopen_task(&task, pr.as_ref(), caller.as_ref(), &text)
         })
         .await
     }
@@ -70,6 +85,21 @@ impl Store {
     pub async fn update_task(&self, task: &Task) -> StoreResult<()> {
         let task = task.clone();
         run_sqlite(&self.sqlite, move |store| store.update_task(&task)).await
+    }
+
+    pub(crate) async fn validate_task_run_route(
+        &self,
+        task: &Task,
+        lease: &RunLease,
+        current_external_project_id: &str,
+    ) -> StoreResult<()> {
+        let task = task.clone();
+        let lease = lease.clone();
+        let current_external_project_id = current_external_project_id.to_string();
+        run_sqlite(&self.sqlite, move |store| {
+            store.validate_task_run_route(&task, &lease, &current_external_project_id)
+        })
+        .await
     }
 
     pub async fn rebind_task_issue_identifier(

--- a/rust/loopflow/src/store/durable.rs
+++ b/rust/loopflow/src/store/durable.rs
@@ -115,6 +115,28 @@ impl Store {
         .await
     }
 
+    /// Reserve an immediate child only if the caller's selected Turn Basis is current.
+    pub(crate) async fn reserve_child_run(
+        &self,
+        caller: &RunLease,
+        work: &WorkRef,
+        trigger: RunTrigger,
+    ) -> StoreResult<(Run, RunLease)> {
+        let _promotion_lock = crate::promotion_lock::acquire_shared()
+            .await
+            .map_err(|error| {
+                StoreError::InvalidData(format!(
+                    "acquire shared promotion lock before child Run reservation: {error}"
+                ))
+            })?;
+        let caller = caller.clone();
+        let work = work.clone();
+        run_sqlite(&self.sqlite, move |store| {
+            store.reserve_child_run(&caller, &work, &trigger)
+        })
+        .await
+    }
+
     pub(crate) async fn reserve_recovery_run(
         &self,
         lease: &RunLease,

--- a/rust/loopflow/src/store/mod.rs
+++ b/rust/loopflow/src/store/mod.rs
@@ -1005,13 +1005,18 @@ mod tests {
     };
     use crate::build_info::{BuildProvenance, MigrationAuthority};
     use crate::child::ChildRef;
-    use crate::durable::{Author, ContainmentObservation, ControlCtx, StopCause, WorkStatus};
+    use crate::durable::{
+        AgentInvocation, AuthenticatedRequest, Author, Basis, BoundaryState, Containment,
+        ContainmentObservation, ControlCtx, EpochState, InvocationRoute, RunAdvance, RunLease,
+        RunTrigger, StopCause, Turn, WorkRef, WorkStatus,
+    };
     use crate::id::WaveId;
     use crate::planning::{LinearIssueId, LinearProjectId, ProjectPlan, TaskPlan};
     use crate::profile::EmailAddress;
     use crate::project::{Project, ProjectId};
     use crate::task::{
-        GithubPr, PmWritebackState, PrPhase, PrPublication, Task, TaskId, TaskPr, TaskPrId,
+        GithubPr, PmWritebackState, PrPhase, PrPublication, Task, TaskEventKind, TaskId, TaskPr,
+        TaskPrId,
     };
     use crate::wave::Wave;
     use std::env;
@@ -1259,6 +1264,67 @@ mod tests {
         }
     }
 
+    async fn start_project_turn(
+        store: &super::Store,
+        work: &WorkRef,
+        basis: Basis,
+        containment: &str,
+    ) -> (RunLease, AgentInvocation, Turn) {
+        let (_run, lease) = store
+            .reserve_run(
+                work,
+                RunTrigger::Input {
+                    basis: basis.clone(),
+                },
+            )
+            .await
+            .unwrap();
+        store
+            .advance_run(
+                &lease,
+                RunAdvance::RunStarting {
+                    containment: Containment::Tmux {
+                        name: containment.to_string(),
+                    },
+                    cwd: PathBuf::from("/repo"),
+                },
+            )
+            .await
+            .unwrap();
+        let crate::durable::AdvanceReceipt::Invocation(invocation) = store
+            .advance_run(
+                &lease,
+                RunAdvance::InvocationStarting {
+                    route: InvocationRoute {
+                        provider: "codex".to_string(),
+                        model: None,
+                        account_id: None,
+                    },
+                    surface: "headless".to_string(),
+                    resume_token: None,
+                    answer_ask_id: None,
+                },
+            )
+            .await
+            .unwrap()
+        else {
+            panic!("expected Invocation receipt")
+        };
+        let crate::durable::AdvanceReceipt::Turn(turn) = store
+            .advance_run(
+                &lease,
+                RunAdvance::TurnStarting {
+                    invocation_id: invocation.id.clone(),
+                },
+            )
+            .await
+            .unwrap()
+        else {
+            panic!("expected Turn receipt")
+        };
+        (lease, invocation, turn)
+    }
+
     #[tokio::test]
     async fn task_run_reservation_refuses_remote_placement() {
         let directory = tempfile::tempdir().unwrap();
@@ -1381,6 +1447,31 @@ mod tests {
             .await
             .unwrap();
 
+        let error = store
+            .steer(
+                &ControlCtx::Run(&parent_lease),
+                &task_work,
+                "unproven parent Turn",
+                None,
+            )
+            .await
+            .expect_err("child control requires a durable parent Turn Basis");
+        assert!(matches!(error, super::StoreError::InvalidAuthority(_)));
+        let invocation = store
+            .open_invocation_for_run(&parent_lease.run_id)
+            .await
+            .unwrap()
+            .unwrap();
+        store
+            .advance_run(
+                &parent_lease,
+                RunAdvance::TurnStarting {
+                    invocation_id: invocation.id,
+                },
+            )
+            .await
+            .unwrap();
+
         let receipt = store
             .steer(
                 &ControlCtx::Run(&parent_lease),
@@ -1418,6 +1509,628 @@ mod tests {
             Err(super::StoreError::InvalidAuthority(_))
         ));
         assert!(crate::durable::RunLeaseToken::parse("run_not-a-capability").is_err());
+    }
+
+    #[tokio::test]
+    async fn newer_parent_steer_fences_stale_child_run_reservation() {
+        let directory = tempfile::tempdir().unwrap();
+        let store = open_store(&StorageConfig::sqlite(directory.path().join("registry.db")))
+            .await
+            .unwrap();
+        let wave = make_wave("/repo");
+        store.create_wave(&wave).await.unwrap();
+        let project = make_project(&wave);
+        store.create_project(&project).await.unwrap();
+        let task = make_task(&wave, &project);
+        store
+            .create_task(&task, &make_task_pr(&task))
+            .await
+            .unwrap();
+        let project_work = WorkRef::Project(project.id.clone());
+        let task_work = WorkRef::Task(task.id.clone());
+
+        let selected = store
+            .append_steer(&project_work, Author::User, "proceed with the Task", None)
+            .await
+            .unwrap();
+        let (_run, project_lease) = store
+            .reserve_run(
+                &project_work,
+                RunTrigger::Input {
+                    basis: selected.steer.basis.clone(),
+                },
+            )
+            .await
+            .unwrap();
+        store
+            .advance_run(
+                &project_lease,
+                RunAdvance::RunStarting {
+                    containment: Containment::Tmux {
+                        name: "project-race".to_string(),
+                    },
+                    cwd: PathBuf::from("/repo"),
+                },
+            )
+            .await
+            .unwrap();
+        let crate::durable::AdvanceReceipt::Invocation(invocation) = store
+            .advance_run(
+                &project_lease,
+                RunAdvance::InvocationStarting {
+                    route: InvocationRoute {
+                        provider: "codex".to_string(),
+                        model: None,
+                        account_id: None,
+                    },
+                    surface: "headless".to_string(),
+                    resume_token: None,
+                    answer_ask_id: None,
+                },
+            )
+            .await
+            .unwrap()
+        else {
+            panic!("expected Invocation receipt")
+        };
+        let crate::durable::AdvanceReceipt::Turn(stale_turn) = store
+            .advance_run(
+                &project_lease,
+                RunAdvance::TurnStarting {
+                    invocation_id: invocation.id.clone(),
+                },
+            )
+            .await
+            .unwrap()
+        else {
+            panic!("expected Turn receipt")
+        };
+        assert_eq!(stale_turn.basis, selected.steer.basis);
+
+        let hold = store
+            .append_steer(
+                &project_work,
+                Author::User,
+                "hold this Task",
+                Some(&selected.steer.basis),
+            )
+            .await
+            .unwrap();
+        let task_basis = store.current_epoch(&task_work).await.unwrap().current_basis;
+        let error = store
+            .reserve_child_run(
+                &project_lease,
+                &task_work,
+                RunTrigger::Input { basis: task_basis },
+            )
+            .await
+            .expect_err("revision N cannot launch after hold N+1");
+
+        assert!(matches!(error, super::StoreError::StaleBasis { .. }));
+        assert!(store.current_run(&task_work).await.unwrap().is_none());
+        let seed = store.boundary_seed(&project_work).await.unwrap();
+        assert_eq!(seed.basis, hold.steer.basis);
+        assert_eq!(
+            seed.steers
+                .iter()
+                .map(|steer| steer.text.as_str())
+                .collect::<Vec<_>>(),
+            ["proceed with the Task", "hold this Task"]
+        );
+
+        store
+            .advance_run(
+                &project_lease,
+                RunAdvance::TurnEnded {
+                    turn_id: stale_turn.id,
+                    outcome: BoundaryState::Succeeded,
+                },
+            )
+            .await
+            .unwrap();
+        let crate::durable::AdvanceReceipt::Turn(next_turn) = store
+            .advance_run(
+                &project_lease,
+                RunAdvance::TurnStarting {
+                    invocation_id: invocation.id,
+                },
+            )
+            .await
+            .unwrap()
+        else {
+            panic!("expected next Turn receipt")
+        };
+        assert_eq!(next_turn.basis, hold.steer.basis);
+        assert!(store.current_run(&task_work).await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn newer_parent_steer_rolls_back_initial_child_creation_before_files_exist() {
+        let directory = tempfile::tempdir().unwrap();
+        let database_path = directory.path().join("registry.db");
+        let store = open_store(&StorageConfig::sqlite(database_path.clone()))
+            .await
+            .unwrap();
+        let wave = make_wave("/repo");
+        store.create_wave(&wave).await.unwrap();
+        let project = make_project(&wave);
+        store.create_project(&project).await.unwrap();
+        let project_work = WorkRef::Project(project.id.clone());
+        let selected = store
+            .append_steer(&project_work, Author::User, "run the child", None)
+            .await
+            .unwrap();
+        let (project_lease, invocation, stale_turn) = start_project_turn(
+            &store,
+            &project_work,
+            selected.steer.basis.clone(),
+            "project-create-race",
+        )
+        .await;
+        let hold = store
+            .append_steer(
+                &project_work,
+                Author::User,
+                "hold every dependent child",
+                Some(&selected.steer.basis),
+            )
+            .await
+            .unwrap();
+        let mut task = make_task(&wave, &project);
+        task.worktree = directory.path().join("uncreated-child-worktree");
+        let pr = make_task_pr(&task);
+
+        let error = store
+            .create_task_run(
+                &ControlCtx::Run(&project_lease),
+                &task,
+                &pr,
+                "a sibling completed; begin file-writing work",
+            )
+            .await
+            .expect_err("revision N cannot create a child after hold N+1");
+
+        assert!(matches!(error, super::StoreError::StaleBasis { .. }));
+        assert!(store.get_task(&task.id).await.unwrap().is_none());
+        assert!(store.task_prs(&task.id).await.unwrap().is_empty());
+        assert!(!task.worktree.exists());
+        let durable_child_rows = |path: &std::path::Path| {
+            rusqlite::Connection::open(path)
+                .unwrap()
+                .query_row(
+                    "SELECT
+                        (SELECT COUNT(*) FROM tasks WHERE id=?1),
+                        (SELECT COUNT(*) FROM epochs WHERE task_id=?1),
+                        (SELECT COUNT(*) FROM steers
+                         WHERE epoch_id IN (SELECT id FROM epochs WHERE task_id=?1)),
+                        (SELECT COUNT(*) FROM task_prs WHERE task_id=?1),
+                        (SELECT COUNT(*) FROM runs
+                         WHERE epoch_id IN (SELECT id FROM epochs WHERE task_id=?1))",
+                    [task.id.as_str()],
+                    |row| {
+                        Ok((
+                            row.get::<_, i64>(0)?,
+                            row.get::<_, i64>(1)?,
+                            row.get::<_, i64>(2)?,
+                            row.get::<_, i64>(3)?,
+                            row.get::<_, i64>(4)?,
+                        ))
+                    },
+                )
+                .unwrap()
+        };
+        assert_eq!(durable_child_rows(&database_path), (0, 0, 0, 0, 0));
+        let seed = store.boundary_seed(&project_work).await.unwrap();
+        assert_eq!(seed.basis, hold.steer.basis);
+        assert_eq!(
+            seed.steers
+                .iter()
+                .map(|steer| steer.text.as_str())
+                .collect::<Vec<_>>(),
+            ["run the child", "hold every dependent child"]
+        );
+
+        store
+            .advance_run(
+                &project_lease,
+                RunAdvance::TurnEnded {
+                    turn_id: stale_turn.id,
+                    outcome: BoundaryState::Succeeded,
+                },
+            )
+            .await
+            .unwrap();
+        let crate::durable::AdvanceReceipt::Turn(current_turn) = store
+            .advance_run(
+                &project_lease,
+                RunAdvance::TurnStarting {
+                    invocation_id: invocation.id,
+                },
+            )
+            .await
+            .unwrap()
+        else {
+            panic!("expected current Turn receipt")
+        };
+        assert_eq!(current_turn.basis, hold.steer.basis);
+
+        let (child_run, _child_lease) = store
+            .create_task_run(
+                &ControlCtx::Run(&project_lease),
+                &task,
+                &pr,
+                "create a different child under current direction",
+            )
+            .await
+            .expect("the current parent Turn can create its immediate child");
+
+        let task_work = WorkRef::Task(task.id.clone());
+        let child_seed = store.boundary_seed(&task_work).await.unwrap();
+        assert_eq!(
+            child_seed.steers[0].author,
+            Author::Run(project_lease.run_id.clone())
+        );
+        assert_eq!(
+            store.current_run(&task_work).await.unwrap().unwrap().id,
+            child_run.id
+        );
+        assert_eq!(durable_child_rows(&database_path), (1, 1, 1, 1, 1));
+        assert!(!task.worktree.exists());
+    }
+
+    #[tokio::test]
+    async fn historical_project_route_cannot_authorize_automated_task_settlement() {
+        let directory = tempfile::tempdir().unwrap();
+        let store = open_store(&StorageConfig::sqlite(directory.path().join("registry.db")))
+            .await
+            .unwrap();
+        let wave = make_wave("/repo");
+        store.create_wave(&wave).await.unwrap();
+        let historical_project = make_project(&wave);
+        store.create_project(&historical_project).await.unwrap();
+        let task = make_task(&wave, &historical_project);
+        let pr = make_task_pr(&task);
+        store.create_task(&task, &pr).await.unwrap();
+        let task_work = WorkRef::Task(task.id.clone());
+        let task_direction = store
+            .append_steer(
+                &task_work,
+                Author::User,
+                "historical successor direction",
+                None,
+            )
+            .await
+            .unwrap();
+        let (_task_run, task_lease) = store
+            .reserve_run(
+                &task_work,
+                RunTrigger::Input {
+                    basis: task_direction.steer.basis.clone(),
+                },
+            )
+            .await
+            .unwrap();
+
+        store
+            .validate_task_run_route(&task, &task_lease, historical_project.plan.id.as_str())
+            .await
+            .expect("the launch Project is initially the current PM route");
+
+        let mut current_project = make_project(&wave);
+        current_project.plan.id = LinearProjectId::new("current-project-uuid").unwrap();
+        current_project.plan.slug = "performance-efficiency".to_string();
+        current_project.plan.name = "Performance and Efficiency".to_string();
+        store.create_project(&current_project).await.unwrap();
+        let current_project_work = WorkRef::Project(current_project.id.clone());
+        let hold = store
+            .append_steer(
+                &current_project_work,
+                Author::User,
+                "hold the historically routed Task",
+                None,
+            )
+            .await
+            .unwrap();
+        let route_error = store
+            .validate_task_run_route(&task, &task_lease, current_project.plan.id.as_str())
+            .await
+            .expect_err("historical Project identity cannot cross a current PM move");
+        assert!(matches!(
+            route_error,
+            super::StoreError::InvalidAuthority(_)
+        ));
+        assert!(route_error.to_string().contains("current PM routing names"));
+        assert_eq!(store.task_prs(&task.id).await.unwrap(), [pr]);
+        assert_eq!(
+            store.current_epoch(&task_work).await.unwrap().state,
+            EpochState::Open
+        );
+        assert_eq!(
+            store.boundary_seed(&task_work).await.unwrap().basis,
+            task_direction.steer.basis
+        );
+        assert_eq!(
+            store.current_run(&task_work).await.unwrap().unwrap().id,
+            task_lease.run_id
+        );
+        assert_eq!(
+            store
+                .boundary_seed(&current_project_work)
+                .await
+                .unwrap()
+                .basis,
+            hold.steer.basis
+        );
+    }
+
+    #[tokio::test]
+    async fn abandoned_task_recovery_requires_user_after_parent_freshness() {
+        let directory = tempfile::tempdir().unwrap();
+        let database_path = directory.path().join("registry.db");
+        let store = open_store(&StorageConfig::sqlite(database_path.clone()))
+            .await
+            .unwrap();
+        let wave = make_wave("/repo");
+        store.create_wave(&wave).await.unwrap();
+        let project = make_project(&wave);
+        store.create_project(&project).await.unwrap();
+        let mut task = make_task(&wave, &project);
+        task.worktree = directory.path().join("preserved-task-worktree");
+        let pr = make_task_pr(&task);
+        let request = AuthenticatedRequest::cli();
+        store.create_task(&task, &pr).await.unwrap();
+        let task_work = WorkRef::Task(task.id.clone());
+        store
+            .append_steer(&task_work, Author::User, "initial Task direction", None)
+            .await
+            .unwrap();
+        let task_basis = store.current_epoch(&task_work).await.unwrap().current_basis;
+        let (historical_run, task_lease) = store
+            .reserve_run(
+                &task_work,
+                RunTrigger::Input {
+                    basis: task_basis.clone(),
+                },
+            )
+            .await
+            .unwrap();
+        store
+            .advance_run(
+                &task_lease,
+                RunAdvance::RunStarting {
+                    containment: Containment::Tmux {
+                        name: "abandoned-task".to_string(),
+                    },
+                    cwd: task.worktree.clone(),
+                },
+            )
+            .await
+            .unwrap();
+        let crate::durable::AdvanceReceipt::Invocation(task_invocation) = store
+            .advance_run(
+                &task_lease,
+                RunAdvance::InvocationStarting {
+                    route: InvocationRoute {
+                        provider: "codex".to_string(),
+                        model: None,
+                        account_id: None,
+                    },
+                    surface: "headless".to_string(),
+                    resume_token: None,
+                    answer_ask_id: None,
+                },
+            )
+            .await
+            .unwrap()
+        else {
+            panic!("expected Task Invocation receipt")
+        };
+        let abandoned = store
+            .abandon(&task_work, "hold this Task", &task_basis)
+            .await
+            .unwrap()
+            .epoch;
+        assert_eq!(abandoned.state, EpochState::Abandoned);
+        let historical_prs = store.task_prs(&task.id).await.unwrap();
+        let historical_task_run = store.run_by_id(&historical_run.id).await.unwrap();
+        let historical_invocations = store.invocations_for_run(&historical_run.id).await.unwrap();
+        assert_eq!(historical_invocations.len(), 1);
+        assert_eq!(historical_invocations[0].id, task_invocation.id);
+
+        let project_work = WorkRef::Project(project.id.clone());
+        let selected = store
+            .append_steer(&project_work, Author::User, "dependency pending", None)
+            .await
+            .unwrap();
+        let (project_lease, invocation, stale_turn) = start_project_turn(
+            &store,
+            &project_work,
+            selected.steer.basis.clone(),
+            "project-recovery-race",
+        )
+        .await;
+        let hold = store
+            .append_steer(
+                &project_work,
+                Author::User,
+                "do not recover this Task",
+                Some(&selected.steer.basis),
+            )
+            .await
+            .unwrap();
+        let mut recovered = task.clone();
+        recovered.phase_epoch += 1;
+        recovered.updated_at = time::OffsetDateTime::now_utc();
+
+        let stale = store
+            .reopen_task(
+                &ControlCtx::Run(&project_lease),
+                &recovered,
+                None,
+                "a sibling completed; recover the Task",
+            )
+            .await
+            .expect_err("stale Project direction cannot reopen terminal Task Work");
+        assert!(matches!(stale, super::StoreError::StaleBasis { .. }));
+        assert!(matches!(
+            store.current_epoch(&task_work).await,
+            Err(super::StoreError::NotFound)
+        ));
+        assert_eq!(store.task_prs(&task.id).await.unwrap(), historical_prs);
+        assert_eq!(
+            store.run_by_id(&historical_run.id).await.unwrap(),
+            historical_task_run
+        );
+        assert_eq!(
+            store.invocations_for_run(&historical_run.id).await.unwrap(),
+            historical_invocations
+        );
+        assert!(!task.worktree.exists());
+
+        store
+            .advance_run(
+                &project_lease,
+                RunAdvance::TurnEnded {
+                    turn_id: stale_turn.id,
+                    outcome: BoundaryState::Succeeded,
+                },
+            )
+            .await
+            .unwrap();
+        let crate::durable::AdvanceReceipt::Turn(current_turn) = store
+            .advance_run(
+                &project_lease,
+                RunAdvance::TurnStarting {
+                    invocation_id: invocation.id,
+                },
+            )
+            .await
+            .unwrap()
+        else {
+            panic!("expected current Turn receipt")
+        };
+        assert_eq!(current_turn.basis, hold.steer.basis);
+        let dependency_only = store
+            .reopen_task(
+                &ControlCtx::Run(&project_lease),
+                &recovered,
+                None,
+                "the dependency is complete",
+            )
+            .await
+            .expect_err("current Project direction is not User recovery authority");
+        assert!(matches!(
+            dependency_only,
+            super::StoreError::InvalidAuthority(_)
+        ));
+        assert!(dependency_only
+            .to_string()
+            .contains("explicit User recovery is required"));
+        assert!(matches!(
+            store.current_epoch(&task_work).await,
+            Err(super::StoreError::NotFound)
+        ));
+        assert_eq!(store.task_prs(&task.id).await.unwrap(), historical_prs);
+        assert!(!task.worktree.exists());
+
+        store
+            .reopen_task(
+                &ControlCtx::User(&request),
+                &recovered,
+                None,
+                "explicit User recovery",
+            )
+            .await
+            .expect("User direction opens exactly one successor Epoch");
+
+        let successor = store.current_epoch(&task_work).await.unwrap();
+        assert_eq!(successor.number, abandoned.number + 1);
+        assert_eq!(successor.state, EpochState::Open);
+        assert_eq!(store.task_prs(&task.id).await.unwrap(), historical_prs);
+        assert_eq!(
+            store.run_by_id(&historical_run.id).await.unwrap(),
+            historical_task_run
+        );
+        assert_eq!(
+            store.invocations_for_run(&historical_run.id).await.unwrap(),
+            historical_invocations
+        );
+        assert!(store.current_run(&task_work).await.unwrap().is_none());
+        let successor_seed = store.boundary_seed(&task_work).await.unwrap();
+        assert_eq!(successor_seed.steers.len(), 1);
+        assert_eq!(successor_seed.steers[0].author, Author::User);
+        assert_eq!(successor_seed.steers[0].text, "explicit User recovery");
+        let steers = SqliteStore::new(&database_path)
+            .unwrap()
+            .list_steers_since(0)
+            .unwrap();
+        assert!(steers
+            .iter()
+            .any(|steer| steer.text == "initial Task direction"));
+        assert!(steers
+            .iter()
+            .any(|steer| steer.text == "explicit User recovery"));
+        assert!(!task.worktree.exists());
+    }
+
+    #[tokio::test]
+    async fn sibling_completion_is_observation_not_task_recovery_authority() {
+        let directory = tempfile::tempdir().unwrap();
+        let store = open_store(&StorageConfig::sqlite(directory.path().join("registry.db")))
+            .await
+            .unwrap();
+        let wave = make_wave("/repo");
+        store.create_wave(&wave).await.unwrap();
+        let project = make_project(&wave);
+        store.create_project(&project).await.unwrap();
+        let target = make_task(&wave, &project);
+        store
+            .create_task(&target, &make_task_pr(&target))
+            .await
+            .unwrap();
+        let target_work = WorkRef::Task(target.id.clone());
+        let target_epoch = store.current_epoch(&target_work).await.unwrap();
+        let target_prs = store.task_prs(&target.id).await.unwrap();
+
+        let mut sibling = make_task(&wave, &project);
+        sibling.plan.id = LinearIssueId::new("sibling-issue-uuid").unwrap();
+        sibling.plan.identifier = "INF-124".to_string();
+        sibling.worktree = PathBuf::from("/repo.inf-124");
+        store
+            .create_task(&sibling, &make_task_pr(&sibling))
+            .await
+            .unwrap();
+        store
+            .append_task_event(
+                &sibling.id,
+                &TaskEventKind::Completed {
+                    summary: "dependency complete".to_string(),
+                },
+            )
+            .await
+            .unwrap();
+        let observations = store
+            .pending_project_observations(&project.id)
+            .await
+            .unwrap();
+        assert_eq!(observations.len(), 1);
+        assert!(store
+            .consume_task_observation_for_project(&project.id, &observations[0])
+            .await
+            .unwrap());
+
+        assert_eq!(
+            store.current_epoch(&target_work).await.unwrap(),
+            target_epoch
+        );
+        assert_eq!(store.task_prs(&target.id).await.unwrap(), target_prs);
+        assert!(store.current_run(&target_work).await.unwrap().is_none());
+        assert!(store
+            .boundary_seed(&target_work)
+            .await
+            .unwrap()
+            .steers
+            .is_empty());
     }
 
     #[tokio::test]

--- a/rust/loopflow/src/store/sqlite/children.rs
+++ b/rust/loopflow/src/store/sqlite/children.rs
@@ -15,7 +15,7 @@ use time::OffsetDateTime;
 use crate::child::{
     AbandonIntent, ChildBodyHandoff, ChildBodyHandoffRequest, ChildRef, ObservationRecipient,
 };
-use crate::durable::{Author, Basis, RunLease};
+use crate::durable::{Author, Basis, Run, RunLease, RunTrigger};
 use crate::id::WaveId;
 use crate::planning::{LinearIssueId, LinearProjectId, ProjectPlan, TaskPlan};
 use crate::project::{
@@ -49,20 +49,29 @@ impl SqliteStore {
         Ok(())
     }
 
-    pub fn insert_task_with_steer(
+    pub fn insert_task_run(
         &self,
         task: &Task,
         pr: &TaskPr,
-        author: &Author,
+        caller: Option<&RunLease>,
         text: &str,
-    ) -> StoreResult<()> {
+    ) -> StoreResult<(Run, RunLease)> {
         let mut conn = self.conn.lock().expect("store mutex poisoned");
         let transaction = conn.transaction_with_behavior(TransactionBehavior::Immediate)?;
         insert_initial_task(&transaction, task, pr)?;
         let work = work_for_child_in(&transaction, &ChildRef::Task(task.id.clone()))?;
-        Self::append_steer_in(&transaction, &work, author, text)?;
+        super::durable::validate_control_caller(&transaction, caller, &work)?;
+        let author = caller.map_or(Author::User, |lease| Author::Run(lease.run_id.clone()));
+        let steer = Self::append_steer_in(&transaction, &work, &author, text)?;
+        let reservation = super::durable::reserve_run_in(
+            &transaction,
+            &work,
+            &RunTrigger::Input {
+                basis: steer.steer.basis,
+            },
+        )?;
         transaction.commit()?;
-        Ok(())
+        Ok(reservation)
     }
 
     /// Reopen the stable Task as a new Epoch. Product identity, PR history,
@@ -71,12 +80,20 @@ impl SqliteStore {
         &self,
         task: &Task,
         pr: Option<&TaskPr>,
-        author: &Author,
+        caller: Option<&RunLease>,
         text: &str,
     ) -> StoreResult<()> {
         validate_task(task)?;
         let mut conn = self.conn.lock().expect("store mutex poisoned");
         let transaction = conn.transaction_with_behavior(TransactionBehavior::Immediate)?;
+        let work = work_for_child_in(&transaction, &ChildRef::Task(task.id.clone()))?;
+        if caller.is_some() {
+            super::durable::validate_control_caller(&transaction, caller, &work)?;
+            return Err(StoreError::InvalidAuthority(
+                "Run cannot recover terminal Task Work; explicit User recovery is required"
+                    .to_string(),
+            ));
+        }
         let previous: String = transaction
             .query_row(
                 "SELECT state FROM epochs WHERE task_id=?1 ORDER BY number DESC LIMIT 1",
@@ -117,7 +134,7 @@ impl SqliteStore {
             work_for_child_in(&transaction, &ChildRef::Task(task.id.clone())).map_err(|error| {
                 StoreError::InvalidData(format!("resolve reopened Task Work: {error}"))
             })?;
-        Self::append_steer_in(&transaction, &work, author, text)
+        Self::append_steer_in(&transaction, &work, &Author::User, text)
             .map_err(|error| StoreError::InvalidData(format!("steer reopened Task: {error}")))?;
         transaction.commit()?;
         Ok(())
@@ -137,6 +154,30 @@ impl SqliteStore {
             return Err(StoreError::NotFound);
         }
         transaction.commit()?;
+        Ok(())
+    }
+
+    pub(crate) fn validate_task_run_route(
+        &self,
+        task: &Task,
+        lease: &RunLease,
+        current_external_project_id: &str,
+    ) -> StoreResult<()> {
+        let conn = self.conn.lock().expect("store mutex poisoned");
+        require_run_owns_child(&conn, &ChildRef::Task(task.id.clone()), lease)?;
+        let durable_external_project_id: String = conn.query_row(
+            "SELECT p.external_project_id
+             FROM tasks t JOIN projects p ON p.id=t.project_id
+             WHERE t.id=?1",
+            [task.id.as_str()],
+            |row| row.get(0),
+        )?;
+        if durable_external_project_id != current_external_project_id {
+            return Err(StoreError::InvalidAuthority(format!(
+                "Task {} durable history belongs to Linear Project {}, but current PM routing names {}; refusing automated Task authority",
+                task.plan.identifier, durable_external_project_id, current_external_project_id
+            )));
+        }
         Ok(())
     }
 

--- a/rust/loopflow/src/store/sqlite/durable.rs
+++ b/rust/loopflow/src/store/sqlite/durable.rs
@@ -149,54 +149,23 @@ impl SqliteStore {
     ) -> StoreResult<(Run, RunLease)> {
         let mut conn = self.conn.lock().expect("store mutex poisoned");
         let tx = conn.transaction_with_behavior(TransactionBehavior::Immediate)?;
-        let epoch = current_epoch_in(&tx, work)?;
-        let home_id = reserving_home_in(&tx, work)?;
-        if let Some(run) = run_for_epoch_in(&tx, &epoch.id)? {
-            return Err(StoreError::RunFenced {
-                target: format!("{} {}", work.kind(), work.id()),
-                run_id: run.id,
-                state: run.state,
-            });
-        }
-        resolve_wait_for_trigger(&tx, &epoch, trigger)?;
-        let token = RunLeaseToken::new();
-        let run = Run {
-            id: RunId::new(),
-            work: work.clone(),
-            epoch_id: epoch.id.clone(),
-            home_id,
-            state: RunState::Reserved,
-            trigger: trigger.clone(),
-            retry_of: match trigger {
-                RunTrigger::Recovery { prior_run_id } => Some(prior_run_id.clone()),
-                _ => None,
-            },
-            containment: None,
-            cwd: None,
-            created_at: OffsetDateTime::now_utc(),
-            started_at: None,
-            ended_at: None,
-        };
-        tx.execute(
-            "INSERT INTO runs (
-                id, epoch_id, home_id, state, trigger_json, retry_of, lease_hash,
-                lease_generation, source_kind, source_id, created_at, ended_at, stop_reason
-             ) VALUES (?1, ?2, ?3, 'reserved', ?4, ?5, ?6, NULL, ?7, ?8, ?9, NULL, NULL)",
-            params![
-                run.id.as_str(),
-                run.epoch_id.as_str(),
-                run.home_id.as_str(),
-                serde_json::to_string(trigger).expect("Run trigger must serialize"),
-                run.retry_of.as_ref().map(RunId::as_str),
-                token.hash(),
-                work.kind(),
-                work.id(),
-                run.created_at.unix_timestamp(),
-            ],
-        )?;
-        let lease = RunLease::new(run.id.clone(), work.clone(), epoch.current_basis, token);
+        let receipt = reserve_run_in(&tx, work, trigger)?;
         tx.commit()?;
-        Ok((run, lease))
+        Ok(receipt)
+    }
+
+    pub(crate) fn reserve_child_run(
+        &self,
+        caller: &RunLease,
+        work: &WorkRef,
+        trigger: &RunTrigger,
+    ) -> StoreResult<(Run, RunLease)> {
+        let mut conn = self.conn.lock().expect("store mutex poisoned");
+        let tx = conn.transaction_with_behavior(TransactionBehavior::Immediate)?;
+        validate_control_caller(&tx, Some(caller), work)?;
+        let receipt = reserve_run_in(&tx, work, trigger)?;
+        tx.commit()?;
+        Ok(receipt)
     }
 
     pub(crate) fn reserve_recovery_run(&self, lease: &RunLease) -> StoreResult<(Run, RunLease)> {
@@ -1863,6 +1832,60 @@ fn write_placement(
     Ok(())
 }
 
+pub(super) fn reserve_run_in(
+    tx: &Transaction<'_>,
+    work: &WorkRef,
+    trigger: &RunTrigger,
+) -> StoreResult<(Run, RunLease)> {
+    let epoch = current_epoch_in(tx, work)?;
+    let home_id = reserving_home_in(tx, work)?;
+    if let Some(run) = run_for_epoch_in(tx, &epoch.id)? {
+        return Err(StoreError::RunFenced {
+            target: format!("{} {}", work.kind(), work.id()),
+            run_id: run.id,
+            state: run.state,
+        });
+    }
+    resolve_wait_for_trigger(tx, &epoch, trigger)?;
+    let token = RunLeaseToken::new();
+    let run = Run {
+        id: RunId::new(),
+        work: work.clone(),
+        epoch_id: epoch.id.clone(),
+        home_id,
+        state: RunState::Reserved,
+        trigger: trigger.clone(),
+        retry_of: match trigger {
+            RunTrigger::Recovery { prior_run_id } => Some(prior_run_id.clone()),
+            _ => None,
+        },
+        containment: None,
+        cwd: None,
+        created_at: OffsetDateTime::now_utc(),
+        started_at: None,
+        ended_at: None,
+    };
+    tx.execute(
+        "INSERT INTO runs (
+            id, epoch_id, home_id, state, trigger_json, retry_of, lease_hash,
+            lease_generation, source_kind, source_id, created_at, ended_at, stop_reason
+         ) VALUES (?1, ?2, ?3, 'reserved', ?4, ?5, ?6, NULL, ?7, ?8, ?9, NULL, NULL)",
+        params![
+            run.id.as_str(),
+            run.epoch_id.as_str(),
+            run.home_id.as_str(),
+            serde_json::to_string(trigger).expect("Run trigger must serialize"),
+            run.retry_of.as_ref().map(RunId::as_str),
+            token.hash(),
+            work.kind(),
+            work.id(),
+            run.created_at.unix_timestamp(),
+        ],
+    )?;
+    let lease = RunLease::new(run.id.clone(), work.clone(), epoch.current_basis, token);
+    Ok((run, lease))
+}
+
 fn inherit_placement(
     tx: &Transaction<'_>,
     work: &WorkRef,
@@ -2876,7 +2899,7 @@ fn query_answerable_asks(
         .collect()
 }
 
-fn validate_control_caller(
+pub(super) fn validate_control_caller(
     conn: &Connection,
     caller: Option<&RunLease>,
     target: &WorkRef,
@@ -2886,7 +2909,33 @@ fn validate_control_caller(
     };
     let run = validate_run_lease(conn, lease)?;
     if parent_work(conn, target)?.as_ref() == Some(&run.work) {
-        Ok(())
+        let parent_epoch = current_epoch_in(conn, &run.work)?;
+        let selected = conn
+            .query_row(
+                "SELECT t.epoch_id, t.basis_rev
+                 FROM agent_turns t
+                 JOIN agent_invocations i ON i.id=t.invocation_id
+                 WHERE i.supervising_run_id=?1
+                 ORDER BY (t.status='running') DESC, t.started_at DESC, t.rowid DESC
+                 LIMIT 1",
+                [run.id.as_str()],
+                |row| Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?)),
+            )
+            .optional()?
+            .map(|(epoch_id, revision)| {
+                Ok::<Basis, StoreError>(Basis {
+                    epoch_id: EpochId::parse(&epoch_id).map_err(invalid_durable)?,
+                    revision: revision as u64,
+                })
+            })
+            .transpose()?
+            .ok_or_else(|| {
+                StoreError::InvalidAuthority(format!(
+                    "Run {} has no durable Turn Basis for child control",
+                    run.id
+                ))
+            })?;
+        validate_basis(&parent_epoch.current_basis, &selected)
     } else {
         Err(StoreError::InvalidAuthority(
             "Run may control only immediate child Work".to_string(),

--- a/rust/loopflow/tests/commit_tests.rs
+++ b/rust/loopflow/tests/commit_tests.rs
@@ -1,7 +1,10 @@
+mod support;
+
 use std::process::Command;
 
 use loopflow::ops::{commit_workflow, CommitOptions, NullProgress};
 use loopflow_test_support::TestRepo;
+use support::EnvGuard;
 
 fn last_commit_message(repo: &TestRepo) -> String {
     let output = Command::new("git")
@@ -34,6 +37,7 @@ fn commit_stages_and_commits() {
 
 #[test]
 fn commit_with_push() {
+    let _env = EnvGuard::new(&[]);
     let repo = TestRepo::new();
     repo.create_file("push.txt", "hello");
 

--- a/rust/loopflow/tests/support/mod.rs
+++ b/rust/loopflow/tests/support/mod.rs
@@ -14,9 +14,11 @@ use time::OffsetDateTime;
 
 /// Ambient authority a live agent process exports. Tests must never inherit the
 /// real Run that invoked the suite.
-const AMBIENT_AGENT_ENV: [&str; 4] = [
+const AMBIENT_AGENT_ENV: [&str; 6] = [
     "LF_RUN_CONTEXT",
+    "LF_RUN_ID",
     "LF_RUN_LEASE",
+    "LF_AGENT_INVOCATION_ID",
     "LF_WAVE_ID",
     "LF_ACCOUNT_LEASE",
 ];

--- a/wave/infrastructure/MEMORY.md
+++ b/wave/infrastructure/MEMORY.md
@@ -34,6 +34,13 @@ Renamed from `systems` in the 2026-07-08 wave/project/task restructure. Steers L
 - **Linear Project names are identity-bearing under the native hierarchy.** The CLI slug derives deterministically from the Project name, and the slug is the cache filename (`projects/<slug>.md`) and the `--project` argument to task commands. Renaming a Linear Project changes its slug, so it moves the cache file and changes every task command's input — a rename is a migration, not a cosmetic edit.
 - **Environment configures a process; it must never decide what the process is.** An earlier runtime chose between booting a listener and being a resident from inherited environment, so a promoted wave could attach to its parent's listener with the parent's token. The current `lf wave` surface keeps that role explicit.
 - **Current PM truth and durable Work history have different lifetimes** (learned 2026-07-21). A terminal Project omitted from the current PM snapshot can still own non-terminal historical Task Work. Wave reads must render the current PM hierarchy and classify the stranded Project/Task separately as Wave-owned degraded evidence; they must not fail the whole join, delete history, or synthesize a PM Project. Recovery must use the stable Work id (`lf work abandon task <work-id>`) because higher-level Task commands may inspect a historical worktree that no longer exists.
+- **Terminal Task state and current PM routing are authorization boundaries**
+  (learned 2026-07-21). An open Linear issue, inherited direction, or sibling
+  completion is evidence, never permission to reopen `Done` or `Abandoned`
+  Work. Recovery from abandonment requires explicit User authority. When
+  Linear moves an issue, historical Task Runs retain their evidence but lose
+  automated PR and completion authority; fail closed before side effects and
+  preserve the full Work, Run, Steer, and PR history for remediation.
 
 ## Model (design settled)
 


### PR DESCRIPTION
## Usage

```bash
lf task run INF-123
lf task recover INF-123
```

`task run` now refuses terminal Work. Abandoned Tasks require explicit user recovery, while completed Tasks require a new Linear task.

## Summary

This PR prevents stale Project turns and historical PM routing from retaining authority over Task automation. Task creation and Run reservation now happen atomically against the parent’s current direction, and automated mutations fail closed before git, PR, or completion side effects when a newer steer or Linear Project move supersedes that authority.

## Changes

- Validate child Run creation against the immediate parent’s durable Turn Basis
- Atomically create the Task, initial steer, PR record, and reserved Run, rolling everything back on stale authority
- Re-check current Linear Project ownership before automated commit, push, publication, merge, rotation, abandonment, and completion operations
- Preserve terminal Task history and restrict abandoned Task recovery to explicit user action
- Cover stale steering races, PM moves, atomic rollback, recovery authority, and sibling observations with behavioral tests