### PR TITLE
release: keep tagged publishers alive through recovery

### DIFF
--- a/.lf/config.yaml
+++ b/.lf/config.yaml
@@ -27,4 +27,4 @@ release:
       - uv
       - run
       - python
-      - scripts/publish_release.py
+      - '{repo}/scripts/publish_release.py'

--- a/docs/lf.md
+++ b/docs/lf.md
@@ -895,7 +895,9 @@ publisher. `lf release run` appends `check` before changing release state, then
 downloads the successful hosted build and invokes it with `publish --tag ...
 --artifacts ...` from an exact-tag worktree. No merged changes is a successful
 no-op. An incomplete latest tag resumes; it never cuts a newer tag around a
-failed publication.
+failed publication. Use `{repo}` in a publisher argument to name the current
+synchronized repository; `LF_RELEASE_SOURCE_REPO` names the leased exact-tag
+worktree during publication.
 
 | Path | What it holds |
 |------|--------------|

--- a/python/tests/test_deploy_website.py
+++ b/python/tests/test_deploy_website.py
@@ -27,9 +27,7 @@ def test_deploy_is_a_green_noop_when_the_tag_is_already_live(
     assert receipts == [receipt]
 
 
-def test_deploy_proves_the_exact_release_tag(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-):
+def test_deploy_proves_the_exact_release_tag(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     images = iter(("registry/previous", "registry/deployed"))
     receipts: list[deploy_website.DeployReceipt] = []
     monkeypatch.setenv("FLY_API_TOKEN", "injected-by-test")
@@ -84,14 +82,51 @@ def test_failed_release_proof_rolls_back_and_stays_red(
     ]
 
 
-def test_failed_fly_command_restores_the_saved_image(
+def test_timed_out_fly_command_keeps_the_healthy_release(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ):
+    images = iter(("registry/previous", "registry/deployed"))
     receipts: list[deploy_website.DeployReceipt] = []
     monkeypatch.setenv("FLY_API_TOKEN", "injected-by-test")
     monkeypatch.setattr(deploy_website, "_verify_tag", lambda repo, tag: "abc123")
     monkeypatch.setattr(deploy_website, "_release_is_healthy", lambda tag: False)
-    monkeypatch.setattr(deploy_website, "_current_image", lambda repo: "registry/previous")
+    monkeypatch.setattr(deploy_website, "_current_image", lambda repo: next(images))
+    monkeypatch.setattr(deploy_website, "_wait_for_release", lambda tag: True)
+    monkeypatch.setattr(
+        deploy_website, "_write_receipt", lambda repo, receipt: receipts.append(receipt)
+    )
+
+    def time_out_new_deploy(
+        command: list[str], cwd: Path, *, capture: bool = False
+    ) -> subprocess.CompletedProcess[str]:
+        if "--build-arg" in command:
+            raise subprocess.CalledProcessError(1, command)
+        return _completed()
+
+    monkeypatch.setattr(deploy_website, "_run", time_out_new_deploy)
+
+    receipt = deploy_website.deploy_website("v1.2.3", tmp_path)
+
+    assert receipt == deploy_website.DeployReceipt(
+        tag="v1.2.3",
+        source_commit="abc123",
+        previous_image="registry/previous",
+        deployed_image="registry/deployed",
+        outcome="deployed",
+    )
+    assert receipts == [receipt]
+
+
+def test_timed_out_fly_command_restores_the_saved_image_when_unhealthy(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    images = iter(("registry/previous", "registry/bad"))
+    receipts: list[deploy_website.DeployReceipt] = []
+    monkeypatch.setenv("FLY_API_TOKEN", "injected-by-test")
+    monkeypatch.setattr(deploy_website, "_verify_tag", lambda repo, tag: "abc123")
+    monkeypatch.setattr(deploy_website, "_release_is_healthy", lambda tag: False)
+    monkeypatch.setattr(deploy_website, "_current_image", lambda repo: next(images))
+    monkeypatch.setattr(deploy_website, "_wait_for_release", lambda tag: False)
     monkeypatch.setattr(deploy_website, "_wait_for_root", lambda: True)
     monkeypatch.setattr(
         deploy_website, "_write_receipt", lambda repo, receipt: receipts.append(receipt)
@@ -114,7 +149,7 @@ def test_failed_fly_command_restores_the_saved_image(
             tag="v1.2.3",
             source_commit="abc123",
             previous_image="registry/previous",
-            deployed_image=None,
+            deployed_image="registry/bad",
             outcome="rolled_back",
         )
     ]

--- a/python/tests/test_release_automation.py
+++ b/python/tests/test_release_automation.py
@@ -243,7 +243,7 @@ def test_infrastructure_cron_runs_the_host_release_after_telemetry():
         "uv",
         "run",
         "python",
-        "scripts/publish_release.py",
+        "{repo}/scripts/publish_release.py",
     ]
 
     bootstrap = (ROOT / "scripts/bootstrap-cron-host.sh").read_text()

--- a/python/tests/test_release_publisher.py
+++ b/python/tests/test_release_publisher.py
@@ -68,6 +68,7 @@ def test_publisher_completes_all_stages_before_marking_release_published(
     (tmp_path / "RELEASE_NOTES.md").write_text("# v1.2.3\n")
     (tmp_path / "swift/dist").mkdir(parents=True)
     receipts: list[publish_release.PublishReceipt] = []
+    commands: list[list[str]] = []
 
     def fake_run(
         command: list[str],
@@ -76,6 +77,7 @@ def test_publisher_completes_all_stages_before_marking_release_published(
         capture: bool = False,
         env: dict[str, str] | None = None,
     ) -> subprocess.CompletedProcess[str]:
+        commands.append(command)
         if command[:3] == ["git", "tag", "--points-at"]:
             return subprocess.CompletedProcess(command, 0, "v1.2.3\n", "")
         if command[:3] == ["git", "rev-parse", "HEAD"]:
@@ -112,3 +114,6 @@ def test_publisher_completes_all_stages_before_marking_release_published(
         "install.sh",
     }
     assert receipts == [receipt]
+    deploy = next(command for command in commands if "deploy_website.py" in command[1])
+    assert deploy[1] == str(publish_release.CONTROL_ROOT / "scripts/deploy_website.py")
+    assert deploy[-2:] == ["--repo", str(tmp_path)]

--- a/release/README.md
+++ b/release/README.md
@@ -74,9 +74,18 @@ and the GitHub Release. It deploys the website from the exact tag and requires
 image and leaves the release incomplete. Publishing the non-draft GitHub
 Release is the final completion marker.
 
+The publisher controller runs from current main while its source path is the
+leased exact-tag worktree. This lets an incomplete immutable tag resume with a
+release-plumbing repair without changing the code or artifacts being shipped.
+An ambiguous Fly command result is accepted only when `/healthz` and the root
+page prove the exact tag; rollback starts only after that production proof
+fails.
+
 The daily run is idempotent. No merged changes is success. If a tag's hosted
 build succeeded but publishing stopped, the next run downloads that run's
 artifacts and resumes the same tag instead of cutting another patch.
+The runner leases that tag's publisher worktree until the publisher exits, so
+concurrent re-entry and worktree cleanup cannot remove a checkout still in use.
 
 Append to `release/unreleased/DECISIONS.md` only when the change captures durable intent: policy choices, scope calls, paths not taken, or decisions a contributor would cite months later. Skip bug-fix churn and mechanical edits.
 

--- a/rust/loopflow/src/engine/git.rs
+++ b/rust/loopflow/src/engine/git.rs
@@ -1,3 +1,5 @@
+use std::fs::{self, File, OpenOptions};
+use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output};
 use std::thread;
@@ -33,6 +35,12 @@ pub enum LandStrategy {
 pub struct LandResult {
     pub merged_commit: String,
     pub branch_deleted: bool,
+}
+
+#[derive(Debug)]
+pub(crate) struct WorktreeLease {
+    path: PathBuf,
+    _file: File,
 }
 
 fn run_git(repo: &Path, args: &[&str]) -> Result<Output, GitError> {
@@ -700,7 +708,79 @@ fn unquote_path(raw: &str) -> String {
         .to_string()
 }
 
-pub fn worktree_remove(repo: &Path, path: &Path) -> Result<(), GitError> {
+fn normalized_worktree_path(repo: &Path, path: &Path) -> PathBuf {
+    if let Ok(path) = path.canonicalize() {
+        return path;
+    }
+    let absolute = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        repo.join(path)
+    };
+    let Some(name) = absolute.file_name() else {
+        return absolute;
+    };
+    absolute
+        .parent()
+        .and_then(|parent| parent.canonicalize().ok())
+        .map(|parent| parent.join(name))
+        .unwrap_or(absolute)
+}
+
+fn worktree_lease_path(repo: &Path, path: &Path) -> Result<PathBuf, GitError> {
+    let common_dir = git_stdout(
+        repo,
+        &["rev-parse", "--path-format=absolute", "--git-common-dir"],
+    )?;
+    let lock_dir = PathBuf::from(common_dir.trim())
+        .join("loopflow")
+        .join("worktree-locks");
+    fs::create_dir_all(&lock_dir)?;
+    let path = normalized_worktree_path(repo, path);
+    let digest = hex::encode(Sha256::digest(path.as_os_str().as_encoded_bytes()));
+    Ok(lock_dir.join(format!("{digest}.lock")))
+}
+
+pub(crate) fn acquire_worktree_lease(
+    repo: &Path,
+    path: &Path,
+    owner: &str,
+) -> Result<WorktreeLease, GitError> {
+    let lock_path = worktree_lease_path(repo, path)?;
+    let mut file = OpenOptions::new()
+        .create(true)
+        .read(true)
+        .write(true)
+        .truncate(false)
+        .open(&lock_path)?;
+    if let Err(error) = fs2::FileExt::try_lock_exclusive(&file) {
+        if error.kind() == std::io::ErrorKind::WouldBlock {
+            let active_owner = fs::read_to_string(&lock_path)
+                .ok()
+                .map(|value| value.trim().to_string())
+                .filter(|value| !value.is_empty())
+                .unwrap_or_else(|| "another active operation".to_string());
+            return Err(GitError::CommandFailed {
+                command: "acquire worktree lease".to_string(),
+                stderr: format!(
+                    "{} is owned by {active_owner}",
+                    normalized_worktree_path(repo, path).display()
+                ),
+            });
+        }
+        return Err(error.into());
+    }
+    file.set_len(0)?;
+    file.write_all(owner.as_bytes())?;
+    file.write_all(b"\n")?;
+    file.flush()?;
+    Ok(WorktreeLease {
+        path: normalized_worktree_path(repo, path),
+        _file: file,
+    })
+}
+
+fn remove_worktree_unchecked(repo: &Path, path: &Path) -> Result<(), GitError> {
     let path_str = path.to_string_lossy();
     let output = run_git(repo, &["worktree", "remove", "--force", path_str.as_ref()])?;
     if !output.status.success() {
@@ -710,6 +790,26 @@ pub fn worktree_remove(repo: &Path, path: &Path) -> Result<(), GitError> {
         });
     }
     Ok(())
+}
+
+pub fn worktree_remove(repo: &Path, path: &Path) -> Result<(), GitError> {
+    let _lease = acquire_worktree_lease(repo, path, "worktree removal")?;
+    remove_worktree_unchecked(repo, path)
+}
+
+pub(crate) fn worktree_remove_owned(
+    repo: &Path,
+    path: &Path,
+    lease: &WorktreeLease,
+) -> Result<(), GitError> {
+    let path = normalized_worktree_path(repo, path);
+    if lease.path != path {
+        return Err(GitError::CommandFailed {
+            command: "remove owned worktree".to_string(),
+            stderr: format!("lease does not own {}", path.display()),
+        });
+    }
+    remove_worktree_unchecked(repo, &path)
 }
 
 /// Move a worktree to a new path.

--- a/rust/loopflow/src/ops/release.rs
+++ b/rust/loopflow/src/ops/release.rs
@@ -13,9 +13,12 @@ use crate::engine::command::{run_command, CommandError};
 use crate::engine::config::{
     load_config_or_default, Config, ReleaseCompletion, ReleaseTargetConfig,
 };
-use crate::engine::git::{delete_local_branch, get_default_branch, sync_main, worktree_remove};
+use crate::engine::git::{
+    acquire_worktree_lease, delete_local_branch, get_default_branch, sync_main, worktree_remove,
+    worktree_remove_owned, WorktreeLease,
+};
 use crate::engine::naming::{git_user, sanitize_for_branch};
-use crate::engine::worktrees::{create_named_worktree, main_repo_root};
+use crate::engine::worktrees::{create_named_worktree, main_repo_root, worktree_path};
 use crate::ops::commit::{commit_workflow, CommitOptions};
 use crate::ops::error::{OpsError, OpsResult};
 use crate::ops::land::{land, LandOptions};
@@ -675,7 +678,7 @@ pub fn release_run(
             &target,
             progress,
         );
-        cleanup_release_worktree(&main_repo, &wt_path, &wt_branch, progress);
+        cleanup_release_worktree(&main_repo, &wt_path, &wt_branch, None, progress);
         let prepared = prepared?;
 
         progress.status("Waiting for release PR to merge...");
@@ -744,7 +747,8 @@ fn run_publisher_check(
     target: &ReleaseTarget,
     progress: &impl Progress,
 ) -> OpsResult<()> {
-    let Some((program, args)) = target.publisher.split_first() else {
+    let publisher = expand_publisher_command(repo, &target.publisher);
+    let Some((program, args)) = publisher.split_first() else {
         return Ok(());
     };
     progress.status("Checking release host...");
@@ -764,7 +768,8 @@ fn run_publisher(
     workflow: &ReleaseWorkflowResult,
     progress: &impl Progress,
 ) -> OpsResult<()> {
-    let Some((program, args)) = target.publisher.split_first() else {
+    let publisher = expand_publisher_command(repo, &target.publisher);
+    let Some((program, args)) = publisher.split_first() else {
         return Ok(());
     };
     if workflow.database_id == 0 {
@@ -772,6 +777,10 @@ fn run_publisher(
             "release workflow for {tag} did not expose a run id"
         )));
     }
+
+    let wt_name = publish_worktree_name(target, tag);
+    let wt_path = worktree_path(repo, &wt_name);
+    let lease = acquire_worktree_lease(repo, &wt_path, &format!("release publisher for {tag}"))?;
 
     let artifact_dir = tempfile::tempdir()?;
     let run_id = workflow.database_id.to_string();
@@ -788,7 +797,6 @@ fn run_publisher(
         ],
     )?;
 
-    let wt_name = publish_worktree_name(target, tag);
     progress.status(&format!(
         "Materializing tagged publisher worktree {wt_name}..."
     ));
@@ -802,6 +810,7 @@ fn run_publisher(
             .arg("--artifacts")
             .arg(artifact_dir.path())
             .env("LF_RELEASE_MAIN_REPO", repo)
+            .env("LF_RELEASE_SOURCE_REPO", &wt.path)
             .env(
                 "LF_RELEASE_WORKFLOW_RUN_ID",
                 workflow.database_id.to_string(),
@@ -812,7 +821,7 @@ fn run_publisher(
             stderr: err.stderr,
         })
     };
-    cleanup_release_worktree(repo, &wt.path, &wt.branch, progress);
+    cleanup_release_worktree(repo, &wt.path, &wt.branch, Some(&lease), progress);
     publish_result?;
 
     if github_release_state(repo, tag)? != GitHubReleaseState::Published {
@@ -821,6 +830,14 @@ fn run_publisher(
         )));
     }
     Ok(())
+}
+
+fn expand_publisher_command(repo: &Path, publisher: &[String]) -> Vec<String> {
+    let repo = repo.to_string_lossy();
+    publisher
+        .iter()
+        .map(|arg| arg.replace("{repo}", &repo))
+        .collect()
 }
 
 #[derive(Debug)]
@@ -1501,9 +1518,14 @@ fn cleanup_release_worktree(
     main_repo: &Path,
     wt_path: &Path,
     branch: &str,
+    lease: Option<&WorktreeLease>,
     progress: &impl Progress,
 ) {
-    if let Err(err) = worktree_remove(main_repo, wt_path) {
+    let result = match lease {
+        Some(lease) => worktree_remove_owned(main_repo, wt_path, lease),
+        None => worktree_remove(main_repo, wt_path),
+    };
+    if let Err(err) = result {
         progress.error(&format!(
             "Warning: could not remove release worktree {}: {err}",
             wt_path.display()

--- a/rust/loopflow/tests/release_tests.rs
+++ b/rust/loopflow/tests/release_tests.rs
@@ -2,6 +2,8 @@ mod support;
 
 use std::fs;
 use std::process::Command;
+use std::thread;
+use std::time::{Duration, Instant};
 
 use loopflow::ops::{
     bump_version, generate_release, release_bump, release_check, release_notes, release_run,
@@ -65,6 +67,18 @@ fn git_output_bare(repo: &TestRepo, args: &[&str]) -> String {
         String::from_utf8_lossy(&output.stderr)
     );
     String::from_utf8_lossy(&output.stdout).trim().to_string()
+}
+
+fn wait_for_path(path: &std::path::Path) {
+    let deadline = Instant::now() + Duration::from_secs(10);
+    while !path.exists() {
+        assert!(
+            Instant::now() < deadline,
+            "timed out waiting for {}",
+            path.display()
+        );
+        thread::sleep(Duration::from_millis(20));
+    }
 }
 
 #[test]
@@ -605,6 +619,149 @@ fn release_run_keeps_a_failed_tag_red_until_a_fix_merges() {
         .expect_err("failed build without a fix should stay red");
 
     assert!(error.to_string().contains("no merged fix is available"));
+}
+
+#[test]
+fn active_tagged_publisher_blocks_concurrent_cleanup_until_exit() {
+    let repo = TestRepo::new();
+    git(&repo, &["tag", "v0.9.1"]);
+    git(&repo, &["push", "origin", "v0.9.1"]);
+    let state = tempfile::tempdir().expect("publisher state");
+    let ready = state.path().join("ready");
+    let publish = state.path().join("publish");
+    let completed = state.path().join("completed");
+    let exit = state.path().join("exit");
+    let published = state.path().join("published");
+    let publisher = repo.path().join("publisher.sh");
+    fs::write(
+        &publisher,
+        format!(
+            r#"#!/bin/sh
+case "$1" in
+  check) exit 0 ;;
+  publish)
+    worktree="$LF_RELEASE_SOURCE_REPO"
+    [ -e "$worktree/.git" ] || {{ echo 'tagged source missing' >&2; exit 41; }}
+    [ ! -f "$worktree/publisher.sh" ] || {{ echo 'publisher control came from tag' >&2; exit 42; }}
+    : > '{}'
+    attempts=0
+    while [ ! -f '{}' ] && [ "$attempts" -lt 500 ]; do
+      attempts=$((attempts + 1))
+      sleep 0.02
+    done
+    [ -d "$worktree" ] || {{ echo 'publisher worktree disappeared' >&2; exit 43; }}
+    : > '{}'
+    : > '{}'
+    attempts=0
+    while [ ! -f '{}' ] && [ "$attempts" -lt 500 ]; do
+      attempts=$((attempts + 1))
+      sleep 0.02
+    done
+    [ -d "$worktree" ] || {{ echo 'publisher worktree disappeared before exit' >&2; exit 44; }}
+    exit 0 ;;
+esac
+exit 2
+"#,
+            ready.display(),
+            publish.display(),
+            published.display(),
+            completed.display(),
+            exit.display(),
+        ),
+    )
+    .expect("write publisher");
+
+    let gh_script = format!(
+        r#"#!/bin/sh
+if [ "$1" = "--version" ]; then
+  echo 'gh version 2.0.0'
+  exit 0
+fi
+case "$1 $2" in
+  'release view')
+    if [ -f '{}' ]; then
+      echo '{{"isDraft":false}}'
+      exit 0
+    fi
+    exit 1 ;;
+  'run list')
+    echo '[{{"databaseId":42,"headBranch":"v0.9.1","status":"completed","conclusion":"success"}}]'
+    exit 0 ;;
+  'run download') exit 0 ;;
+esac
+echo "unexpected gh invocation: $@" >&2
+exit 1
+"#,
+        published.display(),
+    );
+    let _env = EnvGuard::new(&[("gh", gh_script.as_str())]);
+
+    fs::create_dir_all(repo.path().join(".lf")).expect("config dir");
+    fs::write(
+        repo.path().join(".lf/config.yaml"),
+        "release:\n  targets:\n    default:\n      publisher: [\"sh\", \"{repo}/publisher.sh\"]\n",
+    )
+    .expect("release config");
+    git(&repo, &["add", ".lf/config.yaml", "publisher.sh"]);
+    git(&repo, &["commit", "-m", "Add current publisher controller"]);
+    git(&repo, &["push", "origin", "HEAD"]);
+    let tags_before = git_output(&repo, &["tag", "--list"]);
+    let neighbor = repo.create_named_worktree("neighbor");
+    let repo_name = repo
+        .path()
+        .file_name()
+        .expect("repo name")
+        .to_string_lossy();
+    let publisher_worktree = repo
+        .path()
+        .parent()
+        .expect("repo parent")
+        .join(format!("{repo_name}.publish-default-v0-9-1"));
+
+    let release = Command::new(env!("CARGO_BIN_EXE_lf"))
+        .args(["release", "run", "patch"])
+        .current_dir(repo.path())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .expect("start release re-entry");
+
+    wait_for_path(&ready);
+    assert!(publisher_worktree.exists());
+    let removal = Command::new(env!("CARGO_BIN_EXE_lf"))
+        .args(["wt", "remove", "publish-default-v0-9-1"])
+        .current_dir(repo.path())
+        .output()
+        .expect("attempt concurrent cleanup");
+
+    assert!(!removal.status.success());
+    assert!(
+        String::from_utf8_lossy(&removal.stderr).contains("release publisher for v0.9.1"),
+        "unexpected cleanup error: {}",
+        String::from_utf8_lossy(&removal.stderr)
+    );
+    assert!(publisher_worktree.exists());
+    assert!(neighbor.exists());
+
+    fs::write(&publish, "").expect("allow publication");
+    wait_for_path(&completed);
+    assert!(
+        publisher_worktree.exists(),
+        "owner cleanup must wait for publisher exit"
+    );
+    fs::write(&exit, "").expect("allow publisher exit");
+
+    let output = release
+        .wait_with_output()
+        .expect("wait for release re-entry");
+    assert!(
+        output.status.success(),
+        "release re-entry failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(!publisher_worktree.exists());
+    assert!(neighbor.exists());
+    assert_eq!(git_output(&repo, &["tag", "--list"]), tags_before);
 }
 
 #[test]

--- a/scripts/deploy_website.py
+++ b/scripts/deploy_website.py
@@ -171,6 +171,7 @@ def deploy_website(tag: str, repo: Path) -> DeployReceipt:
     _run(["uv", "run", "python", "scripts/check_website_screens.py"], repo)
     previous_image = _current_image(repo)
 
+    deploy_failed = False
     try:
         _run(
             [
@@ -187,14 +188,7 @@ def deploy_website(tag: str, repo: Path) -> DeployReceipt:
             repo / "website",
         )
     except subprocess.CalledProcessError:
-        _rollback(
-            repo,
-            tag,
-            source_commit,
-            previous_image,
-            None,
-            f"Fly deployment failed for {tag}",
-        )
+        deploy_failed = True
 
     deployed_image = _current_image(repo)
     if _wait_for_release(tag):
@@ -202,21 +196,29 @@ def deploy_website(tag: str, repo: Path) -> DeployReceipt:
         _write_receipt(repo, receipt)
         return receipt
 
+    reason = (
+        f"Fly deployment failed for {tag}" if deploy_failed else f"production did not report {tag}"
+    )
     _rollback(
         repo,
         tag,
         source_commit,
         previous_image,
         deployed_image,
-        f"production did not report {tag}",
+        reason,
     )
 
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="Deploy one tagged Loopflow website release")
     parser.add_argument("--tag", required=True)
+    parser.add_argument(
+        "--repo",
+        type=Path,
+        default=Path(__file__).resolve().parent.parent,
+    )
     args = parser.parse_args()
-    repo = Path(__file__).resolve().parent.parent
+    repo = args.repo.resolve()
     main_repo = Path(os.environ.get("LF_RELEASE_MAIN_REPO", repo))
     lock_dir = main_repo / ".lf" / "locks"
     lock_dir.mkdir(parents=True, exist_ok=True)

--- a/scripts/publish_release.py
+++ b/scripts/publish_release.py
@@ -11,6 +11,7 @@ import platform
 import shlex
 import shutil
 import subprocess
+import sys
 import tarfile
 import tempfile
 from dataclasses import asdict, dataclass
@@ -18,7 +19,8 @@ from pathlib import Path
 
 import boto3
 
-ROOT = Path(__file__).resolve().parent.parent
+CONTROL_ROOT = Path(__file__).resolve().parent.parent
+ROOT = Path(os.environ.get("LF_RELEASE_SOURCE_REPO", CONTROL_ROOT))
 TARGETS = (
     "aarch64-apple-darwin",
     "x86_64-apple-darwin",
@@ -75,9 +77,7 @@ def _run(
 def _r2_client():
     return boto3.client(
         "s3",
-        endpoint_url=(
-            f"https://{os.environ['R2_ACCOUNT_ID'].strip()}.r2.cloudflarestorage.com"
-        ),
+        endpoint_url=(f"https://{os.environ['R2_ACCOUNT_ID'].strip()}.r2.cloudflarestorage.com"),
         aws_access_key_id=os.environ["R2_ACCESS_KEY_ID"].strip(),
         aws_secret_access_key=os.environ["R2_SECRET_ACCESS_KEY"].strip(),
         region_name="auto",
@@ -115,9 +115,7 @@ def _find_native_archives(artifact_dir: Path) -> tuple[Path, ...]:
     for target in TARGETS:
         matches = list(artifact_dir.rglob(f"lf-{target}.tar.gz"))
         if len(matches) != 1:
-            raise RuntimeError(
-                f"expected one lf-{target}.tar.gz artifact, found {len(matches)}"
-            )
+            raise RuntimeError(f"expected one lf-{target}.tar.gz artifact, found {len(matches)}")
         archives.append(matches[0])
     return tuple(archives)
 
@@ -245,7 +243,16 @@ def publish_release(tag: str, artifact_dir: Path) -> PublishReceipt:
     _upload_dmg(dmg, f"Loopflow-{version}.dmg", "public, max-age=31536000, immutable")
     stages.append("versioned_dmg_uploaded")
 
-    _run(["uv", "run", "python", "scripts/deploy_website.py", "--tag", tag])
+    _run(
+        [
+            sys.executable,
+            str(CONTROL_ROOT / "scripts/deploy_website.py"),
+            "--tag",
+            tag,
+            "--repo",
+            str(ROOT),
+        ]
+    )
     stages.append("website_deployed")
 
     _upload_dmg(dmg, "Loopflow-latest.dmg", "public, max-age=60")


### PR DESCRIPTION
## Usage

```bash
lf release run patch
```

## Summary

Keeps the exact-tag publisher worktree leased until its subprocess exits, then lets current main supply repaired publisher control while all release source remains pinned to the immutable tag. Exact-tag production health now wins over an ambiguous Fly client timeout, so a healthy deployment is not rolled back.

## Changes

- reject concurrent worktree cleanup while a tagged publisher is active
- clean up only after the publisher exits, without touching neighboring worktrees
- pass the leased tagged source explicitly to the current repo-owned publisher controller
- probe exact-tag health before rollback after any Fly deploy result
- cover healthy-after-timeout, truly unhealthy, current-control/old-source, and concurrent-cleanup paths

## Proof

- 19 Python release tests pass
- 34 Rust release tests and 24 worktree tests pass
- Ruff, rustfmt, and Clippy pass