### PR TITLE
verification: bound local development resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,18 @@ lf usage               # subscription state and spend, per account and repo
 lf performance         # 14-day latency, verification, and spend scorecard
 ```
 
+Keep Loopflow development inside its local resource envelope:
+
+```bash
+uv run python scripts/resource_envelope.py             # attribute disk use to its owner
+uv run python scripts/resource_envelope.py --recover   # clean only safe disposable pressure
+uv run python scripts/test.py                          # preflight, then run affected suites
+```
+
+The verifier keeps 64 GiB free, caps build/test concurrency at four
+low-priority workers, and records build bytes plus child CPU for
+`lf performance`. See [TESTING.md](TESTING.md#bounded-and-honest).
+
 ## The model
 
 | Atom | What it does | Where it lives |

--- a/TESTING.md
+++ b/TESTING.md
@@ -7,6 +7,7 @@ proof that can change the next decision.
 
 ```bash
 uv run pytest python/tests/test_gate_bounded.py        # one Python behavior
+uv run python scripts/resource_envelope.py             # attribute local disk pressure
 uv run python scripts/check_architecture.py            # architecture owners and vocabulary
 uv run python scripts/test.py --list                   # affected-suite plan
 uv run python scripts/test.py --reuse-passing          # affected suites once per exact tree
@@ -43,8 +44,23 @@ uv run python scripts/test.py --base HEAD~5  # diff against a different ref
 
 ### Bounded and honest
 
+```bash
+uv run python scripts/resource_envelope.py
+uv run python scripts/resource_envelope.py --recover
+```
+
+The resource preflight names the owner and budget for every worktree build,
+gate-artifact root, the Loopflow trace store, uv cache, Cargo cache, and free
+disk. Budgets live in `performance/budgets.json`: 64 GiB free, 12 GiB per
+worktree build, 128 GiB across builds, 16 GiB each for traces and uv, and four
+low-priority verification workers. Recovery removes only allowlisted build
+roots from inactive worktrees, old disposable gate output, and entries accepted
+by `uv cache prune`. It never removes source, a worktree, trace evidence, gate
+receipts, or SQLite state. Unresolved pressure stops before product tests run
+and prints the supported next action.
+
 Every phase runs under a printed wall-clock limit. A phase that overruns is
-killed—process group and all—and reported as `TIMEOUT <phase> (budget Ns)`, so
+killed—process group and all—and reported as `VERIFICATION BUDGET`, so
 **no phase can hang the
 gate**. The plan and summary print each phase's `elapsed / budget`; later
 phases remain visible as `not_run` after an earlier failure. On failure the
@@ -61,7 +77,11 @@ Git common directory:
 This evidence is shared by linked worktrees and survives `.lf/tmp` cleanup.
 Records contain operational identity, exact-tree and plan fingerprints,
 phase status, and elapsed time—not commands or output. Persistence failure is
-a warning and never replaces the underlying test result.
+a warning and never replaces the underlying test result. Schema-3 records also
+carry child CPU, minimum observed free disk, build bytes, and source-attributed
+growth. A product assertion remains a product failure; a stopped phase under
+sustained macOS `syspolicyd`/`trustd`/`amfid`/`taskgated` pressure is reported as
+host-security pressure with the product result explicitly unproven.
 
 Read the same gate evidence through the scorecard:
 
@@ -92,7 +112,7 @@ Path → suite mapping:
 | Changed | Suite | Runs |
 |---------|-------|------|
 | `rust/`, `Cargo.toml/lock` | rust | `cargo fmt`, `cargo clippy`, then draft materialization in a disposable exact-tree worktree and `cargo nextest run --all` (falls back to `cargo test --all`) |
-| `python/`, top-level `*.py`, `pyproject.toml` | python | `uv run pytest python/tests/` (scoped to changed `test_*.py` when no source moved) |
+| `python/`, `scripts/*.py`, top-level `*.py`, `pyproject.toml` | python | `uv run pytest python/tests/` (scoped to changed `test_*.py` when no source moved) |
 | `website/`, `docs/` | website | `cd website && uv run python dev.py test` |
 | `swift/` | swift | `swift test --package-path swift -Xswiftc -gnone`, then the multiplatform boundary check |
 | `swift/LoopflowMac/`, `swift/project.yml` | loopflow *(slow)* | xcodegen + xcodebuild |

--- a/performance/budgets.json
+++ b/performance/budgets.json
@@ -2,6 +2,23 @@
   "schema_version": 1,
   "window_days": 14,
   "minimum_p95_samples": 20,
+  "resource_envelope": {
+    "minimum_free_disk_bytes": 68719476736,
+    "maximum_worktree_build_bytes": 12884901888,
+    "maximum_aggregate_build_bytes": 137438953472,
+    "maximum_trace_bytes": 17179869184,
+    "maximum_uv_cache_bytes": 17179869184,
+    "maximum_cargo_cache_bytes": 4294967296,
+    "maximum_gate_artifact_bytes": 4294967296,
+    "maximum_recovery_roots": 8,
+    "maximum_recovery_bytes": 68719476736,
+    "gate_artifact_retention_hours": 168,
+    "max_parallel_jobs": 4,
+    "process_nice": 10,
+    "host_security_cpu_percent": 200.0,
+    "host_security_samples": 3,
+    "sample_interval_seconds": 5.0
+  },
   "metrics": {
     "agent_cost_usd": {
       "unit": "usd",

--- a/python/tests/test_gate_bounded.py
+++ b/python/tests/test_gate_bounded.py
@@ -11,6 +11,8 @@ import sys
 import time
 from pathlib import Path
 
+import pytest
+
 ROOT = Path(__file__).resolve().parents[2]
 SCRIPT = ROOT / "scripts/test.py"
 
@@ -19,6 +21,47 @@ assert _spec is not None and _spec.loader is not None
 gate = importlib.util.module_from_spec(_spec)
 sys.modules["gate_test_runner"] = gate
 _spec.loader.exec_module(gate)
+
+
+def _resource_report() -> dict[str, object]:
+    snapshot = {
+        "ok": True,
+        "filesystem": "/fixture",
+        "total_disk_bytes": 1_000_000,
+        "free_disk_bytes": 900_000,
+        "minimum_free_disk_bytes": 100_000,
+        "max_parallel_jobs": 4,
+        "process_nice": 10,
+        "sources": [
+            {
+                "id": "build:fixture",
+                "kind": "build",
+                "owner": "fixture",
+                "root": str(ROOT),
+                "paths": [str(ROOT / "target")],
+                "bytes": 0,
+                "budget_bytes": 1_000_000,
+                "disposable": True,
+                "active": True,
+                "action": "none",
+            }
+        ],
+        "issues": [],
+        "warnings": [],
+    }
+    return {
+        "schema": 1,
+        "ok": True,
+        "policy_path": "performance/budgets.json",
+        "before": snapshot,
+        "after": snapshot,
+        "recovery": [],
+    }
+
+
+@pytest.fixture(autouse=True)
+def _bounded_resource_fixture(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(gate, "_run_resource_check", lambda _recover: (_resource_report(), None))
 
 
 def _cmd(argv: list[str], label: str) -> "gate.Command":
@@ -50,7 +93,8 @@ def test_hanging_phase_is_killed_at_its_budget(tmp_path, monkeypatch):
     assert outcome.status == "timed_out"
     assert outcome.over_budget is True
     assert outcome.failure is not None
-    assert "TIMEOUT" in outcome.failure and "hang-probe" in outcome.failure
+    assert "VERIFICATION BUDGET" in outcome.failure and "hang-probe" in outcome.failure
+    assert outcome.failure_kind == "verification_budget"
     # Killed near its 1s budget plus the SIGTERM->SIGKILL grace, nowhere near 60s.
     assert elapsed < 20, f"phase took {elapsed:.1f}s; the budget did not bound it"
 
@@ -67,12 +111,54 @@ def test_child_process_dies_with_the_group(tmp_path, monkeypatch):
     assert not marker.exists(), "backgrounded child outlived the group-kill"
 
 
+def test_disk_floor_stops_the_phase_before_exhaustion(tmp_path, monkeypatch):
+    envelope = dict(gate.RESOURCE_ENVELOPE)
+    envelope.update(
+        {
+            "minimum_free_disk_bytes": 100,
+            "sample_interval_seconds": 0.05,
+        }
+    )
+    samples = iter([101, 99])
+    monkeypatch.setattr(gate, "RESOURCE_ENVELOPE", envelope)
+    monkeypatch.setattr(gate, "_free_disk_bytes", lambda: next(samples, 99))
+
+    outcome = gate._run_command(_cmd(["sleep", "60"], "disk-probe"), tmp_path, "probe")
+
+    assert outcome.status == "resource_exhausted"
+    assert outcome.failure_kind == "resource_pressure"
+    assert outcome.failure is not None and "Product result: unproven" in outcome.failure
+    assert "NEXT ACTION" in outcome.failure
+
+
+def test_sustained_syspolicyd_cpu_is_host_pressure_not_a_red_test(tmp_path, monkeypatch):
+    envelope = dict(gate.RESOURCE_ENVELOPE)
+    envelope.update(
+        {
+            "minimum_free_disk_bytes": 0,
+            "sample_interval_seconds": 0.05,
+            "host_security_cpu_percent": 200.0,
+            "host_security_samples": 2,
+        }
+    )
+    monkeypatch.setattr(gate, "RESOURCE_ENVELOPE", envelope)
+    monkeypatch.setattr(gate, "_host_security_pressure", lambda: ("syspolicyd", 350.0))
+
+    outcome = gate._run_command(_cmd(["sleep", "60"], "host-probe"), tmp_path, "probe")
+
+    assert outcome.status == "host_pressure"
+    assert outcome.failure_kind == "host_security_pressure"
+    assert outcome.failure is not None and "syspolicyd" in outcome.failure
+    assert "Product result: unproven" in outcome.failure
+
+
 def test_failing_phase_reports_actionable_failure(tmp_path):
     outcome = gate._run_command(_cmd(["bash", "-c", "exit 3"], "red-probe"), tmp_path, "probe")
     assert outcome.status == "failed"
     assert outcome.failure is not None
-    assert "FAILED" in outcome.failure and "red-probe" in outcome.failure
+    assert "PRODUCT FAILURE" in outcome.failure and "red-probe" in outcome.failure
     assert "exit 3" in outcome.failure
+    assert outcome.failure_kind == "product"
 
 
 def test_passing_phase_returns_measured_outcome(tmp_path):
@@ -81,6 +167,21 @@ def test_passing_phase_returns_measured_outcome(tmp_path):
     assert outcome.elapsed_s >= 0
     assert outcome.budget_s == gate.DEFAULT_BUDGET_S
     assert outcome.failure is None
+    assert outcome.cpu_s is not None
+    assert outcome.minimum_free_disk_bytes is not None
+
+
+def test_phase_runs_at_the_policy_niceness(tmp_path):
+    outcome = gate._run_command(
+        _cmd(["sh", "-c", "ps -o ni= -p $$"], "nice-probe"),
+        tmp_path,
+        "probe",
+    )
+
+    assert outcome.status == "passed"
+    assert int((tmp_path / "nice-probe.log").read_text().strip()) >= int(
+        gate.RESOURCE_ENVELOPE["process_nice"]
+    )
 
 
 def test_missing_tool_is_named_not_a_traceback(tmp_path):
@@ -177,6 +278,49 @@ def test_changed_measurement_warning_preserves_a_failing_result(tmp_path, monkey
 
     assert result == 1
     assert capsys.readouterr().err.count("MEASUREMENT WARNING") == 1
+
+
+def test_resource_preflight_blocks_before_product_commands(tmp_path, monkeypatch, capsys):
+    evidence_root = tmp_path / "evidence"
+    marker = tmp_path / "product-ran"
+    report = _resource_report()
+    report["ok"] = False
+    after = report["after"]
+    assert isinstance(after, dict)
+    after["ok"] = False
+    after["issues"] = [
+        {
+            "code": "disk:free",
+            "owner": "fixture host",
+            "detail": "5 GiB free / 64 GiB floor",
+            "action": "recover fixture builds",
+            "recoverable": True,
+        }
+    ]
+    monkeypatch.setattr(gate, "_gate_evidence_root", lambda: evidence_root)
+    monkeypatch.setattr(gate, "_tree_fingerprint", lambda: "tree")
+    monkeypatch.setattr(
+        gate,
+        "_run_resource_check",
+        lambda _recover: (
+            report,
+            "RESOURCE PRESSURE: disk:free (fixture host)\nNEXT ACTION: recover fixture builds",
+        ),
+    )
+
+    result = gate.run_plans(
+        [_plan(_cmd(["bash", "-c", f"touch {marker}"], "probe"))],
+        kind="full",
+    )
+
+    assert result == 1
+    assert not marker.exists()
+    record = json.loads(next((evidence_root / "full").glob("*.json")).read_text())
+    assert record["status"] == "resource_blocked"
+    assert all(phase["status"] == "not_run" for phase in record["phases"])
+    output = capsys.readouterr().out
+    assert "product suites not run" in output
+    assert "NEXT ACTION" in output
 
 
 def test_identical_tree_and_plan_reuse_a_passing_run(tmp_path, monkeypatch, capsys):
@@ -302,6 +446,7 @@ def test_persisted_schema_contains_only_operational_facts():
         "finished_at",
         "status",
         "phases",
+        "resources",
     }
     assert set(record["phases"][0]) == {
         "suite",
@@ -310,6 +455,9 @@ def test_persisted_schema_contains_only_operational_facts():
         "elapsed_s",
         "status",
         "over_budget",
+        "failure_kind",
+        "cpu_s",
+        "minimum_free_disk_bytes",
     }
     forbidden = {"argv", "output", "environment", "prompt", "diff"}
     assert forbidden.isdisjoint(json.dumps(record).lower().split('"'))
@@ -331,11 +479,40 @@ def test_deleted_python_test_falls_back_to_the_full_suite():
     assert command.argv == ["uv", "run", "pytest", "python/tests/"]
 
 
+def test_python_verifier_change_runs_the_full_python_suite():
+    changed = ["scripts/resource_envelope.py", "python/tests/test_resource_envelope.py"]
+
+    plan = next(
+        item
+        for item in gate.build_plan(changed=changed, run_all=False, forced=set())
+        if item.suite.name == "python"
+    )
+
+    assert plan.run is True
+    assert plan.commands[0].argv == ["uv", "run", "pytest", "python/tests/"]
+
+
 def test_all_never_runs_the_required_host_gate():
     plans = gate.build_plan(changed=[], run_all=True, forced=set())
     ui = next(p for p in plans if p.suite.name == "ui-host")
     assert ui.run is False
     assert "required host gate" in ui.reason
+
+
+def test_build_and_test_commands_share_the_four_worker_budget():
+    jobs = str(gate.MAX_PARALLEL_JOBS)
+    rust = gate._rust_commands([])
+    clippy = next(command for command in rust if command.label == "clippy")
+    tests = next(command for command in rust if command.label == "rust")
+    swift = gate._swift_commands([])
+    loopflow = gate._loopflow_commands([])
+
+    assert clippy.argv[clippy.argv.index("--jobs") + 1] == jobs
+    assert jobs in tests.argv
+    for command in (swift[0], swift[2]):
+        assert command.argv[command.argv.index("--jobs") + 1] == jobs
+    xcodebuild = next(command for command in loopflow if command.label == "xcodebuild")
+    assert xcodebuild.argv[xcodebuild.argv.index("-jobs") + 1] == jobs
 
 
 def test_ui_host_runs_only_when_named():

--- a/python/tests/test_release_automation.py
+++ b/python/tests/test_release_automation.py
@@ -314,7 +314,7 @@ def test_changed_aware_runner_includes_ci_static_checks():
     )
 
     assert "cargo fmt --all -- --check" in result.stdout
-    assert "cargo clippy --all-targets -- -D warnings" in result.stdout
+    assert "cargo clippy --all-targets --jobs 4 -- -D warnings" in result.stdout
     assert "scripts/materialize_rust_tests.py -- cargo" in result.stdout
     assert "cargo nextest run --all" in result.stdout or "cargo test --all" in result.stdout
     assert "uv run python scripts/check_swift_multiplatform_boundaries.py" in result.stdout

--- a/python/tests/test_resource_envelope.py
+++ b/python/tests/test_resource_envelope.py
@@ -1,0 +1,223 @@
+"""Resource pressure is attributed and recovery never crosses into durable work."""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "scripts/resource_envelope.py"
+
+_spec = importlib.util.spec_from_file_location("resource_envelope", SCRIPT)
+assert _spec is not None and _spec.loader is not None
+resources = importlib.util.module_from_spec(_spec)
+sys.modules["resource_envelope"] = resources
+_spec.loader.exec_module(resources)
+
+
+def _policy(**overrides) -> "resources.ResourcePolicy":
+    values = {
+        "minimum_free_disk_bytes": 100,
+        "maximum_worktree_build_bytes": 100,
+        "maximum_aggregate_build_bytes": 150,
+        "maximum_trace_bytes": 100,
+        "maximum_uv_cache_bytes": 100,
+        "maximum_cargo_cache_bytes": 100,
+        "maximum_gate_artifact_bytes": 100,
+        "maximum_recovery_roots": 8,
+        "maximum_recovery_bytes": 10_000_000,
+        "gate_artifact_retention_hours": 168,
+        "max_parallel_jobs": 4,
+        "process_nice": 10,
+        "host_security_cpu_percent": 200.0,
+        "host_security_samples": 3,
+        "sample_interval_seconds": 5.0,
+    }
+    values.update(overrides)
+    return resources.ResourcePolicy(**values)
+
+
+def _source(
+    root: Path,
+    *,
+    id: str,
+    kind: str = "build",
+    owner: str = "feature",
+    active: bool = False,
+    disposable: bool = True,
+    budget: int = 100,
+) -> "resources.ResourceSource":
+    paths = (root / "target",) if kind == "build" else (root,)
+    return resources.ResourceSource(
+        id=id,
+        kind=kind,
+        owner=owner,
+        root=root,
+        paths=paths,
+        bytes=sum(resources._allocated_bytes(path) for path in paths),
+        budget_bytes=budget,
+        disposable=disposable,
+        active=active,
+        action=f"repair {owner}",
+    )
+
+
+def _snapshot(
+    policy: "resources.ResourcePolicy",
+    sources: list["resources.ResourceSource"],
+    free: int = 1_000_000,
+) -> "resources.ResourceSnapshot":
+    return resources.ResourceSnapshot(
+        filesystem="fixture",
+        total_disk_bytes=2_000_000,
+        free_disk_bytes=free,
+        minimum_free_disk_bytes=policy.minimum_free_disk_bytes,
+        max_parallel_jobs=policy.max_parallel_jobs,
+        process_nice=policy.process_nice,
+        sources=tuple(sources),
+        issues=tuple(resources._assess_sources(free, policy, sources)),
+        warnings=(),
+    )
+
+
+def test_over_budget_diagnostics_name_owner_and_remediation(tmp_path: Path) -> None:
+    policy = _policy(minimum_free_disk_bytes=1_000, maximum_trace_bytes=10)
+    trace = _source(
+        tmp_path / "traces",
+        id="trace:home",
+        kind="trace",
+        owner="Loopflow Home",
+        disposable=False,
+        active=True,
+        budget=10,
+    )
+    trace.root.mkdir()
+    (trace.root / "capture").write_bytes(b"evidence")
+    trace = _source(
+        trace.root,
+        id="trace:home",
+        kind="trace",
+        owner="Loopflow Home",
+        disposable=False,
+        active=True,
+        budget=10,
+    )
+
+    issues = resources._assess_sources(50, policy, [trace])
+
+    assert {issue.code for issue in issues} == {"disk:free", "trace:home"}
+    trace_issue = next(issue for issue in issues if issue.code == "trace:home")
+    assert trace_issue.owner == "Loopflow Home"
+    assert trace_issue.action == "repair Loopflow Home"
+    assert trace_issue.recoverable is False
+
+
+def test_recovery_removes_only_inactive_allowlisted_builds(tmp_path: Path) -> None:
+    active = tmp_path / "active"
+    inactive = tmp_path / "inactive"
+    durable = tmp_path / "home"
+    for root in (active, inactive):
+        (root / "target").mkdir(parents=True)
+        (root / "target/artifact").write_bytes(b"x" * 4096)
+        (root / "source.rs").write_text("fn main() {}\n")
+        (root / ".git").write_text("gitdir: retained\n")
+    (durable / "traces").mkdir(parents=True)
+    (durable / "traces/capture.jsonl").write_text("durable\n")
+    (durable / "loopflow.db").write_bytes(b"sqlite")
+
+    policy = _policy(maximum_aggregate_build_bytes=1)
+    sources = [
+        _source(active, id="build:active", owner="active", active=True),
+        _source(inactive, id="build:inactive", owner="inactive"),
+        resources.ResourceSource(
+            id="trace:home",
+            kind="trace",
+            owner="Loopflow Home",
+            root=durable,
+            paths=(durable / "traces",),
+            bytes=resources._allocated_bytes(durable / "traces"),
+            budget_bytes=1_000_000,
+            disposable=False,
+            active=True,
+            action="retain",
+        ),
+    ]
+
+    actions = resources.recover_resources(tmp_path, policy, _snapshot(policy, sources))
+
+    assert [action.source for action in actions] == ["build:inactive"]
+    assert not (inactive / "target").exists()
+    assert (active / "target/artifact").exists()
+    assert (active / "source.rs").exists()
+    assert (inactive / "source.rs").exists()
+    assert (inactive / ".git").exists()
+    assert (durable / "traces/capture.jsonl").exists()
+    assert (durable / "loopflow.db").exists()
+
+
+def test_recovery_root_limit_is_a_hard_bound(tmp_path: Path) -> None:
+    roots = [tmp_path / "one", tmp_path / "two"]
+    for root in roots:
+        (root / "target").mkdir(parents=True)
+        (root / "target/artifact").write_bytes(b"x" * 4096)
+    policy = _policy(maximum_aggregate_build_bytes=1, maximum_recovery_roots=1)
+    sources = [
+        _source(root, id=f"build:{root.name}", owner=root.name) for root in roots
+    ]
+
+    actions = resources.recover_resources(tmp_path, policy, _snapshot(policy, sources))
+
+    assert len(actions) == 1
+    assert sum((root / "target").exists() for root in roots) == 1
+
+
+def test_disk_pressure_prunes_uv_through_its_supported_boundary(
+    tmp_path: Path, monkeypatch
+) -> None:
+    cache = tmp_path / "uv-cache"
+    cache.mkdir()
+    (cache / "archive").write_bytes(b"x" * 4096)
+    policy = _policy(minimum_free_disk_bytes=1_000)
+    source = resources.ResourceSource(
+        id="cache:uv",
+        kind="cache",
+        owner="uv",
+        root=cache,
+        paths=(cache,),
+        bytes=resources._allocated_bytes(cache),
+        budget_bytes=1_000_000,
+        disposable=True,
+        active=False,
+        action="uv cache prune",
+    )
+    called = []
+
+    def _prune() -> "resources.RecoveryAction":
+        called.append(True)
+        return resources.RecoveryAction(
+            "cache:uv", "uv", source.bytes, (), "pruned", "supported boundary"
+        )
+
+    monkeypatch.setattr(resources, "_prune_uv_cache", _prune)
+
+    actions = resources.recover_resources(
+        tmp_path,
+        policy,
+        _snapshot(policy, [source], free=100),
+    )
+
+    assert called == [True]
+    assert actions[0].source == "cache:uv"
+
+
+def test_active_over_budget_build_is_named_but_not_auto_recoverable(tmp_path: Path) -> None:
+    root = tmp_path / "active"
+    (root / "target").mkdir(parents=True)
+    (root / "target/artifact").write_bytes(b"x" * 4096)
+    policy = _policy(maximum_worktree_build_bytes=1, maximum_aggregate_build_bytes=1_000_000)
+    source = _source(root, id="build:active", active=True, budget=1)
+
+    issues = resources._assess_sources(1_000_000, policy, [source])
+
+    assert len(issues) == 1
+    assert issues[0].code == "build:active"
+    assert issues[0].recoverable is False

--- a/rust/loopflow/src/lf/commands/performance.rs
+++ b/rust/loopflow/src/lf/commands/performance.rs
@@ -82,6 +82,7 @@ struct GateRun {
     finished_at: Option<String>,
     status: String,
     phases: Vec<GatePhase>,
+    resources: Option<GateResources>,
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize)]
@@ -89,6 +90,12 @@ struct GatePhase {
     phase: String,
     elapsed_s: f64,
     status: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+struct GateResources {
+    build_disk_bytes: Option<f64>,
+    cpu_seconds: Option<f64>,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -236,7 +243,7 @@ fn load_gate(path: &Path) -> Result<GateRun> {
     let bytes = fs::read(path).with_context(|| format!("read {}", path.display()))?;
     let gate: GateRun =
         serde_json::from_slice(&bytes).with_context(|| format!("parse {}", path.display()))?;
-    if !matches!(gate.schema, 1 | 2) {
+    if !matches!(gate.schema, 1..=3) {
         return Err(anyhow!(
             "unsupported pre-land evidence schema {} in {}",
             gate.schema,
@@ -298,19 +305,23 @@ fn build_report(policy: &BudgetPolicy, input: ScorecardInput) -> Result<Performa
             "Manual git repair",
             "raw git adoption is not yet a durable scored incident",
         )?,
-        unknown_row(
-            policy,
-            "build_disk_bytes",
-            "Build + disk use",
-            "local resource envelopes are owned by LOO-9",
-        )?,
-        unknown_row(
-            policy,
-            "preland_cpu_seconds",
-            "Pre-land CPU",
-            "gate evidence records wall time but not process CPU; collection is owned by LOO-9",
-        )?,
     ]);
+    rows.push(gate_resource_row(
+        policy,
+        &input.gates,
+        "build_disk_bytes",
+        "Build artifacts / gate",
+        window_started,
+        |resources| resources.build_disk_bytes,
+    )?);
+    rows.push(gate_resource_row(
+        policy,
+        &input.gates,
+        "preland_cpu_seconds",
+        "Pre-land child CPU",
+        window_started,
+        |resources| resources.cpu_seconds,
+    )?);
 
     rows.extend(usage_rows(policy, &input.usage, None)?);
     let providers = input
@@ -401,6 +412,34 @@ fn gate_in_window(gate: &GateRun, since: OffsetDateTime) -> bool {
         .as_deref()
         .and_then(|value| OffsetDateTime::parse(value, &Rfc3339).ok())
         .is_some_and(|finished| finished >= since)
+}
+
+fn gate_resource_row(
+    policy: &BudgetPolicy,
+    gates: &[GateRun],
+    metric: &str,
+    label: &str,
+    since: OffsetDateTime,
+    value: impl Fn(&GateResources) -> Option<f64>,
+) -> Result<PerformanceRow> {
+    let eligible = gates
+        .iter()
+        .filter(|gate| gate_in_window(gate, since))
+        .collect::<Vec<_>>();
+    let values = eligible
+        .iter()
+        .filter_map(|gate| gate.resources.as_ref())
+        .filter_map(value)
+        .collect::<Vec<_>>();
+    Ok(measured_row(
+        metric,
+        label,
+        None,
+        values,
+        eligible.len(),
+        metric_budget(policy, metric)?,
+        policy.minimum_p95_samples,
+    ))
 }
 
 fn usage_rows(
@@ -618,7 +657,7 @@ fn format_value(value: f64, unit: &str) -> String {
 mod tests {
     use super::{
         build_report, invocation_belongs_to_repo, load_gate, turn_ended_in_window, BudgetPolicy,
-        GatePhase, GateRun, PerformanceRow, ScorecardInput, UsageSample, Verdict,
+        GatePhase, GateResources, GateRun, PerformanceRow, ScorecardInput, UsageSample, Verdict,
     };
     use serde::Deserialize;
     use std::path::Path;
@@ -673,7 +712,7 @@ mod tests {
     }
 
     #[test]
-    fn reads_the_gate_record_emitted_by_the_landing_path() {
+    fn reads_a_legacy_gate_record_without_inventing_resources() {
         let directory = tempfile::tempdir().unwrap();
         let path = directory.path().join("gate.json");
         std::fs::write(
@@ -707,6 +746,34 @@ mod tests {
         assert_eq!(gate.kind, "changed");
         assert_eq!(gate.status, "passed");
         assert_eq!(gate.phases[0].elapsed_s, 120.0);
+        assert!(gate.resources.is_none());
+    }
+
+    #[test]
+    fn reads_schema_three_resource_evidence() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("gate.json");
+        std::fs::write(
+            &path,
+            r#"{
+              "schema": 3,
+              "kind": "full",
+              "finished_at": "2026-07-21T18:02:00Z",
+              "status": "passed",
+              "phases": [],
+              "resources": {
+                "build_disk_bytes": 4294967296,
+                "cpu_seconds": 42.5
+              }
+            }"#,
+        )
+        .unwrap();
+
+        let gate = load_gate(&path).unwrap();
+        let resources = gate.resources.unwrap();
+
+        assert_eq!(resources.build_disk_bytes, Some(4_294_967_296.0));
+        assert_eq!(resources.cpu_seconds, Some(42.5));
     }
 
     #[test]
@@ -734,7 +801,7 @@ mod tests {
             },
         ];
         let gates = vec![GateRun {
-            schema: 2,
+            schema: 3,
             kind: "full".to_string(),
             finished_at: Some("2026-07-20T00:05:00Z".to_string()),
             status: "passed".to_string(),
@@ -743,6 +810,10 @@ mod tests {
                 elapsed_s: 300.0,
                 status: "passed".to_string(),
             }],
+            resources: Some(GateResources {
+                build_disk_bytes: Some(13.0 * 1024.0_f64.powi(3)),
+                cpu_seconds: Some(720.0),
+            }),
         }];
 
         let report = build_report(

--- a/scripts/resource_envelope.py
+++ b/scripts/resource_envelope.py
@@ -1,0 +1,733 @@
+#!/usr/bin/env python3
+"""Measure and safely recover Loopflow's local development resources."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+import time
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Optional
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+POLICY_PATH = REPO_ROOT / "performance" / "budgets.json"
+BUILD_RELATIVE_PATHS = (
+    Path("target"),
+    Path(".build"),
+    Path("swift/.build"),
+    Path("website/node_modules"),
+)
+GATE_RELATIVE_PATH = Path(".lf/tmp/gate")
+
+
+@dataclass(frozen=True)
+class ResourcePolicy:
+    minimum_free_disk_bytes: int
+    maximum_worktree_build_bytes: int
+    maximum_aggregate_build_bytes: int
+    maximum_trace_bytes: int
+    maximum_uv_cache_bytes: int
+    maximum_cargo_cache_bytes: int
+    maximum_gate_artifact_bytes: int
+    maximum_recovery_roots: int
+    maximum_recovery_bytes: int
+    gate_artifact_retention_hours: int
+    max_parallel_jobs: int
+    process_nice: int
+    host_security_cpu_percent: float
+    host_security_samples: int
+    sample_interval_seconds: float
+
+
+@dataclass(frozen=True)
+class Worktree:
+    path: Path
+    branch: str
+
+
+@dataclass(frozen=True)
+class ResourceSource:
+    id: str
+    kind: str
+    owner: str
+    root: Path
+    paths: tuple[Path, ...]
+    bytes: int
+    budget_bytes: int
+    disposable: bool
+    active: bool
+    action: str
+
+    def as_record(self) -> dict[str, object]:
+        return {
+            "id": self.id,
+            "kind": self.kind,
+            "owner": self.owner,
+            "root": str(self.root),
+            "paths": [str(path) for path in self.paths],
+            "bytes": self.bytes,
+            "budget_bytes": self.budget_bytes,
+            "disposable": self.disposable,
+            "active": self.active,
+            "action": self.action,
+        }
+
+
+@dataclass(frozen=True)
+class ResourceIssue:
+    code: str
+    owner: str
+    detail: str
+    action: str
+    recoverable: bool
+
+
+@dataclass(frozen=True)
+class ResourceSnapshot:
+    filesystem: str
+    total_disk_bytes: int
+    free_disk_bytes: int
+    minimum_free_disk_bytes: int
+    max_parallel_jobs: int
+    process_nice: int
+    sources: tuple[ResourceSource, ...]
+    issues: tuple[ResourceIssue, ...]
+    warnings: tuple[str, ...]
+
+    @property
+    def ok(self) -> bool:
+        return not self.issues
+
+    def as_record(self) -> dict[str, object]:
+        return {
+            "ok": self.ok,
+            "filesystem": self.filesystem,
+            "total_disk_bytes": self.total_disk_bytes,
+            "free_disk_bytes": self.free_disk_bytes,
+            "minimum_free_disk_bytes": self.minimum_free_disk_bytes,
+            "max_parallel_jobs": self.max_parallel_jobs,
+            "process_nice": self.process_nice,
+            "sources": [source.as_record() for source in self.sources],
+            "issues": [asdict(issue) for issue in self.issues],
+            "warnings": list(self.warnings),
+        }
+
+
+@dataclass(frozen=True)
+class RecoveryAction:
+    source: str
+    owner: str
+    removed_bytes: int
+    removed_paths: tuple[str, ...]
+    status: str
+    detail: str
+
+
+@dataclass(frozen=True)
+class ResourceReport:
+    policy_path: str
+    before: ResourceSnapshot
+    after: ResourceSnapshot
+    recovery: tuple[RecoveryAction, ...]
+
+    @property
+    def ok(self) -> bool:
+        return self.after.ok
+
+    def as_record(self) -> dict[str, object]:
+        return {
+            "schema": 1,
+            "ok": self.ok,
+            "policy_path": self.policy_path,
+            "before": self.before.as_record(),
+            "after": self.after.as_record(),
+            "recovery": [asdict(action) for action in self.recovery],
+        }
+
+
+def load_policy(path: Path = POLICY_PATH) -> ResourcePolicy:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    envelope = payload["resource_envelope"]
+    return ResourcePolicy(**envelope)
+
+
+def collect_snapshot(repo: Path, policy: ResourcePolicy) -> ResourceSnapshot:
+    repo = repo.resolve()
+    disk = shutil.disk_usage(repo)
+    worktrees, discovery_error = _discover_worktrees(repo)
+    active_paths, activity_warning = _running_cwds()
+    warnings = [warning for warning in (activity_warning,) if warning]
+    sources: list[ResourceSource] = []
+    measurement_issues: list[ResourceIssue] = []
+
+    if discovery_error is not None:
+        measurement_issues.append(
+            ResourceIssue(
+                code="worktree-discovery",
+                owner=str(repo),
+                detail=discovery_error,
+                action=(
+                    "run `git worktree list --porcelain` from this checkout and repair "
+                    "its metadata"
+                ),
+                recoverable=False,
+            )
+        )
+        worktrees = [Worktree(repo, _branch(repo))]
+
+    for worktree in worktrees:
+        active = active_paths is None or any(
+            _is_within(cwd, worktree.path) for cwd in active_paths
+        )
+        build_paths = tuple(worktree.path / relative for relative in BUILD_RELATIVE_PATHS)
+        sources.append(
+            _measure_source(
+                id=f"build:{worktree.branch}",
+                kind="build",
+                owner=worktree.branch,
+                root=worktree.path,
+                paths=build_paths,
+                budget=policy.maximum_worktree_build_bytes,
+                disposable=True,
+                active=active,
+                action=(
+                    "run `uv run python scripts/resource_envelope.py --recover`; "
+                    "recovery removes only build roots from inactive worktrees"
+                ),
+                issues=measurement_issues,
+            )
+        )
+        gate_path = worktree.path / GATE_RELATIVE_PATH
+        sources.append(
+            _measure_source(
+                id=f"gate:{worktree.branch}",
+                kind="gate",
+                owner=worktree.branch,
+                root=worktree.path,
+                paths=(gate_path,),
+                budget=policy.maximum_gate_artifact_bytes,
+                disposable=True,
+                active=active,
+                action=(
+                    "run `uv run python scripts/resource_envelope.py --recover`; "
+                    "only gate runs older than "
+                    f"{policy.gate_artifact_retention_hours}h are eligible"
+                ),
+                issues=measurement_issues,
+            )
+        )
+
+    authority_home = _authority_home()
+    sources.append(
+        _measure_source(
+            id="trace:home",
+            kind="trace",
+            owner="Loopflow Home",
+            root=authority_home,
+            paths=(authority_home / "traces",),
+            budget=policy.maximum_trace_bytes,
+            disposable=False,
+            active=True,
+            action=(
+                "run `lf runs reconcile` to inspect unclaimed artifacts; retained captures "
+                "need an explicit retention decision and are never auto-deleted"
+            ),
+            issues=measurement_issues,
+        )
+    )
+    uv_cache = _uv_cache_dir()
+    sources.append(
+        _measure_source(
+            id="cache:uv",
+            kind="cache",
+            owner="uv",
+            root=uv_cache,
+            paths=(uv_cache,),
+            budget=policy.maximum_uv_cache_bytes,
+            disposable=True,
+            active=False,
+            action="run `uv cache prune`; recovery uses that supported cache boundary",
+            issues=measurement_issues,
+        )
+    )
+    cargo_home = Path(os.environ.get("CARGO_HOME", Path.home() / ".cargo")).expanduser()
+    sources.append(
+        _measure_source(
+            id="cache:cargo",
+            kind="cache",
+            owner="Cargo",
+            root=cargo_home,
+            paths=(cargo_home / "registry", cargo_home / "git"),
+            budget=policy.maximum_cargo_cache_bytes,
+            disposable=False,
+            active=True,
+            action=(
+                "inspect the named Cargo registry/git roots; shared cache eviction is not "
+                "automatic while builds may be using it"
+            ),
+            issues=measurement_issues,
+        )
+    )
+
+    issues = _assess_sources(disk.free, policy, sources)
+    issues.extend(measurement_issues)
+    issues.sort(key=lambda issue: issue.code)
+    return ResourceSnapshot(
+        filesystem=str(repo),
+        total_disk_bytes=disk.total,
+        free_disk_bytes=disk.free,
+        minimum_free_disk_bytes=policy.minimum_free_disk_bytes,
+        max_parallel_jobs=policy.max_parallel_jobs,
+        process_nice=policy.process_nice,
+        sources=tuple(sorted(sources, key=lambda source: source.id)),
+        issues=tuple(issues),
+        warnings=tuple(warnings),
+    )
+
+
+def recover_resources(
+    repo: Path,
+    policy: ResourcePolicy,
+    snapshot: ResourceSnapshot,
+    now: Optional[float] = None,
+) -> tuple[RecoveryAction, ...]:
+    now = time.time() if now is None else now
+    actions: list[RecoveryAction] = []
+    roots_used = 0
+    bytes_used = 0
+    issue_codes = {issue.code for issue in snapshot.issues}
+    disk_pressure = "disk:free" in issue_codes
+
+    gate_sources = sorted(
+        (source for source in snapshot.sources if source.kind == "gate" and source.bytes),
+        key=lambda source: -source.bytes,
+    )
+    for source in gate_sources:
+        if source.id not in issue_codes and not disk_pressure:
+            continue
+        if roots_used >= policy.maximum_recovery_roots:
+            break
+        if bytes_used + source.bytes > policy.maximum_recovery_bytes:
+            continue
+        action = _prune_old_gate_artifacts(source, policy, now)
+        actions.append(action)
+        roots_used += 1
+        bytes_used += action.removed_bytes
+
+    uv_source = next((source for source in snapshot.sources if source.id == "cache:uv"), None)
+    if (
+        uv_source is not None
+        and ("cache:uv" in issue_codes or disk_pressure)
+        and roots_used < policy.maximum_recovery_roots
+        and bytes_used + uv_source.bytes <= policy.maximum_recovery_bytes
+    ):
+        uv_action = _prune_uv_cache()
+        actions.append(uv_action)
+        roots_used += 1
+        bytes_used += uv_action.removed_bytes
+
+    aggregate_build = sum(source.bytes for source in snapshot.sources if source.kind == "build")
+    needed = max(
+        0,
+        policy.minimum_free_disk_bytes - snapshot.free_disk_bytes,
+        aggregate_build - policy.maximum_aggregate_build_bytes,
+    )
+    needed = max(0, needed - bytes_used)
+    required_builds = {
+        source.id
+        for source in snapshot.sources
+        if source.kind == "build" and source.id in issue_codes
+    }
+    candidates = sorted(
+        (
+            source
+            for source in snapshot.sources
+            if source.kind == "build" and source.disposable and not source.active and source.bytes
+        ),
+        key=lambda source: (source.id not in required_builds, -source.bytes),
+    )
+    for source in candidates:
+        if roots_used >= policy.maximum_recovery_roots:
+            break
+        if bytes_used >= policy.maximum_recovery_bytes:
+            break
+        if source.id not in required_builds and needed <= 0:
+            break
+        if bytes_used + source.bytes > policy.maximum_recovery_bytes:
+            continue
+        action = _remove_build_artifacts(source)
+        actions.append(action)
+        roots_used += 1
+        bytes_used += action.removed_bytes
+        needed = max(0, needed - action.removed_bytes)
+
+    return tuple(actions)
+
+
+def inspect_resources(repo: Path, policy: ResourcePolicy, recover: bool) -> ResourceReport:
+    before = collect_snapshot(repo, policy)
+    recovery = recover_resources(repo, policy, before) if recover and not before.ok else ()
+    after = collect_snapshot(repo, policy) if recovery else before
+    return ResourceReport(str(POLICY_PATH), before, after, tuple(recovery))
+
+
+def _discover_worktrees(repo: Path) -> tuple[list[Worktree], Optional[str]]:
+    result = subprocess.run(
+        ["git", "worktree", "list", "--porcelain"],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        detail = result.stderr.strip() or f"git exited {result.returncode}"
+        return [], f"cannot attribute build roots to worktrees: {detail}"
+
+    worktrees: list[Worktree] = []
+    path: Optional[Path] = None
+    branch = "detached"
+    for line in [*result.stdout.splitlines(), ""]:
+        if line.startswith("worktree "):
+            path = Path(line.removeprefix("worktree ")).resolve()
+            branch = "detached"
+        elif line.startswith("branch refs/heads/"):
+            branch = line.removeprefix("branch refs/heads/")
+        elif not line and path is not None:
+            if branch == "detached":
+                branch = f"detached:{path.name}"
+            worktrees.append(Worktree(path, branch))
+            path = None
+    return worktrees, None
+
+
+def _branch(repo: Path) -> str:
+    result = subprocess.run(
+        ["git", "branch", "--show-current"],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip() or "current"
+
+
+def _running_cwds() -> tuple[Optional[set[Path]], Optional[str]]:
+    try:
+        result = subprocess.run(
+            ["lsof", "-d", "cwd", "-Fn"],
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
+        return None, f"cannot prove inactive worktrees ({exc}); recovery will retain all builds"
+    if result.returncode != 0:
+        return None, (
+            "cannot prove inactive worktrees "
+            f"(lsof exited {result.returncode}); recovery will retain all builds"
+        )
+    paths = {
+        Path(line[1:]).resolve()
+        for line in result.stdout.splitlines()
+        if line.startswith("n/")
+    }
+    return paths, None
+
+
+def _is_within(path: Path, root: Path) -> bool:
+    try:
+        path.relative_to(root)
+        return True
+    except ValueError:
+        return False
+
+
+def _authority_home() -> Path:
+    for name in ("LF_CONTROL_HOME", "LF_HOME"):
+        value = os.environ.get(name)
+        if value:
+            return Path(value).expanduser()
+    return Path.home() / ".lf"
+
+
+def _uv_cache_dir() -> Path:
+    override = os.environ.get("UV_CACHE_DIR")
+    if override:
+        return Path(override).expanduser()
+    result = subprocess.run(["uv", "cache", "dir"], capture_output=True, text=True)
+    if result.returncode == 0 and result.stdout.strip():
+        return Path(result.stdout.strip()).expanduser()
+    return Path(os.environ.get("XDG_CACHE_HOME", Path.home() / ".cache")) / "uv"
+
+
+def _allocated_bytes(path: Path) -> int:
+    if not path.exists() and not path.is_symlink():
+        return 0
+    result = subprocess.run(["du", "-sk", str(path)], capture_output=True, text=True)
+    if result.returncode == 0:
+        first = result.stdout.split(maxsplit=1)
+        if first:
+            return int(first[0]) * 1024
+    detail = result.stderr.strip() or f"du exited {result.returncode}"
+    raise OSError(f"cannot measure {path}: {detail}")
+
+
+def _measure_source(
+    *,
+    id: str,
+    kind: str,
+    owner: str,
+    root: Path,
+    paths: tuple[Path, ...],
+    budget: int,
+    disposable: bool,
+    active: bool,
+    action: str,
+    issues: list[ResourceIssue],
+) -> ResourceSource:
+    measured = 0
+    for path in paths:
+        try:
+            measured += _allocated_bytes(path)
+        except (OSError, ValueError) as exc:
+            issues.append(
+                ResourceIssue(
+                    code=f"measurement:{id}",
+                    owner=owner,
+                    detail=str(exc),
+                    action=f"make {path} readable and rerun the resource check",
+                    recoverable=False,
+                )
+            )
+    return ResourceSource(
+        id=id,
+        kind=kind,
+        owner=owner,
+        root=root,
+        paths=paths,
+        bytes=measured,
+        budget_bytes=budget,
+        disposable=disposable,
+        active=active,
+        action=action,
+    )
+
+
+def _assess_sources(
+    free_disk_bytes: int,
+    policy: ResourcePolicy,
+    sources: list[ResourceSource],
+) -> list[ResourceIssue]:
+    issues = []
+    if free_disk_bytes < policy.minimum_free_disk_bytes:
+        issues.append(
+            ResourceIssue(
+                code="disk:free",
+                owner="host filesystem",
+                detail=(
+                    f"{_format_bytes(free_disk_bytes)} free is below the "
+                    f"{_format_bytes(policy.minimum_free_disk_bytes)} verification floor"
+                ),
+                action=(
+                    "run `uv run python scripts/resource_envelope.py --recover`; "
+                    "verification will not start until the safety floor is restored"
+                ),
+                recoverable=True,
+            )
+        )
+    for source in sources:
+        if source.bytes <= source.budget_bytes:
+            continue
+        issues.append(
+            ResourceIssue(
+                code=source.id,
+                owner=source.owner,
+                detail=(
+                    f"{source.kind} uses {_format_bytes(source.bytes)} / "
+                    f"{_format_bytes(source.budget_bytes)} budget"
+                ),
+                action=source.action,
+                recoverable=source.disposable and not source.active,
+            )
+        )
+    build_bytes = sum(source.bytes for source in sources if source.kind == "build")
+    if build_bytes > policy.maximum_aggregate_build_bytes:
+        issues.append(
+            ResourceIssue(
+                code="build:aggregate",
+                owner="Loopflow worktrees",
+                detail=(
+                    f"build roots use {_format_bytes(build_bytes)} / "
+                    f"{_format_bytes(policy.maximum_aggregate_build_bytes)} aggregate budget"
+                ),
+                action=(
+                    "run `uv run python scripts/resource_envelope.py --recover`; "
+                    "the largest inactive worktree builds are cleaned first"
+                ),
+                recoverable=any(
+                    source.kind == "build" and source.disposable and not source.active
+                    for source in sources
+                ),
+            )
+        )
+    return issues
+
+
+def _remove_build_artifacts(source: ResourceSource) -> RecoveryAction:
+    removed_paths = []
+    removed_bytes = 0
+    allowed = {source.root / relative for relative in BUILD_RELATIVE_PATHS}
+    for path in source.paths:
+        if path not in allowed or path == source.root:
+            return RecoveryAction(
+                source.id,
+                source.owner,
+                0,
+                (),
+                "refused",
+                f"{path} is outside the build-artifact allowlist",
+            )
+        if not path.exists() and not path.is_symlink():
+            continue
+        measured = _allocated_bytes(path)
+        if path.is_dir() and not path.is_symlink():
+            shutil.rmtree(path)
+        else:
+            path.unlink()
+        removed_paths.append(str(path))
+        removed_bytes += measured
+    return RecoveryAction(
+        source.id,
+        source.owner,
+        removed_bytes,
+        tuple(removed_paths),
+        "removed",
+        "removed allowlisted build artifacts; worktree and source retained",
+    )
+
+
+def _prune_old_gate_artifacts(
+    source: ResourceSource,
+    policy: ResourcePolicy,
+    now: float,
+) -> RecoveryAction:
+    gate_root = source.root / GATE_RELATIVE_PATH
+    if source.paths != (gate_root,):
+        return RecoveryAction(
+            source.id,
+            source.owner,
+            0,
+            (),
+            "refused",
+            "gate artifact root is outside the allowlist",
+        )
+    cutoff = now - policy.gate_artifact_retention_hours * 3600
+    removed_paths = []
+    removed_bytes = 0
+    if gate_root.is_dir():
+        for child in gate_root.iterdir():
+            if child.stat().st_mtime >= cutoff:
+                continue
+            measured = _allocated_bytes(child)
+            if child.is_dir() and not child.is_symlink():
+                shutil.rmtree(child)
+            else:
+                child.unlink()
+            removed_paths.append(str(child))
+            removed_bytes += measured
+    return RecoveryAction(
+        source.id,
+        source.owner,
+        removed_bytes,
+        tuple(removed_paths),
+        "removed",
+        f"removed only gate artifacts older than {policy.gate_artifact_retention_hours}h",
+    )
+
+
+def _prune_uv_cache() -> RecoveryAction:
+    before = _allocated_bytes(_uv_cache_dir())
+    result = subprocess.run(["uv", "cache", "prune"], capture_output=True, text=True)
+    after = _allocated_bytes(_uv_cache_dir())
+    detail = result.stderr.strip() or result.stdout.strip()
+    return RecoveryAction(
+        "cache:uv",
+        "uv",
+        max(0, before - after),
+        (),
+        "pruned" if result.returncode == 0 else "failed",
+        detail or f"uv cache prune exited {result.returncode}",
+    )
+
+
+def _format_bytes(value: int) -> str:
+    units = ("B", "KiB", "MiB", "GiB", "TiB")
+    amount = float(value)
+    unit = units[0]
+    for unit in units:
+        if amount < 1024 or unit == units[-1]:
+            break
+        amount /= 1024
+    return f"{amount:.1f} {unit}"
+
+
+def _print_report(report: ResourceReport) -> None:
+    snapshot = report.after
+    status = "PASS" if report.ok else "FAIL"
+    print(
+        f"Resource envelope: {status} · {_format_bytes(snapshot.free_disk_bytes)} free / "
+        f"{_format_bytes(snapshot.minimum_free_disk_bytes)} floor · "
+        f"{snapshot.max_parallel_jobs} workers · nice +{snapshot.process_nice}"
+    )
+    for source in snapshot.sources:
+        if source.bytes == 0 and source.kind in {"build", "gate"}:
+            continue
+        mark = "FAIL" if source.bytes > source.budget_bytes else "ok  "
+        active = " · active" if source.active else ""
+        print(
+            f"{mark}  {source.kind:<6} {_format_bytes(source.bytes):>10} / "
+            f"{_format_bytes(source.budget_bytes):>10}  {source.owner}{active}"
+        )
+    for action in report.recovery:
+        print(
+            f"recover  {action.source} · {_format_bytes(action.removed_bytes)} · "
+            f"{action.status}: {action.detail}"
+        )
+    for issue in snapshot.issues:
+        print(f"\n{issue.code}: {issue.detail}\n  next: {issue.action}")
+    for warning in snapshot.warnings:
+        print(f"\nwarning: {warning}")
+
+
+def _parse_args(argv: Optional[list[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Measure Loopflow build, cache, trace, disk, and CPU budgets."
+    )
+    parser.add_argument("--json", action="store_true", help="emit the complete report as JSON")
+    parser.add_argument(
+        "--recover",
+        action="store_true",
+        help="clean only allowlisted inactive/disposable pressure, then remeasure",
+    )
+    parser.add_argument("--repo", type=Path, default=REPO_ROOT, help="Loopflow checkout to inspect")
+    parser.add_argument("--policy", type=Path, default=POLICY_PATH, help="budget policy JSON")
+    return parser.parse_args(argv)
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    args = _parse_args(argv)
+    policy = load_policy(args.policy)
+    report = inspect_resources(args.repo, policy, args.recover)
+    if args.json:
+        json.dump(report.as_record(), sys.stdout, indent=2, sort_keys=True)
+        sys.stdout.write("\n")
+    else:
+        _print_report(report)
+    return 0 if report.ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/test.py
+++ b/scripts/test.py
@@ -22,6 +22,7 @@ import hashlib
 import json
 import os
 import platform
+import resource as process_resource
 import secrets
 import shutil
 import signal
@@ -47,7 +48,22 @@ XCODE_DERIVED_DATA = ".build/xcode-derived-data"
 # Failure artifacts (phase logs, xcresult bundles) land here so a worker can
 # repair the first red signal without reopening Xcode. Ignored (.lf/tmp/*).
 GATE_ARTIFACT_ROOT = REPO_ROOT / ".lf" / "tmp" / "gate"
-GATE_EVIDENCE_SCHEMA = 2
+GATE_EVIDENCE_SCHEMA = 3
+RESOURCE_SCRIPT = REPO_ROOT / "scripts" / "resource_envelope.py"
+RESOURCE_POLICY_PATH = REPO_ROOT / "performance" / "budgets.json"
+HOST_SECURITY_PROCESSES = {"amfid", "syspolicyd", "taskgated", "trustd"}
+
+
+def _load_resource_policy() -> dict[str, object]:
+    payload = json.loads(RESOURCE_POLICY_PATH.read_text(encoding="utf-8"))
+    envelope = payload.get("resource_envelope")
+    if not isinstance(envelope, dict):
+        raise ValueError(f"resource_envelope is missing from {RESOURCE_POLICY_PATH}")
+    return envelope
+
+
+RESOURCE_ENVELOPE = _load_resource_policy()
+MAX_PARALLEL_JOBS = int(RESOURCE_ENVELOPE["max_parallel_jobs"])
 
 
 def _run_artifact_root() -> Path:
@@ -150,6 +166,10 @@ def _toplevel_py(changed: list[str]) -> bool:
     return any("/" not in p and p.endswith(".py") for p in changed)
 
 
+def _scripts_py(changed: list[str]) -> bool:
+    return any(p.startswith("scripts/") and p.endswith(".py") for p in changed)
+
+
 # --- Suites --------------------------------------------------------------
 
 
@@ -185,13 +205,40 @@ class Suite:
 
 def _rust_commands(_changed: list[str]) -> list[Command]:
     if shutil.which("cargo-nextest"):
-        test_argv = ["cargo", "nextest", "run", "--all"]
+        test_argv = [
+            "cargo",
+            "nextest",
+            "run",
+            "--all",
+            "--build-jobs",
+            str(MAX_PARALLEL_JOBS),
+            "--test-threads",
+            str(MAX_PARALLEL_JOBS),
+        ]
     else:
-        test_argv = ["cargo", "test", "--all"]
+        test_argv = [
+            "cargo",
+            "test",
+            "--all",
+            "--jobs",
+            str(MAX_PARALLEL_JOBS),
+            "--",
+            "--test-threads",
+            str(MAX_PARALLEL_JOBS),
+        ]
     return [
         Command(["cargo", "fmt", "--all", "--", "--check"], REPO_ROOT, "rustfmt"),
         Command(
-            ["cargo", "clippy", "--all-targets", "--", "-D", "warnings"],
+            [
+                "cargo",
+                "clippy",
+                "--all-targets",
+                "--jobs",
+                str(MAX_PARALLEL_JOBS),
+                "--",
+                "-D",
+                "warnings",
+            ],
             REPO_ROOT,
             "clippy",
         ),
@@ -222,6 +269,7 @@ def _python_commands(changed: list[str]) -> list[Command]:
     touches_source = (
         any(p.startswith("python/") and p not in test_files for p in changed)
         or _toplevel_py(changed)
+        or _scripts_py(changed)
         or _touches_exact(changed, "pyproject.toml", "uv.lock")
     )
     if test_files and not touches_source:
@@ -244,7 +292,16 @@ def _website_commands(_changed: list[str]) -> list[Command]:
 def _swift_commands(_changed: list[str]) -> list[Command]:
     return [
         Command(
-            ["swift", "test", "--package-path", "swift", "-Xswiftc", "-gnone"],
+            [
+                "swift",
+                "test",
+                "--package-path",
+                "swift",
+                "--jobs",
+                str(MAX_PARALLEL_JOBS),
+                "-Xswiftc",
+                "-gnone",
+            ],
             REPO_ROOT,
             "swift",
         ),
@@ -254,7 +311,16 @@ def _swift_commands(_changed: list[str]) -> list[Command]:
             "swift-boundaries",
         ),
         Command(
-            ["swift", "build", "--package-path", "swift", "--product", "LoopflowMac"],
+            [
+                "swift",
+                "build",
+                "--package-path",
+                "swift",
+                "--product",
+                "LoopflowMac",
+                "--jobs",
+                str(MAX_PARALLEL_JOBS),
+            ],
             REPO_ROOT,
             "swift-build",
         ),
@@ -282,6 +348,8 @@ def _loopflow_commands(_changed: list[str]) -> list[Command]:
                 "platform=macOS",
                 "-derivedDataPath",
                 XCODE_DERIVED_DATA,
+                "-jobs",
+                str(MAX_PARALLEL_JOBS),
                 "-disableAutomaticPackageResolution",
                 *XCODE_LOCAL_SIGNING,
             ],
@@ -363,6 +431,10 @@ def _ui_host_commands(_changed: list[str]) -> list[Command]:
                 "-only-testing:LoopflowUITests",
                 "-resultBundlePath",
                 str(xcresult),
+                "-jobs",
+                str(MAX_PARALLEL_JOBS),
+                "-parallel-testing-worker-count",
+                str(MAX_PARALLEL_JOBS),
                 *XCODE_LOCAL_SIGNING,
             ],
             swift_dir,
@@ -399,10 +471,11 @@ SUITES: list[Suite] = [
     Suite(
         name="python",
         slow=False,
-        trigger_desc="python/ or top-level *.py",
+        trigger_desc="python/, scripts/*.py, or top-level *.py",
         match=lambda c: (
             _touches(c, "python/")
             or _toplevel_py(c)
+            or _scripts_py(c)
             or _touches_exact(c, "pyproject.toml", "uv.lock")
         ),
         build=_python_commands,
@@ -546,6 +619,59 @@ def print_plan(plans: list[Plan], changed: list[str]) -> None:
                 print(f"         $ {_fmt_cmd(cmd)}  (budget {_budget_for(cmd.label)}s)")
 
 
+# --- Resource envelope ---------------------------------------------------
+
+
+def _run_resource_check(recover: bool) -> tuple[Optional[dict[str, object]], Optional[str]]:
+    argv = [sys.executable, str(RESOURCE_SCRIPT), "--json", "--repo", str(REPO_ROOT)]
+    if recover:
+        argv.append("--recover")
+    try:
+        result = subprocess.run(argv, cwd=REPO_ROOT, capture_output=True, text=True, timeout=60)
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return None, f"RESOURCE MEASUREMENT FAILED: {exc}"
+    try:
+        report = json.loads(result.stdout)
+    except json.JSONDecodeError:
+        detail = result.stderr.strip() or result.stdout.strip() or f"exit {result.returncode}"
+        return None, f"RESOURCE MEASUREMENT FAILED: {detail}"
+    if not isinstance(report, dict):
+        return None, "RESOURCE MEASUREMENT FAILED: report is not a JSON object"
+    if report.get("ok") is True and result.returncode == 0:
+        return report, None
+    after = report.get("after")
+    issues = after.get("issues") if isinstance(after, dict) else None
+    if not isinstance(issues, list) or not issues:
+        detail = result.stderr.strip() or f"resource check exited {result.returncode}"
+        return report, f"RESOURCE PRESSURE: {detail}"
+    lines = ["RESOURCE PRESSURE: verification did not start inside its envelope."]
+    for issue in issues:
+        if not isinstance(issue, dict):
+            continue
+        lines.append(
+            f"- {issue.get('code', 'unknown')} ({issue.get('owner', 'unknown')}): "
+            f"{issue.get('detail', 'no detail')}"
+        )
+        lines.append(f"  NEXT ACTION: {issue.get('action', 'inspect the named source')}")
+    return report, "\n".join(lines)
+
+
+def _resource_summary(report: dict[str, object], label: str) -> str:
+    after = report.get("after")
+    if not isinstance(after, dict):
+        return f"Resource {label}: UNKNOWN"
+    free = after.get("free_disk_bytes")
+    floor = after.get("minimum_free_disk_bytes")
+    jobs = after.get("max_parallel_jobs")
+    nice = after.get("process_nice")
+    if not isinstance(free, int) or not isinstance(floor, int):
+        return f"Resource {label}: UNKNOWN"
+    return (
+        f"Resource {label}: PASS · {free / 2**30:.1f} GiB free / "
+        f"{floor / 2**30:.1f} GiB floor · {jobs} workers · nice +{nice}"
+    )
+
+
 # --- Durable evidence ----------------------------------------------------
 
 
@@ -558,6 +684,9 @@ class PhaseOutcome:
     status: str
     over_budget: bool
     failure: Optional[str] = None
+    failure_kind: Optional[str] = None
+    cpu_s: Optional[float] = None
+    minimum_free_disk_bytes: Optional[int] = None
 
     def as_record(self) -> dict[str, object]:
         return {
@@ -567,6 +696,9 @@ class PhaseOutcome:
             "elapsed_s": round(self.elapsed_s, 3),
             "status": self.status,
             "over_budget": self.over_budget,
+            "failure_kind": self.failure_kind,
+            "cpu_s": None if self.cpu_s is None else round(self.cpu_s, 3),
+            "minimum_free_disk_bytes": self.minimum_free_disk_bytes,
         }
 
 
@@ -583,6 +715,7 @@ class GateRun:
     finished_at: Optional[str]
     status: str
     phases: list[PhaseOutcome]
+    resources: Optional[dict[str, object]] = None
 
     def update_phase(self, outcome: PhaseOutcome) -> None:
         for index, phase in enumerate(self.phases):
@@ -605,8 +738,103 @@ class GateRun:
             "finished_at": self.finished_at,
             "status": self.status,
             "phases": [phase.as_record() for phase in self.phases],
+            "resources": self.resources,
         }
         return record
+
+
+def _resource_receipt(
+    preflight: Optional[dict[str, object]],
+    postflight: Optional[dict[str, object]],
+    phases: list[PhaseOutcome],
+) -> Optional[dict[str, object]]:
+    if preflight is None:
+        return None
+    before = preflight.get("after")
+    after_report = postflight or preflight
+    after = after_report.get("after")
+    if not isinstance(before, dict) or not isinstance(after, dict):
+        return None
+    before_sources = before.get("sources")
+    after_sources = after.get("sources")
+    if not isinstance(before_sources, list) or not isinstance(after_sources, list):
+        return None
+
+    def _indexed(sources: list[object]) -> dict[str, dict[str, object]]:
+        return {
+            source["id"]: source
+            for source in sources
+            if isinstance(source, dict) and isinstance(source.get("id"), str)
+        }
+
+    before_by_id = _indexed(before_sources)
+    after_by_id = _indexed(after_sources)
+    sources = []
+    for source_id in sorted(set(before_by_id) | set(after_by_id)):
+        initial = before_by_id.get(source_id, {})
+        final = after_by_id.get(source_id, {})
+        before_bytes = initial.get("bytes")
+        after_bytes = final.get("bytes")
+        if not isinstance(before_bytes, int):
+            before_bytes = None
+        if not isinstance(after_bytes, int):
+            after_bytes = None
+        sources.append(
+            {
+                "id": source_id,
+                "kind": final.get("kind", initial.get("kind")),
+                "owner": final.get("owner", initial.get("owner")),
+                "budget_bytes": final.get("budget_bytes", initial.get("budget_bytes")),
+                "before_bytes": before_bytes,
+                "after_bytes": after_bytes,
+                "growth_bytes": (
+                    after_bytes - before_bytes
+                    if before_bytes is not None and after_bytes is not None
+                    else None
+                ),
+            }
+        )
+
+    current = str(REPO_ROOT.resolve())
+    current_build = next(
+        (
+            source
+            for source in after_sources
+            if isinstance(source, dict)
+            and source.get("kind") == "build"
+            and source.get("root") == current
+        ),
+        None,
+    )
+    build_disk_bytes = current_build.get("bytes") if isinstance(current_build, dict) else None
+    aggregate_build_bytes = sum(
+        source.get("bytes", 0)
+        for source in after_sources
+        if isinstance(source, dict)
+        and source.get("kind") == "build"
+        and isinstance(source.get("bytes"), int)
+    )
+    cpu_values = [phase.cpu_s for phase in phases if phase.cpu_s is not None]
+    free_values = [
+        value
+        for value in (
+            before.get("free_disk_bytes"),
+            after.get("free_disk_bytes"),
+            *(phase.minimum_free_disk_bytes for phase in phases),
+        )
+        if isinstance(value, int)
+    ]
+    return {
+        "build_disk_bytes": build_disk_bytes,
+        "aggregate_build_bytes": aggregate_build_bytes,
+        "cpu_seconds": sum(cpu_values) if cpu_values else None,
+        "minimum_free_disk_bytes": min(free_values) if free_values else None,
+        "max_parallel_jobs": after.get("max_parallel_jobs"),
+        "process_nice": after.get("process_nice"),
+        "sources": sources,
+        "recovery": preflight.get("recovery", []),
+        "issues": after.get("issues", []),
+    }
 
 
 def _utc_now() -> datetime:
@@ -733,6 +961,7 @@ def _new_gate_run(
     tree_fingerprint: Optional[str],
     plan_fingerprint: str,
     now: Optional[datetime] = None,
+    resources: Optional[dict[str, object]] = None,
 ) -> GateRun:
     started = now or _utc_now()
     run_id = f"{started.strftime('%Y%m%dT%H%M%SZ')}-{os.getpid()}-{secrets.token_hex(4)}"
@@ -751,6 +980,7 @@ def _new_gate_run(
         finished_at=None,
         status="running",
         phases=phases,
+        resources=resources,
     )
 
 
@@ -796,9 +1026,16 @@ def _start_recorder(
     plans: list[Plan],
     tree_fingerprint: Optional[str],
     plan_fingerprint: str,
+    resources: Optional[dict[str, object]] = None,
 ) -> Optional[_GateRecorder]:
     try:
-        run = _new_gate_run(kind, plans, tree_fingerprint, plan_fingerprint)
+        run = _new_gate_run(
+            kind,
+            plans,
+            tree_fingerprint,
+            plan_fingerprint,
+            resources=resources,
+        )
         path = _gate_evidence_root() / kind / f"{run.run_id}.json"
     except (OSError, subprocess.SubprocessError) as exc:
         print(
@@ -849,6 +1086,51 @@ def _kill_group(proc: "subprocess.Popen[str]") -> None:
             pass
 
 
+def _command_exists(cmd: Command) -> bool:
+    executable = Path(cmd.argv[0])
+    if executable.is_absolute():
+        return executable.exists()
+    if executable.parent != Path("."):
+        return (cmd.cwd / executable).exists()
+    return shutil.which(cmd.argv[0]) is not None
+
+
+def _child_cpu_seconds() -> float:
+    usage = process_resource.getrusage(process_resource.RUSAGE_CHILDREN)
+    return usage.ru_utime + usage.ru_stime
+
+
+def _free_disk_bytes() -> int:
+    return shutil.disk_usage(REPO_ROOT).free
+
+
+def _host_security_pressure() -> Optional[tuple[str, float]]:
+    if platform.system() != "Darwin":
+        return None
+    result = subprocess.run(
+        ["ps", "-Ao", "pcpu=,comm="],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        return None
+    hottest: Optional[tuple[str, float]] = None
+    for line in result.stdout.splitlines():
+        fields = line.strip().split(maxsplit=1)
+        if len(fields) != 2:
+            continue
+        try:
+            cpu = float(fields[0])
+        except ValueError:
+            continue
+        name = Path(fields[1]).name
+        if name not in HOST_SECURITY_PROCESSES:
+            continue
+        if hottest is None or cpu > hottest[1]:
+            hottest = (name, cpu)
+    return hottest
+
+
 def _run_command(cmd: Command, artifact_dir: Path, suite: str) -> PhaseOutcome:
     """Run one command bounded by its budget, streaming output live and teeing
     it to a per-phase log."""
@@ -856,10 +1138,58 @@ def _run_command(cmd: Command, artifact_dir: Path, suite: str) -> PhaseOutcome:
     artifact_dir.mkdir(parents=True, exist_ok=True)
     log_path = artifact_dir / f"{cmd.label}.log"
     started = time.monotonic()
+    cpu_started = _child_cpu_seconds()
+    minimum_free = _free_disk_bytes()
+    disk_floor = int(RESOURCE_ENVELOPE["minimum_free_disk_bytes"])
+    sample_interval = float(RESOURCE_ENVELOPE["sample_interval_seconds"])
+    security_limit = float(RESOURCE_ENVELOPE["host_security_cpu_percent"])
+    security_samples = int(RESOURCE_ENVELOPE["host_security_samples"])
+
+    def _finish(
+        status: str,
+        failure: Optional[str],
+        failure_kind: Optional[str],
+        over_budget: bool,
+    ) -> PhaseOutcome:
+        nonlocal minimum_free
+        try:
+            minimum_free = min(minimum_free, _free_disk_bytes())
+        except OSError:
+            pass
+        return PhaseOutcome(
+            suite=suite,
+            phase=cmd.label,
+            budget_s=budget,
+            elapsed_s=time.monotonic() - started,
+            status=status,
+            over_budget=over_budget,
+            failure=failure,
+            failure_kind=failure_kind,
+            cpu_s=max(0.0, _child_cpu_seconds() - cpu_started),
+            minimum_free_disk_bytes=minimum_free,
+        )
+
+    if not _command_exists(cmd):
+        return _finish(
+            "missing_tool",
+            (
+                f"MISSING TOOL: '{cmd.argv[0]}' is not installed on this host. "
+                f"Install it or run the {cmd.label} phase where it exists."
+            ),
+            "missing_tool",
+            False,
+        )
+
+    run_argv = cmd.argv
+    nice = shutil.which("nice")
+    process_nice = int(RESOURCE_ENVELOPE["process_nice"])
+    if nice is not None and process_nice > 0:
+        run_argv = [nice, "-n", str(process_nice), *cmd.argv]
+
     with open(log_path, "w") as logf:
         try:
             proc = subprocess.Popen(
-                cmd.argv,
+                run_argv,
                 cwd=cmd.cwd,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.STDOUT,
@@ -868,18 +1198,14 @@ def _run_command(cmd: Command, artifact_dir: Path, suite: str) -> PhaseOutcome:
                 text=True,
             )
         except FileNotFoundError:
-            elapsed = time.monotonic() - started
-            return PhaseOutcome(
-                suite=suite,
-                phase=cmd.label,
-                budget_s=budget,
-                elapsed_s=elapsed,
-                status="missing_tool",
-                over_budget=False,
-                failure=(
+            return _finish(
+                "missing_tool",
+                (
                     f"MISSING TOOL: '{cmd.argv[0]}' is not installed on this host. "
                     f"Install it or run the {cmd.label} phase where it exists."
                 ),
+                "missing_tool",
+                False,
             )
 
         def _pump() -> None:
@@ -891,25 +1217,75 @@ def _run_command(cmd: Command, artifact_dir: Path, suite: str) -> PhaseOutcome:
 
         pump = threading.Thread(target=_pump, daemon=True)
         pump.start()
+        pressure_count = 0
+        pressure: Optional[tuple[str, float]] = None
+        deadline = started + budget
         try:
-            proc.wait(timeout=budget)
-        except subprocess.TimeoutExpired:
+            while proc.poll() is None:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    _kill_group(proc)
+                    pump.join(timeout=5)
+                    elapsed = time.monotonic() - started
+                    return _finish(
+                        "timed_out",
+                        (
+                            f"VERIFICATION BUDGET: phase '{cmd.label}' exceeded its {budget}s "
+                            f"wall limit (ran {elapsed:.0f}s) and was killed with its process "
+                            f"group. Product result: unproven. Log: {log_path}"
+                        ),
+                        "verification_budget",
+                        True,
+                    )
+                try:
+                    proc.wait(timeout=min(sample_interval, remaining))
+                except subprocess.TimeoutExpired:
+                    try:
+                        free = _free_disk_bytes()
+                        minimum_free = min(minimum_free, free)
+                    except OSError:
+                        free = disk_floor
+                    if free < disk_floor:
+                        _kill_group(proc)
+                        pump.join(timeout=5)
+                        return _finish(
+                            "resource_exhausted",
+                            (
+                                f"RESOURCE PRESSURE: free disk crossed the "
+                                f"{disk_floor / 2**30:.0f} GiB safety floor during "
+                                f"'{cmd.label}', so its process group was killed. Product result: "
+                                "unproven. NEXT ACTION: run `uv run python "
+                                "scripts/resource_envelope.py --recover`, then rerun the gate. "
+                                f"Log: {log_path}"
+                            ),
+                            "resource_pressure",
+                            False,
+                        )
+                    pressure = _host_security_pressure()
+                    if pressure is not None and pressure[1] >= security_limit:
+                        pressure_count += 1
+                    else:
+                        pressure_count = 0
+                    if pressure_count >= security_samples and pressure is not None:
+                        _kill_group(proc)
+                        pump.join(timeout=5)
+                        return _finish(
+                            "host_pressure",
+                            (
+                                f"HOST SECURITY PRESSURE: {pressure[0]} held {pressure[1]:.0f}% "
+                                f"CPU for {pressure_count} samples while '{cmd.label}' ran, so the "
+                                "verification group was stopped at low priority. Product result: "
+                                "unproven. NEXT ACTION: let macOS verification drain, inspect "
+                                "`ps -Ao pid,pcpu,comm | sort -k2 -nr | head`, then rerun. "
+                                f"Log: {log_path}"
+                            ),
+                            "host_security_pressure",
+                            False,
+                        )
+        except KeyboardInterrupt:
             _kill_group(proc)
             pump.join(timeout=5)
-            elapsed = time.monotonic() - started
-            return PhaseOutcome(
-                suite=suite,
-                phase=cmd.label,
-                budget_s=budget,
-                elapsed_s=elapsed,
-                status="timed_out",
-                over_budget=True,
-                failure=(
-                    f"TIMEOUT: phase '{cmd.label}' exceeded its {budget}s budget "
-                    f"(ran {elapsed:.0f}s) and was killed. No phase hangs the gate. "
-                    f"Log: {log_path}"
-                ),
-            )
+            raise
         pump.join(timeout=5)
 
     elapsed = time.monotonic() - started
@@ -919,27 +1295,21 @@ def _run_command(cmd: Command, artifact_dir: Path, suite: str) -> PhaseOutcome:
             reason = f"killed by signal {-proc.returncode}"
         else:
             reason = f"exit {proc.returncode}"
-        return PhaseOutcome(
-            suite=suite,
-            phase=cmd.label,
-            budget_s=budget,
-            elapsed_s=elapsed,
-            status="failed",
-            over_budget=over_budget,
-            failure=f"FAILED ({cmd.label}, {reason}). Log: {log_path}",
+        return _finish(
+            "failed",
+            f"PRODUCT FAILURE ({cmd.label}, {reason}). Log: {log_path}",
+            "product",
+            over_budget,
         )
     failure = None
+    failure_kind = None
     if over_budget:
-        failure = f"OVER BUDGET: phase '{cmd.label}' ran {elapsed:.1f}s / {budget}s budget"
-    return PhaseOutcome(
-        suite=suite,
-        phase=cmd.label,
-        budget_s=budget,
-        elapsed_s=elapsed,
-        status="passed",
-        over_budget=over_budget,
-        failure=failure,
-    )
+        failure = (
+            f"VERIFICATION BUDGET: phase '{cmd.label}' ran "
+            f"{elapsed:.1f}s / {budget}s wall limit"
+        )
+        failure_kind = "verification_budget"
+    return _finish("passed", failure, failure_kind, over_budget)
 
 
 def _run_suite(
@@ -967,12 +1337,13 @@ def _run_suite(
         print(f"\n$ {_fmt_cmd(cmd)}  (budget {_budget_for(cmd.label)}s)", flush=True)
         outcome = _run_command(cmd, artifact_dir, plan.suite.name)
         if outcome.failure is not None:
-            if plan.suite.classify is not None:
+            if plan.suite.classify is not None and outcome.failure_kind == "product":
                 log_path = artifact_dir / f"{cmd.label}.log"
                 log_text = log_path.read_text() if log_path.exists() else ""
                 refined = plan.suite.classify(log_text)
                 if refined is not None:
                     outcome.failure = refined
+                    outcome.failure_kind = "missing_capability"
         phases[index] = outcome
         checkpoint_phase(outcome)
         if outcome.failure is not None:
@@ -993,12 +1364,33 @@ def run_plans(
         print(f"Gate budget: {total_budget}s across {len(running)} suites ({', '.join(running)})")
         print(f"Artifacts on failure: {artifact_root}")
 
+    preflight, preflight_failure = _run_resource_check(True)
+    if preflight is not None and preflight_failure is None:
+        print(_resource_summary(preflight, "preflight"))
+
     try:
         tree_fingerprint = _tree_fingerprint()
     except (OSError, subprocess.SubprocessError) as exc:
         tree_fingerprint = None
         print(f"MEASUREMENT WARNING: cannot fingerprint the working tree: {exc}", file=sys.stderr)
     plan_fingerprint = _plan_fingerprint(plans)
+
+    initial_resources = _resource_receipt(preflight, None, [])
+    if preflight_failure is not None:
+        recorder = _start_recorder(
+            kind,
+            plans,
+            tree_fingerprint,
+            plan_fingerprint,
+            resources=initial_resources,
+        )
+        if recorder is not None:
+            recorder.run.status = "resource_blocked"
+            recorder.run.finished_at = _format_timestamp(_utc_now())
+            recorder.checkpoint()
+        print(f"\n{preflight_failure}")
+        print("\nResult: FAIL (resource preflight; product suites not run)")
+        return 1
 
     if reuse_passing and kind == "changed" and running and tree_fingerprint is not None:
         try:
@@ -1013,12 +1405,19 @@ def run_plans(
             )
             return 0
 
-    recorder = _start_recorder(kind, plans, tree_fingerprint, plan_fingerprint)
+    recorder = _start_recorder(
+        kind,
+        plans,
+        tree_fingerprint,
+        plan_fingerprint,
+        resources=initial_resources,
+    )
 
     def _checkpoint_phase(outcome: PhaseOutcome) -> None:
         if recorder is None:
             return
         recorder.run.update_phase(outcome)
+        recorder.run.resources = _resource_receipt(preflight, None, recorder.run.phases)
         recorder.checkpoint()
 
     outcomes: dict[str, SuiteOutcome] = {}
@@ -1027,8 +1426,16 @@ def run_plans(
             outcomes[plan.suite.name] = _run_suite(plan, artifact_root, _checkpoint_phase)
 
     failed = [(name, outcome) for name, outcome in outcomes.items() if not outcome.ok]
+    phases = [phase for outcome in outcomes.values() for phase in outcome.phases]
+    postflight, postflight_failure = _run_resource_check(False)
+    resource_breach = postflight_failure if postflight is not None else None
+    if postflight is not None and postflight_failure is None:
+        print(_resource_summary(postflight, "postflight"))
+    elif postflight is None and postflight_failure is not None:
+        print(f"MEASUREMENT WARNING: {postflight_failure}", file=sys.stderr)
     if recorder is not None:
-        recorder.run.status = "failed" if failed else "passed"
+        recorder.run.resources = _resource_receipt(preflight, postflight, phases)
+        recorder.run.status = "failed" if failed or resource_breach else "passed"
         recorder.run.finished_at = _format_timestamp(_utc_now())
         recorder.checkpoint()
 
@@ -1043,6 +1450,8 @@ def run_plans(
                     "passed": "PASS",
                     "failed": "FAIL",
                     "timed_out": "TIMEOUT",
+                    "resource_exhausted": "RESOURCE",
+                    "host_pressure": "HOST",
                     "missing_tool": "MISSING",
                     "not_run": "NOT RUN",
                 }[phase.status]
@@ -1050,7 +1459,8 @@ def run_plans(
                 over = "  OVER BUDGET" if phase.over_budget else ""
                 print(
                     f"  {status:<7} {phase.suite}/{phase.phase:<20} "
-                    f"{elapsed} / {phase.budget_s}s budget{over}"
+                    f"{elapsed} / {phase.budget_s}s budget · "
+                    f"{phase.cpu_s or 0.0:.1f}s CPU{over}"
                 )
             status = "PASS" if outcome.ok else "FAIL"
             detail = f"{outcome.elapsed_s:.0f}s / {_plan_budget(plan)}s budget"
@@ -1062,15 +1472,23 @@ def run_plans(
     passed = [name for name, o in outcomes.items() if o.ok]
     total_elapsed = sum(o.elapsed_s for o in outcomes.values())
     print()
-    if not outcomes:
+    if not outcomes and resource_breach is None:
         print("No suites ran (nothing changed). Use --all to force the full matrix.")
         return 0
-    if failed:
+    if failed or resource_breach is not None:
         for name, outcome in failed:
             print(f"[{name}] {outcome.failure}")
-        names = ", ".join(name for name, _ in failed)
+        if resource_breach is not None:
+            print(f"[resources] {resource_breach}")
+        names = ", ".join(
+            [
+                *(name for name, _ in failed),
+                *(("resources",) if resource_breach else ()),
+            ]
+        )
+        failure_count = len(failed) + int(resource_breach is not None)
         print(
-            f"\nResult: FAIL ({len(passed)} passed, {len(failed)} failed: {names}) "
+            f"\nResult: FAIL ({len(passed)} passed, {failure_count} failed: {names}) "
             f"in {total_elapsed:.0f}s / {total_budget}s budget"
         )
         return 1

--- a/tests/fixtures/performance_scorecard.json
+++ b/tests/fixtures/performance_scorecard.json
@@ -43,5 +43,23 @@
     "p95": 9.0,
     "verdict": "fail",
     "reason": "observed value exceeds budget"
+  },
+  {
+    "id": "build_disk_bytes",
+    "eligible": 1,
+    "measured": 1,
+    "p50": 13958643712.0,
+    "p95": 13958643712.0,
+    "verdict": "fail",
+    "reason": "observed value exceeds budget"
+  },
+  {
+    "id": "preland_cpu_seconds",
+    "eligible": 1,
+    "measured": 1,
+    "p50": 720.0,
+    "p95": 720.0,
+    "verdict": "collecting",
+    "reason": "1 samples; p95 requires 20"
   }
 ]


### PR DESCRIPTION
## Usage

```bash
uv run python scripts/resource_envelope.py
uv run python scripts/resource_envelope.py --recover
uv run python scripts/test.py
lf performance
```

## Summary

Keeps local verification inside a measured resource envelope so builds cannot silently exhaust disk or misreport host pressure as a product failure. The gate now attributes resource use, safely recovers disposable pressure, and stops before or during verification when the host cannot provide trustworthy results.

## Changes

- Added repository-owned budgets for disk headroom, build artifacts, shared caches, gate output, concurrency, and macOS security-process pressure
- Added safe recovery for inactive worktree builds, old gate artifacts, and supported uv cache pruning while preserving source, worktrees, traces, receipts, and SQLite state
- Runs build and test commands with four low-priority workers and monitors free disk and host-security CPU throughout each phase
- Records child CPU, minimum free disk, build bytes, source attribution, and typed failure causes in schema-3 gate evidence
- Surfaces measured build-disk and pre-land CPU metrics through `lf performance`
- Documents the bounded verification workflow and adds behavioral coverage for attribution, recovery boundaries, preflight blocking, in-flight pressure, and worker limits