### PR TITLE
waves: add repository-scoped ownership and relocation

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -31,10 +31,10 @@ User intent
 | **User** — the authenticated human or external harness | User authority authors root input and approves external effects; an in-Run process cannot impersonate it. | [`Author`](../rust/loopflow/src/durable.rs), [`AuthenticatedRequest`](../rust/loopflow/src/durable.rs) | No User row; authored effects persist on the concept they change. | `lf` | `lf :`, `lf desktop` | `exec:open`, `exec:osascript`, `exec:pbpaste`, `exec:id` |
 | **Skill** — one reusable prompt with assembled context | Repository/builtin Skill Markdown is authoritative; discovery selects one source. | [`Skill`](../rust/loopflow/src/engine/flow.rs), [`SkillSource`](../rust/loopflow/src/lf/discovery.rs) | `.lf/skills/`, builtin Skill files, installed vendor Skill directories | `lf-prompt` | `lf skill`, `lf sync-skills`, `lf list` (Skill/Flow catalog) | `exec:python3` |
 | **Flow** — an ordered composition of Skills | Repository/builtin Flow YAML and the current playhead decide the next step. | [`Flow`](../rust/loopflow/src/engine/flow.rs), [`FlowPosition`](../rust/loopflow/src/durable.rs) | `.lf/flows/` | `lf __flow-step` | `lf flow` | — |
-| **Wave** — durable operating context with goal, memory, cadence, chat, and project selection | `wave/<name>/GOAL.md` and `MEMORY.md` own repository intent; the Linear Initiative owns shared planning membership. | [`Wave`](../rust/loopflow/src/wave/types.rs), [`WaveConfig`](../rust/loopflow/src/engine/wave_config.rs) | `waves`; `wave/<name>/`; `.lf/journal/waves/<name>/journal.jsonl` | `lf __resident` behind the Wave listener | `lf wave`, `lf start`, `lf stop`, `lf pause`, `lf resume`, `lf chat`, `lf ls`, `lf status`, `lf roadmap`, `lf cron`; `wave GET /health`, `wave GET /conversation`, `wave GET /events`, `wave GET /playhead`, `wave POST /messages`, `wave POST /observations`, `wave POST /stop`, `wave POST /resident/attach`, `wave POST /resident/deltas`, `wave GET /resident/context` | Discord when configured |
+| **Wave** — durable operating context with goal, memory, cadence, chat, and project selection | The Wave UUID is durable identity; canonical repository plus normalized slug is its mutable human locator. `wave/<name>/GOAL.md` and `MEMORY.md` own repository intent; the Linear Initiative owns shared planning membership. | [`Wave`](../rust/loopflow/src/wave/types.rs), [`WaveLocator`](../rust/loopflow/src/wave/types.rs), [`CanonicalRepo`](../rust/loopflow/src/repository.rs), [`WaveConfig`](../rust/loopflow/src/engine/wave_config.rs) | `waves`; `wave/<name>/`; `.lf/journal/waves/<name>/journal.jsonl`; an in-flight relocation receipt under `.lf/tmp/wave-relocations/` | `lf __resident` behind the Wave listener; listener and relocation share the repository locator lock | `lf wave`, `lf start`, `lf stop`, `lf pause`, `lf resume`, `lf chat`, `lf ls`, `lf status`, `lf roadmap`, `lf cron`, `lf work relocate wave`; `wave GET /health`, `wave GET /conversation`, `wave GET /events`, `wave GET /playhead`, `wave POST /messages`, `wave POST /observations`, `wave POST /stop`, `wave POST /resident/attach`, `wave POST /resident/deltas`, `wave GET /resident/context` | Discord when configured |
 | **Project** — one measured bet inside exactly one Wave | The Linear Project definition and KRs are planning truth; the Project Work row owns pursuit lifecycle only. | [`Project`](../rust/loopflow/src/project/mod.rs), [`PmProject`](../rust/loopflow/src/pm/mod.rs) | `projects`, `project_events`, `observation_outbox`; Linear Project content | Project runner inside its Run | `lf project` | Linear |
 | **Task** — concrete work inside exactly one Project | The Linear Issue owns directive/status; Task Work owns execution lifecycle, one delivery worktree, and its serial PR chain. Git owns commits/branches; GitHub owns PR/check/merge truth. | [`Task`](../rust/loopflow/src/task/mod.rs), [`TaskPr`](../rust/loopflow/src/task/mod.rs), [`CiIncident`](../rust/loopflow/src/task/mod.rs) | `tasks`, `task_events`, `task_prs`, `ci_incidents`, `task_linear_observations`, `task_linear_ingested_comments`; Linear Issue; Git worktree | Task runner inside its Run; foreground mechanical operations and Home webhook reconciliation record delivery evidence. | `lf task`, `lf pr`, `lf wt`, `lf rebase`, `lf commit`, `lf ci` | Linear, `provider:github`, `exec:git`, `exec:gh` |
-| **PM projection** — locally readable current planning snapshot | Linear remains authoritative; sync atomically replaces the projection and reads never author through it. | [`PmSnapshotRow`](../rust/loopflow/src/store/mod.rs), [`PmWave`](../rust/loopflow/src/pm/mod.rs) | `pm_snapshots` | Foreground PM sync or Home webhook reconciliation | `lf pm` | `provider:linear` |
+| **PM projection** — locally readable current planning snapshot | Linear remains authoritative; the Wave UUID keys the projection so locator changes preserve it. Sync atomically replaces the projection and reads never author through it. | [`PmSnapshotRow`](../rust/loopflow/src/store/mod.rs), [`PmWave`](../rust/loopflow/src/pm/mod.rs) | `pm_snapshots` | Foreground PM sync or Home webhook reconciliation | `lf pm` | `provider:linear` |
 | **Epoch / Basis** — one attempt at Work truth and its authored-input revision | The Work controller opens/settles Epochs; only committed Steers advance Basis. Terminal Work outranks stale Run observations. | [`Epoch`](../rust/loopflow/src/durable.rs), [`Basis`](../rust/loopflow/src/durable.rs), [`DoneProposal`](../rust/loopflow/src/durable.rs) | `epochs`, `epoch_revisions`, `work_truth`, `work_flow_positions`, `done_proposals` | Current Work controller; active Run proposes completion against an exact Basis | `lf work`, `lf activity` | — |
 | **Steer** — durable authored correction to one Work | User or authorized parent Run writes it; incorporation is proven at a later successful Basis boundary. Live send is latency only. | [`Steer`](../rust/loopflow/src/durable.rs), [`Send`](../rust/loopflow/src/durable.rs) | `steers`, `sends`, `tool_responses` | Store transaction, then best-effort provider delivery | Work-specific `steer` commands and `lf work steer` | Model provider when delivery is live |
 | **Ask / Answer** — one Turn-local blocking question and immutable response | The route is derived from Work ancestry; the first authorized User or parent-Run answer wins. | [`AskExchange`](../rust/loopflow/src/durable.rs), [`Answer`](../rust/loopflow/src/durable.rs) | `ask_exchanges`, `ask_linear_comment_outbox` | Asking Turn blocks; authorized answerer commits; Linear comment outbox publishes later | `lf ask`, `lf work asks`, `lf work answer` | Linear comments for Task exchanges |
@@ -123,6 +123,19 @@ never writes the journal directly. `lfd` is Home keeper machinery, not an agent
 or remote-control authority. Crossing Homes is an explicit foreground `lf ssh`
 hop whose target proves its Home identity.
 
+Wave selection always resolves `(canonical repository, slug)` to one UUID.
+Bare-slug diagnostics fail when more than one repository owns the slug; no
+read or mutation chooses one by order. A scoped lookup repairs an equivalent
+legacy path spelling to the canonical repository in one transaction.
+`lf work relocate wave <uuid>` is the only semantic locator mutation: it fences
+the Wave chord, moves authored files and the journal, commits the new locator
+transactionally, and leaves PM, Work, Run, and Home-placement rows joined to the
+unchanged UUID. A target-local `.lf/tmp/wave-relocations/<uuid>.json` receipt
+bridges the filesystem/SQLite commit boundary; retrying after a committed crash
+finishes verified source cleanup, then removes the receipt. Repository moves
+also require compatible configured PM Teams so relocation cannot impersonate
+the separate `lf pm reteam` operation.
+
 ## Truth and projections
 
 The map is the ownership index. Truth remains distributed across Home-local
@@ -182,6 +195,8 @@ and current runtime source do not.
 
 - Wave → Project → Task is the complete planning hierarchy: no recursive or
   orphan Projects.
+- A Wave UUID is stable across rename and repository rehome; repository-scoped
+  locators are unique, and bare slugs are never mutation authority.
 - Linear owns current Project/Task planning; SQLite projections never become an
   authoring fallback.
 - One non-ended Run exists per Epoch; only its current opaque lease writes as

--- a/docs/lf.md
+++ b/docs/lf.md
@@ -279,6 +279,8 @@ lf task resume DES-123 --model codex --reason "Claude quota exhausted"
 lf project resume <linear-project-id> --model codex
 lf work status task task_... --json                  # stable Work projection
 lf work place wave wave_... home_...                 # move idle Wave Work to a Home
+lf work relocate wave wave_... --name platform       # rename a stopped Wave
+lf work relocate wave wave_... --repo ../moved-repo  # repair or move its repository
 lf flow scan-pass "scan the runtime"               # one pass, no loop worktree
 ```
 
@@ -298,6 +300,12 @@ Its provider process and transcript are replaceable execution state: plain
 Work, durable Steers, worktree, and PR chain while selecting another provider.
 The Task remains resumable through serial PRs, review, and explicit
 completion.
+Wave names are repository-scoped. Relocation requires the UUID because the
+repository and name may both change; it preserves authored Wave files, journal,
+PM binding, Work/Run history, and Home placement. It refuses live Wave,
+Project, or Task Runs and never keeps an old-name alias. UUID-addressed `lf
+work` reads and mutations also verify that the selected Work belongs to the
+invoking repository; a UUID from another repository is not a capability.
 Every Task runs `first → loop N → finally`. Its Project supplies those three
 flows; Task launch pins their resolved names. `--first`, `--loop`, and
 `--finally` override them only while creating the Task. A skill that needs judgment runs

--- a/docs/waves.md
+++ b/docs/waves.md
@@ -229,6 +229,22 @@ Project and Task movement stays closed while their Runs remain the
 executor. The shared Run supervisor will open that placement boundary without
 another Work-to-Run routing bridge.
 
+A Wave name is local to its canonical repository. Its UUID remains stable when
+the name or repository changes, so relocation is separate from Home placement:
+
+```bash
+lf work relocate wave <wave-id> --name platform
+lf work relocate wave <wave-id> --repo ../moved-repository
+```
+
+Stop the Wave and its descendants first. Relocation preserves its Linear
+Initiative projection, Work and Run history, journal, authored files, and Home
+placement. A repository move carries the complete Wave chord, and renaming a
+Wave carries descendants whose authored paths are nested below it. Configured
+source and target PM Teams must match; use `lf pm reteam` for an intentional
+provider ownership change. Divergent target files fail closed instead of being
+merged, and retry finishes cleanup if the locator committed before a crash.
+
 `lfd` is the one keeper process per Home. Its in-process `WaveHost` starts every
 eligible Wave known to the local store across repositories, then reconciles
 every 30 seconds. Starting or stopping one Wave does not kill `lfd` or disturb

--- a/python/tests/test_gate_bounded.py
+++ b/python/tests/test_gate_bounded.py
@@ -62,6 +62,11 @@ def _resource_report() -> dict[str, object]:
 @pytest.fixture(autouse=True)
 def _bounded_resource_fixture(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(gate, "_run_resource_check", lambda _recover: (_resource_report(), None))
+    monkeypatch.setattr(
+        gate,
+        "_free_disk_bytes",
+        lambda: int(gate.RESOURCE_ENVELOPE["minimum_free_disk_bytes"]) + 1,
+    )
 
 
 def _cmd(argv: list[str], label: str) -> "gate.Command":

--- a/rust/loopflow/src/bin/lf.rs
+++ b/rust/loopflow/src/bin/lf.rs
@@ -429,7 +429,7 @@ fn with_runtime<T>(
     command: &[String],
     run: impl FnOnce() -> anyhow::Result<T>,
 ) -> anyhow::Result<T> {
-    let attribution = loopflow::engine::wave_context::run_attribution();
+    let attribution = loopflow::engine::wave_context::run_attribution(Some(repo_root));
     if let Some(failure) = attribution.failure.as_deref() {
         warn!(
             error = failure,
@@ -1341,9 +1341,12 @@ fn main() -> anyhow::Result<()> {
             Some(Commands::Project {
                 cmd: ProjectCommand::Promote { slug, wave },
             }) => in_repo_runtime(&args, |repo| {
-                let parent =
-                    loopflow::engine::wave_context::resolve_managed_wave_name_sync(wave.as_deref())
-                        .map_err(|err| match err {
+                let parent = loopflow::engine::wave_context::resolve_managed_wave_sync(
+                    Some(repo),
+                    wave.as_deref(),
+                )
+                .map(|wave| wave.name().to_string())
+                .map_err(|err| match err {
                             loopflow::engine::wave_context::WaveResolveError::NoContext => {
                                 anyhow::anyhow!(
                                     "cannot determine parent wave; pass --wave <name>"
@@ -1372,7 +1375,7 @@ fn main() -> anyhow::Result<()> {
                 in_repo_runtime(&args, |_| loopflow::lf::commands::invocation::run(cmd))
             }
             Some(Commands::Work { cmd }) => {
-                in_repo_runtime(&args, |_| loopflow::lf::commands::work::run(cmd))
+                in_repo_runtime(&args, |repo| loopflow::lf::commands::work::run(cmd, repo))
             }
             Some(Commands::WorkRunner { kind, work_id }) => {
                 let work = match kind.as_str() {

--- a/rust/loopflow/src/engine/wave_context.rs
+++ b/rust/loopflow/src/engine/wave_context.rs
@@ -3,15 +3,15 @@
 //! the relevant Turn explicitly.
 //!
 //! Resolution: explicit `--wave` (the caller passes it) > `LF_WAVE_ID` from a
-//! managed Work process. Repository location cannot identify a
-//! Wave: every Wave and Project operates from the same canonical checkout.
+//! managed Work process. Human names resolve only inside the canonical
+//! repository; the UUID remains durable identity across locator changes.
 //!
 //! Wave state (journal, endpoint pointer, MEMORY.md) lives under the ORIGIN
 //! repo — a worktree resolves its main repo first.
 
 use crate::id::WaveId;
 use crate::wave::server::endpoint_path;
-use crate::wave::Wave;
+use crate::wave::{Wave, WaveLocator};
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::sync::{Mutex, OnceLock};
@@ -19,28 +19,19 @@ use std::sync::{Mutex, OnceLock};
 /// The durable Wave attributed to this process.
 pub const WAVE_ID_ENV: &str = "LF_WAVE_ID";
 
-/// Resolve the Wave owned by a managed process.
-///
-/// Humans choose a Wave explicitly. Managed Wave, Project, and Task processes
-/// inherit `LF_WAVE_ID` from their launcher.
-pub fn resolve_ambient_wave(env_wave_id: Option<&str>) -> Option<String> {
-    env_wave_id
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-        .map(str::to_string)
-}
-
 /// Resolve this process's ambient Wave name through the durable Wave id.
 pub fn resolve_ambient_wave_name() -> Option<String> {
-    let env_wave_id = std::env::var(WAVE_ID_ENV).ok()?;
-    wave_name_for_id(&env_wave_id)
+    let repo = crate::engine::repo::find_repo_root().ok();
+    resolve_managed_wave_sync(repo.as_deref(), None)
+        .ok()
+        .map(|wave| wave.name().to_string())
 }
 
 /// The run-attribution decision for the current process: the wave name to
 /// attribute a run to (if any), plus a classified failure to record when a
 /// supplied managed identity failed validation.
 ///
-/// - valid UUID or hand-set name → `wave: Some(name)`, `failure: None`
+/// - valid UUID or registered repository-local name → `wave: Some(name)`, `failure: None`
 /// - no managed identity (`NoContext`) → `wave: None`, `failure: None`
 ///   (worktree inference stays a legitimate fallback for this case alone)
 /// - stale UUID / registry read failure → `wave: None`, `failure: Some(...)`
@@ -55,13 +46,13 @@ pub struct RunAttribution {
     pub failure: Option<String>,
 }
 
-/// The run-attribution decision for the current process environment. One
-/// classification shared by every trace/run attribution site
+/// The run-attribution decision for the current process environment inside
+/// `repo`. One classification shared by every trace/run attribution site
 /// ([`crate::journal::ensure_run_context`] and the `lf` run wrapper).
-pub fn run_attribution() -> RunAttribution {
-    match resolve_managed_wave_name_sync(None) {
-        Ok(name) => RunAttribution {
-            wave: Some(name),
+pub fn run_attribution(repo: Option<&Path>) -> RunAttribution {
+    match resolve_managed_wave_sync(repo, None) {
+        Ok(wave) => RunAttribution {
+            wave: Some(wave.name().to_string()),
             failure: None,
         },
         Err(WaveResolveError::NoContext) => RunAttribution {
@@ -86,41 +77,14 @@ fn attribution_failure_text(error: &WaveResolveError) -> String {
     }
 }
 
-/// The Wave a managed run is attributed to, or `None` when there is no valid
-/// managed identity. Thin wrapper over [`run_attribution`] for non-attribution
-/// callers (`lf home`); trace/run attribution uses [`run_attribution`] directly
-/// so a stale identity is propagated, not swallowed.
-pub fn resolve_run_wave_name() -> Option<String> {
-    run_attribution().wave
-}
-
 /// Resolve a top-level `--wave` to the durable Wave row used by prompt,
 /// journal, and child-process attribution. Surfaces the same
 /// [`WaveResolveError`] classification as the shared resolver: an empty name is
 /// [`WaveResolveError::EmptyExplicit`], an unknown name is
 /// [`WaveResolveError::UnknownExplicit`].
 pub fn resolve_explicit_wave(name: &str) -> anyhow::Result<Wave> {
-    let name = crate::ops::util::normalize_wave_name(name)
-        .ok_or_else(|| anyhow::anyhow!("{}", WaveResolveError::EmptyExplicit))?;
-    let lookup_name = name.clone();
-    let lookup = std::thread::spawn(move || {
-        let runtime = tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()
-            .expect("current-thread runtime always builds");
-        runtime.block_on(async move {
-            let store = crate::store::open_existing_store()
-                .await
-                .ok_or_else(|| anyhow::anyhow!("no wave registry on this machine"))?;
-            store
-                .get_wave_by_name(&lookup_name)
-                .await
-                .map_err(|error| anyhow::anyhow!("failed to read wave registry: {error}"))
-        })
-    })
-    .join()
-    .map_err(|_| anyhow::anyhow!("failed to resolve explicit wave '{name}'"))??;
-    lookup.ok_or_else(|| anyhow::anyhow!("{}", WaveResolveError::UnknownExplicit(name)))
+    let repo = crate::engine::repo::find_repo_root().ok();
+    resolve_managed_wave_sync(repo.as_deref(), Some(name)).map_err(anyhow::Error::from)
 }
 
 /// Why an ambient Wave could not be resolved. The cases a caller must be able
@@ -148,102 +112,126 @@ pub enum WaveResolveError {
          run `lf ls` to list known waves, or pass --wave <known-name>"
     )]
     UnknownExplicit(String),
+    /// More than one repository owns the requested slug and the caller
+    /// supplied no repository context.
+    #[error("wave '{slug}' is ambiguous; it belongs to: {repositories}")]
+    AmbiguousWave { slug: String, repositories: String },
+    /// A durable UUID resolved, but not inside the repository invoking the
+    /// command.
+    #[error("wave {wave_id} belongs to {actual}, not invoking repository {expected}")]
+    RepositoryMismatch {
+        wave_id: WaveId,
+        expected: String,
+        actual: String,
+    },
     /// The registry read itself failed (I/O, not a miss).
     #[error("failed to read wave registry: {0}")]
     Registry(String),
 }
 
-/// THE resolver for the ambient Wave's durable name. One rule, shared by every
-/// consumer that acts on "the wave I am inside":
-///
-/// 1. explicit `--wave` always wins — normalized and validated against the
-///    registry. An unknown name is [`WaveResolveError::UnknownExplicit`]; an
-///    empty one is [`WaveResolveError::EmptyExplicit`]. No store →
-///    [`WaveResolveError::Registry`] (a machine with no registry has no valid
-///    wave names). Creation flows that accept unregistered names bypass this
-///    resolver.
-/// 2. else `LF_WAVE_ID` as a durable registry **UUID** → mapped to its Wave's
-///    name through the store. A UUID the registry has no row for is
-///    [`WaveResolveError::StaleIdentity`], never silently re-read as a name.
-/// 3. else `LF_WAVE_ID` as a hand-set **name** (intentional fallback) → used
-///    directly (no membership check — PM keys files by name, status reports
-///    no row).
-/// 4. else [`WaveResolveError::NoContext`].
-///
-/// The env is only a pointer used to find the durable Wave; identity is the
-/// registry row, never the string in the environment.
-pub async fn resolve_managed_wave_name(
+async fn resolve_slug(
+    store: &crate::store::Store,
+    repo: Option<&Path>,
+    slug: &str,
+) -> Result<Wave, WaveResolveError> {
+    if let Some(repo) = repo {
+        let locator = WaveLocator::discover(repo, slug)
+            .map_err(|error| WaveResolveError::Registry(error.to_string()))?;
+        return store
+            .get_wave_at(&locator)
+            .await
+            .map_err(|error| WaveResolveError::Registry(error.to_string()))?
+            .ok_or_else(|| WaveResolveError::UnknownExplicit(slug.to_string()));
+    }
+
+    let waves = store
+        .find_waves_by_slug(slug)
+        .await
+        .map_err(|error| WaveResolveError::Registry(error.to_string()))?;
+    match waves.as_slice() {
+        [wave] => Ok(wave.clone()),
+        [] => Err(WaveResolveError::UnknownExplicit(slug.to_string())),
+        _ => Err(WaveResolveError::AmbiguousWave {
+            slug: slug.to_string(),
+            repositories: waves
+                .iter()
+                .map(|wave| wave.repo())
+                .collect::<Vec<_>>()
+                .join(", "),
+        }),
+    }
+}
+
+/// Resolve the durable Wave row selected by explicit or ambient context.
+pub async fn resolve_managed_wave(
     store: Option<&crate::store::Store>,
+    repo: Option<&Path>,
     explicit: Option<&str>,
     env_wave_id: Option<&str>,
-) -> Result<String, WaveResolveError> {
+) -> Result<Wave, WaveResolveError> {
     if let Some(raw) = explicit {
-        let name =
+        let slug =
             crate::ops::util::normalize_wave_name(raw).ok_or(WaveResolveError::EmptyExplicit)?;
         let store = store.ok_or_else(|| {
             WaveResolveError::Registry("no wave registry on this machine".to_string())
         })?;
-        return match store.get_wave_by_name(&name).await {
-            Ok(Some(_)) => Ok(name),
-            Ok(None) => Err(WaveResolveError::UnknownExplicit(name)),
-            Err(error) => Err(WaveResolveError::Registry(error.to_string())),
-        };
+        return resolve_slug(store, repo, &slug).await;
     }
+
     let raw = env_wave_id
         .map(str::trim)
         .filter(|value| !value.is_empty())
         .ok_or(WaveResolveError::NoContext)?;
+    let store = store.ok_or_else(|| WaveResolveError::StaleIdentity(raw.to_string()))?;
     if let Ok(id) = raw.parse::<WaveId>() {
-        let store = store.ok_or_else(|| WaveResolveError::StaleIdentity(raw.to_string()))?;
-        return match store.get_wave(&id).await {
-            Ok(Some(row)) => Ok(row.name().to_string()),
-            Ok(None) => Err(WaveResolveError::StaleIdentity(raw.to_string())),
-            Err(error) => Err(WaveResolveError::Registry(error.to_string())),
-        };
+        let wave = store
+            .get_wave(&id)
+            .await
+            .map_err(|error| WaveResolveError::Registry(error.to_string()))?
+            .ok_or_else(|| WaveResolveError::StaleIdentity(raw.to_string()))?;
+        if let Some(repo) = repo {
+            let locator = WaveLocator::discover(repo, wave.name())
+                .map_err(|error| WaveResolveError::Registry(error.to_string()))?;
+            let scoped = store
+                .get_wave_at(&locator)
+                .await
+                .map_err(|error| WaveResolveError::Registry(error.to_string()))?;
+            if let Some(scoped) = scoped {
+                if scoped.id() == &id {
+                    return Ok(scoped);
+                }
+            }
+            return Err(WaveResolveError::RepositoryMismatch {
+                wave_id: id,
+                expected: locator.repo().to_string(),
+                actual: wave.repo().to_string(),
+            });
+        }
+        return Ok(wave);
     }
-    // A hand-set name: use it directly. No registry membership required — the
-    // name is the durable key file and PM surfaces already use.
-    crate::ops::util::normalize_wave_name(raw).ok_or(WaveResolveError::NoContext)
+
+    let slug = crate::ops::util::normalize_wave_name(raw).ok_or(WaveResolveError::NoContext)?;
+    resolve_slug(store, repo, &slug)
+        .await
+        .map_err(|error| match error {
+            WaveResolveError::UnknownExplicit(_) => {
+                WaveResolveError::StaleIdentity(raw.to_string())
+            }
+            other => other,
+        })
 }
 
-/// [`resolve_managed_wave_name`] for sync, store-free call sites (`lf pm …`).
-/// Reads `LF_WAVE_ID` from the env. The explicit arm validates against the
-/// registry (opening a store on a scratch thread — the same idiom as the UUID
-/// arm); the hand-set-name arm touches no store. Context assembly is sync and
-/// sometimes already inside a runtime.
-pub fn resolve_managed_wave_name_sync(explicit: Option<&str>) -> Result<String, WaveResolveError> {
-    if let Some(raw) = explicit {
-        let name =
-            crate::ops::util::normalize_wave_name(raw).ok_or(WaveResolveError::EmptyExplicit)?;
-        let name = name.to_string();
-        return std::thread::spawn(move || {
-            let runtime = tokio::runtime::Builder::new_current_thread()
-                .enable_all()
-                .build()
-                .expect("current-thread runtime always builds");
-            runtime.block_on(async move {
-                let store = crate::store::open_existing_store().await;
-                resolve_managed_wave_name(store.as_ref(), Some(&name), None).await
-            })
-        })
-        .join()
-        .unwrap_or_else(|_| {
-            Err(WaveResolveError::Registry(
-                "resolver thread panicked".to_string(),
-            ))
-        });
-    }
+/// Resolve a durable Wave row from synchronous command and context assembly.
+/// The caller supplies its repository scope; explicit names win over the
+/// ambient `LF_WAVE_ID`. The scratch thread keeps this safe inside an existing
+/// async runtime without creating a name-only resolution API.
+pub fn resolve_managed_wave_sync(
+    repo: Option<&Path>,
+    explicit: Option<&str>,
+) -> Result<Wave, WaveResolveError> {
+    let repo = repo.map(Path::to_path_buf);
+    let explicit = explicit.map(str::to_string);
     let env_wave_id = std::env::var(WAVE_ID_ENV).ok();
-    let raw = env_wave_id
-        .as_deref()
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-        .ok_or(WaveResolveError::NoContext)?;
-    // Fast path: a hand-set name needs no registry.
-    if raw.parse::<WaveId>().is_err() {
-        return crate::ops::util::normalize_wave_name(raw).ok_or(WaveResolveError::NoContext);
-    }
-    let raw = raw.to_string();
     std::thread::spawn(move || {
         let runtime = tokio::runtime::Builder::new_current_thread()
             .enable_all()
@@ -251,7 +239,13 @@ pub fn resolve_managed_wave_name_sync(explicit: Option<&str>) -> Result<String, 
             .expect("current-thread runtime always builds");
         runtime.block_on(async move {
             let store = crate::store::open_existing_store().await;
-            resolve_managed_wave_name(store.as_ref(), None, Some(&raw)).await
+            resolve_managed_wave(
+                store.as_ref(),
+                repo.as_deref(),
+                explicit.as_deref(),
+                env_wave_id.as_deref(),
+            )
+            .await
         })
     })
     .join()
@@ -314,28 +308,6 @@ fn query_repo_origin(repo_root: &Path) -> PathBuf {
         .unwrap_or_else(|| repo_root.to_path_buf())
 }
 
-/// Map an ambient `LF_WAVE_ID` value to its durable Wave name through the shared
-/// [`resolve_managed_wave_name`] rule: a UUID maps through the store, a hand-set
-/// name is used directly. The store API is async and context assembly is sync
-/// (sometimes already inside a runtime — flow skills), so it runs on a scratch
-/// thread. Any resolve error (`StaleIdentity`, registry I/O) → `None`, and
-/// resolution falls back to the worktree.
-fn wave_name_for_id(id: &str) -> Option<String> {
-    let id = id.to_string();
-    std::thread::spawn(move || {
-        let rt = tokio::runtime::Runtime::new().ok()?;
-        rt.block_on(async {
-            let store = crate::store::open_existing_store().await;
-            resolve_managed_wave_name(store.as_ref(), None, Some(&id))
-                .await
-                .ok()
-        })
-    })
-    .join()
-    .ok()
-    .flatten()
-}
-
 /// The origin repo a wave's state lives under: the main checkout when
 /// `repo_root` is a worktree root, `repo_root` itself otherwise (see
 /// [`repo_origin`] for the guard).
@@ -346,18 +318,19 @@ pub fn wave_origin(repo_root: &Path) -> PathBuf {
 /// The Wave's prompt memory, read directly from applicable `MEMORY.md` files.
 pub fn gather_wave_memory(repo_root: &Path, wave: &str) -> Option<String> {
     let origin = wave_origin(repo_root);
-    let chain = memory_wave_chain(wave).unwrap_or_else(|| vec![wave.to_string()]);
+    let chain = memory_wave_chain(&origin, wave).unwrap_or_else(|| vec![wave.to_string()]);
     gather_memory_chain(&origin, &chain)
 }
 
 /// Resolve lexical memory scope through the registry.
-fn memory_wave_chain(wave: &str) -> Option<Vec<String>> {
+fn memory_wave_chain(origin: &Path, wave: &str) -> Option<Vec<String>> {
+    let origin = origin.to_path_buf();
     let wave = wave.to_string();
     std::thread::spawn(move || {
         let rt = tokio::runtime::Runtime::new().ok()?;
         rt.block_on(async {
             let store = crate::store::open_existing_store().await?;
-            memory_wave_chain_from_store(&store, &wave).await
+            memory_wave_chain_from_store(&store, &origin, &wave).await
         })
     })
     .join()
@@ -367,9 +340,11 @@ fn memory_wave_chain(wave: &str) -> Option<Vec<String>> {
 
 async fn memory_wave_chain_from_store(
     store: &crate::store::Store,
+    origin: &Path,
     wave: &str,
 ) -> Option<Vec<String>> {
-    let mut current = store.get_wave_by_name(wave).await.ok().flatten()?;
+    let locator = WaveLocator::discover(origin, wave).ok()?;
+    let mut current = store.get_wave_at(&locator).await.ok().flatten()?;
     let mut seen = HashSet::new();
     let mut chain = Vec::new();
     loop {
@@ -437,64 +412,44 @@ fn render_wave_memory(base: &str) -> Option<String> {
 mod tests {
     use super::*;
 
-    /// The one rule the ambient call sites share: managed identity is explicit
-    /// in the process environment.
-    #[test]
-    fn ambient_rule_env_id_wins_and_is_trimmed() {
-        assert_eq!(
-            resolve_ambient_wave(Some(" wave-1 ")),
-            Some("wave-1".to_string())
-        );
-        assert_eq!(resolve_ambient_wave(Some("  ")), None);
-        assert_eq!(resolve_ambient_wave(None), None);
-    }
-
-    /// Trace attribution and `lf home` read the ambient wave through
-    /// [`resolve_run_wave_name`]. A hand-set `LF_WAVE_ID=<name>` (not a UUID)
-    /// now resolves to that name — the fix — while an absent env is `None` so
-    /// the caller falls back to the worktree. The name arm touches no store.
-    #[test]
-    fn run_wave_name_resolves_a_hand_set_name_and_none_without_context() {
-        let _lock = crate::journal::test_env_lock();
-        let previous = std::env::var(WAVE_ID_ENV).ok();
-
-        std::env::set_var(WAVE_ID_ENV, "product");
-        assert_eq!(resolve_run_wave_name(), Some("product".to_string()));
-
-        std::env::remove_var(WAVE_ID_ENV);
-        assert_eq!(resolve_run_wave_name(), None);
-
-        match previous {
-            Some(value) => std::env::set_var(WAVE_ID_ENV, value),
-            None => std::env::remove_var(WAVE_ID_ENV),
-        }
-    }
-
     /// `run_attribution` keeps the classified failure instead of swallowing it.
     /// Absent context is `(None, None)` — worktree inference stays a legitimate
-    /// fallback for it alone. A hand-set name, even one no registry row backs, is
-    /// durable and never stale: it attributes to itself with no failure (a
-    /// "stale name" is not a state the resolver produces — only UUIDs go stale).
-    /// The name arm touches no store.
+    /// fallback for it alone. A hand-set name resolves through the same scoped
+    /// registry as every human command; an unregistered name is stale context,
+    /// never self-authenticating identity.
     #[test]
     fn run_attribution_classifies_absent_context_and_hand_set_names() {
-        let _lock = crate::journal::test_env_lock();
+        let ledger = crate::journal::TestLedgerGuard::new();
         let previous = std::env::var(WAVE_ID_ENV).ok();
+        let repo = crate::engine::repo::find_repo_root().unwrap();
+        let runtime = tokio::runtime::Runtime::new().unwrap();
+        runtime.block_on(async {
+            let store = crate::store::open_store(&crate::store::StorageConfig::sqlite(
+                ledger.home().join("loopflow.db"),
+            ))
+            .await
+            .unwrap();
+            crate::wave::registry::ensure_wave_row(&store, &repo, "product")
+                .await
+                .unwrap();
+        });
 
         std::env::remove_var(WAVE_ID_ENV);
-        let absent = run_attribution();
+        let absent = run_attribution(Some(&repo));
         assert_eq!(absent.wave, None);
         assert_eq!(absent.failure, None);
 
         std::env::set_var(WAVE_ID_ENV, "product");
-        let named = run_attribution();
+        let named = run_attribution(Some(&repo));
         assert_eq!(named.wave.as_deref(), Some("product"));
         assert_eq!(named.failure, None);
 
         std::env::set_var(WAVE_ID_ENV, "ghost");
-        let unregistered = run_attribution();
-        assert_eq!(unregistered.wave.as_deref(), Some("ghost"));
-        assert_eq!(unregistered.failure, None);
+        let unregistered = run_attribution(Some(&repo));
+        assert_eq!(unregistered.wave, None);
+        assert!(unregistered
+            .failure
+            .is_some_and(|failure| failure.contains("context is stale")));
 
         match previous {
             Some(value) => std::env::set_var(WAVE_ID_ENV, value),
@@ -570,7 +525,7 @@ mod tests {
         .unwrap();
         std::fs::write(tmp.path().join("wave/release/MEMORY.md"), "Child decision.").unwrap();
 
-        let chain = memory_wave_chain_from_store(&store, "release")
+        let chain = memory_wave_chain_from_store(&store, tmp.path(), "release")
             .await
             .expect("scope resolves");
         assert_eq!(chain, ["platform", "release"]);

--- a/rust/loopflow/src/flowloop/wave.rs
+++ b/rust/loopflow/src/flowloop/wave.rs
@@ -373,14 +373,21 @@ async fn wave_control(wave: &str) -> Result<Option<WaveControl>> {
     }
     let store = Arc::new(open_store(&storage_config_from_env()?).await?);
     let lease = crate::ops::required_run_lease(&store).await?;
-    let registered = store
-        .get_wave_by_name(wave)
-        .await?
-        .ok_or_else(|| anyhow!("Wave {wave} is absent from the control store"))?;
-    if lease.work != WorkRef::Wave(registered.id().clone()) {
+    let WorkRef::Wave(wave_id) = &lease.work else {
         return Err(anyhow!(
-            "ambient Run {} does not own Wave {wave}",
+            "ambient Run {} does not own Wave Work",
             lease.run_id
+        ));
+    };
+    let registered = store
+        .get_wave(wave_id)
+        .await?
+        .ok_or_else(|| anyhow!("Wave {wave_id} is absent from the control store"))?;
+    if registered.name() != wave {
+        return Err(anyhow!(
+            "ambient Run {} owns Wave '{}', not '{wave}'",
+            lease.run_id,
+            registered.name()
         ));
     }
     Ok(Some(WaveControl {
@@ -2050,13 +2057,15 @@ mod tests {
 
     #[tokio::test]
     async fn one_wake_runs_one_full_wave_flow_then_idles() {
-        let loop_ = boot(Duration::from_secs(600), "echo done").await;
+        let mut loop_ = boot(Duration::from_secs(600), "echo done").await;
 
         loop_
             .runtime
             .deliver(MessageOp::Message, "first wake".into())
             .expect("first wake");
-        wait_for("first Wave flow", || loop_.pass_count() == 3).await;
+        for _ in 0..3 {
+            loop_.next_seed().await;
+        }
         tokio::time::sleep(Duration::from_millis(100)).await;
         assert_eq!(
             loop_.pass_count(),
@@ -2068,7 +2077,9 @@ mod tests {
             .runtime
             .deliver(MessageOp::Message, "second wake".into())
             .expect("second wake");
-        wait_for("second Wave flow", || loop_.pass_count() == 6).await;
+        for _ in 0..3 {
+            loop_.next_seed().await;
+        }
     }
 
     #[tokio::test]
@@ -2147,12 +2158,12 @@ mod tests {
     /// and the next full Wave iteration drains the whole queue.
     #[tokio::test]
     async fn messages_during_a_pass_coalesce_into_one_boundary_pass() {
-        let loop_ = boot(Duration::from_secs(600), "sleep 0.4; echo done").await;
+        let mut loop_ = boot(Duration::from_secs(600), "sleep 0.4; echo done").await;
         loop_
             .runtime
             .deliver(MessageOp::Message, "first".into())
             .expect("user turn");
-        wait_for("pass 1 spawned", || loop_.pass_count() == 1).await;
+        loop_.next_seed().await;
 
         // Two messages land mid-pass: queued, never rejected. Give the SSE
         // hop time to reach the loop before the pass exits (the biased
@@ -2168,14 +2179,11 @@ mod tests {
 
         // Clarify, pursue, and mutate finish the current iteration before the
         // queued human direction starts the next one.
-        wait_for("next iteration spawned", || loop_.pass_count() == 4).await;
-        let wake = wake_of(&loop_.seed(3));
+        loop_.next_seed().await;
+        loop_.next_seed().await;
+        let wake = wake_of(&loop_.next_seed().await);
         assert!(wake.contains("second") && wake.contains("third"));
 
-        wait_for("next iteration TurnStarted journaled", || {
-            started_answers(&loop_.journal_events()).len() == 4
-        })
-        .await;
         let answers = started_answers(&loop_.journal_events());
         assert!(answers[1].is_empty());
         assert!(answers[2].is_empty());

--- a/rust/loopflow/src/journal/mod.rs
+++ b/rust/loopflow/src/journal/mod.rs
@@ -457,7 +457,7 @@ fn ensure_run_context(
     }
 
     let main_repo = main_repo_root(repo_root).ok();
-    let attribution = crate::engine::wave_context::run_attribution();
+    let attribution = crate::engine::wave_context::run_attribution(main_repo.as_deref());
     let wave_name = attribution.wave;
     if let Some(failure) = attribution.failure.as_deref() {
         debug!(
@@ -1141,7 +1141,7 @@ mod tests {
         std::env::set_var(crate::engine::wave_context::WAVE_ID_ENV, stale_id.as_str());
 
         // `with_runtime` resolves once and records wave + failure; mirror that.
-        let attribution = crate::engine::wave_context::run_attribution();
+        let attribution = crate::engine::wave_context::run_attribution(Some(&worktree));
         assert_eq!(
             attribution.wave, None,
             "stale identity attributes to no wave"

--- a/rust/loopflow/src/lf/commands/auth.rs
+++ b/rust/loopflow/src/lf/commands/auth.rs
@@ -1539,11 +1539,29 @@ mod tests {
         let _lock = crate::journal::test_env_lock();
         let home = tempfile::tempdir().unwrap();
         let previous = std::env::var_os("LF_HOME");
+        let previous_db_path = std::env::var_os("LF_DB_PATH");
+        let previous_control_home = std::env::var_os(crate::store::CONTROL_HOME_ENV);
+        let previous_control_db_path = std::env::var_os(crate::store::CONTROL_DB_PATH_ENV);
         std::env::set_var("LF_HOME", home.path());
+        std::env::remove_var("LF_DB_PATH");
+        std::env::remove_var(crate::store::CONTROL_HOME_ENV);
+        std::env::remove_var(crate::store::CONTROL_DB_PATH_ENV);
         let result = import_account("codex", "engineering@example.com", None).await;
         match previous {
             Some(value) => std::env::set_var("LF_HOME", value),
             None => std::env::remove_var("LF_HOME"),
+        }
+        match previous_db_path {
+            Some(value) => std::env::set_var("LF_DB_PATH", value),
+            None => std::env::remove_var("LF_DB_PATH"),
+        }
+        match previous_control_home {
+            Some(value) => std::env::set_var(crate::store::CONTROL_HOME_ENV, value),
+            None => std::env::remove_var(crate::store::CONTROL_HOME_ENV),
+        }
+        match previous_control_db_path {
+            Some(value) => std::env::set_var(crate::store::CONTROL_DB_PATH_ENV, value),
+            None => std::env::remove_var(crate::store::CONTROL_DB_PATH_ENV),
         }
 
         let error = result.expect_err("Codex imports must require a stored login");
@@ -1622,8 +1640,25 @@ mod account_first_tests {
     use crate::provider_account::lease::ACCOUNT_LEASE_ENV;
     use crate::provider_account::{account_home_path, parse_account_id};
     use crate::provider_auth::Provider;
-    use crate::store::{open_store, CredentialState, ProviderAccount, RoutingState, StorageConfig};
+    use crate::store::{
+        open_store, CredentialState, ProviderAccount, RoutingState, StorageConfig,
+        CONTROL_DB_PATH_ENV, CONTROL_HOME_ENV,
+    };
     use tempfile::tempdir;
+
+    const CONNECT_ENV: &[&str] = &[
+        "HOME",
+        "LF_HOME",
+        "LF_DB_PATH",
+        CONTROL_HOME_ENV,
+        CONTROL_DB_PATH_ENV,
+        "PATH",
+        ACCOUNT_LEASE_ENV,
+        "LF_TEST_CODEX_AUTH_JSON",
+        "LF_TEST_CODEX_COUNT",
+        "LF_TEST_CODEX_HOMES",
+        "LF_TEST_CODEX_FAIL_FIRST",
+    ];
 
     struct EnvRestore(Vec<(&'static str, Option<OsString>)>);
 
@@ -1697,6 +1732,8 @@ cp "$LF_TEST_CODEX_AUTH_JSON" "$CODEX_HOME/auth.json"
         std::env::set_var("HOME", temp);
         std::env::set_var("LF_HOME", temp);
         std::env::remove_var("LF_DB_PATH");
+        std::env::remove_var(CONTROL_HOME_ENV);
+        std::env::remove_var(CONTROL_DB_PATH_ENV);
         std::env::remove_var(ACCOUNT_LEASE_ENV);
         std::env::set_var("LF_TEST_CODEX_AUTH_JSON", auth_json);
         std::env::set_var("LF_TEST_CODEX_COUNT", temp.join("codex-count"));
@@ -1766,17 +1803,7 @@ cp "$LF_TEST_CODEX_AUTH_JSON" "$CODEX_HOME/auth.json"
     async fn connect_tries_access_profiles_in_configured_order() {
         let _lock = crate::journal::test_env_lock();
         let temp = tempdir().unwrap();
-        let _restore = EnvRestore::capture(&[
-            "HOME",
-            "LF_HOME",
-            "LF_DB_PATH",
-            "PATH",
-            ACCOUNT_LEASE_ENV,
-            "LF_TEST_CODEX_AUTH_JSON",
-            "LF_TEST_CODEX_COUNT",
-            "LF_TEST_CODEX_HOMES",
-            "LF_TEST_CODEX_FAIL_FIRST",
-        ]);
+        let _restore = EnvRestore::capture(CONNECT_ENV);
         configure_connect_test(temp.path(), "operator@example.com", true);
         write_chrome_profiles(
             temp.path(),
@@ -1825,17 +1852,7 @@ cp "$LF_TEST_CODEX_AUTH_JSON" "$CODEX_HOME/auth.json"
     async fn connect_skips_drifted_venue_and_names_both_logins() {
         let _lock = crate::journal::test_env_lock();
         let temp = tempdir().unwrap();
-        let _restore = EnvRestore::capture(&[
-            "HOME",
-            "LF_HOME",
-            "LF_DB_PATH",
-            "PATH",
-            ACCOUNT_LEASE_ENV,
-            "LF_TEST_CODEX_AUTH_JSON",
-            "LF_TEST_CODEX_COUNT",
-            "LF_TEST_CODEX_HOMES",
-            "LF_TEST_CODEX_FAIL_FIRST",
-        ]);
+        let _restore = EnvRestore::capture(CONNECT_ENV);
         configure_connect_test(temp.path(), "operator@example.com", false);
         write_chrome_profiles(
             temp.path(),
@@ -1886,17 +1903,7 @@ cp "$LF_TEST_CODEX_AUTH_JSON" "$CODEX_HOME/auth.json"
     async fn connect_identity_mismatch_preserves_account_and_removes_staged_home() {
         let _lock = crate::journal::test_env_lock();
         let temp = tempdir().unwrap();
-        let _restore = EnvRestore::capture(&[
-            "HOME",
-            "LF_HOME",
-            "LF_DB_PATH",
-            "PATH",
-            ACCOUNT_LEASE_ENV,
-            "LF_TEST_CODEX_AUTH_JSON",
-            "LF_TEST_CODEX_COUNT",
-            "LF_TEST_CODEX_HOMES",
-            "LF_TEST_CODEX_FAIL_FIRST",
-        ]);
+        let _restore = EnvRestore::capture(CONNECT_ENV);
         configure_connect_test(temp.path(), "other@example.com", false);
         write_chrome_profiles(
             temp.path(),

--- a/rust/loopflow/src/lf/commands/chat.rs
+++ b/rust/loopflow/src/lf/commands/chat.rs
@@ -30,7 +30,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use crate::engine::wave_context::{
-    read_endpoint_pointer, resolve_managed_wave_name, wave_origin, WaveResolveError,
+    read_endpoint_pointer, resolve_managed_wave, wave_origin, WaveResolveError,
 };
 use crate::lf::commands::thread;
 use crate::lf::commands::util::{find_repo_root, message_text};
@@ -437,21 +437,20 @@ pub(crate) async fn resolve_target(
     // is the ambient wave (default or `--parent`); an explicit `--wave` always
     // wins, so its stale/mis-set env is never consulted.
     let mut own_row: Option<Wave> = None;
-    let mut own_name: Option<String> = None;
     if args.wave.is_none() {
         if let Some(id) = env_wave_id {
-            // The shared ambient-Wave rule: `LF_WAVE_ID` as a durable UUID
-            // maps to its registry name, else a hand-set name is used
-            // directly. A UUID the registry has never seen is a loud
-            // `StaleIdentity` error, never a silent drop.
-            let name = resolve_managed_wave_name(store.map(|store| &**store), None, Some(id))
-                .await
-                .map_err(|err| anyhow!("{err}"))?;
-            own_row = match store {
-                Some(store) => store.get_wave_by_name(&name).await?,
-                None => None,
-            };
-            own_name = Some(name);
+            // The shared ambient-Wave rule: a durable UUID maps through the
+            // registry; a hand-set name resolves inside this repository. Stale
+            // context is a loud error, never a silent drop.
+            let row = resolve_managed_wave(
+                store.map(|store| &**store),
+                main_repo.as_deref(),
+                None,
+                Some(id),
+            )
+            .await
+            .map_err(|err| anyhow!("{err}"))?;
+            own_row = Some(row);
         }
     }
 
@@ -463,11 +462,9 @@ pub(crate) async fn resolve_target(
                 WaveResolveError::Registry("no wave registry on this machine".to_string())
             )
         })?;
-        let row = store
-            .get_wave_by_name(&name)
+        let row = resolve_managed_wave(Some(&**store), main_repo.as_deref(), Some(&name), None)
             .await
-            .map_err(|err| anyhow!("failed to read wave registry: {err}"))?
-            .ok_or_else(|| anyhow!("{}", WaveResolveError::UnknownExplicit(name.clone())))?;
+            .map_err(|err| anyhow!("{err}"))?;
         (Some(row), name)
     } else if args.parent {
         let store = store.ok_or_else(|| {
@@ -489,13 +486,7 @@ pub(crate) async fn resolve_target(
                 let name = row.name().to_string();
                 (Some(row), name)
             }
-            None => {
-                // No wave context anywhere: the publish has no subscriber.
-                let Some(name) = own_name.clone() else {
-                    return Ok(None);
-                };
-                (None, name)
-            }
+            None => return Ok(None),
         }
     };
 

--- a/rust/loopflow/src/lf/commands/home.rs
+++ b/rust/loopflow/src/lf/commands/home.rs
@@ -9,7 +9,7 @@ use std::path::Path;
 
 use anyhow::anyhow;
 
-use crate::engine::wave_context::resolve_managed_wave_name_sync;
+use crate::engine::wave_context::resolve_managed_wave_sync;
 use crate::engine::wave_home::{HomeActionDto, HomeRuntimeDto, HomeState};
 use crate::lf::HomeCommand;
 
@@ -70,17 +70,18 @@ fn observe_cmd(home_id: &crate::durable::HomeId, route: &str, json: bool) -> any
     Ok(())
 }
 
-fn probe_cmd(wave: Option<&str>, json: bool, _repo: &Path) -> anyhow::Result<()> {
-    let name = resolve_managed_wave_name_sync(wave).map_err(|err| anyhow!("{err}"))?;
+fn probe_cmd(wave: Option<&str>, json: bool, repo: &Path) -> anyhow::Result<()> {
+    let selected = resolve_managed_wave_sync(Some(repo), wave).map_err(|err| anyhow!("{err}"))?;
+    let wave_id = selected.id().clone();
     let rt = tokio::runtime::Runtime::new()?;
-    let runtime = rt.block_on(async {
+    let (wave, runtime) = rt.block_on(async {
         let store = crate::store::open_existing_store()
             .await
             .ok_or_else(|| anyhow!("lf home probe needs an initialized local store"))?;
         let wave = store
-            .get_wave_by_name(&name)
+            .get_wave(&wave_id)
             .await?
-            .ok_or_else(|| anyhow!("Wave '{name}' was not found"))?;
+            .ok_or_else(|| anyhow!("Wave {wave_id} was not found"))?;
         let placement = store
             .placement(&crate::durable::WorkRef::Wave(wave.id().clone()))
             .await?;
@@ -88,14 +89,14 @@ fn probe_cmd(wave: Option<&str>, json: bool, _repo: &Path) -> anyhow::Result<()>
             .home_by_id(&placement.home_id)
             .await?
             .ok_or_else(|| anyhow!("Home {} was not found", placement.home_id))?;
-        Ok::<_, anyhow::Error>(
-            crate::ops::home::probe_home(&name, &home, Path::new(wave.repo())).await,
-        )
+        let runtime =
+            crate::ops::home::probe_home(wave.name(), &home, Path::new(wave.repo())).await;
+        Ok::<_, anyhow::Error>((wave, runtime))
     })?;
     if json {
         println!("{}", serde_json::to_string(&runtime)?);
     } else {
-        print_runtime(&name, &runtime);
+        print_runtime(wave.name(), &runtime);
     }
     Ok(())
 }
@@ -114,15 +115,16 @@ pub fn start(waves: &[String], wave_ids: &[String], json: bool, repo: &Path) -> 
     Ok(())
 }
 
-pub fn stop(name: &str, _repo: &Path) -> anyhow::Result<()> {
+pub fn stop(name: &str, repo: &Path) -> anyhow::Result<()> {
     let name = crate::ops::util::normalize_wave_name(name)
         .ok_or_else(|| anyhow!("invalid wave name: '{name}'"))?;
+    let locator = crate::wave::WaveLocator::discover(repo, &name)?;
     let runtime = tokio::runtime::Runtime::new()?;
     let stopped = runtime.block_on(async {
         let Some(store) = crate::store::open_existing_store().await else {
             return Ok::<_, anyhow::Error>(None);
         };
-        let Some(wave) = store.get_wave_by_name(&name).await? else {
+        let Some(wave) = store.get_wave_at(&locator).await? else {
             return Ok(None);
         };
         let local = store.local_home().await?;
@@ -148,8 +150,7 @@ async fn start_inner(
     );
     let local = store.local_home().await?;
     validate_expected_home(&local.id)?;
-    let repo =
-        crate::engine::worktrees::main_repo_root(repo).unwrap_or_else(|_| repo.to_path_buf());
+    let repo = crate::repository::CanonicalRepo::discover(repo)?;
     let wave_ids = parse_wave_ids(raw_wave_ids)?;
     let normalized_names = names
         .iter()
@@ -169,17 +170,17 @@ async fn start_inner(
             return Err(anyhow!("--wave-id names unselected Wave '{name}'"));
         }
     }
-    crate::lfd::ensure(&local.id, &repo).await?;
+    crate::lfd::ensure(&local.id, repo.as_path()).await?;
     let selected = if names.is_empty() {
         if !wave_ids.is_empty() {
             return Err(anyhow!("--wave-id requires explicit Wave names"));
         }
-        let repo_name = repo.display().to_string();
+        let repo_name = repo.to_string();
         let known = store.list_waves(Some(&repo_name)).await?;
         if known.is_empty() {
             return Err(anyhow!(
                 "no Waves found in {}; create one with `lf wave create <name>`",
-                repo.display()
+                repo
             ));
         }
         crate::wave_host::waves_for_home(&store, &local.id, Some(&repo_name))
@@ -194,7 +195,8 @@ async fn start_inner(
     } else {
         let mut candidates = Vec::with_capacity(normalized_names.len());
         for name in &normalized_names {
-            let existing_wave = store.get_wave_by_name(name).await?;
+            let locator = crate::wave::WaveLocator::new(repo.clone(), name)?;
+            let existing_wave = store.get_wave_at(&locator).await?;
             let prior_home = match existing_wave.as_ref() {
                 Some(wave) => Some(
                     store
@@ -211,9 +213,15 @@ async fn start_inner(
             let created = existing_wave.is_none();
             let wave_result = match wave_ids.get(&name) {
                 Some(id) => {
-                    crate::wave::registry::ensure_wave_row_with_id(&store, &repo, &name, id).await
+                    crate::wave::registry::ensure_wave_row_with_id(
+                        &store,
+                        repo.as_path(),
+                        &name,
+                        id,
+                    )
+                    .await
                 }
-                None => crate::wave::registry::ensure_wave_row(&store, &repo, &name).await,
+                None => crate::wave::registry::ensure_wave_row(&store, repo.as_path(), &name).await,
             };
             let wave = match wave_result {
                 Ok(wave) => wave,
@@ -310,11 +318,10 @@ async fn start_inner(
     if !failures.is_empty() {
         return Err(anyhow!(failures.join("; ")));
     }
-
     let mut responses = Vec::with_capacity(selected.len());
     for selection in &selected {
         let wave = store
-            .get_wave_by_name(selection.wave.name())
+            .get_wave(selection.wave.id())
             .await?
             .ok_or_else(|| anyhow!("Wave '{}' disappeared after start", selection.wave.name()))?;
         let snapshot = crate::lf::commands::waves::snapshot_wave(&store, &wave).await?;

--- a/rust/loopflow/src/lf/commands/ops/mod.rs
+++ b/rust/loopflow/src/lf/commands/ops/mod.rs
@@ -526,13 +526,13 @@ pub fn run_pm(cmd: &PmCommand) -> Result<()> {
     let progress = &CliProgress;
     let repo_root = find_repo_root()?;
     // The one ambient-Wave rule for every PM arm: `--wave` wins, else
-    // `LF_WAVE_ID` (durable UUID → registry name, hand-set name as fallback).
+    // `LF_WAVE_ID` (durable UUID or repository-scoped registered name).
     // `NoContext` stays `None` so a bare command keeps its "all waves" / "pass
     // --wave" behavior outside a managed process; a stale id is a loud error.
     let ambient_wave = |explicit: Option<&str>| -> Result<Option<String>> {
         use crate::engine::wave_context::WaveResolveError;
-        match crate::engine::wave_context::resolve_managed_wave_name_sync(explicit) {
-            Ok(name) => Ok(Some(name)),
+        match crate::engine::wave_context::resolve_managed_wave_sync(Some(&repo_root), explicit) {
+            Ok(wave) => Ok(Some(wave.name().to_string())),
             Err(WaveResolveError::NoContext) => Ok(None),
             Err(other) => Err(other.into()),
         }
@@ -1106,17 +1106,22 @@ pub fn cron_cmd(cmd: &CronCommand) -> Result<()> {
             flow,
             schedule,
         } => {
+            let repo_root = find_repo_root()?;
             // The one ambient-Wave rule, like every PM arm: `--wave` wins, else
-            // `LF_WAVE_ID` (UUID → registry name, hand-set name as fallback). A
+            // `LF_WAVE_ID` (UUID or repository-scoped registered name). A
             // scheduled invocation needs a concrete wave, so `NoContext` is the
             // familiar "pass --wave" error.
-            let wave = crate::engine::wave_context::resolve_managed_wave_name_sync(wave.as_deref())
-                .map_err(|err| match err {
-                    crate::engine::wave_context::WaveResolveError::NoContext => {
-                        anyhow!("cannot determine wave; pass --wave <name>")
-                    }
-                    other => other.into(),
-                })?;
+            let wave = crate::engine::wave_context::resolve_managed_wave_sync(
+                Some(&repo_root),
+                wave.as_deref(),
+            )
+            .map(|wave| wave.name().to_string())
+            .map_err(|err| match err {
+                crate::engine::wave_context::WaveResolveError::NoContext => {
+                    anyhow!("cannot determine wave; pass --wave <name>")
+                }
+                other => other.into(),
+            })?;
             require_release_cron_binary()?;
             let authority = cron_authority(&wave)?;
             ensure_cron_placement(&wave, &authority)?;
@@ -1340,14 +1345,18 @@ struct CronAuthority {
 }
 
 fn cron_authority(wave_name: &str) -> Result<CronAuthority> {
+    let repo_root = find_repo_root()?;
     tokio::runtime::Runtime::new()?.block_on(async {
         let store = crate::store::open_registry_for_authority()
             .await
             .map_err(cron_registry_error)?;
-        let wave = store
-            .get_wave_by_name(wave_name)
-            .await?
-            .ok_or_else(|| anyhow!("Wave '{wave_name}' was not found in the local registry"))?;
+        let wave = crate::engine::wave_context::resolve_managed_wave(
+            Some(&store),
+            Some(&repo_root),
+            Some(wave_name),
+            None,
+        )
+        .await?;
         let placement = store
             .placement(&crate::durable::WorkRef::Wave(wave.id().clone()))
             .await?;

--- a/rust/loopflow/src/lf/commands/runs.rs
+++ b/rust/loopflow/src/lf/commands/runs.rs
@@ -1105,12 +1105,21 @@ pub struct ExecLedgerEntry {
 }
 
 /// The skill runs one Wave produced, newest first.
-pub(crate) fn wave_runs(wave: &str) -> Result<(Vec<SkillRunEntry>, bool)> {
-    collect_runs(WorkFilter {
-        wave: Some(wave),
-        project: None,
-        task: None,
-    })
+pub(crate) fn wave_runs(wave_id: &crate::id::WaveId) -> Result<(Vec<SkillRunEntry>, bool)> {
+    let since = chrono::Utc::now().timestamp() - WINDOW_DAYS * 24 * 3600;
+    let store = open_ledger().map_err(|err| anyhow!("run ledger unavailable: {err}"))?;
+    let events = store
+        .list_run_events_since(since)
+        .map_err(|err| anyhow!("failed to read run ledger: {err}"))?;
+    let invocations = store
+        .agent_invocations_for_wave_since(wave_id, since)
+        .map_err(|err| anyhow!("failed to read skill invocations: {err}"))?
+        .into_iter()
+        .filter(|invocation| invocation.skill.is_some())
+        .collect::<Vec<_>>();
+    let mut runs = summarize_filtered_runs(&store, events, invocations)?;
+    let truncated = cap_runs(&mut runs);
+    Ok((runs, truncated))
 }
 
 fn sort_runs(runs: &mut [SkillRunEntry]) {

--- a/rust/loopflow/src/lf/commands/ssh.rs
+++ b/rust/loopflow/src/lf/commands/ssh.rs
@@ -182,6 +182,7 @@ fn bind_home_start_wave_ids(target: &SshTarget, lf_args: &[String]) -> anyhow::R
         .filter_map(|binding| binding.split_once('=').map(|(name, _)| name.to_string()))
         .collect::<std::collections::HashSet<_>>();
     let runtime = tokio::runtime::Runtime::new().context("failed to create async runtime")?;
+    let repo = crate::engine::repo::find_repo_root().ok();
     let bindings = runtime.block_on(async {
         let Some(store) = crate::store::open_existing_store().await else {
             return Ok::<_, anyhow::Error>(Vec::new());
@@ -194,8 +195,17 @@ fn bind_home_start_wave_ids(target: &SshTarget, lf_args: &[String]) -> anyhow::R
             if existing.contains(&name) {
                 continue;
             }
-            if let Some(wave) = store.get_wave_by_name(&name).await? {
-                bindings.push(format!("{}={}", wave.name(), wave.id()));
+            match crate::engine::wave_context::resolve_managed_wave(
+                Some(&store),
+                repo.as_deref(),
+                Some(&name),
+                None,
+            )
+            .await
+            {
+                Ok(wave) => bindings.push(format!("{}={}", wave.name(), wave.id())),
+                Err(crate::engine::wave_context::WaveResolveError::UnknownExplicit(_)) => {}
+                Err(error) => return Err(anyhow!(error)),
             }
         }
         Ok(bindings)

--- a/rust/loopflow/src/lf/commands/util.rs
+++ b/rust/loopflow/src/lf/commands/util.rs
@@ -334,6 +334,7 @@ mod tests {
     use crate::provider_account::new_account;
     use crate::store::{
         open_store, CredentialType, ProviderAccountId, ProviderToken, StorageConfig,
+        CONTROL_DB_PATH_ENV, CONTROL_HOME_ENV,
     };
     use std::ffi::OsString;
 
@@ -528,6 +529,8 @@ mod tests {
         let _restore = EnvRestore::capture(&[
             "LF_HOME",
             "LF_DB_PATH",
+            CONTROL_HOME_ENV,
+            CONTROL_DB_PATH_ENV,
             "LF_ACCOUNT_LEASE",
             "LF_TEST_SESSION_ENV",
             "CLAUDE_CONFIG_DIR",
@@ -535,6 +538,8 @@ mod tests {
         ]);
         std::env::set_var("LF_HOME", temp.path());
         std::env::remove_var("LF_DB_PATH");
+        std::env::remove_var(CONTROL_HOME_ENV);
+        std::env::remove_var(CONTROL_DB_PATH_ENV);
         std::env::remove_var("LF_ACCOUNT_LEASE");
         std::env::set_var("CLAUDE_CONFIG_DIR", "ambient");
 
@@ -590,6 +595,8 @@ mod tests {
         let _restore = EnvRestore::capture(&[
             "LF_HOME",
             "LF_DB_PATH",
+            CONTROL_HOME_ENV,
+            CONTROL_DB_PATH_ENV,
             "LF_ACCOUNT_LEASE",
             "LF_TEST_SESSION_ENV",
             "OPENCODE_API_KEY",
@@ -597,6 +604,8 @@ mod tests {
         ]);
         std::env::set_var("LF_HOME", temp.path());
         std::env::remove_var("LF_DB_PATH");
+        std::env::remove_var(CONTROL_HOME_ENV);
+        std::env::remove_var(CONTROL_DB_PATH_ENV);
         std::env::remove_var("LF_ACCOUNT_LEASE");
         std::env::set_var("OPENCODE_API_KEY", "ambient-key");
 

--- a/rust/loopflow/src/lf/commands/waves.rs
+++ b/rust/loopflow/src/lf/commands/waves.rs
@@ -548,7 +548,7 @@ pub fn ls(json: bool) -> Result<()> {
         for wave in waves {
             snapshots.push(snapshot_wave(&store, &wave).await?);
         }
-        snapshots.sort_by(|a, b| a.name.cmp(&b.name));
+        snapshots.sort_by(|a, b| a.repo.cmp(&b.repo).then(a.name.cmp(&b.name)));
         if json {
             println!("{}", serde_json::to_string(&snapshots)?);
         } else {
@@ -610,7 +610,7 @@ pub fn status(wave: Option<&str>, json: bool) -> Result<()> {
         let home_runtime =
             crate::ops::home::probe_home(wave.name(), &snapshot.home, Path::new(wave.repo())).await;
         let status = WaveDetailSnapshot {
-            runs: Evidence::from_result(crate::lf::commands::runs::wave_runs(wave.name())),
+            runs: Evidence::from_result(crate::lf::commands::runs::wave_runs(wave.id())),
             attention,
             wave: snapshot,
             loop_state,
@@ -649,22 +649,20 @@ pub fn roadmap(wave: Option<&str>, json: bool) -> Result<()> {
             return Ok(());
         };
         // The ONE ambient-Wave rule: `--wave` wins, else `LF_WAVE_ID` (durable
-        // UUID → registry name, hand-set name as fallback). Roadmap is the one
+        // UUID or repository-scoped registered name). Roadmap is the one
         // command where `NoContext` is a valid default — it lists every wave.
         // A stale UUID is a loud error, never a silent drop to global scope.
         let env_wave_id = std::env::var(crate::engine::wave_context::WAVE_ID_ENV).ok();
-        let waves = match crate::engine::wave_context::resolve_managed_wave_name(
+        let repo = crate::engine::repo::find_repo_root().ok();
+        let waves = match crate::engine::wave_context::resolve_managed_wave(
             Some(&store),
+            repo.as_deref(),
             wave,
             env_wave_id.as_deref(),
         )
         .await
         {
-            Ok(name) => vec![store
-                .get_wave_by_name(&name)
-                .await
-                .map_err(|err| anyhow!("failed to read wave registry: {err}"))?
-                .ok_or_else(|| anyhow!("wave '{name}' is not in the registry"))?],
+            Ok(wave) => vec![wave],
             Err(crate::engine::wave_context::WaveResolveError::NoContext) => store
                 .list_waves(None)
                 .await
@@ -872,22 +870,18 @@ fn project_section(project: &ProjectDetailSnapshot, liveness: Liveness) -> Roadm
 /// The wave `lf status` is about: the name the caller typed, else the wave this
 /// process is running inside.
 async fn resolve_status_wave(store: &SharedStore, requested: Option<&str>) -> Result<Wave> {
-    // One shared rule for `--wave` and ambient `LF_WAVE_ID` (durable UUID
-    // first, hand-set name as an intentional fallback). Status needs the row,
-    // so it resolves the name, then requires a registry row for it — a wave
-    // with no row has no runs to report.
-    let name = crate::engine::wave_context::resolve_managed_wave_name(
+    // One shared rule for `--wave` and ambient `LF_WAVE_ID`: durable UUID or
+    // repository-scoped registered name. Status consumes the resolved row
+    // directly, so no second lookup can cross repositories.
+    let repo = crate::engine::repo::find_repo_root().ok();
+    crate::engine::wave_context::resolve_managed_wave(
         Some(&**store),
+        repo.as_deref(),
         requested,
         ambient_wave().as_deref(),
     )
     .await
-    .map_err(|err| anyhow!("{err}"))?;
-    store
-        .get_wave_by_name(&name)
-        .await
-        .map_err(|err| anyhow!("failed to read wave registry: {err}"))?
-        .ok_or_else(|| anyhow!("wave '{name}' is not in this machine's registry"))
+    .map_err(|err| anyhow!("{err}"))
 }
 
 /// One tmux reading for the whole command. `lf status` checks a handful of tmux
@@ -1215,11 +1209,8 @@ async fn child_run_alive(
 /// tell it apart from "the plan is empty" keeps the `Option`; `lf status`
 /// flattens it to an empty plan, `lf roadmap` renders it as unavailable.
 async fn read_pm_planning(store: &SharedStore, wave: &Wave) -> Result<Option<PmSnapshot>> {
-    let repo = crate::engine::worktrees::main_repo_root(Path::new(wave.repo()))
-        .unwrap_or_else(|_| Path::new(wave.repo()).to_path_buf());
-    let repo = std::fs::canonicalize(&repo).unwrap_or(repo);
     let Some(row) = store
-        .pm_snapshot(repo.to_string_lossy().into_owned(), wave.name().to_string())
+        .pm_snapshot(wave.id())
         .await
         .map_err(|err| anyhow!("failed to read PM snapshot: {err}"))?
     else {
@@ -1244,7 +1235,7 @@ async fn validate_pm_portfolio(store: &SharedStore, waves: &[Wave]) -> Result<()
             .unwrap_or_else(|_| Path::new(wave.repo()).to_path_buf());
         let repo = std::fs::canonicalize(&repo).unwrap_or(repo);
         let Some(row) = store
-            .pm_snapshot(repo.to_string_lossy().into_owned(), wave.name().to_string())
+            .pm_snapshot(wave.id())
             .await
             .map_err(|err| anyhow!("failed to read PM snapshot: {err}"))?
         else {
@@ -2029,10 +2020,11 @@ fn print_wave_table(snapshots: &[WaveSnapshot]) {
     }
     let colors = Colors::default();
     println!(
-        "{bold}{name:<16}  {status:<8}  {turns:<7}  {live:<5}  {tasks:>5}  {projects:>8}  {home:<16}  ENDPOINT{reset}",
+        "{bold}{name:<16}  {repo:<28}  {status:<8}  {turns:<7}  {live:<5}  {tasks:>5}  {projects:>8}  {home:<16}  ENDPOINT{reset}",
         bold = colors.bold,
         reset = colors.reset,
         name = "WAVE",
+        repo = "REPOSITORY",
         status = "STATUS",
         turns = "TURNS",
         live = "LIVE",
@@ -2042,8 +2034,9 @@ fn print_wave_table(snapshots: &[WaveSnapshot]) {
     );
     for wave in snapshots {
         println!(
-            "{name:<16}  {status:<8}  {turns:<7}  {live:<5}  {tasks:>5}  {projects:>8}  {home:<16}  {endpoint}",
+            "{name:<16}  {repo:<28}  {status:<8}  {turns:<7}  {live:<5}  {tasks:>5}  {projects:>8}  {home:<16}  {endpoint}",
             name = truncate(&wave.name, 16),
+            repo = truncate_start(&wave.repo, 28),
             status = work_status_label(&wave.status),
             turns = if wave.paused { "paused" } else { "enabled" },
             live = if wave.live { "yes" } else { "no" },
@@ -2507,6 +2500,18 @@ fn truncate(value: &str, width: usize) -> String {
     format!("{head}\u{2026}")
 }
 
+fn truncate_start(value: &str, width: usize) -> String {
+    let length = value.chars().count();
+    if length <= width {
+        return value.to_string();
+    }
+    let tail = value
+        .chars()
+        .skip(length.saturating_sub(width.saturating_sub(1)))
+        .collect::<String>();
+    format!("\u{2026}{tail}")
+}
+
 #[cfg(test)]
 mod tests {
     use std::time::Duration;
@@ -2514,13 +2519,22 @@ mod tests {
     use time::OffsetDateTime;
 
     use super::{
-        derive_task_attention, next_move_for_task, LocalProgressEvidence,
+        derive_task_attention, next_move_for_task, truncate_start, LocalProgressEvidence,
         LocalProgressEvidenceState, NextMove, NextMoveOwner, TaskAttentionEvidence,
         TaskAttentionLevel, TaskProcessEvidence, TaskProcessEvidenceState, TaskRuntimeSnapshot,
     };
     use crate::child::{observe, BodyEvidence, BodyIntent};
     use crate::durable::WorkStatus;
     use crate::task::{CiObservation, CiState, PrMergeMode, PrMergeRequest, PrPhase};
+
+    #[test]
+    fn repository_columns_keep_the_distinguishing_path_tail() {
+        assert_eq!(
+            truncate_start("/long/shared/prefix/alpha", 10),
+            "\u{2026}fix/alpha"
+        );
+        assert_eq!(truncate_start("beta", 10), "beta");
+    }
 
     #[test]
     fn only_a_durable_ask_marks_a_running_task_as_waiting_on_the_user() {

--- a/rust/loopflow/src/lf/commands/work.rs
+++ b/rust/loopflow/src/lf/commands/work.rs
@@ -1,5 +1,6 @@
 use anyhow::{anyhow, Context};
 use serde::Serialize;
+use std::path::Path;
 
 use crate::durable::{
     Answer, AskExchange, AuthenticatedRequest, ControlCtx, EpochReceipt, InterruptReceipt,
@@ -21,20 +22,22 @@ struct WorkProjection {
 #[serde(tag = "kind", rename_all = "snake_case")]
 enum WorkReceipt {
     Placed(Placement),
+    Relocated(crate::wave::relocate::WaveRelocationReceipt),
     Steer(SteerReceipt),
     Interrupted(InterruptReceipt),
     Abandoned(EpochReceipt),
 }
 
-pub fn run(command: &WorkCommand) -> anyhow::Result<()> {
-    tokio::runtime::Runtime::new()?.block_on(run_async(command))
+pub fn run(command: &WorkCommand, repo: &Path) -> anyhow::Result<()> {
+    tokio::runtime::Runtime::new()?.block_on(run_async(command, repo))
 }
 
-async fn run_async(command: &WorkCommand) -> anyhow::Result<()> {
+async fn run_async(command: &WorkCommand, repo: &Path) -> anyhow::Result<()> {
     let store = open_shared_store().await?;
     match command {
         WorkCommand::Status { kind, id, json } => {
             let work = parse_work(kind, id)?;
+            require_work_repository(&store, &work, repo).await?;
             let projection = projection(&store, &work).await?;
             print_projection(&projection, *json)?;
         }
@@ -45,6 +48,7 @@ async fn run_async(command: &WorkCommand) -> anyhow::Result<()> {
             json,
         } => {
             let work = parse_work(kind, id)?;
+            require_work_repository(&store, &work, repo).await?;
             if !matches!(work, WorkRef::Wave(_)) {
                 return Err(anyhow!(
                     "only Wave Work can move until Project and Task execution uses the shared Run supervisor"
@@ -53,6 +57,27 @@ async fn run_async(command: &WorkCommand) -> anyhow::Result<()> {
             let placement = store.place_work(&work, home_id).await?;
             print_receipt(&WorkReceipt::Placed(placement), *json)?;
         }
+        WorkCommand::Relocate {
+            kind,
+            id,
+            repo: target_repo,
+            name,
+            json,
+        } => {
+            if kind != "wave" {
+                return Err(anyhow!("only Wave Work has a repository locator"));
+            }
+            let wave_id = WaveId::parse(id)?;
+            let receipt = crate::wave::relocate::relocate_wave(
+                &store,
+                &wave_id,
+                repo,
+                target_repo.as_deref(),
+                name.as_deref(),
+            )
+            .await?;
+            print_receipt(&WorkReceipt::Relocated(receipt), *json)?;
+        }
         WorkCommand::Steer {
             kind,
             id,
@@ -60,7 +85,9 @@ async fn run_async(command: &WorkCommand) -> anyhow::Result<()> {
             json,
         } => {
             let work = parse_work(kind, id)?;
-            let receipt = if let Some(lease) = crate::ops::ambient_run_lease(&store).await? {
+            let lease = crate::ops::ambient_run_lease(&store).await?;
+            require_work_repository(&store, &work, repo).await?;
+            let receipt = if let Some(lease) = lease {
                 store
                     .steer(&ControlCtx::Run(&lease), &work, message, None)
                     .await?
@@ -78,6 +105,7 @@ async fn run_async(command: &WorkCommand) -> anyhow::Result<()> {
                 (Some(lease), None, None) => store.pending_asks_for_parent(&lease.work).await?,
                 (Some(lease), Some(kind), Some(id)) => {
                     let parent = parse_work(kind, id)?;
+                    require_work_repository(&store, &parent, repo).await?;
                     if parent != lease.work {
                         return Err(anyhow!(
                             "ambient Run owns {} {}, not {} {}",
@@ -114,6 +142,7 @@ async fn run_async(command: &WorkCommand) -> anyhow::Result<()> {
         }
         WorkCommand::Interrupt { kind, id, json } => {
             let work = parse_work(kind, id)?;
+            require_work_repository(&store, &work, repo).await?;
             let run = store
                 .current_run(&work)
                 .await?
@@ -137,6 +166,7 @@ async fn run_async(command: &WorkCommand) -> anyhow::Result<()> {
             json,
         } => {
             let work = parse_work(kind, id)?;
+            require_work_repository(&store, &work, repo).await?;
             if crate::ops::ambient_run_lease(&store).await?.is_some() {
                 return Err(anyhow!(
                     "Run callers cannot abandon Work; use the authenticated User surface"
@@ -197,6 +227,42 @@ fn parse_work(kind: &str, id: &str) -> anyhow::Result<WorkRef> {
     }
 }
 
+async fn require_work_repository(store: &Store, work: &WorkRef, repo: &Path) -> anyhow::Result<()> {
+    let wave_id = match work {
+        WorkRef::Wave(wave_id) => wave_id.clone(),
+        WorkRef::Project(project_id) => {
+            store
+                .get_project(project_id)
+                .await?
+                .ok_or_else(|| anyhow!("Project {project_id} is not registered"))?
+                .wave_id
+        }
+        WorkRef::Task(task_id) => {
+            store
+                .get_task(task_id)
+                .await?
+                .ok_or_else(|| anyhow!("Task {task_id} is not registered"))?
+                .wave_id
+        }
+    };
+    let wave = store
+        .get_wave(&wave_id)
+        .await?
+        .ok_or_else(|| anyhow!("Wave {wave_id} is not registered"))?;
+    let locator = crate::wave::WaveLocator::discover(repo, wave.name())?;
+    let local = store.get_wave_at(&locator).await?;
+    if local.as_ref().map(crate::wave::Wave::id) != Some(&wave_id) {
+        return Err(anyhow!(
+            "{} {} belongs to repository {}, not invoking repository {}",
+            work.kind(),
+            work.id(),
+            wave.repo(),
+            locator.repo()
+        ));
+    }
+    Ok(())
+}
+
 fn print_projection(projection: &WorkProjection, json: bool) -> anyhow::Result<()> {
     if json {
         println!("{}", serde_json::to_string_pretty(projection)?);
@@ -227,6 +293,14 @@ fn print_receipt(receipt: &WorkReceipt, json: bool) -> anyhow::Result<()> {
                 placement.work.kind(),
                 placement.work.id(),
                 placement.home_id
+            ),
+            WorkReceipt::Relocated(relocation) => println!(
+                "Wave {}  {}/{}  ->  {}/{}",
+                relocation.wave_id,
+                relocation.from_repo,
+                relocation.from_name,
+                relocation.to_repo,
+                relocation.to_name
             ),
             WorkReceipt::Steer(receipt) => println!("steered {}", receipt.steer.id),
             WorkReceipt::Interrupted(receipt) => println!("interrupted {}", receipt.run_id),

--- a/rust/loopflow/src/lf/mod.rs
+++ b/rust/loopflow/src/lf/mod.rs
@@ -750,6 +750,18 @@ pub enum WorkCommand {
         #[arg(long)]
         json: bool,
     },
+    /// Rename or rehome stopped Wave Work without changing its identity
+    Relocate {
+        #[arg(value_parser = ["wave"])]
+        kind: String,
+        id: String,
+        #[arg(long)]
+        repo: Option<PathBuf>,
+        #[arg(long)]
+        name: Option<String>,
+        #[arg(long)]
+        json: bool,
+    },
     /// Append authored direction through User or active parent Run authority
     Steer {
         #[arg(value_parser = ["wave", "project", "task"])]

--- a/rust/loopflow/src/ops/pm.rs
+++ b/rust/loopflow/src/ops/pm.rs
@@ -661,15 +661,6 @@ fn storage_config_from_env() -> OpsResult<crate::store::StorageConfig> {
         .map_err(|err| OpsError::Message(format!("failed to resolve credential store: {err}")))
 }
 
-fn pm_repo_key(repo: &Path) -> String {
-    let root =
-        crate::engine::worktrees::main_repo_root(repo).unwrap_or_else(|_| repo.to_path_buf());
-    std::fs::canonicalize(&root)
-        .unwrap_or(root)
-        .to_string_lossy()
-        .into_owned()
-}
-
 async fn pm_store() -> OpsResult<Store> {
     open_store(&storage_config_from_env()?)
         .await
@@ -705,9 +696,18 @@ pub(crate) fn format_age(secs: i64) -> String {
 }
 
 async fn snapshot_row(repo: &Path, wave: &str) -> OpsResult<Option<PmSnapshotRow>> {
-    pm_store()
-        .await?
-        .pm_snapshot(pm_repo_key(repo), wave.to_string())
+    let store = pm_store().await?;
+    let locator = crate::wave::WaveLocator::discover(repo, wave)
+        .map_err(|error| OpsError::Message(error.to_string()))?;
+    let Some(wave) = store
+        .get_wave_at(&locator)
+        .await
+        .map_err(|err| OpsError::Message(format!("failed to read Wave registry: {err}")))?
+    else {
+        return Ok(None);
+    };
+    store
+        .pm_snapshot(wave.id())
         .await
         .map_err(|err| OpsError::Message(format!("failed to read PM snapshot: {err}")))
 }
@@ -887,10 +887,12 @@ async fn store_pm_snapshot_with_store(
             "failed to serialize PM snapshot for wave/{wave}: {err}"
         ))
     })?;
+    let registered = crate::wave::registry::ensure_wave_row(store, repo, wave)
+        .await
+        .map_err(|err| OpsError::Message(format!("failed to register PM Wave: {err}")))?;
     store
         .put_pm_snapshot(PmSnapshotRow {
-            repo: pm_repo_key(repo),
-            wave: wave.to_string(),
+            wave_id: registered.id().clone(),
             provider: ctx.provider.as_str().to_string(),
             initiative: ctx.initiative.clone(),
             synced_at: time::OffsetDateTime::now_utc().unix_timestamp(),
@@ -2937,8 +2939,10 @@ async fn canonical_wave_title_path_with_store(
     wave: &str,
     store: &Store,
 ) -> OpsResult<String> {
+    let locator = crate::wave::WaveLocator::discover(repo, wave)
+        .map_err(|error| OpsError::Message(error.to_string()))?;
     let Some(mut current) = store
-        .get_wave_by_name(wave)
+        .get_wave_at(&locator)
         .await
         .map_err(|error| OpsError::Message(format!("failed to read Wave ancestry: {error}")))?
     else {
@@ -2965,14 +2969,6 @@ async fn canonical_wave_title_path_with_store(
         let current_repo = std::fs::canonicalize(current.repo())
             .unwrap_or_else(|_| Path::new(current.repo()).to_path_buf());
         if current_repo != main {
-            // Root Wave names are repository-local PM identity. The runtime
-            // registry still has a legacy machine-global name index, so a
-            // same-named root Wave in another repository must not steal this
-            // repository's Project title path. Nested Waves still require
-            // durable ancestry because their parent path cannot be inferred.
-            if !wave.contains('/') && main.join("wave").join(wave).join("GOAL.md").is_file() {
-                return Ok(title_case(wave));
-            }
             return Err(OpsError::Message(format!(
                 "Wave ancestry for wave/{wave} crosses repositories at {} ({})",
                 current.name(),

--- a/rust/loopflow/src/ops/project.rs
+++ b/rust/loopflow/src/ops/project.rs
@@ -89,12 +89,14 @@ async fn project_work_status(store: &Store, project: &Project) -> OpsResult<Work
         .map_err(|error| project_error(error.to_string()))
 }
 
-pub(crate) fn require_registered_wave(wave: &str) -> OpsResult<Wave> {
+pub(crate) fn require_registered_wave(repo: &Path, wave: &str) -> OpsResult<Wave> {
+    let locator = crate::wave::WaveLocator::discover(repo, wave)
+        .map_err(|error| project_error(error.to_string()))?;
     let wave = wave.to_string();
     block_on_project(async move {
         project_store()
             .await?
-            .get_wave_by_name(&wave)
+            .get_wave_at(&locator)
             .await
             .map_err(|error| project_error(format!("failed to read owning Wave: {error}")))?
             .ok_or_else(|| {
@@ -164,6 +166,8 @@ pub(crate) fn reserve_project(
     resolved: crate::ops::task_pm::ResolvedProject,
     directive: Option<String>,
 ) -> OpsResult<Project> {
+    let locator = crate::wave::WaveLocator::discover(repo, &resolved.snapshot.wave)
+        .map_err(|error| project_error(error.to_string()))?;
     let config = load_config_or_default(Some(repo));
     let agent = config.agent();
     let (provider, _) = parse_agent(agent);
@@ -189,7 +193,7 @@ pub(crate) fn reserve_project(
             }
         }
         let wave = store
-            .get_wave_by_name(&resolved.snapshot.wave)
+            .get_wave_at(&locator)
             .await
             .map_err(|error| project_error(format!("failed to read owning Wave: {error}")))?
             .ok_or_else(|| {
@@ -311,7 +315,7 @@ pub fn project_start(
     directive: Option<String>,
 ) -> OpsResult<Project> {
     let main = ensure_clean_main(repo, "Project start")?;
-    let wave = crate::engine::wave_context::resolve_managed_wave_name_sync(wave).map_err(
+    let wave = crate::engine::wave_context::resolve_managed_wave_sync(Some(&main), wave).map_err(
         |err| match err {
             crate::engine::wave_context::WaveResolveError::NoContext => {
                 project_error("cannot determine wave; pass --wave <name>")
@@ -319,7 +323,7 @@ pub fn project_start(
             other => project_error(other.to_string()),
         },
     )?;
-    require_registered_wave(&wave)?;
+    let wave = wave.name().to_string();
     let project = crate::ops::pm::pm_create_project(&main, Some(&wave), title)?;
     if let Err(error) =
         crate::ops::task_pm::load_wave(&main, &wave, crate::ops::pm::PmRefresh::Force)
@@ -775,13 +779,17 @@ async fn prepare_promotion_with_store(
     parent: &str,
     child: &str,
 ) -> OpsResult<()> {
+    let parent_locator = crate::wave::WaveLocator::discover(repo, parent)
+        .map_err(|error| project_error(error.to_string()))?;
+    let child_locator = crate::wave::WaveLocator::discover(repo, child)
+        .map_err(|error| project_error(error.to_string()))?;
     let parent = store
-        .get_wave_by_name(parent)
+        .get_wave_at(&parent_locator)
         .await
         .map_err(|error| project_error(format!("failed to read parent Wave: {error}")))?
         .ok_or_else(|| project_error(format!("parent Wave '{parent}' is not registered")))?;
     let existing = store
-        .get_wave_by_name(child)
+        .get_wave_at(&child_locator)
         .await
         .map_err(|error| project_error(format!("failed to read child Wave: {error}")))?;
     if let Some(mut child_wave) = existing {
@@ -793,12 +801,6 @@ async fn prepare_promotion_with_store(
                 "child Wave '{child}' already belongs to another parent"
             )));
         }
-        if Path::new(child_wave.repo()) != repo {
-            return Err(project_error(format!(
-                "child Wave '{child}' is registered to another repository ({})",
-                child_wave.repo()
-            )));
-        }
         if child_wave.parent_wave_id().is_none() {
             child_wave = child_wave.with_parent(parent.id().clone());
             store.update_wave(&child_wave).await.map_err(|error| {
@@ -808,8 +810,12 @@ async fn prepare_promotion_with_store(
         return Ok(());
     }
 
-    let child_wave = Wave::new(WaveId::new(), child.to_string(), repo.display().to_string())
-        .with_parent(parent.id().clone());
+    let child_wave = Wave::new(
+        WaveId::new(),
+        child_locator.slug().to_string(),
+        child_locator.repo().to_string(),
+    )
+    .with_parent(parent.id().clone());
     store
         .create_wave(&child_wave)
         .await
@@ -881,25 +887,27 @@ async fn wake_child_observer(endpoint: &str, parent: &str, wave: &str) {
 }
 
 async fn record_promotion(store: &Store, repo: &Path, parent: &str, child: &str) -> OpsResult<()> {
+    let parent_locator = crate::wave::WaveLocator::discover(repo, parent)
+        .map_err(|error| OpsError::Message(error.to_string()))?;
+    let child_locator = crate::wave::WaveLocator::discover(repo, child)
+        .map_err(|error| OpsError::Message(error.to_string()))?;
     let parent = store
-        .get_wave_by_name(parent)
+        .get_wave_at(&parent_locator)
         .await
         .map_err(|err| OpsError::Message(format!("failed to read parent wave: {err}")))?
         .ok_or_else(|| OpsError::Message(format!("parent wave '{parent}' is not registered")))?;
     let mut child_wave = match store
-        .get_wave_by_name(child)
+        .get_wave_at(&child_locator)
         .await
         .map_err(|err| OpsError::Message(format!("failed to read child wave: {err}")))?
     {
         Some(wave) => wave,
-        None => Wave::new(WaveId::new(), child.to_string(), repo.display().to_string()),
+        None => Wave::new(
+            WaveId::new(),
+            child_locator.slug().to_string(),
+            child_locator.repo().to_string(),
+        ),
     };
-    if Path::new(child_wave.repo()) != repo {
-        return Err(OpsError::Message(format!(
-            "child Wave '{child}' is registered to another repository ({})",
-            child_wave.repo()
-        )));
-    }
     child_wave
         .record_promotion(parent.id(), time::OffsetDateTime::now_utc())
         .map_err(OpsError::Message)?;
@@ -1148,7 +1156,7 @@ mod tests {
             .unwrap();
 
         let child = store
-            .get_wave_by_name("infrastructure")
+            .get_wave_at(&crate::wave::WaveLocator::discover(tmp.path(), "infrastructure").unwrap())
             .await
             .unwrap()
             .unwrap();
@@ -1185,32 +1193,21 @@ mod tests {
             .await
             .unwrap();
 
-        let child = store
-            .get_wave_by_name("release-stability")
-            .await
-            .unwrap()
-            .unwrap();
+        let locator = crate::wave::WaveLocator::discover(tmp.path(), "release-stability").unwrap();
+        let child = store.get_wave_at(&locator).await.unwrap().unwrap();
         assert_eq!(child.parent_wave_id(), Some(parent.id()));
         let promoted_at = child.promoted_at().expect("promotion occurrence");
-        assert_eq!(child.repo(), tmp.path().display().to_string());
+        assert_eq!(child.repo(), locator.repo().to_string());
 
         record_promotion(&store, tmp.path(), "platform", "release-stability")
             .await
             .unwrap();
-        let replayed = store
-            .get_wave_by_name("release-stability")
-            .await
-            .unwrap()
-            .unwrap();
+        let replayed = store.get_wave_at(&locator).await.unwrap().unwrap();
         assert_eq!(replayed.promoted_at(), Some(promoted_at));
 
         let stale = replayed.with_parent(WaveId::new());
         store.update_wave(&stale).await.unwrap();
-        let preserved = store
-            .get_wave_by_name("release-stability")
-            .await
-            .unwrap()
-            .unwrap();
+        let preserved = store.get_wave_at(&locator).await.unwrap().unwrap();
         assert_eq!(preserved.parent_wave_id(), Some(parent.id()));
         assert_eq!(preserved.promoted_at(), Some(promoted_at));
     }

--- a/rust/loopflow/src/ops/task.rs
+++ b/rust/loopflow/src/ops/task.rs
@@ -745,7 +745,7 @@ pub fn task_start(
         .map_err(|error| task_error(error.to_string()))?;
     let project =
         crate::ops::task_pm::resolve_project(&main, project_id, crate::ops::pm::PmRefresh::Auto)?;
-    crate::ops::project::require_registered_wave(&project.snapshot.wave)
+    crate::ops::project::require_registered_wave(&main, &project.snapshot.wave)
         .map_err(|error| task_error(error.to_string()))?;
     let project_flows = project
         .project

--- a/rust/loopflow/src/provider_account.rs
+++ b/rust/loopflow/src/provider_account.rs
@@ -1486,8 +1486,16 @@ mod account_first_tests {
             permissions.set_mode(0o755);
             fs::set_permissions(&claude, permissions).unwrap();
         }
-        let _restore = EnvRestore::capture(&["LF_HOME", "PATH", lease::ACCOUNT_LEASE_ENV]);
+        let _restore = EnvRestore::capture(&[
+            "LF_HOME",
+            "LF_CONTROL_HOME",
+            "LF_CONTROL_DB_PATH",
+            "PATH",
+            lease::ACCOUNT_LEASE_ENV,
+        ]);
         std::env::set_var("LF_HOME", temp.path());
+        std::env::set_var("LF_CONTROL_HOME", temp.path());
+        std::env::remove_var("LF_CONTROL_DB_PATH");
         let path = std::env::var_os("PATH").unwrap_or_default();
         std::env::set_var(
             "PATH",
@@ -1532,8 +1540,15 @@ mod account_first_tests {
     async fn hard_limit_moves_the_route_to_the_next_account() {
         let _lock = crate::journal::test_env_lock();
         let temp = tempdir().unwrap();
-        let _restore = EnvRestore::capture(&["LF_HOME", lease::ACCOUNT_LEASE_ENV]);
+        let _restore = EnvRestore::capture(&[
+            "LF_HOME",
+            "LF_CONTROL_HOME",
+            "LF_CONTROL_DB_PATH",
+            lease::ACCOUNT_LEASE_ENV,
+        ]);
         std::env::set_var("LF_HOME", temp.path());
+        std::env::set_var("LF_CONTROL_HOME", temp.path());
+        std::env::remove_var("LF_CONTROL_DB_PATH");
         std::env::remove_var(lease::ACCOUNT_LEASE_ENV);
         let store = Arc::new(
             open_store(&StorageConfig::sqlite(temp.path().join("loopflow.db")))
@@ -1706,8 +1721,15 @@ mod account_first_tests {
     async fn missing_routes_are_unmanaged_and_unusable_routes_fail() {
         let _lock = crate::journal::test_env_lock();
         let temp = tempdir().unwrap();
-        let _restore = EnvRestore::capture(&["LF_HOME", lease::ACCOUNT_LEASE_ENV]);
+        let _restore = EnvRestore::capture(&[
+            "LF_HOME",
+            "LF_CONTROL_HOME",
+            "LF_CONTROL_DB_PATH",
+            lease::ACCOUNT_LEASE_ENV,
+        ]);
         std::env::set_var("LF_HOME", temp.path());
+        std::env::set_var("LF_CONTROL_HOME", temp.path());
+        std::env::remove_var("LF_CONTROL_DB_PATH");
         std::env::remove_var(lease::ACCOUNT_LEASE_ENV);
 
         assert!(resolve_provider_account(Provider::Claude, None)
@@ -1753,8 +1775,15 @@ mod account_first_tests {
     async fn accounts_form_an_implicit_route_when_no_route_is_configured() {
         let _lock = crate::journal::test_env_lock();
         let temp = tempdir().unwrap();
-        let _restore = EnvRestore::capture(&["LF_HOME", lease::ACCOUNT_LEASE_ENV]);
+        let _restore = EnvRestore::capture(&[
+            "LF_HOME",
+            "LF_CONTROL_HOME",
+            "LF_CONTROL_DB_PATH",
+            lease::ACCOUNT_LEASE_ENV,
+        ]);
         std::env::set_var("LF_HOME", temp.path());
+        std::env::set_var("LF_CONTROL_HOME", temp.path());
+        std::env::remove_var("LF_CONTROL_DB_PATH");
         std::env::remove_var(lease::ACCOUNT_LEASE_ENV);
         let store = Arc::new(
             open_store(&StorageConfig::sqlite(temp.path().join("loopflow.db")))

--- a/rust/loopflow/src/provider_account/lease.rs
+++ b/rust/loopflow/src/provider_account/lease.rs
@@ -1406,9 +1406,13 @@ mod tests {
         let temp = tempdir().unwrap();
         let _home = RestoreEnv::capture("LF_HOME");
         let _database = RestoreEnv::capture("LF_DB_PATH");
+        let _control_home = RestoreEnv::capture("LF_CONTROL_HOME");
+        let _control_database = RestoreEnv::capture("LF_CONTROL_DB_PATH");
         let _lease = RestoreEnv::capture(ACCOUNT_LEASE_ENV);
         std::env::set_var("LF_HOME", temp.path());
         std::env::remove_var("LF_DB_PATH");
+        std::env::set_var("LF_CONTROL_HOME", temp.path());
+        std::env::remove_var("LF_CONTROL_DB_PATH");
         std::env::remove_var(ACCOUNT_LEASE_ENV);
 
         let store = Arc::new(
@@ -1470,6 +1474,8 @@ mod tests {
         let temp = tempdir().unwrap();
         let _home = RestoreEnv::capture("LF_HOME");
         let _database = RestoreEnv::capture("LF_DB_PATH");
+        let _control_home = RestoreEnv::capture("LF_CONTROL_HOME");
+        let _control_database = RestoreEnv::capture("LF_CONTROL_DB_PATH");
         let _lease = RestoreEnv::capture(ACCOUNT_LEASE_ENV);
         let _selection = RestoreEnv::capture(ACCOUNT_SELECTION_ENV);
 
@@ -1477,6 +1483,8 @@ mod tests {
         let target_database = target_home.join("loopflow.db");
         std::env::set_var("LF_HOME", &target_home);
         std::env::set_var("LF_DB_PATH", &target_database);
+        std::env::set_var("LF_CONTROL_HOME", &target_home);
+        std::env::set_var("LF_CONTROL_DB_PATH", &target_database);
         std::env::remove_var(ACCOUNT_LEASE_ENV);
         std::env::remove_var(ACCOUNT_SELECTION_ENV);
         let target_store = Arc::new(

--- a/rust/loopflow/src/repository.rs
+++ b/rust/loopflow/src/repository.rs
@@ -1,9 +1,53 @@
 use std::fmt;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::str::FromStr;
 
 use serde::{Deserialize, Serialize};
+
+/// The Home-local identity of a repository checkout.
+///
+/// Linked worktrees collapse to their main checkout and symlink spellings
+/// collapse to one absolute path. Provider repository identity remains
+/// [`RepoId`]; this type owns local Wave addressing.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[serde(transparent)]
+pub struct CanonicalRepo(PathBuf);
+
+#[derive(Debug, thiserror::Error)]
+#[error("cannot canonicalize repository {path}: {message}")]
+pub struct CanonicalRepoError {
+    path: PathBuf,
+    message: String,
+}
+
+impl CanonicalRepo {
+    pub fn discover(path: &Path) -> Result<Self, CanonicalRepoError> {
+        let main =
+            crate::engine::worktrees::main_repo_root(path).unwrap_or_else(|_| path.to_path_buf());
+        let canonical = main.canonicalize().map_err(|error| CanonicalRepoError {
+            path: main,
+            message: error.to_string(),
+        })?;
+        if !canonical.is_dir() {
+            return Err(CanonicalRepoError {
+                path: canonical,
+                message: "repository root is not a directory".to_string(),
+            });
+        }
+        Ok(Self(canonical))
+    }
+
+    pub fn as_path(&self) -> &Path {
+        &self.0
+    }
+}
+
+impl fmt::Display for CanonicalRepo {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.display().fmt(formatter)
+    }
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct RepoId(String);

--- a/rust/loopflow/src/store/migrations.rs
+++ b/rust/loopflow/src/store/migrations.rs
@@ -1614,6 +1614,7 @@ mod tests {
     const REOPEN_REPAIR_NAME: &str = "retire_obsolete_pm_reopen_writebacks";
     const GATE_PROPOSAL_REPAIR_NAME: &str = "repair_legacy_task_gate_proposals";
     const LEGACY_TASK_FLOW_REPAIR_NAME: &str = "repair_legacy_task_flow";
+    const REPOSITORY_OWNED_WAVES_NAME: &str = "repository_owned_waves";
 
     fn _draft_is_canonical(name: &str) -> bool {
         let marker = format!("-- draft: {name}");
@@ -1940,6 +1941,151 @@ mod tests {
             .map(|offset| body_start + offset)
             .unwrap_or(sql.len());
         conn.execute_batch(&sql[body_start..body_end]).unwrap();
+    }
+
+    fn apply_before_current_draft(conn: &rusqlite::Connection, name: &str) {
+        if _draft_is_canonical(name) {
+            apply_before_draft(conn, name);
+        } else {
+            apply_set(conn, MIGRATIONS).unwrap();
+        }
+    }
+
+    fn current_draft_sql(name: &str) -> String {
+        if !_draft_is_canonical(name) {
+            return migration_sql_for_test(name);
+        }
+        let (_, sql, draft_offset) = draft_location(name);
+        let body_start = sql[draft_offset..]
+            .find('\n')
+            .map(|offset| draft_offset + offset + 1)
+            .unwrap_or(sql.len());
+        let body_end = sql[body_start..]
+            .find("\n-- draft: ")
+            .map(|offset| body_start + offset)
+            .unwrap_or(sql.len());
+        sql[body_start..body_end].to_string()
+    }
+
+    #[test]
+    fn repository_owned_waves_preserve_uuid_projection_and_allow_duplicate_slugs() {
+        let conn = open();
+        apply_before_current_draft(&conn, REPOSITORY_OWNED_WAVES_NAME);
+        conn.execute(
+            "INSERT INTO waves (id, name, repo, created_at) VALUES ('wave-a', 'infrastructure', '/repo/a', 1)",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO pm_snapshots (repo, wave, provider, initiative, synced_at, payload)
+             VALUES ('/repo/a', 'infrastructure', 'linear', 'initiative-a', 2, '{}')",
+            [],
+        )
+        .unwrap();
+        conn.execute_batch(
+            "INSERT INTO projects (id, wave_id, external_project_id, created_at)
+             VALUES ('project-a', 'wave-a', 'linear-project-a', 3);
+             INSERT INTO tasks (id, project_id, external_issue_id, issue_identifier, created_at)
+             VALUES ('task-a', 'project-a', 'linear-task-a', 'LOO-127', 4);
+             INSERT INTO epochs (
+                 id, number, task_id, state, current_rev, created_at, terminal_at
+             ) VALUES ('epoch-a', 1, 'task-a', 'done', 0, 5, 6);
+             INSERT INTO runs (
+                 id, epoch_id, home_id, state, trigger_json, source_kind,
+                 source_id, created_at, ended_at
+             ) VALUES (
+                 'run-a', 'epoch-a', (SELECT id FROM homes LIMIT 1), 'ended',
+                 '{\"kind\":\"migration\"}', 'task', 'task-a', 5, 6
+             );
+             INSERT INTO work_placements (task_id, home_id, placed_at)
+             VALUES ('task-a', (SELECT id FROM homes LIMIT 1), 4);",
+        )
+        .unwrap();
+
+        conn.pragma_update(None, "foreign_keys", "OFF").unwrap();
+        conn.execute_batch(&current_draft_sql(REPOSITORY_OWNED_WAVES_NAME))
+            .unwrap();
+        validate_foreign_keys(&conn).unwrap();
+        conn.pragma_update(None, "foreign_keys", "ON").unwrap();
+        conn.execute(
+            "INSERT INTO waves (id, name, repo, created_at) VALUES ('wave-b', 'infrastructure', '/repo/b', 3)",
+            [],
+        )
+        .unwrap();
+
+        assert_eq!(
+            conn.query_row(
+                "SELECT wave_id || ':' || initiative FROM pm_snapshots",
+                [],
+                |row| row.get::<_, String>(0),
+            )
+            .unwrap(),
+            "wave-a:initiative-a"
+        );
+        assert_eq!(
+            conn.query_row(
+                "SELECT COUNT(*) FROM waves WHERE name = 'infrastructure'",
+                [],
+                |row| row.get::<_, i64>(0),
+            )
+            .unwrap(),
+            2
+        );
+        assert_eq!(
+            conn.query_row(
+                "SELECT waves.id || ':' || projects.id || ':' || tasks.id || ':' || runs.id
+                 FROM runs
+                 JOIN epochs ON epochs.id = runs.epoch_id
+                 JOIN tasks ON tasks.id = epochs.task_id
+                 JOIN projects ON projects.id = tasks.project_id
+                 JOIN waves ON waves.id = projects.wave_id
+                 WHERE runs.id = 'run-a'",
+                [],
+                |row| row.get::<_, String>(0),
+            )
+            .unwrap(),
+            "wave-a:project-a:task-a:run-a"
+        );
+        assert_eq!(
+            conn.query_row(
+                "SELECT COUNT(*) FROM work_placements WHERE task_id = 'task-a'",
+                [],
+                |row| row.get::<_, i64>(0),
+            )
+            .unwrap(),
+            1
+        );
+    }
+
+    #[test]
+    fn repository_owned_waves_abort_on_an_unmatched_pm_projection() {
+        let mut conn = open();
+        apply_before_current_draft(&conn, REPOSITORY_OWNED_WAVES_NAME);
+        conn.execute(
+            "INSERT INTO waves (id, name, repo, created_at) VALUES ('wave-a', 'infrastructure', '/repo/a', 1)",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO pm_snapshots (repo, wave, provider, initiative, synced_at, payload)
+             VALUES ('/missing', 'infrastructure', 'linear', 'orphan', 2, '{}')",
+            [],
+        )
+        .unwrap();
+
+        let transaction = conn.transaction().unwrap();
+        let error = transaction
+            .execute_batch(&current_draft_sql(REPOSITORY_OWNED_WAVES_NAME))
+            .unwrap_err();
+        assert!(error.to_string().contains("NOT NULL"));
+        transaction.rollback().unwrap();
+
+        assert_eq!(columns(&conn, "pm_snapshots")[..2], ["repo", "wave"]);
+        assert_eq!(
+            conn.query_row("SELECT COUNT(*) FROM waves", [], |row| row.get::<_, i64>(0))
+                .unwrap(),
+            1
+        );
     }
 
     #[test]
@@ -3019,7 +3165,9 @@ mod tests {
         )
         .unwrap();
 
+        conn.execute_batch("BEGIN EXCLUSIVE").unwrap();
         apply_set(&conn, MIGRATIONS).unwrap();
+        conn.execute_batch("COMMIT").unwrap();
         let stale: String = conn
             .query_row(
                 "SELECT pm_writeback_json FROM tasks WHERE external_issue_id='issue-reopen'",
@@ -3355,9 +3503,10 @@ mod tests {
         );
         assert!(MIGRATIONS.len() > 2, "need a tail beyond the fixture");
 
-        // The generated tail advances it, and applying it again is a no-op.
-        apply_set(&conn, MIGRATIONS).unwrap();
-        apply_set(&conn, MIGRATIONS).unwrap();
+        // The generated tail advances it through the production transaction,
+        // and applying it again is a no-op.
+        apply_sqlite(&conn).unwrap();
+        apply_sqlite(&conn).unwrap();
 
         assert_eq!(applied_versions(&conn).unwrap().len(), MIGRATIONS.len());
         assert_eq!(

--- a/rust/loopflow/src/store/migrations/drafts/repository_owned_waves__192203949848460f89d4712a9abcdbeb.sql
+++ b/rust/loopflow/src/store/migrations/drafts/repository_owned_waves__192203949848460f89d4712a9abcdbeb.sql
@@ -1,0 +1,48 @@
+-- name: repository_owned_waves
+-- id: 192203949848460f89d4712a9abcdbeb
+-- depends_on:
+-- A Wave's UUID is durable identity. Its repository and slug are one mutable,
+-- repository-scoped locator.
+CREATE TABLE waves_next (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL,
+    repo TEXT NOT NULL,
+    created_at INTEGER NOT NULL,
+    parent_wave_id TEXT REFERENCES waves_next(id) ON DELETE CASCADE,
+    promoted_at INTEGER,
+    UNIQUE (repo, name)
+);
+
+INSERT INTO waves_next (
+    id, name, repo, created_at, parent_wave_id, promoted_at
+)
+SELECT id, name, repo, created_at, parent_wave_id, promoted_at
+FROM waves;
+
+DROP TABLE waves;
+ALTER TABLE waves_next RENAME TO waves;
+CREATE INDEX idx_waves_parent ON waves(parent_wave_id);
+
+CREATE TABLE pm_snapshots_next (
+    wave_id TEXT NOT NULL PRIMARY KEY REFERENCES waves(id) ON DELETE CASCADE,
+    provider TEXT NOT NULL,
+    initiative TEXT NOT NULL,
+    synced_at INTEGER NOT NULL,
+    payload TEXT NOT NULL
+);
+
+-- The NOT NULL primary key makes an unmatched legacy projection abort the
+-- migration instead of silently disappearing.
+INSERT INTO pm_snapshots_next (
+    wave_id, provider, initiative, synced_at, payload
+)
+SELECT (
+    SELECT waves.id
+    FROM waves
+    WHERE waves.repo = pm_snapshots.repo
+      AND waves.name = pm_snapshots.wave
+), provider, initiative, synced_at, payload
+FROM pm_snapshots;
+
+DROP TABLE pm_snapshots;
+ALTER TABLE pm_snapshots_next RENAME TO pm_snapshots;

--- a/rust/loopflow/src/store/mod.rs
+++ b/rust/loopflow/src/store/mod.rs
@@ -9,7 +9,7 @@ use crate::profile::{
     AccessProfile, AccountAccessProfile, EmailAddress, ProfileId, ProviderRoute, RouteScope,
 };
 use crate::provider_auth::Provider;
-use crate::wave::Wave;
+use crate::wave::{Wave, WaveLocator};
 mod children;
 pub(crate) mod ci_incidents;
 mod durable;
@@ -78,12 +78,19 @@ pub struct TurnSpendRow {
 /// replaces this row atomically so readers never observe a partial refresh.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PmSnapshotRow {
-    pub repo: String,
-    pub wave: String,
+    pub wave_id: WaveId,
     pub provider: String,
     pub initiative: String,
     pub synced_at: i64,
     pub payload: String,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct WaveLocatorUpdate {
+    pub wave_id: WaveId,
+    pub expected_repo: String,
+    pub expected_slug: String,
+    pub target: WaveLocator,
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -424,17 +431,42 @@ impl Store {
         run_sqlite(&self.sqlite, move |store| store.put_pm_snapshot(&snapshot)).await
     }
 
-    pub async fn pm_snapshot(
-        &self,
-        repo: String,
-        wave: String,
-    ) -> StoreResult<Option<PmSnapshotRow>> {
-        run_sqlite(&self.sqlite, move |store| store.pm_snapshot(&repo, &wave)).await
+    pub async fn pm_snapshot(&self, wave_id: &WaveId) -> StoreResult<Option<PmSnapshotRow>> {
+        let wave_id = wave_id.clone();
+        run_sqlite(&self.sqlite, move |store| store.pm_snapshot(&wave_id)).await
     }
 
     pub async fn list_waves(&self, repo: Option<&str>) -> StoreResult<Vec<Wave>> {
-        let repo = repo.map(str::to_string);
-        run_sqlite(&self.sqlite, move |store| store.list_waves(repo.as_deref())).await
+        let Some(repo) = repo else {
+            return run_sqlite(&self.sqlite, move |store| store.list_waves(None)).await;
+        };
+        let canonical = match crate::repository::CanonicalRepo::discover(Path::new(repo)) {
+            Ok(canonical) => canonical,
+            Err(_) => {
+                let repo = repo.to_string();
+                return run_sqlite(&self.sqlite, move |store| store.list_waves(Some(&repo))).await;
+            }
+        };
+        let all = run_sqlite(&self.sqlite, move |store| store.list_waves(None)).await?;
+        for wave in all {
+            if wave.repo() == canonical.to_string() {
+                continue;
+            }
+            let equivalent = crate::repository::CanonicalRepo::discover(Path::new(wave.repo()))
+                .is_ok_and(|stored| stored == canonical);
+            if !equivalent {
+                continue;
+            }
+            let wave_id = wave.id().clone();
+            let expected_repo = wave.repo().to_string();
+            let target_repo = canonical.to_string();
+            run_sqlite(&self.sqlite, move |store| {
+                store.repair_wave_repo(&wave_id, &expected_repo, &target_repo)
+            })
+            .await?;
+        }
+        let repo = canonical.to_string();
+        run_sqlite(&self.sqlite, move |store| store.list_waves(Some(&repo))).await
     }
 
     /// A chord's contents: the waves whose `parent_wave_id` is `parent`,
@@ -449,9 +481,48 @@ impl Store {
         run_sqlite(&self.sqlite, move |store| store.get_wave(&wave_id)).await
     }
 
-    pub async fn get_wave_by_name(&self, name: &str) -> StoreResult<Option<Wave>> {
-        let name = name.to_string();
-        run_sqlite(&self.sqlite, move |store| store.get_wave_by_name(&name)).await
+    pub async fn get_wave_at(&self, locator: &WaveLocator) -> StoreResult<Option<Wave>> {
+        let locator = locator.clone();
+        if let Some(wave) = run_sqlite(&self.sqlite, {
+            let locator = locator.clone();
+            move |store| store.get_wave_at(&locator)
+        })
+        .await?
+        {
+            return Ok(Some(wave));
+        }
+
+        let candidates = self.find_waves_by_slug(locator.slug()).await?;
+        let equivalent = candidates
+            .into_iter()
+            .filter(|wave| {
+                crate::repository::CanonicalRepo::discover(Path::new(wave.repo()))
+                    .is_ok_and(|repo| &repo == locator.repo())
+            })
+            .collect::<Vec<_>>();
+        let [wave] = equivalent.as_slice() else {
+            if equivalent.len() > 1 {
+                return Err(StoreError::InvalidData(format!(
+                    "multiple stored Wave locators canonicalize to {}/{}",
+                    locator.repo(),
+                    locator.slug()
+                )));
+            }
+            return Ok(None);
+        };
+        let wave_id = wave.id().clone();
+        let expected_repo = wave.repo().to_string();
+        let target_repo = locator.repo().to_string();
+        run_sqlite(&self.sqlite, move |store| {
+            store.repair_wave_repo(&wave_id, &expected_repo, &target_repo)
+        })
+        .await?;
+        self.get_wave(wave.id()).await
+    }
+
+    pub async fn find_waves_by_slug(&self, slug: &str) -> StoreResult<Vec<Wave>> {
+        let slug = slug.to_string();
+        run_sqlite(&self.sqlite, move |store| store.find_waves_by_slug(&slug)).await
     }
 
     pub async fn create_wave(&self, wave: &Wave) -> StoreResult<()> {
@@ -462,6 +533,10 @@ impl Store {
     pub async fn update_wave(&self, wave: &Wave) -> StoreResult<()> {
         let wave = wave.clone();
         run_sqlite(&self.sqlite, move |store| store.update_wave(&wave)).await
+    }
+
+    pub(crate) async fn relocate_waves(&self, updates: Vec<WaveLocatorUpdate>) -> StoreResult<()> {
+        run_sqlite(&self.sqlite, move |store| store.relocate_waves(&updates)).await
     }
 
     pub async fn delete_wave(&self, wave_id: &WaveId) -> StoreResult<()> {
@@ -2850,7 +2925,7 @@ mod tests {
 
         let updated = Wave::new(
             wave.id().clone(),
-            wave.name().to_string(),
+            "renamed-without-relocation".to_string(),
             "/repo-updated".to_string(),
         );
         assert!(updated.promoted_at().is_none());
@@ -2860,7 +2935,12 @@ mod tests {
             .await
             .expect("get wave")
             .expect("wave exists");
-        assert_eq!(loaded.repo(), "/repo-updated");
+        assert_eq!(
+            loaded.repo(),
+            "/repo",
+            "ordinary Wave updates cannot bypass relocation"
+        );
+        assert_eq!(loaded.name(), wave.name());
 
         store.delete_wave(wave.id()).await.expect("delete wave");
         assert!(store
@@ -2956,9 +3036,10 @@ mod tests {
         let store = open_store(&StorageConfig::sqlite(db_path.clone()))
             .await
             .expect("store should open");
+        let wave = Wave::new(WaveId::new(), "product".to_string(), "/repo".to_string());
+        store.create_wave(&wave).await.expect("create Wave");
         let mut snapshot = PmSnapshotRow {
-            repo: "/repo".to_string(),
-            wave: "product".to_string(),
+            wave_id: wave.id().clone(),
             provider: "linear".to_string(),
             initiative: "initiative-1".to_string(),
             synced_at: 1,
@@ -2976,10 +3057,7 @@ mod tests {
             .expect("replace snapshot");
 
         assert_eq!(
-            store
-                .pm_snapshot("/repo".to_string(), "product".to_string())
-                .await
-                .expect("read snapshot"),
+            store.pm_snapshot(wave.id()).await.expect("read snapshot"),
             Some(snapshot)
         );
         let _ = std::fs::remove_file(db_path);

--- a/rust/loopflow/src/store/sqlite.rs
+++ b/rust/loopflow/src/store/sqlite.rs
@@ -14,12 +14,13 @@ use crate::store::token_crypto;
 use crate::store::{
     AccountLimitRow, CredentialState, PmSnapshotRow, ProviderAccount, ProviderAccountId,
     ProviderAccountSelection, RoutingState, RunEventRow, StoreError, StoreResult, TurnSpendRow,
+    WaveLocatorUpdate,
 };
 use crate::trace::{
     AgentInvocationRow, AgentTurnRow, ContextAsset, ContextAssetKind, ContextAssetRow,
     ContextChannel, ContextDecision, ContextDecisionKind, ContextDecisionRow, ContextScope,
 };
-use crate::wave::Wave;
+use crate::wave::{Wave, WaveLocator};
 
 mod children;
 mod ci_incidents;
@@ -452,16 +453,15 @@ impl SqliteStore {
     pub fn put_pm_snapshot(&self, snapshot: &PmSnapshotRow) -> StoreResult<()> {
         let conn = self.conn.lock().expect("store mutex poisoned");
         conn.execute(
-            "INSERT INTO pm_snapshots (repo, wave, provider, initiative, synced_at, payload)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6)
-             ON CONFLICT(repo, wave) DO UPDATE SET
+            "INSERT INTO pm_snapshots (wave_id, provider, initiative, synced_at, payload)
+             VALUES (?1, ?2, ?3, ?4, ?5)
+             ON CONFLICT(wave_id) DO UPDATE SET
                provider = excluded.provider,
                initiative = excluded.initiative,
                synced_at = excluded.synced_at,
                payload = excluded.payload",
             params![
-                snapshot.repo,
-                snapshot.wave,
+                snapshot.wave_id,
                 snapshot.provider,
                 snapshot.initiative,
                 snapshot.synced_at,
@@ -471,20 +471,19 @@ impl SqliteStore {
         Ok(())
     }
 
-    pub fn pm_snapshot(&self, repo: &str, wave: &str) -> StoreResult<Option<PmSnapshotRow>> {
+    pub fn pm_snapshot(&self, wave_id: &WaveId) -> StoreResult<Option<PmSnapshotRow>> {
         let conn = self.conn.lock().expect("store mutex poisoned");
         conn.query_row(
-            "SELECT repo, wave, provider, initiative, synced_at, payload
-             FROM pm_snapshots WHERE repo = ?1 AND wave = ?2",
-            params![repo, wave],
+            "SELECT wave_id, provider, initiative, synced_at, payload
+             FROM pm_snapshots WHERE wave_id = ?1",
+            params![wave_id],
             |row| {
                 Ok(PmSnapshotRow {
-                    repo: row.get(0)?,
-                    wave: row.get(1)?,
-                    provider: row.get(2)?,
-                    initiative: row.get(3)?,
-                    synced_at: row.get(4)?,
-                    payload: row.get(5)?,
+                    wave_id: row.get(0)?,
+                    provider: row.get(1)?,
+                    initiative: row.get(2)?,
+                    synced_at: row.get(3)?,
+                    payload: row.get(4)?,
                 })
             },
         )
@@ -531,9 +530,6 @@ impl SqliteStore {
             "INSERT INTO waves (id, name, repo, created_at, parent_wave_id, promoted_at)
              VALUES (?1, ?2, ?3, ?4, ?5, ?6)
              ON CONFLICT(id) DO UPDATE SET
-               name = excluded.name,
-               repo = excluded.repo,
-               created_at = excluded.created_at,
                parent_wave_id = COALESCE(waves.parent_wave_id, excluded.parent_wave_id),
                promoted_at = COALESCE(waves.promoted_at, excluded.promoted_at)",
             params![
@@ -1286,16 +1282,77 @@ impl SqliteStore {
         wave.transpose()
     }
 
-    pub fn get_wave_by_name(&self, name: &str) -> StoreResult<Option<Wave>> {
+    pub fn get_wave_at(&self, locator: &WaveLocator) -> StoreResult<Option<Wave>> {
         let conn = self.conn.lock().expect("store mutex poisoned");
         let mut stmt = conn.prepare(
             "SELECT id, name, repo, created_at, parent_wave_id, promoted_at
-             FROM waves WHERE name = ?1",
+             FROM waves WHERE repo = ?1 AND name = ?2",
         )?;
         let wave = stmt
-            .query_row(params![name], |row| Ok(map_wave_row(row)))
+            .query_row(params![locator.repo().to_string(), locator.slug()], |row| {
+                Ok(map_wave_row(row))
+            })
             .optional()?;
         wave.transpose()
+    }
+
+    pub(crate) fn repair_wave_repo(
+        &self,
+        wave_id: &WaveId,
+        expected_repo: &str,
+        target_repo: &str,
+    ) -> StoreResult<()> {
+        let mut conn = self.conn.lock().expect("store mutex poisoned");
+        let tx = conn.transaction_with_behavior(TransactionBehavior::Immediate)?;
+        let current = tx
+            .query_row(
+                "SELECT repo, name FROM waves WHERE id = ?1",
+                params![wave_id],
+                |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?)),
+            )
+            .optional()?
+            .ok_or_else(|| StoreError::InvalidData(format!("Wave {wave_id} is not registered")))?;
+        if current.0 == target_repo {
+            tx.commit()?;
+            return Ok(());
+        }
+        if current.0 != expected_repo {
+            return Err(StoreError::InvalidData(format!(
+                "Wave {wave_id} repository changed from {expected_repo} while its canonical path was being repaired"
+            )));
+        }
+        let collision = tx
+            .query_row(
+                "SELECT id FROM waves WHERE repo = ?1 AND name = ?2 AND id != ?3",
+                params![target_repo, current.1, wave_id],
+                |row| row.get::<_, String>(0),
+            )
+            .optional()?;
+        if let Some(collision) = collision {
+            return Err(StoreError::InvalidData(format!(
+                "cannot repair Wave {wave_id} repository to {target_repo}: locator belongs to Wave {collision}"
+            )));
+        }
+        tx.execute(
+            "UPDATE waves SET repo = ?2 WHERE id = ?1 AND repo = ?3",
+            params![wave_id, target_repo, expected_repo],
+        )?;
+        tx.commit()?;
+        Ok(())
+    }
+
+    pub fn find_waves_by_slug(&self, slug: &str) -> StoreResult<Vec<Wave>> {
+        let conn = self.conn.lock().expect("store mutex poisoned");
+        let mut stmt = conn.prepare(
+            "SELECT id, name, repo, created_at, parent_wave_id, promoted_at
+             FROM waves WHERE name = ?1 ORDER BY repo",
+        )?;
+        let rows = stmt.query_map(params![slug], |row| Ok(map_wave_row(row)))?;
+        let mut waves = Vec::new();
+        for wave in rows {
+            waves.push(wave??);
+        }
+        Ok(waves)
     }
 
     pub fn create_wave(&self, wave: &Wave) -> StoreResult<()> {
@@ -1304,6 +1361,84 @@ impl SqliteStore {
 
     pub fn update_wave(&self, wave: &Wave) -> StoreResult<()> {
         self.upsert_wave(wave)
+    }
+
+    pub(crate) fn relocate_waves(&self, updates: &[WaveLocatorUpdate]) -> StoreResult<()> {
+        let mut conn = self.conn.lock().expect("store mutex poisoned");
+        let tx = conn.transaction_with_behavior(TransactionBehavior::Immediate)?;
+        for update in updates {
+            let current = tx
+                .query_row(
+                    "SELECT repo, name FROM waves WHERE id = ?1",
+                    params![update.wave_id],
+                    |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?)),
+                )
+                .optional()?
+                .ok_or_else(|| {
+                    StoreError::InvalidData(format!("Wave {} is not registered", update.wave_id))
+                })?;
+            if current != (update.expected_repo.clone(), update.expected_slug.clone()) {
+                return Err(StoreError::InvalidData(format!(
+                    "Wave {} moved from {}/{} while relocation was staged",
+                    update.wave_id, update.expected_repo, update.expected_slug
+                )));
+            }
+
+            let collision = tx
+                .query_row(
+                    "SELECT id FROM waves
+                     WHERE repo = ?1 AND name = ?2 AND id != ?3",
+                    params![
+                        update.target.repo().to_string(),
+                        update.target.slug(),
+                        update.wave_id
+                    ],
+                    |row| row.get::<_, String>(0),
+                )
+                .optional()?;
+            if let Some(collision) = collision {
+                return Err(StoreError::InvalidData(format!(
+                    "target {}/{} already belongs to Wave {collision}",
+                    update.target.repo(),
+                    update.target.slug()
+                )));
+            }
+
+            let active_run = tx
+                .query_row(
+                    "SELECT r.id
+                     FROM runs r
+                     JOIN epochs e ON e.id = r.epoch_id
+                     LEFT JOIN projects ep ON ep.id = e.project_id
+                     LEFT JOIN tasks et ON et.id = e.task_id
+                     LEFT JOIN projects tp ON tp.id = et.project_id
+                     WHERE r.state != 'ended'
+                       AND (e.wave_id = ?1 OR ep.wave_id = ?1 OR tp.wave_id = ?1)
+                     LIMIT 1",
+                    params![update.wave_id],
+                    |row| row.get::<_, String>(0),
+                )
+                .optional()?;
+            if let Some(run_id) = active_run {
+                return Err(StoreError::InvalidData(format!(
+                    "cannot relocate Wave {} while Run {run_id} is active",
+                    update.wave_id
+                )));
+            }
+        }
+
+        for update in updates {
+            tx.execute(
+                "UPDATE waves SET repo = ?2, name = ?3 WHERE id = ?1",
+                params![
+                    update.wave_id,
+                    update.target.repo().to_string(),
+                    update.target.slug()
+                ],
+            )?;
+        }
+        tx.commit()?;
+        Ok(())
     }
 
     pub fn delete_wave(&self, wave_id: &WaveId) -> StoreResult<()> {
@@ -1814,6 +1949,34 @@ impl SqliteStore {
                     account_id, resume_token, answer_ask_id
              FROM agent_invocations WHERE started_at >= ?1 ORDER BY started_at, rowid",
             params![since],
+        )
+    }
+
+    pub fn agent_invocations_for_wave_since(
+        &self,
+        wave_id: &WaveId,
+        since: i64,
+    ) -> StoreResult<Vec<AgentInvocationRow>> {
+        self.query_agent_invocations(
+            "SELECT ai.id, ai.run_id, ai.process_id, ai.started_at, ai.ended_at,
+                    ai.repo, ai.worktree, ai.wave, ai.flow, ai.skill, ai.project,
+                    ai.task, ai.provider, ai.model, ai.surface, ai.capture_status,
+                    ai.incomplete_reason, ai.outcome, ai.artifact_dir,
+                    ai.conversation_path, ai.provider_events_path,
+                    ai.provider_session_id, ai.provider_session_path,
+                    ai.conversation_event_count, ai.conversation_bytes,
+                    ai.supervising_run_id, ai.account_id, ai.resume_token,
+                    ai.answer_ask_id
+             FROM agent_invocations ai
+             JOIN runs r ON r.id = ai.supervising_run_id
+             JOIN epochs e ON e.id = r.epoch_id
+             LEFT JOIN projects ep ON ep.id = e.project_id
+             LEFT JOIN tasks et ON et.id = e.task_id
+             LEFT JOIN projects tp ON tp.id = et.project_id
+             WHERE ai.started_at >= ?2
+               AND (e.wave_id = ?1 OR ep.wave_id = ?1 OR tp.wave_id = ?1)
+             ORDER BY ai.started_at, ai.rowid",
+            params![wave_id, since],
         )
     }
 

--- a/rust/loopflow/src/wave/README.md
+++ b/rust/loopflow/src/wave/README.md
@@ -23,11 +23,14 @@ scheduler and provider process. It reads the listener's inbox and returns
 ordered deltas; it never writes the journal directly.
 
 Repository mutations belong to Tasks in their own sibling worktrees.
-The Wave coordinates Projects and Tasks from the canonical checkout.
+The Wave coordinates Projects and Tasks from the canonical checkout. Its UUID
+is stable identity; canonical checkout plus normalized name is its mutable
+locator. Two repositories may each own a Wave named `product` without sharing
+state.
 
 ## Persistence and discovery
 
-The origin repository holds the Wave's durable files:
+The Wave's current canonical repository holds its durable files:
 
 ```text
 .lf/journal/waves/<name>/journal.jsonl
@@ -50,10 +53,27 @@ source-tagged authored input and never inherits `LF_DISCORD_TOKEN`. Binding
 ownership is explicit: the configured Home is the only Home allowed to attach,
 and an OS-held lease prevents concurrent listeners across its checkouts.
 
-The shared `~/.lf/loopflow.db` stores the Wave row and typed Project and Task
-observations. A Wave can still run when that store does not
-exist, but child observations are unavailable. The live endpoint enforces one
-listener per Wave; `--force` explicitly takes over a live endpoint.
+The shared `~/.lf/loopflow.db` stores the Wave UUID, its repository-scoped
+locator, and typed Project and Task observations. Human commands resolve the
+name only inside the invoking repository; a diagnostic bare-name lookup fails
+when several repositories own that name. A Wave can still run when that store
+does not exist, but child observations are unavailable. The live endpoint and
+locator lock enforce one listener per repository-scoped Wave; `--force`
+explicitly takes over a live endpoint.
+
+Rename or rehome a stopped Wave by UUID:
+
+```bash
+lf work relocate wave <wave-id> --name platform
+lf work relocate wave <wave-id> --repo ../moved-repository
+```
+
+Relocation preserves the UUID, PM projection, Work and Run history, Home
+placement, authored files, and journal. It moves a complete Wave chord when the
+repository changes, carries nested descendants through a rename, requires
+compatible configured PM Teams, and refuses live Work or divergent target
+files. Retry completes verified source cleanup after a crash at the commit
+boundary.
 
 ## Thread
 

--- a/rust/loopflow/src/wave/mod.rs
+++ b/rust/loopflow/src/wave/mod.rs
@@ -52,6 +52,7 @@ pub(crate) mod discord;
 pub mod journal;
 pub(crate) mod memory;
 pub mod playhead;
+pub mod relocate;
 
 pub(crate) mod registry;
 pub mod resident;
@@ -64,7 +65,7 @@ mod types;
 pub mod wire;
 
 pub(crate) use types::PromotionWake;
-pub use types::Wave;
+pub use types::{Wave, WaveLocator, WaveLocatorError};
 
 use std::future::Future;
 use std::path::{Path, PathBuf};
@@ -339,6 +340,37 @@ where
     F: Future<Output = ()> + Send + 'static,
 {
     let ListenerSignals { startup, shutdown } = signals;
+    let _locator_lock = match relocate::WaveLocatorLock::acquire(&repo_root, &wave) {
+        Ok(lock) => lock,
+        Err(lock_error) if force => {
+            if !request_stop(&repo_root, &wave).await? {
+                return Err(lock_error);
+            }
+            relocate::WaveLocatorLock::acquire(&repo_root, &wave)?
+        }
+        Err(lock_error) => return Err(lock_error),
+    };
+    if let Some(config) = registry_config.as_ref() {
+        let current = config
+            .store
+            .get_wave(config.wave.id())
+            .await?
+            .ok_or_else(|| {
+                anyhow!(
+                    "Wave {} disappeared before listener start",
+                    config.wave.id()
+                )
+            })?;
+        let locator = WaveLocator::discover(&repo_root, &wave)?;
+        if current.repo() != locator.repo().to_string() || current.name() != locator.slug() {
+            return Err(anyhow!(
+                "Wave {} moved to {}/{} before listener start",
+                current.id(),
+                current.repo(),
+                current.name()
+            ));
+        }
+    }
     // File-level one-brain floor, before anything else: an existing pointer
     // that answers /health for this wave is a live server — refuse (unless
     // --force takes over and overwrites); a dead pointer is stale and gets
@@ -1504,6 +1536,111 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn same_named_waves_in_two_repositories_serve_independently() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let repo_a = tmp.path().join("alpha");
+        let repo_b = tmp.path().join("beta");
+        for repo in [&repo_a, &repo_b] {
+            std::fs::create_dir_all(repo.join("wave/infrastructure")).unwrap();
+            std::fs::write(
+                repo.join("wave/infrastructure/GOAL.md"),
+                format!("# {}\n", repo.file_name().unwrap().to_string_lossy()),
+            )
+            .unwrap();
+        }
+
+        let store = Arc::new(
+            crate::store::open_store(&crate::store::StorageConfig::sqlite(
+                tmp.path().join("registry.db"),
+            ))
+            .await
+            .unwrap(),
+        );
+        let wave_a = registry::ensure_wave_row(&store, &repo_a, "infrastructure")
+            .await
+            .unwrap();
+        let wave_b = registry::ensure_wave_row(&store, &repo_b, "infrastructure")
+            .await
+            .unwrap();
+        assert_ne!(wave_a.id(), wave_b.id());
+
+        let (stop_a_tx, stop_a_rx) = tokio::sync::oneshot::channel::<()>();
+        let (stop_b_tx, stop_b_rx) = tokio::sync::oneshot::channel::<()>();
+        let handle_a = tokio::spawn(run_listener(
+            repo_a.clone(),
+            "infrastructure".to_string(),
+            Some(registry::RegistryConfig {
+                store: store.clone(),
+                wave: wave_a.clone(),
+            }),
+            false,
+            false,
+            None,
+            async move {
+                let _ = stop_a_rx.await;
+            },
+        ));
+        let handle_b = tokio::spawn(run_listener(
+            repo_b.clone(),
+            "infrastructure".to_string(),
+            Some(registry::RegistryConfig {
+                store,
+                wave: wave_b.clone(),
+            }),
+            false,
+            false,
+            None,
+            async move {
+                let _ = stop_b_rx.await;
+            },
+        ));
+
+        let endpoint_a = server::endpoint_path(&repo_a, "infrastructure");
+        let endpoint_b = server::endpoint_path(&repo_b, "infrastructure");
+        wait_for(|| endpoint_a.exists() && endpoint_b.exists()).await;
+        let address_a = std::fs::read_to_string(&endpoint_a).unwrap();
+        let address_b = std::fs::read_to_string(&endpoint_b).unwrap();
+        assert_ne!(address_a, address_b);
+        for address in [&address_a, &address_b] {
+            let health: serde_json::Value =
+                reqwest::get(format!("http://{}/health", address.trim()))
+                    .await
+                    .unwrap()
+                    .json()
+                    .await
+                    .unwrap();
+            assert_eq!(health["wave"], "infrastructure");
+        }
+
+        let response = reqwest::Client::new()
+            .post(format!("http://{}/messages", address_a.trim()))
+            .json(&serde_json::json!({ "op": "message", "text": "alpha only" }))
+            .send()
+            .await
+            .unwrap();
+        assert!(response.status().is_success());
+        assert_eq!(
+            journal::read_events(&journal::journal_path(&repo_a, "infrastructure"))
+                .iter()
+                .filter(|event| matches!(event.kind, journal::EventKind::UserMessage { .. }))
+                .count(),
+            1
+        );
+        assert_eq!(
+            journal::read_events(&journal::journal_path(&repo_b, "infrastructure"))
+                .iter()
+                .filter(|event| matches!(event.kind, journal::EventKind::UserMessage { .. }))
+                .count(),
+            0
+        );
+
+        stop_a_tx.send(()).unwrap();
+        stop_b_tx.send(()).unwrap();
+        handle_a.await.unwrap().unwrap();
+        handle_b.await.unwrap().unwrap();
+    }
+
+    #[tokio::test]
     async fn serve_publishes_and_removes_discovery_pointer_and_token() {
         let tmp = tempfile::tempdir().expect("tempdir");
         std::fs::create_dir_all(tmp.path().join("wave/ship")).unwrap();
@@ -1703,5 +1840,42 @@ mod tests {
         shutdown_tx.send(()).unwrap();
         first.await.unwrap().unwrap();
         assert!(!endpoint.exists(), "first server still owns its shutdown");
+    }
+
+    #[tokio::test]
+    async fn force_stops_the_current_listener_before_taking_its_locator_lock() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        std::fs::create_dir_all(tmp.path().join("wave/ship")).unwrap();
+        let repo = tmp.path().to_path_buf();
+
+        let (_first_stop_tx, first_stop_rx) = tokio::sync::oneshot::channel::<()>();
+        let first_repo = repo.clone();
+        let first = tokio::spawn(async move {
+            run_listener(first_repo, "ship".into(), None, false, false, None, async {
+                let _ = first_stop_rx.await;
+            })
+            .await
+        });
+        let endpoint = server::endpoint_path(&repo, "ship");
+        wait_for(|| endpoint.exists()).await;
+        let first_address = std::fs::read_to_string(&endpoint).unwrap();
+
+        let (second_stop_tx, second_stop_rx) = tokio::sync::oneshot::channel::<()>();
+        let second_repo = repo.clone();
+        let second = tokio::spawn(async move {
+            run_listener(second_repo, "ship".into(), None, true, false, None, async {
+                let _ = second_stop_rx.await;
+            })
+            .await
+        });
+        wait_for(|| {
+            std::fs::read_to_string(&endpoint).is_ok_and(|address| address != first_address)
+        })
+        .await;
+        first.await.unwrap().unwrap();
+
+        second_stop_tx.send(()).unwrap();
+        second.await.unwrap().unwrap();
+        assert!(!endpoint.exists());
     }
 }

--- a/rust/loopflow/src/wave/registry.rs
+++ b/rust/loopflow/src/wave/registry.rs
@@ -14,10 +14,10 @@ use tokio::process::Command;
 use tokio::sync::RwLock;
 
 use crate::id::WaveId;
-use crate::store::{open_existing_store, SharedStore, StoreResult};
+use crate::store::{open_existing_store, SharedStore, Store, StoreResult};
 use crate::task::TaskObservation;
 use crate::wave::runtime::WaveRuntime;
-use crate::wave::Wave;
+use crate::wave::{Wave, WaveLocator};
 
 /// How often the observer re-reads the store between turns. Modest by
 /// design: the loop also refreshes right before every turn it takes.
@@ -40,18 +40,16 @@ pub struct RegistryConfig {
 ///
 /// # Errors
 /// Store failures only; the caller treats them as soft (run unregistered).
-pub async fn ensure_wave_row(
-    store: &SharedStore,
-    main_repo: &Path,
-    name: &str,
-) -> StoreResult<Wave> {
-    let existing = store.get_wave_by_name(name).await?;
+pub async fn ensure_wave_row(store: &Store, main_repo: &Path, name: &str) -> StoreResult<Wave> {
+    let locator = WaveLocator::discover(main_repo, name)
+        .map_err(|error| crate::store::StoreError::InvalidData(error.to_string()))?;
+    let existing = store.get_wave_at(&locator).await?;
     let is_new = existing.is_none();
     let wave = existing.unwrap_or_else(|| {
         Wave::new(
             WaveId::new(),
-            name.to_string(),
-            main_repo.display().to_string(),
+            locator.slug().to_string(),
+            locator.repo().to_string(),
         )
     });
     store.create_wave(&wave).await?;
@@ -69,12 +67,14 @@ pub async fn ensure_wave_row(
 /// A remote Home may observe a different repo path, but never mint a second id
 /// for the same named Work.
 pub async fn ensure_wave_row_with_id(
-    store: &SharedStore,
+    store: &Store,
     main_repo: &Path,
     name: &str,
     wave_id: &WaveId,
 ) -> StoreResult<Wave> {
-    if let Some(existing) = store.get_wave_by_name(name).await? {
+    let locator = WaveLocator::discover(main_repo, name)
+        .map_err(|error| crate::store::StoreError::InvalidData(error.to_string()))?;
+    if let Some(existing) = store.get_wave_at(&locator).await? {
         if existing.id() != wave_id {
             return Err(crate::store::StoreError::InvalidData(format!(
                 "Wave '{name}' is {} on this Home, not authoritative id {wave_id}",
@@ -91,8 +91,8 @@ pub async fn ensure_wave_row_with_id(
     }
     let wave = Wave::new(
         wave_id.clone(),
-        name.to_string(),
-        main_repo.display().to_string(),
+        locator.slug().to_string(),
+        locator.repo().to_string(),
     );
     store.create_wave(&wave).await?;
     Ok(wave)
@@ -380,12 +380,18 @@ mod tests {
             .await
             .expect("row created");
         let stored = store
-            .get_wave_by_name("ship")
+            .get_wave_at(&WaveLocator::discover(&repo, "ship").unwrap())
             .await
             .expect("lookup")
             .expect("row exists");
         assert_eq!(stored.id(), wave.id());
-        assert_eq!(stored.repo(), repo.display().to_string());
+        assert_eq!(
+            stored.repo(),
+            WaveLocator::discover(&repo, "ship")
+                .unwrap()
+                .repo()
+                .to_string()
+        );
 
         let again = ensure_wave_row(&store, &repo, "ship")
             .await

--- a/rust/loopflow/src/wave/relocate.rs
+++ b/rust/loopflow/src/wave/relocate.rs
@@ -1,0 +1,911 @@
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
+use std::fs::{File, OpenOptions};
+use std::path::{Path, PathBuf};
+
+use anyhow::{anyhow, Context, Result};
+use fs2::FileExt;
+use serde::{Deserialize, Serialize};
+
+use crate::durable::WorkRef;
+use crate::id::WaveId;
+use crate::repository::CanonicalRepo;
+use crate::store::{Store, WaveLocatorUpdate};
+use crate::wave::server::{live_endpoint, ENDPOINT_FILE};
+use crate::wave::wire::RESIDENT_TOKEN_FILE;
+use crate::wave::{Wave, WaveLocator};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct WaveRelocationReceipt {
+    pub wave_id: String,
+    pub from_repo: String,
+    pub from_name: String,
+    pub to_repo: String,
+    pub to_name: String,
+    pub waves_moved: usize,
+}
+
+#[derive(Debug)]
+pub(crate) struct WaveLocatorLock {
+    _file: File,
+}
+
+impl WaveLocatorLock {
+    pub(crate) fn acquire(repo: &Path, slug: &str) -> Result<Self> {
+        let path = repo
+            .join(".lf/tmp/locks/waves")
+            .join(format!("{slug}.lock"));
+        let parent = path
+            .parent()
+            .ok_or_else(|| anyhow!("Wave lock has no parent: {}", path.display()))?;
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("create Wave lock directory {}", parent.display()))?;
+        let file = OpenOptions::new()
+            .create(true)
+            .truncate(false)
+            .read(true)
+            .write(true)
+            .open(&path)
+            .with_context(|| format!("open Wave locator lock {}", path.display()))?;
+        file.try_lock_exclusive().map_err(|error| {
+            anyhow!(
+                "Wave locator {}/{} is active or being relocated; stop it first (--force cannot break the relocation fence): {error}",
+                repo.display(),
+                slug
+            )
+        })?;
+        Ok(Self { _file: file })
+    }
+}
+
+#[derive(Debug, Clone)]
+struct PlannedWaveMove {
+    wave: Wave,
+    target: WaveLocator,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+struct RelocationPath {
+    wave_id: WaveId,
+    from_repo: String,
+    from_name: String,
+    to_repo: String,
+    to_name: String,
+}
+
+impl RelocationPath {
+    fn from_planned(planned: &PlannedWaveMove) -> Self {
+        Self {
+            wave_id: planned.wave.id().clone(),
+            from_repo: planned.wave.repo().to_string(),
+            from_name: planned.wave.name().to_string(),
+            to_repo: planned.target.repo().to_string(),
+            to_name: planned.target.slug().to_string(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+struct RelocationRecovery {
+    receipt: WaveRelocationReceipt,
+    paths: Vec<RelocationPath>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum TreeEntry {
+    Directory,
+    File(Vec<u8>),
+    Symlink(PathBuf),
+}
+
+pub async fn relocate_wave(
+    store: &Store,
+    wave_id: &WaveId,
+    invoking_repo: &Path,
+    target_repo: Option<&Path>,
+    target_name: Option<&str>,
+) -> Result<WaveRelocationReceipt> {
+    let original_wave = store
+        .get_wave(wave_id)
+        .await?
+        .ok_or_else(|| anyhow!("Wave {wave_id} is not registered"))?;
+    let invoking_repo = CanonicalRepo::discover(invoking_repo)?;
+    let mut wave = original_wave.clone();
+    if CanonicalRepo::discover(Path::new(wave.repo())).is_ok_and(|repo| repo == invoking_repo) {
+        let locator = WaveLocator::new(invoking_repo.clone(), wave.name())?;
+        let scoped = store
+            .get_wave_at(&locator)
+            .await?
+            .ok_or_else(|| anyhow!("Wave {} disappeared during repository repair", wave.id()))?;
+        if scoped.id() != wave.id() {
+            return Err(anyhow!(
+                "repository repair resolved {}/{} to Wave {}, not {}",
+                locator.repo(),
+                locator.slug(),
+                scoped.id(),
+                wave.id()
+            ));
+        }
+        wave = scoped;
+    }
+    WaveLocator::new(invoking_repo.clone(), wave.name())?;
+    let target_repo = match target_repo {
+        Some(repo) => CanonicalRepo::discover(repo)?,
+        None => CanonicalRepo::discover(Path::new(wave.repo())).map_err(|error| {
+            anyhow!(
+                "Wave {} has stale repository {}; pass --repo <existing-checkout>: {error}",
+                wave.id(),
+                wave.repo()
+            )
+        })?,
+    };
+    let target = WaveLocator::new(target_repo, target_name.unwrap_or(wave.name()))?;
+    let source_repo = CanonicalRepo::discover(Path::new(wave.repo())).ok();
+    match source_repo.as_ref() {
+        Some(source) if source != &invoking_repo => {
+            return Err(anyhow!(
+                "Wave {} belongs to {}; invoke relocation from that repository",
+                wave.id(),
+                wave.repo()
+            ));
+        }
+        None if target.repo() != &invoking_repo => {
+            return Err(anyhow!(
+                "Wave {} has stale repository {}; invoke relocation from its explicit target {}",
+                wave.id(),
+                wave.repo(),
+                target.repo()
+            ));
+        }
+        _ => {}
+    }
+    if wave.repo() == target.repo().to_string() && wave.name() == target.slug() {
+        if let Some(receipt) = recover_committed_relocation(store, &wave, &invoking_repo).await? {
+            return Ok(receipt);
+        }
+        if original_wave.repo() != wave.repo() || original_wave.name() != wave.name() {
+            return Ok(WaveRelocationReceipt {
+                wave_id: wave.id().to_string(),
+                from_repo: original_wave.repo().to_string(),
+                from_name: original_wave.name().to_string(),
+                to_repo: wave.repo().to_string(),
+                to_name: wave.name().to_string(),
+                waves_moved: 1,
+            });
+        }
+        return Err(anyhow!("relocation must change --repo or --name"));
+    }
+    if wave.repo() != target.repo().to_string() && wave.parent_wave_id().is_some() {
+        return Err(anyhow!(
+            "repository relocation must start from a root Wave; {} has parent {}",
+            wave.id(),
+            wave.parent_wave_id().expect("parent checked as present")
+        ));
+    }
+    ensure_repository_team_compatible(&wave, &target)?;
+
+    let moves = plan_moves(store, wave, target).await?;
+    preflight(store, &moves).await?;
+    let recovery = relocation_recovery(&moves);
+    let _locks = acquire_locks(&recovery.paths)?;
+    ensure_no_live_endpoints(&recovery.paths).await?;
+    write_recovery(&recovery)?;
+
+    for planned in &moves {
+        stage_wave_paths(planned)?;
+    }
+
+    let updates = moves
+        .iter()
+        .map(|planned| WaveLocatorUpdate {
+            wave_id: planned.wave.id().clone(),
+            expected_repo: planned.wave.repo().to_string(),
+            expected_slug: planned.wave.name().to_string(),
+            target: planned.target.clone(),
+        })
+        .collect();
+    store.relocate_waves(updates).await?;
+
+    for planned in &moves {
+        remove_old_paths(&RelocationPath::from_planned(planned)).with_context(|| {
+            format!(
+                "Wave {} relocation committed at {}/{} but cleanup of {}/{} failed",
+                planned.wave.id(),
+                planned.target.repo(),
+                planned.target.slug(),
+                planned.wave.repo(),
+                planned.wave.name()
+            )
+        })?;
+    }
+    remove_recovery(&recovery)?;
+
+    let root = moves
+        .first()
+        .expect("relocation always contains the requested Wave");
+    Ok(WaveRelocationReceipt {
+        wave_id: root.wave.id().to_string(),
+        from_repo: root.wave.repo().to_string(),
+        from_name: root.wave.name().to_string(),
+        to_repo: root.target.repo().to_string(),
+        to_name: root.target.slug().to_string(),
+        waves_moved: moves.len(),
+    })
+}
+
+fn ensure_repository_team_compatible(wave: &Wave, target: &WaveLocator) -> Result<()> {
+    let Ok(source) = CanonicalRepo::discover(Path::new(wave.repo())) else {
+        return Ok(());
+    };
+    if &source == target.repo() {
+        return Ok(());
+    }
+    let source_team = crate::ops::pm::repository_team_for_snapshot_validation(source.as_path())
+        .map_err(|error| anyhow!(error.to_string()))?;
+    let target_team =
+        crate::ops::pm::repository_team_for_snapshot_validation(target.repo().as_path())
+            .map_err(|error| anyhow!(error.to_string()))?;
+    if let (Some(source_team), Some(target_team)) = (source_team, target_team) {
+        if source_team != target_team {
+            return Err(anyhow!(
+                "cannot rehome Wave {} from repository Team {} to {}; run `lf pm reteam` explicitly before relocating",
+                wave.id(),
+                source_team,
+                target_team
+            ));
+        }
+    }
+    Ok(())
+}
+
+async fn plan_moves(
+    store: &Store,
+    root: Wave,
+    target: WaveLocator,
+) -> Result<Vec<PlannedWaveMove>> {
+    let rehome = root.repo() != target.repo().to_string();
+    let rename = root.name() != target.slug();
+    let mut moves = vec![PlannedWaveMove {
+        wave: root.clone(),
+        target,
+    }];
+    if !rehome && !rename {
+        return Ok(moves);
+    }
+
+    let mut pending = VecDeque::from([root.id().clone()]);
+    while let Some(parent) = pending.pop_front() {
+        for child in store.list_child_waves(&parent).await? {
+            pending.push_back(child.id().clone());
+            let target_slug =
+                relocated_descendant_slug(root.name(), moves[0].target.slug(), child.name());
+            if !rehome && target_slug.is_none() {
+                continue;
+            }
+            moves.push(PlannedWaveMove {
+                target: WaveLocator::new(
+                    moves[0].target.repo().clone(),
+                    target_slug.as_deref().unwrap_or(child.name()),
+                )?,
+                wave: child,
+            });
+        }
+    }
+    Ok(moves)
+}
+
+fn relocated_descendant_slug(root: &str, target: &str, candidate: &str) -> Option<String> {
+    let relative = Path::new(candidate).strip_prefix(root).ok()?;
+    if relative.as_os_str().is_empty() {
+        return None;
+    }
+    Path::new(target)
+        .join(relative)
+        .to_str()
+        .map(str::to_string)
+}
+
+async fn preflight(store: &Store, moves: &[PlannedWaveMove]) -> Result<()> {
+    let moved_ids = moves
+        .iter()
+        .map(|planned| planned.wave.id().to_string())
+        .collect::<BTreeSet<_>>();
+    let registered = store.list_waves(None).await?;
+    for planned in moves {
+        ensure_move_paths_do_not_overlap(planned)?;
+        if let Some(existing) = store.get_wave_at(&planned.target).await? {
+            if existing.id() != planned.wave.id() {
+                return Err(anyhow!(
+                    "target {}/{} already belongs to Wave {}",
+                    planned.target.repo(),
+                    planned.target.slug(),
+                    existing.id()
+                ));
+            }
+        }
+        let source_repo = CanonicalRepo::discover(Path::new(planned.wave.repo())).ok();
+        for other in &registered {
+            if moved_ids.contains(&other.id().to_string()) {
+                continue;
+            }
+            let Ok(other_repo) = CanonicalRepo::discover(Path::new(other.repo())) else {
+                continue;
+            };
+            let inside_source = source_repo.as_ref().is_some_and(|repo| {
+                repo == &other_repo && is_strict_descendant(other.name(), planned.wave.name())
+            });
+            let inside_target = &other_repo == planned.target.repo()
+                && is_strict_descendant(other.name(), planned.target.slug());
+            if inside_source || inside_target {
+                return Err(anyhow!(
+                    "cannot relocate {}/{} because it contains registered Wave {}/{} ({})",
+                    planned.wave.repo(),
+                    planned.wave.name(),
+                    other.repo(),
+                    other.name(),
+                    other.id()
+                ));
+            }
+        }
+        ensure_wave_stopped(store, planned.wave.id()).await?;
+    }
+    Ok(())
+}
+
+fn ensure_move_paths_do_not_overlap(planned: &PlannedWaveMove) -> Result<()> {
+    let source_repo = Path::new(planned.wave.repo());
+    let target_repo = planned.target.repo().as_path();
+    for (source, target) in [
+        (
+            authored_path(source_repo, planned.wave.name()),
+            authored_path(target_repo, planned.target.slug()),
+        ),
+        (
+            journal_path(source_repo, planned.wave.name()),
+            journal_path(target_repo, planned.target.slug()),
+        ),
+    ] {
+        if source != target && (source.starts_with(&target) || target.starts_with(&source)) {
+            return Err(anyhow!(
+                "Wave relocation paths overlap; choose a sibling locator: {} -> {}",
+                source.display(),
+                target.display()
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn is_strict_descendant(candidate: &str, parent: &str) -> bool {
+    candidate != parent && Path::new(candidate).starts_with(parent)
+}
+
+async fn ensure_wave_stopped(store: &Store, wave_id: &WaveId) -> Result<()> {
+    let mut work = vec![WorkRef::Wave(wave_id.clone())];
+    work.extend(
+        store
+            .list_projects(Some(wave_id))
+            .await?
+            .into_iter()
+            .map(|project| WorkRef::Project(project.id)),
+    );
+    work.extend(
+        store
+            .list_tasks(Some(wave_id))
+            .await?
+            .into_iter()
+            .map(|task| WorkRef::Task(task.id)),
+    );
+    for work in work {
+        if let Some(run) = store.current_run(&work).await? {
+            return Err(anyhow!(
+                "cannot relocate Wave {wave_id} while Run {} owns {} {}",
+                run.id,
+                work.kind(),
+                work.id()
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn acquire_locks(paths: &[RelocationPath]) -> Result<Vec<WaveLocatorLock>> {
+    let mut locators = BTreeSet::new();
+    for path in paths {
+        let source_repo = CanonicalRepo::discover(Path::new(&path.from_repo))
+            .map(|repo| repo.as_path().to_path_buf())
+            .unwrap_or_else(|_| PathBuf::from(&path.from_repo));
+        if source_repo.is_dir() {
+            locators.insert((source_repo, path.from_name.clone()));
+        }
+        locators.insert((PathBuf::from(&path.to_repo), path.to_name.clone()));
+    }
+    locators
+        .into_iter()
+        .map(|(repo, slug)| WaveLocatorLock::acquire(&repo, &slug))
+        .collect()
+}
+
+async fn ensure_no_live_endpoints(paths: &[RelocationPath]) -> Result<()> {
+    let mut locators = BTreeSet::new();
+    for path in paths {
+        locators.insert((PathBuf::from(&path.from_repo), path.from_name.as_str()));
+        locators.insert((PathBuf::from(&path.to_repo), path.to_name.as_str()));
+    }
+    for (repo, slug) in locators {
+        if let Some(endpoint) = live_endpoint(&repo, slug).await {
+            return Err(anyhow!(
+                "cannot relocate live Wave at {}/{} ({endpoint})",
+                repo.display(),
+                slug
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn authored_path(repo: &Path, slug: &str) -> PathBuf {
+    repo.join("wave").join(slug)
+}
+
+fn journal_path(repo: &Path, slug: &str) -> PathBuf {
+    repo.join(".lf/journal/waves").join(slug)
+}
+
+fn stage_wave_paths(planned: &PlannedWaveMove) -> Result<()> {
+    let source_repo = Path::new(planned.wave.repo());
+    let target_repo = planned.target.repo().as_path();
+    let stale_source = !source_repo.is_dir();
+    stage_tree(
+        &authored_path(source_repo, planned.wave.name()),
+        &authored_path(target_repo, planned.target.slug()),
+        true,
+        true,
+        stale_source,
+    )?;
+    stage_tree(
+        &journal_path(source_repo, planned.wave.name()),
+        &journal_path(target_repo, planned.target.slug()),
+        false,
+        false,
+        stale_source,
+    )
+}
+
+fn stage_tree(
+    source: &Path,
+    target: &Path,
+    required: bool,
+    skip_boot_files: bool,
+    stale_source: bool,
+) -> Result<()> {
+    if source == target {
+        return Ok(());
+    }
+    if !source.exists() {
+        if stale_source && (target.exists() || !required) {
+            return Ok(());
+        }
+        if !required && !target.exists() {
+            return Ok(());
+        }
+        return Err(anyhow!(
+            "relocation source is missing and the target cannot be trusted: {} -> {}",
+            source.display(),
+            target.display()
+        ));
+    }
+    if target.exists() {
+        if tree_contents(source, skip_boot_files)? == tree_contents(target, skip_boot_files)? {
+            remove_boot_files(target)?;
+            return Ok(());
+        }
+        return Err(anyhow!(
+            "relocation target diverges from source: {} -> {}",
+            source.display(),
+            target.display()
+        ));
+    }
+
+    let parent = target
+        .parent()
+        .ok_or_else(|| anyhow!("relocation target has no parent: {}", target.display()))?;
+    std::fs::create_dir_all(parent)?;
+    let name = target
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("wave");
+    let temporary = parent.join(format!(
+        ".{name}.lf-relocate-{}",
+        uuid::Uuid::new_v4().simple()
+    ));
+    let staged = (|| {
+        copy_tree(source, &temporary, skip_boot_files)?;
+        if tree_contents(source, skip_boot_files)? != tree_contents(&temporary, skip_boot_files)? {
+            return Err(anyhow!(
+                "staged relocation did not verify: {}",
+                temporary.display()
+            ));
+        }
+        std::fs::rename(&temporary, target).with_context(|| {
+            format!(
+                "publish staged Wave path {} -> {}",
+                temporary.display(),
+                target.display()
+            )
+        })?;
+        Ok(())
+    })();
+    if staged.is_err() {
+        let _ = std::fs::remove_dir_all(&temporary);
+    }
+    staged
+}
+
+fn copy_tree(source: &Path, target: &Path, skip_boot_files: bool) -> Result<()> {
+    std::fs::create_dir_all(target)?;
+    for entry in std::fs::read_dir(source)? {
+        let entry = entry?;
+        let name = entry.file_name();
+        if skip_boot_files
+            && name
+                .to_str()
+                .is_some_and(|name| matches!(name, ENDPOINT_FILE | RESIDENT_TOKEN_FILE))
+        {
+            continue;
+        }
+        let source_path = entry.path();
+        let target_path = target.join(&name);
+        let metadata = std::fs::symlink_metadata(&source_path)?;
+        if metadata.is_dir() {
+            copy_tree(&source_path, &target_path, skip_boot_files)?;
+        } else if metadata.file_type().is_symlink() {
+            copy_symlink(&source_path, &target_path)?;
+        } else {
+            std::fs::copy(&source_path, &target_path)?;
+        }
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn copy_symlink(source: &Path, target: &Path) -> Result<()> {
+    std::os::unix::fs::symlink(std::fs::read_link(source)?, target)?;
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn copy_symlink(source: &Path, _target: &Path) -> Result<()> {
+    Err(anyhow!(
+        "cannot preserve symlink during relocation: {}",
+        source.display()
+    ))
+}
+
+fn tree_contents(root: &Path, skip_boot_files: bool) -> Result<BTreeMap<PathBuf, TreeEntry>> {
+    fn visit(
+        root: &Path,
+        current: &Path,
+        skip_boot_files: bool,
+        entries: &mut BTreeMap<PathBuf, TreeEntry>,
+    ) -> Result<()> {
+        for entry in std::fs::read_dir(current)? {
+            let entry = entry?;
+            let name = entry.file_name();
+            if skip_boot_files
+                && name
+                    .to_str()
+                    .is_some_and(|name| matches!(name, ENDPOINT_FILE | RESIDENT_TOKEN_FILE))
+            {
+                continue;
+            }
+            let path = entry.path();
+            let relative = path.strip_prefix(root)?.to_path_buf();
+            let metadata = std::fs::symlink_metadata(&path)?;
+            if metadata.is_dir() {
+                entries.insert(relative, TreeEntry::Directory);
+                visit(root, &path, skip_boot_files, entries)?;
+            } else if metadata.file_type().is_symlink() {
+                entries.insert(relative, TreeEntry::Symlink(std::fs::read_link(path)?));
+            } else {
+                entries.insert(relative, TreeEntry::File(std::fs::read(path)?));
+            }
+        }
+        Ok(())
+    }
+
+    let mut entries = BTreeMap::new();
+    visit(root, root, skip_boot_files, &mut entries)?;
+    Ok(entries)
+}
+
+fn remove_boot_files(path: &Path) -> Result<()> {
+    for name in [ENDPOINT_FILE, RESIDENT_TOKEN_FILE] {
+        match std::fs::remove_file(path.join(name)) {
+            Ok(()) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => return Err(error.into()),
+        }
+    }
+    Ok(())
+}
+
+fn remove_old_paths(path: &RelocationPath) -> Result<()> {
+    let source_repo = Path::new(&path.from_repo);
+    let target_repo = Path::new(&path.to_repo);
+    for (source, target, skip_boot_files) in [
+        (
+            authored_path(source_repo, &path.from_name),
+            authored_path(target_repo, &path.to_name),
+            true,
+        ),
+        (
+            journal_path(source_repo, &path.from_name),
+            journal_path(target_repo, &path.to_name),
+            false,
+        ),
+    ] {
+        if source != target && source.exists() {
+            if !target.exists()
+                || tree_contents(&source, skip_boot_files)?
+                    != tree_contents(&target, skip_boot_files)?
+            {
+                return Err(anyhow!(
+                    "old Wave path changed after staging; preserving both copies: {} -> {}",
+                    source.display(),
+                    target.display()
+                ));
+            }
+            std::fs::remove_dir_all(&source)
+                .with_context(|| format!("remove old Wave path {}", source.display()))?;
+        }
+    }
+    Ok(())
+}
+
+fn relocation_recovery(moves: &[PlannedWaveMove]) -> RelocationRecovery {
+    let root = moves
+        .first()
+        .expect("relocation always contains the requested Wave");
+    RelocationRecovery {
+        receipt: WaveRelocationReceipt {
+            wave_id: root.wave.id().to_string(),
+            from_repo: root.wave.repo().to_string(),
+            from_name: root.wave.name().to_string(),
+            to_repo: root.target.repo().to_string(),
+            to_name: root.target.slug().to_string(),
+            waves_moved: moves.len(),
+        },
+        paths: moves.iter().map(RelocationPath::from_planned).collect(),
+    }
+}
+
+fn recovery_path(recovery: &RelocationRecovery) -> PathBuf {
+    Path::new(&recovery.receipt.to_repo)
+        .join(".lf/tmp/wave-relocations")
+        .join(format!("{}.json", recovery.receipt.wave_id))
+}
+
+fn recovery_path_for_wave(wave: &Wave) -> PathBuf {
+    Path::new(wave.repo())
+        .join(".lf/tmp/wave-relocations")
+        .join(format!("{}.json", wave.id()))
+}
+
+fn write_recovery(recovery: &RelocationRecovery) -> Result<()> {
+    let path = recovery_path(recovery);
+    if path.exists() {
+        let existing: RelocationRecovery = serde_json::from_slice(&std::fs::read(&path)?)?;
+        if existing == *recovery {
+            return Ok(());
+        }
+        return Err(anyhow!(
+            "Wave {} has a different unfinished relocation at {}",
+            recovery.receipt.wave_id,
+            path.display()
+        ));
+    }
+    let parent = path
+        .parent()
+        .ok_or_else(|| anyhow!("relocation recovery path has no parent: {}", path.display()))?;
+    std::fs::create_dir_all(parent)?;
+    let temporary = parent.join(format!(
+        ".{}.{}",
+        path.file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or("relocation"),
+        uuid::Uuid::new_v4().simple()
+    ));
+    let bytes = serde_json::to_vec_pretty(recovery)?;
+    let mut file = OpenOptions::new()
+        .create_new(true)
+        .write(true)
+        .open(&temporary)?;
+    std::io::Write::write_all(&mut file, &bytes)?;
+    file.sync_all()?;
+    std::fs::rename(&temporary, &path)?;
+    File::open(parent)?.sync_all()?;
+    Ok(())
+}
+
+fn remove_recovery(recovery: &RelocationRecovery) -> Result<()> {
+    let path = recovery_path(recovery);
+    match std::fs::remove_file(&path) {
+        Ok(()) => {
+            let parent = path.parent().ok_or_else(|| {
+                anyhow!("relocation recovery path has no parent: {}", path.display())
+            })?;
+            File::open(parent)?.sync_all()?;
+            Ok(())
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error.into()),
+    }
+}
+
+async fn recover_committed_relocation(
+    store: &Store,
+    wave: &Wave,
+    invoking_repo: &CanonicalRepo,
+) -> Result<Option<WaveRelocationReceipt>> {
+    let path = recovery_path_for_wave(wave);
+    if !path.exists() {
+        return Ok(None);
+    }
+    if Path::new(wave.repo()) != invoking_repo.as_path() {
+        return Err(anyhow!(
+            "unfinished relocation for Wave {} must be recovered from {}",
+            wave.id(),
+            wave.repo()
+        ));
+    }
+    let recovery: RelocationRecovery = serde_json::from_slice(&std::fs::read(&path)?)
+        .with_context(|| format!("read relocation recovery {}", path.display()))?;
+    if recovery.receipt.wave_id != wave.id().to_string() {
+        return Err(anyhow!(
+            "relocation recovery {} belongs to Wave {}, not {}",
+            path.display(),
+            recovery.receipt.wave_id,
+            wave.id()
+        ));
+    }
+    for move_path in &recovery.paths {
+        let current = store.get_wave(&move_path.wave_id).await?.ok_or_else(|| {
+            anyhow!(
+                "Wave {} disappeared during relocation recovery",
+                move_path.wave_id
+            )
+        })?;
+        if current.repo() != move_path.to_repo || current.name() != move_path.to_name {
+            return Err(anyhow!(
+                "relocation recovery cannot clean up before Wave {} reaches {}/{}",
+                current.id(),
+                move_path.to_repo,
+                move_path.to_name
+            ));
+        }
+        ensure_wave_stopped(store, current.id()).await?;
+    }
+    let _locks = acquire_locks(&recovery.paths)?;
+    ensure_no_live_endpoints(&recovery.paths).await?;
+    for move_path in &recovery.paths {
+        remove_old_paths(move_path)?;
+    }
+    remove_recovery(&recovery)?;
+    Ok(Some(recovery.receipt))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        recovery_path, relocate_wave, relocation_recovery, remove_old_paths, stage_tree,
+        write_recovery, PlannedWaveMove, RelocationPath,
+    };
+    use crate::id::WaveId;
+    use crate::store::{open_store, StorageConfig, WaveLocatorUpdate};
+    use crate::wave::{Wave, WaveLocator};
+
+    #[test]
+    fn committed_cleanup_preserves_a_source_that_changed_after_staging() {
+        let tmp = tempfile::tempdir().unwrap();
+        let source_repo = tmp.path().join("source");
+        let target_repo = tmp.path().join("target");
+        std::fs::create_dir_all(source_repo.join("wave/infrastructure")).unwrap();
+        std::fs::create_dir_all(target_repo.join("wave/platform")).unwrap();
+        std::fs::write(
+            source_repo.join("wave/infrastructure/GOAL.md"),
+            "changed after staging\n",
+        )
+        .unwrap();
+        std::fs::write(
+            target_repo.join("wave/platform/GOAL.md"),
+            "staged content\n",
+        )
+        .unwrap();
+        let path = RelocationPath {
+            wave_id: WaveId::new(),
+            from_repo: source_repo.display().to_string(),
+            from_name: "infrastructure".to_string(),
+            to_repo: target_repo.display().to_string(),
+            to_name: "platform".to_string(),
+        };
+
+        let error = remove_old_paths(&path).unwrap_err();
+
+        assert!(error.to_string().contains("preserving both copies"));
+        assert!(source_repo.join("wave/infrastructure/GOAL.md").is_file());
+        assert!(target_repo.join("wave/platform/GOAL.md").is_file());
+    }
+
+    #[test]
+    fn absent_source_journal_never_adopts_an_unrelated_target() {
+        let tmp = tempfile::tempdir().unwrap();
+        let source = tmp.path().join("source/journal");
+        let target = tmp.path().join("target/journal");
+        std::fs::create_dir_all(target.parent().unwrap()).unwrap();
+        std::fs::create_dir_all(&target).unwrap();
+        std::fs::write(target.join("events.jsonl"), "unrelated\n").unwrap();
+
+        let error = stage_tree(&source, &target, false, false, false).unwrap_err();
+
+        assert!(error.to_string().contains("target cannot be trusted"));
+        assert_eq!(
+            std::fs::read_to_string(target.join("events.jsonl")).unwrap(),
+            "unrelated\n"
+        );
+    }
+
+    #[tokio::test]
+    async fn retry_after_commit_finishes_filesystem_cleanup() {
+        let tmp = tempfile::tempdir().unwrap();
+        let source_repo = tmp.path().join("source");
+        let target_repo = tmp.path().join("target");
+        std::fs::create_dir_all(source_repo.join("wave/infrastructure")).unwrap();
+        std::fs::create_dir_all(&target_repo).unwrap();
+        std::fs::write(
+            source_repo.join("wave/infrastructure/GOAL.md"),
+            "# infrastructure\n",
+        )
+        .unwrap();
+        let store = open_store(&StorageConfig::sqlite(tmp.path().join("registry.db")))
+            .await
+            .unwrap();
+        let wave = Wave::new(
+            WaveId::new(),
+            "infrastructure".to_string(),
+            std::fs::canonicalize(&source_repo)
+                .unwrap()
+                .display()
+                .to_string(),
+        );
+        store.create_wave(&wave).await.unwrap();
+        let target = WaveLocator::discover(&target_repo, "platform").unwrap();
+        let planned = PlannedWaveMove {
+            wave: wave.clone(),
+            target: target.clone(),
+        };
+        super::stage_wave_paths(&planned).unwrap();
+        let recovery = relocation_recovery(std::slice::from_ref(&planned));
+        write_recovery(&recovery).unwrap();
+        store
+            .relocate_waves(vec![WaveLocatorUpdate {
+                wave_id: wave.id().clone(),
+                expected_repo: wave.repo().to_string(),
+                expected_slug: wave.name().to_string(),
+                target,
+            }])
+            .await
+            .unwrap();
+        assert!(source_repo.join("wave/infrastructure").is_dir());
+        assert!(recovery_path(&recovery).is_file());
+
+        let receipt = relocate_wave(&store, wave.id(), &target_repo, None, None)
+            .await
+            .unwrap();
+
+        assert_eq!(receipt.from_name, "infrastructure");
+        assert_eq!(receipt.to_name, "platform");
+        assert!(!source_repo.join("wave/infrastructure").exists());
+        assert!(target_repo.join("wave/platform/GOAL.md").is_file());
+        assert!(!recovery_path(&recovery).exists());
+    }
+}

--- a/rust/loopflow/src/wave/types.rs
+++ b/rust/loopflow/src/wave/types.rs
@@ -4,6 +4,49 @@ use serde::{Deserialize, Serialize};
 use time::OffsetDateTime;
 
 use crate::id::WaveId;
+use crate::repository::{CanonicalRepo, CanonicalRepoError};
+
+/// A Wave's mutable human address inside one canonical repository.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct WaveLocator {
+    repo: CanonicalRepo,
+    slug: String,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum WaveLocatorError {
+    #[error(transparent)]
+    Repository(#[from] CanonicalRepoError),
+    #[error("invalid Wave slug {0:?}")]
+    InvalidSlug(String),
+}
+
+impl WaveLocator {
+    pub fn discover(repo: &std::path::Path, slug: &str) -> Result<Self, WaveLocatorError> {
+        Self::new(CanonicalRepo::discover(repo)?, slug)
+    }
+
+    pub fn new(repo: CanonicalRepo, slug: &str) -> Result<Self, WaveLocatorError> {
+        let slug = crate::ops::util::normalize_wave_name(slug)
+            .ok_or_else(|| WaveLocatorError::InvalidSlug(slug.to_string()))?;
+        if slug.contains('\\')
+            || slug
+                .split('/')
+                .any(|component| component.is_empty() || matches!(component, "." | ".."))
+        {
+            return Err(WaveLocatorError::InvalidSlug(slug));
+        }
+        Ok(Self { repo, slug })
+    }
+
+    pub fn repo(&self) -> &CanonicalRepo {
+        &self.repo
+    }
+
+    pub fn slug(&self) -> &str {
+        &self.slug
+    }
+}
 
 /// The one-time typed wake derived from a child Wave's durable promotion occurrence.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -29,7 +72,7 @@ impl PromotionWake {
 pub struct Wave {
     id: WaveId,
     name: String,
-    /// The single repo this wave targets. A wave = exactly one repo.
+    /// Current canonical repository half of the mutable locator.
     repo: String,
     #[serde(with = "time::serde::rfc3339::option")]
     created_at: Option<OffsetDateTime>,
@@ -153,5 +196,27 @@ mod tests {
         let unchanged = promoted.with_parent(other_parent);
         assert_eq!(unchanged.parent_wave_id(), Some(&parent));
         assert!(unchanged.promoted_at().is_some());
+    }
+
+    #[test]
+    fn locator_slugs_allow_safe_nesting_but_never_path_traversal() {
+        let repo = crate::repository::CanonicalRepo::discover(
+            &std::env::current_dir().expect("current directory"),
+        )
+        .unwrap();
+        assert_eq!(
+            WaveLocator::new(repo.clone(), "goals/release")
+                .unwrap()
+                .slug(),
+            "goals/release"
+        );
+        for unsafe_slug in [
+            "../escape",
+            "goals/../escape",
+            "goals//release",
+            "goals\\release",
+        ] {
+            assert!(WaveLocator::new(repo.clone(), unsafe_slug).is_err());
+        }
     }
 }

--- a/rust/loopflow/src/wave_host.rs
+++ b/rust/loopflow/src/wave_host.rs
@@ -424,7 +424,7 @@ mod tests {
     use crate::durable::{Containment, HomeId, RunAdvance, RunState, RunTrigger, WorkRef};
     use crate::id::WaveId;
     use crate::store::{open_store, StorageConfig};
-    use crate::wave::Wave;
+    use crate::wave::{Wave, WaveLocator};
 
     use super::{waves_for_home, WaveHost, WaveStartState};
 
@@ -466,10 +466,11 @@ mod tests {
                 .expect("open store"),
         );
         let local = store.local_home().await.expect("read local Home");
+        let locator = WaveLocator::discover(&repo, "product").expect("discover Wave locator");
         let wave = Wave::new(
             WaveId::new(),
             "product".to_string(),
-            repo.display().to_string(),
+            locator.repo().to_string(),
         );
         store.create_wave(&wave).await.expect("create Wave");
         let work = WorkRef::Wave(wave.id().clone());
@@ -540,7 +541,7 @@ mod tests {
             .await
             .expect("observe remote Home");
         let remote_wave = store
-            .get_wave_by_name("remote-placement")
+            .get_wave_at(&crate::wave::WaveLocator::discover(&repo, "remote-placement").unwrap())
             .await
             .expect("read remote Wave")
             .expect("remote Wave exists");
@@ -615,10 +616,11 @@ mod tests {
             ),
         )
         .expect("write Wave goal");
+        let locator = WaveLocator::discover(&repo, "product").expect("discover Wave locator");
         let wave = Wave::new(
             WaveId::new(),
             "product".to_string(),
-            repo.display().to_string(),
+            locator.repo().to_string(),
         );
         store.create_wave(&wave).await.expect("create Wave");
         let host = WaveHost::new(local.id, store, None);

--- a/rust/loopflow/tests/lfd_tests.rs
+++ b/rust/loopflow/tests/lfd_tests.rs
@@ -102,6 +102,8 @@ fn spawn_lfd(repo: &std::path::Path, db_path: &std::path::Path, addr: SocketAddr
         .arg(addr.to_string())
         .env("LF_DB_PATH", db_path)
         .env("LF_HOME", repo.join(".lf-test"))
+        .env("LF_CONTROL_HOME", repo.join(".lf-test"))
+        .env_remove("LF_CONTROL_DB_PATH")
         .env("LF_LINEAR_WEBHOOK_SECRET", SECRET)
         .env("LF_LINEAR_VIEWER_ID", VIEWER_ID)
         .stdout(Stdio::null())

--- a/rust/loopflow/tests/repository_team_matrix.rs
+++ b/rust/loopflow/tests/repository_team_matrix.rs
@@ -7,7 +7,7 @@ use loopflow::id::WaveId;
 use loopflow::ops::pm::{canonical_wave_title_path, list_local_waves};
 use loopflow::store::sqlite::SqliteStore;
 use loopflow::store::PmSnapshotRow;
-use loopflow::wave::Wave;
+use loopflow::wave::{Wave, WaveLocator};
 
 fn git(repo: &Path, args: &[&str]) {
     let output = Command::new("git")
@@ -79,10 +79,13 @@ fn snapshot(
 }
 
 fn put_snapshot(store: &SqliteStore, repo: &Path, wave: &str, initiative: &str, payload: String) {
+    let registered = store
+        .get_wave_at(&WaveLocator::discover(repo, wave).unwrap())
+        .unwrap()
+        .expect("registered Wave");
     store
         .put_pm_snapshot(&PmSnapshotRow {
-            repo: std::fs::canonicalize(repo).unwrap().display().to_string(),
-            wave: wave.to_string(),
+            wave_id: registered.id().clone(),
             provider: "linear".to_string(),
             initiative: initiative.to_string(),
             synced_at: chrono::Utc::now().timestamp(),
@@ -97,8 +100,10 @@ fn lf_command(home: &Path, repo: &Path, args: &[&str]) -> Command {
         .args(args)
         .current_dir(repo)
         .env("LF_HOME", home)
+        .env("LF_CONTROL_HOME", home)
         .env("HOME", home)
         .env_remove("LF_DB_PATH")
+        .env_remove("LF_CONTROL_DB_PATH")
         .env_remove("LF_WAVE_ID");
     command
 }
@@ -166,25 +171,33 @@ fn repository_team_matrix() {
 
     let database = home.join("loopflow.db");
     let store = SqliteStore::new(&database).unwrap();
+    let repo_locator = WaveLocator::discover(&repo, "survival").unwrap();
     let survival = Wave::new(
         WaveId::new(),
         "survival".to_string(),
-        repo.display().to_string(),
+        repo_locator.repo().to_string(),
     );
     let infrastructure = Wave::new(
         WaveId::new(),
         "survival/infrastructure".to_string(),
-        repo.display().to_string(),
+        repo_locator.repo().to_string(),
     )
     .with_parent(survival.id().clone());
+    let intelligence = Wave::new(
+        WaveId::new(),
+        "intelligence".to_string(),
+        repo_locator.repo().to_string(),
+    );
     store.create_wave(&survival).unwrap();
     store.create_wave(&infrastructure).unwrap();
+    store.create_wave(&intelligence).unwrap();
     let foreign_repo = tempfile::tempdir().unwrap();
+    let foreign_locator = WaveLocator::discover(foreign_repo.path(), "intelligence").unwrap();
     store
         .create_wave(&Wave::new(
             WaveId::new(),
             "intelligence".to_string(),
-            foreign_repo.path().display().to_string(),
+            foreign_locator.repo().to_string(),
         ))
         .unwrap();
     put_snapshot(
@@ -248,11 +261,15 @@ fn repository_team_matrix() {
     );
     let old_home = std::env::var_os("LF_HOME");
     let old_db = std::env::var_os("LF_DB_PATH");
+    let old_control_home = std::env::var_os("LF_CONTROL_HOME");
+    let old_control_db = std::env::var_os("LF_CONTROL_DB_PATH");
     // SAFETY: this integration binary contains one test; no sibling thread can
     // observe the temporary storage selection.
     unsafe {
         std::env::set_var("LF_HOME", &home);
+        std::env::set_var("LF_CONTROL_HOME", &home);
         std::env::remove_var("LF_DB_PATH");
+        std::env::remove_var("LF_CONTROL_DB_PATH");
     }
     assert_eq!(
         canonical_wave_title_path(&repo, "survival/infrastructure").unwrap(),
@@ -271,6 +288,14 @@ fn repository_team_matrix() {
         match old_db {
             Some(value) => std::env::set_var("LF_DB_PATH", value),
             None => std::env::remove_var("LF_DB_PATH"),
+        }
+        match old_control_home {
+            Some(value) => std::env::set_var("LF_CONTROL_HOME", value),
+            None => std::env::remove_var("LF_CONTROL_HOME"),
+        }
+        match old_control_db {
+            Some(value) => std::env::set_var("LF_CONTROL_DB_PATH", value),
+            None => std::env::remove_var("LF_CONTROL_DB_PATH"),
         }
     }
 
@@ -308,12 +333,12 @@ fn repository_team_matrix() {
     let control_survival = Wave::new(
         WaveId::new(),
         "survival".to_string(),
-        repo.display().to_string(),
+        repo_locator.repo().to_string(),
     );
     let control_infrastructure = Wave::new(
         WaveId::new(),
         "survival/infrastructure".to_string(),
-        repo.display().to_string(),
+        repo_locator.repo().to_string(),
     )
     .with_parent(control_survival.id().clone());
     control_store.create_wave(&control_survival).unwrap();
@@ -370,7 +395,7 @@ fn repository_team_matrix() {
 
     // Reopening the store preserves the local ancestry and foreign collision.
     let reopened = SqliteStore::new(&database).unwrap();
-    assert_eq!(reopened.list_waves(None).unwrap().len(), 3);
+    assert_eq!(reopened.list_waves(None).unwrap().len(), 4);
 
     // A duplicated Project/Issue association fails before Work or worktree creation.
     put_snapshot(
@@ -448,11 +473,12 @@ fn repository_team_matrix() {
     git(&legacy_repo, &["add", "."]);
     git(&legacy_repo, &["commit", "-m", "seed legacy fixture"]);
     let legacy_store = SqliteStore::new(&home.join("loopflow.db")).unwrap();
+    let legacy_locator = WaveLocator::discover(&legacy_repo, "product").unwrap();
     legacy_store
         .create_wave(&Wave::new(
             WaveId::new(),
             "product".to_string(),
-            legacy_repo.display().to_string(),
+            legacy_locator.repo().to_string(),
         ))
         .unwrap();
     put_snapshot(

--- a/rust/loopflow/tests/status_tests.rs
+++ b/rust/loopflow/tests/status_tests.rs
@@ -7,7 +7,9 @@ use std::path::Path;
 use std::process::Command;
 
 use loopflow::child::ChildRef;
-use loopflow::durable::{Containment, RunAdvance, RunTrigger};
+use loopflow::durable::{
+    Containment, ContainmentObservation, RunAdvance, RunTrigger, StopCause, WorkRef,
+};
 use loopflow::id::WaveId;
 use loopflow::planning::{LinearIssueId, LinearProjectId, ProjectPlan, TaskPlan};
 use loopflow::project::{Project, ProjectId};
@@ -17,22 +19,46 @@ use loopflow::task::{
     Observation, PmWritebackState, Task, TaskId, TaskLifecyclePhase, TaskLifecyclePlan, TaskPr,
     TaskPrId,
 };
-use loopflow::trace::{AgentInvocationRow, AgentTurnRow};
+use loopflow::trace::{AgentInvocationRow, AgentTurnRow, SupervisedInvocation};
 use loopflow::wave::Wave;
 use time::OffsetDateTime;
+
+const INVOCATION_ID: &str = "invocation_00000000000000000000000000000001";
 
 /// A machine home holding one wave with lookup noise, a flow, and a skill. The
 /// registry and the ledgers are the same database.
 fn seed(home: &Path, wave_name: &str) -> Wave {
     std::fs::create_dir_all(home).expect("home");
+    let repo = home.join("repo");
+    std::fs::create_dir_all(&repo).expect("repo");
     let db = home.join("loopflow.db");
     let store = SqliteStore::new(&db).expect("open store");
     let wave = Wave::new(
         WaveId::new(),
         wave_name.to_string(),
-        home.join("repo").display().to_string(),
+        repo.display().to_string(),
     );
     store.create_wave(&wave).expect("register wave");
+    let work = WorkRef::Wave(wave.id().clone());
+    let (_, lease) = store
+        .reserve_run(&work, &RunTrigger::User)
+        .expect("reserve Run");
+    store
+        .advance_run(
+            &lease,
+            &RunAdvance::RunStarting {
+                containment: Containment::ProcessGroup { id: 1 },
+                cwd: repo.clone(),
+            },
+        )
+        .expect("start Run");
+    store
+        .stop_run(
+            &lease,
+            &StopCause::Requested,
+            ContainmentObservation::Absent,
+        )
+        .expect("stop Run");
 
     let now = chrono::Utc::now().timestamp();
     let event = |seq: i64, ts: i64, event: &str| RunEventRow {
@@ -92,7 +118,7 @@ fn seed(home: &Path, wave_name: &str) -> Wave {
         .expect("seed resident end");
 
     let invocation = AgentInvocationRow {
-        id: "invocation-wave-mutate".to_string(),
+        id: INVOCATION_ID.to_string(),
         run_id: "run-resident".to_string(),
         answer_ask_id: None,
         process_id: "proc-resident".to_string(),
@@ -118,7 +144,13 @@ fn seed(home: &Path, wave_name: &str) -> Wave {
         provider_session_path: None,
         conversation_event_count: 2,
         conversation_bytes: 10,
-        supervision: None,
+        supervision: Some(SupervisedInvocation {
+            invocation_id: loopflow::durable::AgentInvocationId::parse(INVOCATION_ID)
+                .expect("invocation id"),
+            supervising_run_id: lease.run_id,
+            account_id: None,
+            resume_token: None,
+        }),
     };
     let turn = AgentTurnRow {
         id: "turn-wave-mutate".to_string(),
@@ -171,7 +203,8 @@ fn status_json(home: &Path, args: &[&str], ambient_wave_id: Option<&str>) -> ser
         .env_remove("LF_CONTROL_HOME")
         .env_remove("LF_CONTROL_DB_PATH")
         .env_remove("LF_TRACE_ID")
-        .env_remove("LF_WAVE_ID");
+        .env_remove("LF_WAVE_ID")
+        .current_dir(home.join("repo"));
     if let Some(id) = ambient_wave_id {
         command.env("LF_WAVE_ID", id);
     }
@@ -191,6 +224,9 @@ fn status_human(home: &Path, wave: &str) -> String {
         .args(["status", wave])
         .env("LF_HOME", home)
         .env_remove("LF_DB_PATH")
+        .env_remove("LF_CONTROL_HOME")
+        .env_remove("LF_CONTROL_DB_PATH")
+        .current_dir(home.join("repo"))
         .output()
         .expect("lf status runs");
     assert!(
@@ -210,7 +246,8 @@ fn roadmap_json(home: &Path, wave: &str) -> serde_json::Value {
         .env_remove("LF_CONTROL_HOME")
         .env_remove("LF_CONTROL_DB_PATH")
         .env_remove("LF_TRACE_ID")
-        .env_remove("LF_WAVE_ID");
+        .env_remove("LF_WAVE_ID")
+        .current_dir(home.join("repo"));
     prepend_test_bin(&mut command, home);
     let output = command.output().expect("lf roadmap runs");
     assert!(
@@ -410,11 +447,7 @@ fn seed_stale_project_work(home: &Path) {
     });
     store
         .put_pm_snapshot(&PmSnapshotRow {
-            repo: std::fs::canonicalize(repo)
-                .expect("canonical repo")
-                .display()
-                .to_string(),
-            wave: "product".to_string(),
+            wave_id: wave.id().clone(),
             provider: "linear".to_string(),
             initiative: "initiative-product".to_string(),
             synced_at: now.unix_timestamp(),
@@ -428,6 +461,8 @@ fn execs_json(home: &Path) -> serde_json::Value {
         .args(["execs", "--json"])
         .env("LF_HOME", home)
         .env_remove("LF_DB_PATH")
+        .env_remove("LF_CONTROL_HOME")
+        .env_remove("LF_CONTROL_DB_PATH")
         .output()
         .expect("lf execs runs");
     assert!(
@@ -443,6 +478,8 @@ fn runs_json(home: &Path) -> serde_json::Value {
         .args(["runs", "--json"])
         .env("LF_HOME", home)
         .env_remove("LF_DB_PATH")
+        .env_remove("LF_CONTROL_HOME")
+        .env_remove("LF_CONTROL_DB_PATH")
         .output()
         .expect("lf runs runs");
     assert!(
@@ -460,6 +497,8 @@ fn runs_json_filtered(home: &Path, filter: &[&str]) -> serde_json::Value {
         .arg("--json")
         .env("LF_HOME", home)
         .env_remove("LF_DB_PATH")
+        .env_remove("LF_CONTROL_HOME")
+        .env_remove("LF_CONTROL_DB_PATH")
         .output()
         .expect("lf runs runs");
     assert!(
@@ -475,6 +514,8 @@ fn trace_json(home: &Path, exec_id: &str) -> serde_json::Value {
         .args(["trace", exec_id, "--json"])
         .env("LF_HOME", home)
         .env_remove("LF_DB_PATH")
+        .env_remove("LF_CONTROL_HOME")
+        .env_remove("LF_CONTROL_DB_PATH")
         .output()
         .expect("lf trace runs");
     assert!(
@@ -545,7 +586,7 @@ fn runs_are_skill_invocations_with_context_and_token_evidence() {
     let runs = runs.as_array().expect("run array");
     assert_eq!(runs.len(), 1);
     let run = &runs[0];
-    assert_eq!(run["id"], "invocation-wave-mutate");
+    assert_eq!(run["id"], INVOCATION_ID);
     assert_eq!(run["trace_id"], "run-resident");
     assert_eq!(run["exec_id"], "proc-resident");
     assert_eq!(run["skill"], "wave/mutate");
@@ -612,7 +653,7 @@ fn trace_opens_from_the_invocation_id_lf_runs_prints() {
     let home = tempfile::tempdir().expect("tempdir");
     seed(home.path(), "audit-trace-invocation");
 
-    let trace = trace_json(home.path(), "invocation-wave-mutate");
+    let trace = trace_json(home.path(), INVOCATION_ID);
     assert_eq!(trace["trace_id"], "run-resident");
     let spans = trace["spans"].as_array().expect("span array");
     assert!(spans
@@ -641,6 +682,7 @@ fn a_wave_with_no_runs_reports_an_empty_reading_not_a_missing_one() {
     let home = tempfile::tempdir().expect("tempdir");
     std::fs::create_dir_all(home.path()).expect("home");
     let store = SqliteStore::new(&home.path().join("loopflow.db")).expect("open store");
+    std::fs::create_dir_all(home.path().join("repo")).expect("repo");
     let wave = Wave::new(
         WaveId::new(),
         "audit-c".to_string(),

--- a/rust/loopflow/tests/wave_repository_ownership.rs
+++ b/rust/loopflow/tests/wave_repository_ownership.rs
@@ -1,0 +1,656 @@
+use std::path::Path;
+use std::process::Command;
+
+use loopflow::durable::{
+    AdvanceReceipt, Containment, ContainmentObservation, HomeId, InvocationRoute, RunAdvance,
+    RunTrigger, StopCause, WorkRef,
+};
+use loopflow::engine::wave_context::{resolve_managed_wave, WaveResolveError};
+use loopflow::id::WaveId;
+use loopflow::planning::{LinearIssueId, LinearProjectId, ProjectPlan, TaskPlan};
+use loopflow::project::{Project, ProjectId};
+use loopflow::store::sqlite::SqliteStore;
+use loopflow::store::{open_store, PmSnapshotRow, StorageConfig};
+use loopflow::task::{
+    Observation, PmWritebackState, Task, TaskId, TaskLifecyclePhase, TaskLifecyclePlan, TaskPr,
+    TaskPrId,
+};
+use loopflow::trace::{AgentInvocationRow, AgentTurnRow, SupervisedInvocation};
+use loopflow::wave::journal;
+use loopflow::wave::relocate::relocate_wave;
+use loopflow::wave::{Wave, WaveLocator};
+use time::OffsetDateTime;
+
+fn repository(path: &Path) {
+    std::fs::create_dir_all(path).unwrap();
+    let output = Command::new("git")
+        .args(["init", "-b", "main"])
+        .current_dir(path)
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+}
+
+fn author_wave(repo: &Path, slug: &str, marker: &str) {
+    let wave = repo.join("wave").join(slug);
+    std::fs::create_dir_all(&wave).unwrap();
+    std::fs::write(wave.join("GOAL.md"), format!("# {marker}\n")).unwrap();
+    let journal = journal::journal_path(repo, slug);
+    std::fs::create_dir_all(journal.parent().unwrap()).unwrap();
+    std::fs::write(journal, format!("{{\"repository\":\"{marker}\"}}\n")).unwrap();
+}
+
+fn registered_wave(repo: &Path, slug: &str) -> Wave {
+    let locator = WaveLocator::discover(repo, slug).unwrap();
+    Wave::new(
+        WaveId::new(),
+        locator.slug().to_string(),
+        locator.repo().to_string(),
+    )
+}
+
+fn project(wave: &Wave) -> Project {
+    let now = OffsetDateTime::now_utc();
+    Project {
+        id: ProjectId::new(),
+        plan: ProjectPlan {
+            id: LinearProjectId::new("project-alpha").unwrap(),
+            slug: "architecture".to_string(),
+            name: "Architecture".to_string(),
+            prompt_context: "Keep identity boring.".to_string(),
+            pm_snapshot_synced_at: now.unix_timestamp(),
+        },
+        wave_id: wave.id().clone(),
+        iteration: 1,
+        observation_cursor: 0,
+        last_state_fingerprint: None,
+        agent: "codex".to_string(),
+        provider: "codex".to_string(),
+        provider_session_id: None,
+        abandon_intent: None,
+        created_at: now,
+        updated_at: now,
+    }
+}
+
+fn task(wave: &Wave, project: &Project, repo: &Path) -> (Task, TaskPr) {
+    let now = OffsetDateTime::now_utc();
+    let id = TaskId::new();
+    let task = Task {
+        id: id.clone(),
+        plan: TaskPlan {
+            id: LinearIssueId::new("issue-alpha").unwrap(),
+            identifier: "LOO-127".to_string(),
+            title: "Repository-owned Waves".to_string(),
+            description: "Preserve Task history through relocation.".to_string(),
+            pm_snapshot_synced_at: now.unix_timestamp(),
+        },
+        pm_writeback: PmWritebackState::Current,
+        wave_id: wave.id().clone(),
+        project_id: project.id.clone(),
+        worktree: repo.join("task-worktree"),
+        workspace_slug: "repository-owned-waves".to_string(),
+        lifecycle: TaskLifecyclePlan::defaults(),
+        lifecycle_phase: TaskLifecyclePhase::Loop,
+        phase_epoch: 1,
+        phase_cursor: 0,
+        phase_iteration: 0,
+        gate_cycle: 0,
+        gate_proposal: None,
+        agent: "codex".to_string(),
+        provider: "codex".to_string(),
+        provider_session_id: None,
+        abandon_intent: None,
+        created_at: now,
+        updated_at: now,
+        observation: Observation::NotRequired,
+    };
+    let pr = TaskPr {
+        id: TaskPrId::new(),
+        task_id: id,
+        sequence: 1,
+        slug: task.workspace_slug.clone(),
+        branch: "jack/repository-owned-waves".to_string(),
+        base_commit: "deadbeef".to_string(),
+        parent_pr_id: None,
+        publication: None,
+        merge_commit: None,
+        abandoned_at: None,
+        ci_observation: None,
+        github_observation: None,
+        linear_attachment_id: None,
+        linear_comment_id: None,
+        linear_link_error: None,
+        created_at: now,
+        updated_at: now,
+    };
+    (task, pr)
+}
+
+fn lf_command(home: &Path, repo: &Path, args: &[&str]) -> std::process::Output {
+    Command::new(env!("CARGO_BIN_EXE_lf"))
+        .args(args)
+        .current_dir(repo)
+        .env("LF_HOME", home)
+        .env_remove("LF_DB_PATH")
+        .env_remove("LF_CONTROL_HOME")
+        .env_remove("LF_CONTROL_DB_PATH")
+        .env_remove("LF_RUN_CONTEXT")
+        .env_remove("LF_RUN_LEASE")
+        .env_remove("LF_AGENT_INVOCATION_ID")
+        .env_remove("LF_ACCOUNT_LEASE")
+        .output()
+        .unwrap()
+}
+
+fn lf_output(home: &Path, repo: &Path, args: &[&str]) -> std::process::Output {
+    let output = lf_command(home, repo, args);
+    assert!(
+        output.status.success(),
+        "lf {} failed: {}",
+        args.join(" "),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    output
+}
+
+fn lf(home: &Path, repo: &Path, args: &[&str]) -> serde_json::Value {
+    let output = lf_output(home, repo, args);
+    serde_json::from_slice(&output.stdout).unwrap()
+}
+
+fn count_wave_runs(database: &Path, wave_id: &WaveId) -> i64 {
+    rusqlite::Connection::open(database)
+        .unwrap()
+        .query_row(
+            "SELECT COUNT(*)
+             FROM runs
+             JOIN epochs ON epochs.id = runs.epoch_id
+             LEFT JOIN projects ON projects.id = epochs.project_id
+             LEFT JOIN tasks ON tasks.id = epochs.task_id
+             LEFT JOIN projects task_projects ON task_projects.id = tasks.project_id
+             WHERE epochs.wave_id = ?1
+                OR projects.wave_id = ?1
+                OR task_projects.wave_id = ?1",
+            [wave_id.as_str()],
+            |row| row.get(0),
+        )
+        .unwrap()
+}
+
+fn capture_project_invocation(
+    database: &Path,
+    run_id: &loopflow::durable::RunId,
+    invocation_id: &loopflow::durable::AgentInvocationId,
+) {
+    let now = OffsetDateTime::now_utc().unix_timestamp();
+    let invocation = AgentInvocationRow {
+        id: invocation_id.to_string(),
+        run_id: "trace-alpha".to_string(),
+        answer_ask_id: None,
+        process_id: "process-alpha".to_string(),
+        started_at: now - 1,
+        ended_at: Some(now),
+        repo: "/historical/alpha".to_string(),
+        worktree: "/historical/alpha".to_string(),
+        wave: Some("infrastructure".to_string()),
+        flow: Some("project".to_string()),
+        skill: Some("repository-ownership".to_string()),
+        project: Some("architecture".to_string()),
+        task: None,
+        provider: "codex".to_string(),
+        model: Some("gpt-5".to_string()),
+        surface: "headless".to_string(),
+        capture_status: "complete".to_string(),
+        incomplete_reason: None,
+        outcome: "completed".to_string(),
+        artifact_dir: "traces/repository-ownership".to_string(),
+        conversation_path: "traces/repository-ownership/conversation.jsonl".to_string(),
+        provider_events_path: None,
+        provider_session_id: None,
+        provider_session_path: None,
+        conversation_event_count: 1,
+        conversation_bytes: 1,
+        supervision: Some(SupervisedInvocation {
+            invocation_id: invocation_id.clone(),
+            supervising_run_id: run_id.clone(),
+            account_id: None,
+            resume_token: None,
+        }),
+    };
+    let turn = AgentTurnRow {
+        id: "turn-repository-ownership".to_string(),
+        invocation_id: invocation.id.clone(),
+        ordinal: 1,
+        provider_turn_id: None,
+        started_at: now - 1,
+        ended_at: Some(now),
+        status: "completed".to_string(),
+        input_op: "initial".to_string(),
+        context_coverage: "assembled".to_string(),
+        tokenizer: "o200k_base".to_string(),
+        system_prompt_path: None,
+        task_prompt_path: "traces/repository-ownership/task.md".to_string(),
+        system_tokens: 0,
+        task_tokens: 1,
+        supplied_context_tokens: 1,
+        provider_input_tokens: Some(1),
+        provider_total_input_tokens: Some(1),
+        peak_input_tokens: Some(1),
+        context_window_tokens: Some(100),
+        provider_output_tokens: Some(1),
+        reasoning_tokens: None,
+        cache_read_tokens: Some(0),
+        cache_write_tokens: None,
+        cost_usd: None,
+        context_gather_ms: 1,
+        context_render_ms: 1,
+        context_persist_ms: 1,
+        first_event_seq: None,
+        last_event_seq: None,
+        root_output: None,
+        basis: None,
+    };
+    SqliteStore::new(database)
+        .unwrap()
+        .insert_trace_capture(&invocation, &turn, &[], &[])
+        .unwrap();
+}
+
+#[tokio::test]
+async fn repositories_own_same_named_waves_and_relocation_preserves_identity() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path().join("home");
+    let repo_a = tmp.path().join("alpha");
+    let repo_b = tmp.path().join("beta");
+    let repo_c = tmp.path().join("gamma");
+    let repo_wrong_team = tmp.path().join("wrong-team");
+    repository(&repo_a);
+    repository(&repo_b);
+    repository(&repo_c);
+    repository(&repo_wrong_team);
+    author_wave(&repo_a, "infrastructure", "alpha");
+    author_wave(&repo_b, "infrastructure", "beta");
+
+    std::fs::create_dir_all(&home).unwrap();
+    let database = home.join("loopflow.db");
+    let store = open_store(&StorageConfig::sqlite(database.clone()))
+        .await
+        .unwrap();
+    let alpha = registered_wave(&repo_a, "infrastructure");
+    let beta = registered_wave(&repo_b, "infrastructure");
+    store.create_wave(&alpha).await.unwrap();
+    store.create_wave(&beta).await.unwrap();
+    assert_ne!(alpha.id(), beta.id());
+
+    #[cfg(unix)]
+    {
+        let alias = tmp.path().join("alpha-alias");
+        std::os::unix::fs::symlink(&repo_a, &alias).unwrap();
+        let legacy = Wave::new(
+            WaveId::new(),
+            "legacy".to_string(),
+            alias.display().to_string(),
+        );
+        store.create_wave(&legacy).await.unwrap();
+        let resolved = store
+            .get_wave_at(&WaveLocator::discover(&repo_a, "legacy").unwrap())
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(resolved.id(), legacy.id());
+        assert_eq!(
+            resolved.repo(),
+            std::fs::canonicalize(&repo_a)
+                .unwrap()
+                .display()
+                .to_string()
+        );
+    }
+
+    let alpha_resolved =
+        resolve_managed_wave(Some(&store), Some(&repo_a), Some("infrastructure"), None)
+            .await
+            .unwrap();
+    let beta_resolved =
+        resolve_managed_wave(Some(&store), Some(&repo_b), Some("infrastructure"), None)
+            .await
+            .unwrap();
+    assert_eq!(alpha_resolved.id(), alpha.id());
+    assert_eq!(beta_resolved.id(), beta.id());
+    assert!(matches!(
+        resolve_managed_wave(Some(&store), None, Some("infrastructure"), None).await,
+        Err(WaveResolveError::AmbiguousWave { .. })
+    ));
+    assert!(matches!(
+        resolve_managed_wave(Some(&store), Some(&repo_b), None, Some(alpha.id().as_str()),).await,
+        Err(WaveResolveError::RepositoryMismatch { .. })
+    ));
+
+    let list = lf(&home, &repo_a, &["ls", "--json"]);
+    let listed = list.as_array().unwrap();
+    assert_eq!(
+        listed
+            .iter()
+            .filter(|wave| wave["name"] == "infrastructure")
+            .count(),
+        2
+    );
+    assert_eq!(
+        lf(&home, &repo_a, &["status", "infrastructure", "--json"])["wave"]["id"],
+        alpha.id().as_str()
+    );
+    assert_eq!(
+        lf(&home, &repo_b, &["status", "infrastructure", "--json"])["wave"]["id"],
+        beta.id().as_str()
+    );
+    let human_list = String::from_utf8(lf_output(&home, &repo_a, &["ls"]).stdout).unwrap();
+    assert!(human_list.contains("REPOSITORY"));
+    assert!(human_list
+        .lines()
+        .any(|line| { line.contains("infrastructure") && line.contains("alpha") }));
+    assert!(human_list
+        .lines()
+        .any(|line| { line.contains("infrastructure") && line.contains("beta") }));
+
+    let alpha_placement = store
+        .placement(&WorkRef::Wave(alpha.id().clone()))
+        .await
+        .unwrap();
+    let foreign_home = HomeId::new();
+    store
+        .observe_home(&foreign_home, "ssh://operator@foreign-home")
+        .await
+        .unwrap();
+    let foreign_place = lf_command(
+        &home,
+        &repo_b,
+        &[
+            "work",
+            "place",
+            "wave",
+            alpha.id().as_str(),
+            foreign_home.as_str(),
+            "--json",
+        ],
+    );
+    assert!(!foreign_place.status.success());
+    assert!(String::from_utf8_lossy(&foreign_place.stderr).contains("not invoking repository"));
+    assert_eq!(
+        store
+            .placement(&WorkRef::Wave(alpha.id().clone()))
+            .await
+            .unwrap()
+            .home_id,
+        alpha_placement.home_id
+    );
+
+    store
+        .put_pm_snapshot(PmSnapshotRow {
+            wave_id: alpha.id().clone(),
+            provider: "linear".to_string(),
+            initiative: "initiative-alpha".to_string(),
+            synced_at: 1,
+            payload: r#"{"projects":[],"items":[]}"#.to_string(),
+        })
+        .await
+        .unwrap();
+    let project = project(&alpha);
+    store.create_project(&project).await.unwrap();
+    let (task, task_pr) = task(&alpha, &project, &repo_a);
+    store.create_task(&task, &task_pr).await.unwrap();
+    let placement = alpha_placement;
+    let task_work = WorkRef::Task(task.id.clone());
+    let (_, lease) = store
+        .reserve_run(&task_work, RunTrigger::User)
+        .await
+        .unwrap();
+    store
+        .advance_run(
+            &lease,
+            RunAdvance::RunStarting {
+                containment: Containment::ProcessGroup { id: 7 },
+                cwd: repo_a.clone(),
+            },
+        )
+        .await
+        .unwrap();
+    let invocation = store
+        .advance_run(
+            &lease,
+            RunAdvance::InvocationStarting {
+                route: InvocationRoute {
+                    provider: "codex".to_string(),
+                    model: Some("gpt-5".to_string()),
+                    account_id: None,
+                },
+                surface: "headless".to_string(),
+                resume_token: None,
+                answer_ask_id: None,
+            },
+        )
+        .await
+        .unwrap();
+    let AdvanceReceipt::Invocation(invocation) = invocation else {
+        panic!("expected Invocation receipt")
+    };
+    capture_project_invocation(&database, &lease.run_id, &invocation.id);
+
+    let active_error = relocate_wave(&store, alpha.id(), &repo_a, None, Some("platform"))
+        .await
+        .unwrap_err();
+    assert!(active_error.to_string().contains("while Run"));
+    assert_eq!(
+        store.get_wave(alpha.id()).await.unwrap().unwrap().name(),
+        "infrastructure"
+    );
+    assert!(repo_a.join("wave/infrastructure").is_dir());
+    store
+        .stop_run(&lease, StopCause::Requested, ContainmentObservation::Absent)
+        .await
+        .unwrap();
+    let runs_before = count_wave_runs(&database, alpha.id());
+
+    let overlap = relocate_wave(
+        &store,
+        alpha.id(),
+        &repo_a,
+        None,
+        Some("infrastructure/platform"),
+    )
+    .await
+    .unwrap_err();
+    assert!(overlap.to_string().contains("paths overlap"));
+    assert!(repo_a.join("wave/infrastructure/GOAL.md").is_file());
+
+    for (repo, team) in [
+        (&repo_a, "team-alpha"),
+        (&repo_c, "team-alpha"),
+        (&repo_wrong_team, "team-beta"),
+    ] {
+        std::fs::create_dir_all(repo.join(".lf")).unwrap();
+        std::fs::write(
+            repo.join(".lf/config.yaml"),
+            format!("pm:\n  linear_team: {team}\n"),
+        )
+        .unwrap();
+    }
+    let team_error = relocate_wave(&store, alpha.id(), &repo_a, Some(&repo_wrong_team), None)
+        .await
+        .unwrap_err();
+    assert!(team_error.to_string().contains("repository Team"));
+
+    author_wave(&repo_a, "infrastructure/child", "nested");
+    let nested = registered_wave(&repo_a, "infrastructure/child");
+    store.create_wave(&nested).await.unwrap();
+    let nested_error = relocate_wave(&store, alpha.id(), &repo_a, None, Some("platform"))
+        .await
+        .unwrap_err();
+    assert!(nested_error
+        .to_string()
+        .contains("contains registered Wave"));
+    assert!(repo_a.join("wave/infrastructure/child/GOAL.md").is_file());
+    store.delete_wave(nested.id()).await.unwrap();
+    std::fs::remove_dir_all(repo_a.join("wave/infrastructure/child")).unwrap();
+
+    author_wave(&repo_a, "infrastructure/child", "chord-child");
+    let child = registered_wave(&repo_a, "infrastructure/child").with_parent(alpha.id().clone());
+    store.create_wave(&child).await.unwrap();
+
+    let occupied = registered_wave(&repo_a, "occupied");
+    store.create_wave(&occupied).await.unwrap();
+    let collision = relocate_wave(&store, alpha.id(), &repo_a, None, Some("occupied"))
+        .await
+        .unwrap_err();
+    assert!(collision.to_string().contains("already belongs"));
+
+    author_wave(&repo_a, "platform", "divergent");
+    let divergence = relocate_wave(&store, alpha.id(), &repo_a, None, Some("platform"))
+        .await
+        .unwrap_err();
+    assert!(divergence.to_string().contains("diverges"));
+    assert!(repo_a.join("wave/infrastructure").is_dir());
+    std::fs::remove_dir_all(repo_a.join("wave/platform")).unwrap();
+    std::fs::remove_dir_all(repo_a.join(".lf/journal/waves/platform")).unwrap();
+
+    rusqlite::Connection::open(&database)
+        .unwrap()
+        .execute_batch(
+            "CREATE TRIGGER fail_wave_relocation
+             BEFORE UPDATE OF repo, name ON waves
+             BEGIN SELECT RAISE(ABORT, 'injected relocation failure'); END;",
+        )
+        .unwrap();
+    let injected = relocate_wave(&store, alpha.id(), &repo_a, None, Some("platform"))
+        .await
+        .unwrap_err();
+    assert!(injected.to_string().contains("injected relocation failure"));
+    assert_eq!(
+        store.get_wave(alpha.id()).await.unwrap().unwrap().name(),
+        "infrastructure"
+    );
+    assert!(repo_a.join("wave/infrastructure").is_dir());
+    assert!(repo_a.join("wave/platform").is_dir());
+    rusqlite::Connection::open(&database)
+        .unwrap()
+        .execute_batch("DROP TRIGGER fail_wave_relocation")
+        .unwrap();
+
+    let relocation = lf(
+        &home,
+        &repo_a,
+        &[
+            "work",
+            "relocate",
+            "wave",
+            alpha.id().as_str(),
+            "--name",
+            "platform",
+            "--json",
+        ],
+    );
+    assert_eq!(relocation["kind"], "relocated");
+    assert_eq!(relocation["wave_id"], alpha.id().as_str());
+    assert_eq!(relocation["waves_moved"], 2);
+    let renamed = store.get_wave(alpha.id()).await.unwrap().unwrap();
+    assert_eq!(renamed.name(), "platform");
+    assert_eq!(
+        std::fs::read_to_string(repo_a.join("wave/platform/GOAL.md")).unwrap(),
+        "# alpha\n"
+    );
+    assert!(!repo_a.join("wave/infrastructure").exists());
+    let renamed_child = store.get_wave(child.id()).await.unwrap().unwrap();
+    assert_eq!(renamed_child.name(), "platform/child");
+    assert!(repo_a.join("wave/platform/child/GOAL.md").is_file());
+    assert_eq!(
+        store
+            .get_wave_at(&WaveLocator::discover(&repo_b, "infrastructure").unwrap())
+            .await
+            .unwrap()
+            .unwrap()
+            .id(),
+        beta.id()
+    );
+
+    relocate_wave(&store, alpha.id(), &repo_a, Some(&repo_c), None)
+        .await
+        .unwrap();
+    assert!(!repo_a.join("wave/platform").exists());
+    assert_eq!(
+        std::fs::read_to_string(repo_c.join("wave/platform/GOAL.md")).unwrap(),
+        "# alpha\n"
+    );
+
+    let repo_d = tmp.path().join("delta");
+    std::fs::rename(&repo_c, &repo_d).unwrap();
+    relocate_wave(&store, alpha.id(), &repo_d, Some(&repo_d), None)
+        .await
+        .unwrap();
+    let moved = store.get_wave(alpha.id()).await.unwrap().unwrap();
+    assert_eq!(
+        moved.repo(),
+        std::fs::canonicalize(&repo_d)
+            .unwrap()
+            .display()
+            .to_string()
+    );
+    assert_eq!(moved.name(), "platform");
+    let moved_child = store.get_wave(child.id()).await.unwrap().unwrap();
+    assert_eq!(moved_child.repo(), moved.repo());
+    assert_eq!(moved_child.name(), "platform/child");
+    assert_eq!(
+        store
+            .pm_snapshot(alpha.id())
+            .await
+            .unwrap()
+            .unwrap()
+            .initiative,
+        "initiative-alpha"
+    );
+    assert_eq!(
+        store
+            .placement(&WorkRef::Wave(alpha.id().clone()))
+            .await
+            .unwrap()
+            .home_id,
+        placement.home_id
+    );
+    assert_eq!(count_wave_runs(&database, alpha.id()), runs_before);
+    assert_eq!(
+        store
+            .get_project(&project.id)
+            .await
+            .unwrap()
+            .unwrap()
+            .wave_id,
+        alpha.id().clone()
+    );
+    let preserved_task = store.get_task(&task.id).await.unwrap().unwrap();
+    assert_eq!(preserved_task.wave_id, alpha.id().clone());
+    assert_eq!(preserved_task.project_id, project.id);
+    assert!(journal::journal_path(&repo_d, "platform").is_file());
+
+    let status = lf(&home, &repo_d, &["status", "platform", "--json"]);
+    assert_eq!(status["wave"]["id"], alpha.id().as_str());
+    assert!(status["runs"]["items"].as_array().is_some_and(|items| items
+        .iter()
+        .any(|item| { item.to_string().contains("repository-ownership") })));
+
+    let error = relocate_wave(&store, alpha.id(), &repo_b, None, Some("hijacked"))
+        .await
+        .unwrap_err();
+    assert!(error.to_string().contains("invoke relocation from"));
+    assert_eq!(
+        store.get_wave(alpha.id()).await.unwrap().unwrap().name(),
+        "platform"
+    );
+    assert_eq!(
+        store
+            .get_wave_at(&WaveLocator::discover(&repo_b, "infrastructure").unwrap())
+            .await
+            .unwrap()
+            .unwrap()
+            .id(),
+        beta.id()
+    );
+}

--- a/rust/loopflow/tests/wave_resolution_matrix.rs
+++ b/rust/loopflow/tests/wave_resolution_matrix.rs
@@ -374,7 +374,7 @@ fn make_envs(product_uuid: &str, stale_uuid: &str) -> Vec<Env> {
             id: "stale-name",
             wave_id: Some("ghost".to_string()),
             explicit_wave: None,
-            default_expected: Outcome::Resolved,
+            default_expected: Outcome::StaleIdentity,
         },
         Env {
             id: "explicit-unknown",
@@ -397,13 +397,6 @@ fn expected_outcome(cmd: &Cmd, env: &Env) -> Outcome {
     // Creation flows may name the Wave being registered.
     if env.id == "explicit-unknown" && cmd.id == "pm init" {
         return Outcome::Resolved;
-    }
-
-    // Project start now resolves caller authority at the CLI surface before
-    // creating anything. An inherited hand-set name without a registry row is
-    // stale transport evidence, not an explicit target selection.
-    if cmd.id == "project start" && env.id == "stale-name" {
-        return Outcome::StaleIdentity;
     }
 
     if env.id == "absent" {
@@ -505,14 +498,9 @@ fn seed(home: &Path, repo: &Path) -> Wave {
         repo.display().to_string(),
     );
     store.create_wave(&wave).expect("register wave");
-    let repo_key = std::fs::canonicalize(repo)
-        .expect("canonicalize repo")
-        .display()
-        .to_string();
     store
         .put_pm_snapshot(&PmSnapshotRow {
-            repo: repo_key,
-            wave: "product".to_string(),
+            wave_id: wave.id().clone(),
             provider: "linear".to_string(),
             initiative: "initiative-1".to_string(),
             synced_at: chrono::Utc::now().timestamp(),
@@ -875,6 +863,12 @@ fn cron_add_rejects_a_development_binary_before_mutation() {
         .env("LF_HOME", &home)
         .env("HOME", &home)
         .env("LF_WAVE_ID", alpha_uuid)
+        .env_remove("LF_DB_PATH")
+        .env_remove("LF_CONTROL_HOME")
+        .env_remove("LF_CONTROL_DB_PATH")
+        .env_remove("LF_RUN_CONTEXT")
+        .env_remove("LF_RUN_LEASE")
+        .env_remove("LF_AGENT_INVOCATION_ID")
         .output()
         .expect("run cron add");
 

--- a/rust/loopflow/tests/wave_resolution_tests.rs
+++ b/rust/loopflow/tests/wave_resolution_tests.rs
@@ -9,7 +9,7 @@
 use std::path::Path;
 use std::process::Command;
 
-use loopflow::engine::wave_context::{resolve_managed_wave_name, WaveResolveError};
+use loopflow::engine::wave_context::{resolve_managed_wave, WaveResolveError};
 use loopflow::id::WaveId;
 use loopflow::store::sqlite::SqliteStore;
 use loopflow::store::{open_store, PmSnapshotRow, StorageConfig};
@@ -24,10 +24,15 @@ async fn resolver_matrix_agrees_across_every_environment() {
     let store = open_store(&StorageConfig::sqlite(tmp.path().join("loopflow.db")))
         .await
         .expect("open store");
+    let repo = tmp.path().join("repo");
+    std::fs::create_dir_all(&repo).expect("repo");
     let wave = Wave::new(
         WaveId::new(),
         "product".to_string(),
-        tmp.path().join("repo").display().to_string(),
+        std::fs::canonicalize(&repo)
+            .expect("canonical repo")
+            .display()
+            .to_string(),
     );
     store.create_wave(&wave).await.expect("register wave");
     let uuid = wave.id().as_str();
@@ -36,79 +41,109 @@ async fn resolver_matrix_agrees_across_every_environment() {
     // Project/Task Work ids never touch Wave identity, so one cell covers
     // all three. UUID first: mapped to its registry name.
     assert_eq!(
-        resolve_managed_wave_name(Some(&store), None, Some(uuid))
+        resolve_managed_wave(Some(&store), Some(&repo), None, Some(uuid))
             .await
-            .expect("uuid resolves"),
-        "product"
+            .expect("uuid resolves")
+            .id(),
+        wave.id()
     );
 
     // Hand-set name: the intentional fallback. `LF_WAVE_ID=product` resolves
     // even though it is not a UUID.
     assert_eq!(
-        resolve_managed_wave_name(Some(&store), None, Some("product"))
+        resolve_managed_wave(Some(&store), Some(&repo), None, Some("product"))
             .await
-            .expect("hand-set name resolves"),
-        "product"
+            .expect("hand-set name resolves")
+            .id(),
+        wave.id()
     );
 
     // Explicit `--wave` always wins, even over a (wrong) ambient id.
     assert_eq!(
-        resolve_managed_wave_name(Some(&store), Some("product"), Some("something-else"))
-            .await
-            .expect("explicit wins"),
-        "product"
+        resolve_managed_wave(
+            Some(&store),
+            Some(&repo),
+            Some("product"),
+            Some("something-else"),
+        )
+        .await
+        .expect("explicit wins")
+        .id(),
+        wave.id()
     );
 
     // Stale identity: a real UUID the registry has never seen. Not silently
     // re-read as a name — a distinct, classified error.
     let stale = WaveId::new();
-    assert_eq!(
-        resolve_managed_wave_name(Some(&store), None, Some(stale.as_str())).await,
-        Err(WaveResolveError::StaleIdentity(stale.as_str().to_string()))
-    );
+    assert!(matches!(
+        resolve_managed_wave(Some(&store), Some(&repo), None, Some(stale.as_str())).await,
+        Err(WaveResolveError::StaleIdentity(value)) if value == stale.as_str()
+    ));
 
     // No context: neither `--wave` nor `LF_WAVE_ID` (empty counts as absent).
-    assert_eq!(
-        resolve_managed_wave_name(Some(&store), None, None).await,
+    assert!(matches!(
+        resolve_managed_wave(Some(&store), Some(&repo), None, None).await,
         Err(WaveResolveError::NoContext)
-    );
-    assert_eq!(
-        resolve_managed_wave_name(Some(&store), None, Some("   ")).await,
+    ));
+    assert!(matches!(
+        resolve_managed_wave(Some(&store), Some(&repo), None, Some("   ")).await,
         Err(WaveResolveError::NoContext)
-    );
+    ));
 
     // An empty `--wave` is an explicit-but-unusable request, not "no context".
-    assert_eq!(
-        resolve_managed_wave_name(Some(&store), Some("  "), None).await,
+    assert!(matches!(
+        resolve_managed_wave(Some(&store), Some(&repo), Some("  "), None).await,
         Err(WaveResolveError::EmptyExplicit)
-    );
+    ));
 
     // An explicit `--wave` naming a wave the registry has never seen is a
     // classified error — never a silent accept. The resolver owns this rule;
     // every consumer surfaces the same classification.
-    assert_eq!(
-        resolve_managed_wave_name(Some(&store), Some("definitely-unknown"), None).await,
-        Err(WaveResolveError::UnknownExplicit(
-            "definitely-unknown".to_string()
-        ))
-    );
+    assert!(matches!(
+        resolve_managed_wave(
+            Some(&store),
+            Some(&repo),
+            Some("definitely-unknown"),
+            None,
+        )
+        .await,
+        Err(WaveResolveError::UnknownExplicit(value)) if value == "definitely-unknown"
+    ));
 
     // No registry on this machine + an explicit name → error, not silent
     // accept. A machine with no registry has no valid wave names.
     assert!(matches!(
-        resolve_managed_wave_name(None, Some("product"), None).await,
+        resolve_managed_wave(None, Some(&repo), Some("product"), None).await,
         Err(WaveResolveError::Registry(_))
     ));
 
-    // A hand-set name for a wave with no registry row still resolves to that
-    // name — membership is each consumer's concern (PM keys files/snapshots by
-    // name; status then reports it has no row). The resolver stays consistent.
-    assert_eq!(
-        resolve_managed_wave_name(Some(&store), None, Some("ghost"))
-            .await
-            .expect("unregistered name resolves to itself"),
-        "ghost"
+    assert!(matches!(
+        resolve_managed_wave(Some(&store), Some(&repo), None, Some("ghost")).await,
+        Err(WaveResolveError::StaleIdentity(value)) if value == "ghost"
+    ));
+
+    let other_repo = tmp.path().join("other-repo");
+    std::fs::create_dir_all(&other_repo).expect("other repo");
+    let other = Wave::new(
+        WaveId::new(),
+        "product".to_string(),
+        std::fs::canonicalize(&other_repo)
+            .expect("canonical other repo")
+            .display()
+            .to_string(),
     );
+    store
+        .create_wave(&other)
+        .await
+        .expect("register other Wave");
+    assert!(matches!(
+        resolve_managed_wave(Some(&store), None, Some("product"), None).await,
+        Err(WaveResolveError::AmbiguousWave { .. })
+    ));
+    assert!(matches!(
+        resolve_managed_wave(Some(&store), Some(&repo), None, Some(other.id().as_str())).await,
+        Err(WaveResolveError::RepositoryMismatch { .. })
+    ));
 }
 
 /// Seed a machine home with one PM-linked wave and a fresh cache-only snapshot,
@@ -123,14 +158,9 @@ fn seed(home: &Path, repo: &Path, wave_name: &str) -> Wave {
         repo.display().to_string(),
     );
     store.create_wave(&wave).expect("register wave");
-    let repo_key = std::fs::canonicalize(repo)
-        .expect("canonicalize repo")
-        .display()
-        .to_string();
     store
         .put_pm_snapshot(&PmSnapshotRow {
-            repo: repo_key,
-            wave: wave_name.to_string(),
+            wave_id: wave.id().clone(),
             provider: "linear".to_string(),
             initiative: "initiative-1".to_string(),
             synced_at: chrono::Utc::now().timestamp(),

--- a/rust/loopflow/tests/wave_start_tests.rs
+++ b/rust/loopflow/tests/wave_start_tests.rs
@@ -10,6 +10,7 @@ use loopflow::child::ObservationRecipient;
 use loopflow::planning::{LinearProjectId, ProjectPlan};
 use loopflow::project::{Project, ProjectEventKind, ProjectId};
 use loopflow::store::{open_store, StorageConfig};
+use loopflow::wave::WaveLocator;
 use time::OffsetDateTime;
 
 const COMMAND_TIMEOUT: Duration = Duration::from_secs(10);
@@ -171,13 +172,15 @@ async fn supported_wave_starts_reach_bounded_live_or_rolled_back_states() {
         .await
         .expect("open fresh Home registry");
     let local = store.local_home().await.expect("read Home");
+    let good_locator = WaveLocator::discover(&repo, "good").expect("locate good Wave");
     let good = store
-        .get_wave_by_name("good")
+        .get_wave_at(&good_locator)
         .await
         .expect("read good Wave")
         .expect("good Wave is registered");
+    let broken_locator = WaveLocator::discover(&repo, "broken").expect("locate broken Wave");
     assert!(store
-        .get_wave_by_name("broken")
+        .get_wave_at(&broken_locator)
         .await
         .expect("read broken Wave")
         .is_none());

--- a/scripts/check_architecture.py
+++ b/scripts/check_architecture.py
@@ -467,6 +467,27 @@ def _link_errors(root: Path, text: str) -> list[str]:
     return errors
 
 
+def _wave_locator_errors(root: Path) -> list[str]:
+    errors: list[str] = []
+    source_root = root / "rust/loopflow/src"
+    for path in sorted(source_root.rglob("*.rs")):
+        source = _production_rust(path.read_text())
+        for number, line in enumerate(source.splitlines(), start=1):
+            if "get_wave_by_name(" in line:
+                relative = path.relative_to(root)
+                errors.append(
+                    f"bare Wave lookup get_wave_by_name at {relative}:{number}; "
+                    "resolve by WaveId or WaveLocator"
+                )
+            if "resolve_managed_wave_name" in line:
+                relative = path.relative_to(root)
+                errors.append(
+                    f"name-only Wave resolver at {relative}:{number}; "
+                    "resolve the Wave row and derive its display name at the leaf"
+                )
+    return errors
+
+
 def _cover(
     name: str,
     discovered: set[str],
@@ -525,6 +546,7 @@ def check_repository(root: Path = REPO_ROOT) -> Report:
         coverage.append(_shim_coverage(root, shim_tokens, errors))
         errors.extend(_vocabulary_errors(root, vocabulary_rows))
         errors.extend(_link_errors(root, map_section + projections_section + shims_section))
+        errors.extend(_wave_locator_errors(root))
     except (OSError, ValueError, IndexError, sqlite3.Error) as error:
         errors.append(str(error))
     return Report(coverage=coverage, errors=errors)

--- a/scripts/materialize_rust_tests.py
+++ b/scripts/materialize_rust_tests.py
@@ -22,8 +22,13 @@ from typing import Iterator
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 AMBIENT_WORK_AUTHORITY = (
+    "LF_AGENT_INVOCATION_ID",
+    "LF_CONTROL_BIN",
+    "LF_PROCESS_ID",
     "LF_RUN_CONTEXT",
+    "LF_RUN_ID",
     "LF_RUN_LEASE",
+    "LF_TRACE_ID",
     "LF_WAVE_ID",
     "LF_ACCOUNT_LEASE",
 )
@@ -171,6 +176,8 @@ def main(argv: list[str] | None = None) -> int:
             environment = os.environ.copy()
             for name in AMBIENT_WORK_AUTHORITY:
                 environment.pop(name, None)
+            environment["LF_CONTROL_HOME"] = str(worktree / ".lf-test-control")
+            environment.pop("LF_CONTROL_DB_PATH", None)
             environment.setdefault("CARGO_TARGET_DIR", str(REPO_ROOT / "target"))
             return subprocess.run(args.command, cwd=worktree, env=environment).returncode
     except (OSError, RuntimeError, ValueError, subprocess.CalledProcessError) as exc:


### PR DESCRIPTION
## Usage

```bash
lf work relocate wave wave_... --name platform
lf work relocate wave wave_... --repo ../moved-repository
```

## Summary

Makes the Wave UUID its durable identity while treating the canonical repository and normalized name as a mutable locator. Repositories can now own same-named Waves independently, and stopped Waves can be renamed or rehomed without losing their authored files, journal, planning projection, Work and Run history, or Home placement.

## Changes

- Scope Wave lookup and uniqueness to canonical repository plus name, with ambiguous bare-name lookups failing closed
- Add UUID-addressed Wave relocation with listener fencing, active-Run checks, target validation, PM Team compatibility, and crash-recovery receipts
- Move nested descendant Waves, authored content, and journals when their locator changes
- Key PM projections by stable Wave UUID and migrate existing registry data to repository-owned locators
- Reject UUID-addressed Work operations from repositories that do not own the selected Wave
- Document the ownership model and add coverage for same-named Waves, relocation recovery, collisions, stale paths, and repository boundaries