### PR TITLE
cron: bootstrap the infrastructure wave on its placed home

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -47,4 +47,4 @@ jobs:
 
           # GITHUB_TOKEN tag pushes don't trigger other workflows,
           # so explicitly dispatch the release workflow.
-          gh workflow run release.yml --ref "$version" -f tag="$version"
+          gh workflow run release.yml --ref "$version"

--- a/docs/lf.md
+++ b/docs/lf.md
@@ -797,19 +797,31 @@ never appears in process arguments or the service file.
 
 ## lf cron
 
-Install local launchd jobs that run `lf` commands on a schedule. (Wave crons
-in `GOAL.md` frontmatter are separate — the resident fires those; see
-[Waves](waves.md#crons).)
+Reconcile a Wave's `GOAL.md` schedules onto its placed macOS Home and inspect
+each launchd firing through durable receipts.
 
 ```bash
-lf cron add --wave coordination --flow govern-coordination --schedule daily
-lf cron list
-lf cron remove --wave coordination --flow govern-coordination
+lf cron preflight --wave infrastructure
+lf cron sync --wave infrastructure
+lf cron list --wave infrastructure --json
+lf cron trigger --wave infrastructure --flow telemetry-daily --wait --timeout 15m
+lf cron history --wave infrastructure --days 35
 ```
 
-`add` writes `~/Library/LaunchAgents/loopflow.cron.<wave>.<flow>.plist` and
-loads it with launchd; the job runs `lf <flow> --wave <wave>` from the
-current repo.
+`preflight` proves the installed release binary, Wave placement, authoritative
+checkout, target catalog, and fixed-daily schedules without changing launchd.
+`sync` repeats those checks before changing
+launchd, refuses a Home that does not own the Wave placement, and prunes jobs
+removed from the declaration. Jobs execute through the installed release `lf`
+with a secret-free host environment. Each firing writes a running receipt
+before the target starts and atomically replaces it with `succeeded` or
+`failed`; an interrupted runner remains visibly stale. Logs stay under
+`<repo>/.lf/logs/`, while receipts survive checkout replacement under
+`<LF_HOME>/cron/receipts/`.
+
+`trigger` asks launchd to fire the installed job; it never bypasses the
+configured path. `history` defaults to 35 days so nightly, weekly, credential,
+and host-drift observation windows share one evidence surface.
 
 ## lf pm
 

--- a/python/tests/test_release_automation.py
+++ b/python/tests/test_release_automation.py
@@ -205,6 +205,18 @@ def test_release_build_workflow_is_credential_free():
     assert not (ROOT / ".github/workflows/website-deploy.yml").exists()
 
 
+def test_auto_tag_dispatch_matches_the_input_free_release_contract():
+    release = yaml.load(
+        (ROOT / ".github/workflows/release.yml").read_text(),
+        Loader=yaml.BaseLoader,
+    )
+    assert not release["on"]["workflow_dispatch"]
+
+    auto_tag = (ROOT / ".github/workflows/auto-tag.yml").read_text()
+    assert 'gh workflow run release.yml --ref "$version"' in auto_tag
+    assert "-f tag=" not in auto_tag
+
+
 def test_host_publisher_owns_credentialed_release_steps():
     publisher = (ROOT / "scripts/publish_release.py").read_text()
 
@@ -248,11 +260,23 @@ def test_infrastructure_cron_runs_the_host_release_after_telemetry():
 
     bootstrap = (ROOT / "scripts/bootstrap-cron-host.sh").read_text()
     assert "--remote-native" not in bootstrap
-    assert 'lf ssh "$host" --version' in bootstrap
-    assert 'lf ssh "$host" cron sync --wave "$wave"' in bootstrap
-    assert 'lf ssh "$host" cron list' in bootstrap
+    assert 'local_home="$(lf home id)"' in bootstrap
+    assert 'placed_home="$(lf status "$wave" --json' in bootstrap
+    assert "--git-common-dir" in bootstrap
+    assert 'lf cron preflight --wave "$wave"' in bootstrap
+    assert '"${minimal_env[@]}" lf cron sync --wave "$wave"' in bootstrap
+    assert 'lf cron list --wave "$wave" --json' in bootstrap
+    assert 'lf cron trigger' in bootstrap
+    assert '--flow telemetry-daily --wait --timeout 15m' in bootstrap
+    assert '--flow release-run --wait --timeout 3h' in bootstrap
+    assert 'lf cron history --wave "$wave" --days 35' in bootstrap
+    assert "env -i" in bootstrap
+    assert "DOPPLER_TOKEN" not in bootstrap
+    assert bootstrap.index('lf cron preflight --wave "$wave"') < bootstrap.index(
+        "scripts/publish_release.py check"
+    )
     assert bootstrap.index("scripts/publish_release.py check") < bootstrap.index(
-        'lf ssh "$host" cron sync'
+        'lf cron sync --wave "$wave"'
     )
 
 

--- a/release/CRON_HOST.md
+++ b/release/CRON_HOST.md
@@ -1,94 +1,92 @@
-# Maintained cron host
+# Maintained cron Home
 
-A maintained cron host runs `lf` on a schedule so health checks and patch
-releases happen whether or not anyone is at a keyboard. The runtime is explicit:
-**launchd invokes top-level `lf` commands** — no daemon, no resident wave
-listener required.
+Run the infrastructure Wave's declared telemetry and release jobs on the Home
+that owns its durable placement. Placement is the authority; a hostname in a
+document is not.
 
-## The host
+```bash
+lf home id
+lf status infrastructure --json | jq -r '.wave.home.id'
+scripts/bootstrap-cron-host.sh infrastructure
+lf cron history --wave infrastructure --days 35
+```
 
-| Host | Tailnet | Role |
-|------|---------|------|
-| `mini-heart` | `100.96.227.95` (`*.tail0eda02.ts.net`), macOS | First maintained `lf cron` host |
+The two Home ids must match. `bootstrap-cron-host.sh` fails before changing
+launchd when they differ.
 
-Reach it over Tailscale: `lf ssh mini-heart --version`. First contact needs
-the host key trusted and Tailscale up on both ends. `lf ssh` is bounded
-(`ConnectTimeout=10`, `BatchMode=yes`), so an unreachable host fails in seconds
-instead of hanging.
+## Host prerequisites
 
-The host is a committed fact on purpose — an agent should discover it by reading
-the repo, not by opening the Tailscale console.
+- Promote an installed release `lf`; cron installation rejects development and
+  task-worktree binaries.
+- Keep the repository's authoritative checkout on the placed Home.
+- Configure at least one managed Claude or Codex account in the Home store.
+- Install `doppler`, `uv`, `gh`, `cargo`, `flyctl`, `security`, `swift`,
+  `xcrun`, and `jq` on the host path.
+- Configure Doppler project `loopflow`, config `prd`, without storing or
+  printing secret values in the repository or launchd plist.
+- Install the Developer ID signing identity and host-native GitHub, registry,
+  R2, notarization, and Fly authority required by the release publisher.
 
-## Prerequisites on the host
+The bootstrap reconstructs a minimal environment containing only host paths,
+Home/store paths, and basic locale/temp settings. It verifies a managed provider
+account live, then runs the publisher's read-only check through:
 
-- `lf` on `PATH` (install/refresh via `scripts/install.py`).
-- Doppler configured for the release project so secrets resolve without ever
-  printing a value: `doppler setup` once, out of band. `lf cron sync` never reads
-  or forwards secrets; scheduled `lf` runs resolve their own via Doppler.
-- GitHub CLI auth able to create release PRs/tags, download workflow artifacts,
-  and publish releases; an app-scoped Fly deploy token; crates.io, R2,
-  notarization, and signing credentials available through Doppler.
-- An Apple Silicon Mac with the Developer ID signing identity installed, plus
-  `cargo`, `flyctl`, `gh`, `security`, `swift`, `uv`, and `xcrun` on `PATH`.
-- An agent provider available for the `release` flow. Release-note generation
-  has a deterministic fallback, but the flow itself is agent-owned.
-- A checkout of this repo; run `lf cron sync` from inside it.
+```bash
+doppler run --project loopflow --config prd -- \
+  uv run python scripts/publish_release.py check
+```
+
+Doppler injects values only into that process. The script never reads or prints
+a secret and never forwards a Task lease, provider lease, GitHub token, PM
+token, or invocation context.
 
 ## Repo-owned schedules
 
-Schedules live in the wave's `wave/<wave>/GOAL.md` frontmatter — one declaration,
-read by both the resident wave listener and the launchd host:
+Schedules live in `wave/infrastructure/GOAL.md`:
 
 ```yaml
 crons:
-  - flow: telemetry-daily      # runs `op: doctor`; exits non-zero on any red check
-    schedule: "0 0 9 * * *"    # 6-field cron expr: 09:00 daily
-  - flow: release-run          # runs `lf release run patch`
-    schedule: "0 0 10 * * *"   # after telemetry, host-local
+  - flow: telemetry-daily
+    schedule: "0 0 9 * * *"
+  - flow: release-run
+    schedule: "0 0 10 * * *"
 ```
 
-Install / update them on the host in one idempotent command:
+`lf cron sync --wave infrastructure` validates both targets and both fixed
+daily schedules before it writes a plist. It captures the non-secret host path,
+Home id, Home/store paths, authoritative checkout, installed binary, exact
+schedule, and log path. Scheduled execution repeats the placement check and
+fails with a receipt instead of running after ownership moves.
+
+`lf cron preflight --wave infrastructure` performs the installed-binary,
+placement, checkout, catalog, and schedule checks without changing launchd;
+the bootstrap runs it before any credential probe.
+
+launchd uses host-local time and coalesces missed calendar firings after wake.
+Receipts record the actual start; declarations alone never count as evidence of
+a nightly run. Place the Wave on an always-on Home when uninterrupted wall-clock
+cadence matters.
+
+## Durable evidence
 
 ```bash
-lf cron sync --wave infrastructure   # reconcile launchd jobs to match GOAL.md
-lf cron list                         # prove what's installed
+lf cron list --wave infrastructure --json
+lf cron trigger --wave infrastructure --flow telemetry-daily --wait --timeout 15m
+lf cron trigger --wave infrastructure --flow release-run --wait --timeout 3h
+lf cron history --wave infrastructure --days 35 --json
 ```
 
-`sync` installs a launchd job per declared cron, prunes jobs for the wave whose
-flow is no longer declared, and reports any schedule launchd can't run. Edit
-`GOAL.md`, re-run `sync`, and launchd matches the declaration.
+`list` reports the exact schedule, loaded state, installed Home, repo, binary,
+and latest receipt. `trigger` exercises launchd rather than invoking the target
+directly. Every firing writes a private, versioned receipt under
+`<LF_HOME>/cron/receipts/<wave>/<flow>/`; receipts contain identity, timing,
+outcome, exit status, and the log path, never environment values or output.
 
-## Bootstrap
+An early failure is `failed`, a successful no-op is `succeeded`, and a killed
+runner remains `running` but is rendered `stale`. Detailed output stays at
+`<repo>/.lf/logs/cron.<wave>.<flow>.log`. These rows begin the 14-night,
+four-release, and 30-day authority/host-drift observation windows; bootstrap
+does not claim that elapsed evidence in advance.
 
-```bash
-scripts/bootstrap-cron-host.sh mini-heart infrastructure
-```
-
-Probes reachability and host-native auth over bounded SSH,
-runs the release publisher's read-only credential/tool preflight, syncs the
-repo-owned schedules, and lists the result. Idempotent and secret-free; re-run
-it any time to reconcile.
-
-## Failure surfacing (v0)
-
-launchd writes each job's stdout+stderr to
-`<repo>/.lf/logs/cron.<wave>.<flow>.log`; the release publisher additionally
-writes redacted JSON receipts under `<repo>/.lf/logs/`. `lf doctor` (via
-`telemetry-daily`) exits non-zero on a failed check. A red run leaves a non-zero
-exit and a named stage in the log. No-change release runs exit successfully.
-
-## Known limitations (v0)
-
-- **Timezone.** launchd `StartCalendarInterval` fires on **host-local** time; the
-  resident listener reads the same cron expression as UTC. The declared HH:MM is
-  applied host-local on the launchd host. Fine for a daily health check; set the
-  host clock/timezone deliberately.
-- **Schedule shape.** Only a fixed daily time translates to launchd. Sub-daily,
-  weekly, or multi-time expressions are reported as skipped by `sync` (the resident
-  listener still honors the full expression). The launchd host is daily-only for now.
-
-## Scope
-
-Loopflow is the first real deployment. Cadenza mirrors this cadence as separate
-follow-on work once this host proves the shape — do not generalize a multi-product
-deploy layer before a second host needs it.
+Loopflow remains the concrete deployment. Mirror this shape into Cadenza only
+when its release needs it; do not extract a generic deployment platform.

--- a/release/README.md
+++ b/release/README.md
@@ -8,8 +8,8 @@ find release -maxdepth 2 -type f | sort
 ```
 
 ```bash
-lf cron sync --wave infrastructure   # daily patch release on the maintained host
-lf cron list
+scripts/bootstrap-cron-host.sh infrastructure  # preflight, sync, and configured-path receipts
+lf cron history --wave infrastructure --days 35
 ```
 
 ```bash

--- a/rust/loopflow/src/durable.rs
+++ b/rust/loopflow/src/durable.rs
@@ -93,6 +93,7 @@ durable_id!(SteerId, "steer_");
 durable_id!(SendId, "send_");
 durable_id!(ToolResponseId, "response_");
 durable_id!(DoneProposalId, "done_");
+durable_id!(CronReceiptId, "cron_");
 
 impl ProjectId {
     pub(crate) fn from_raw(value: impl Into<String>) -> Self {

--- a/rust/loopflow/src/lf/commands/ops/mod.rs
+++ b/rust/loopflow/src/lf/commands/ops/mod.rs
@@ -13,7 +13,7 @@ use crate::engine::{
     SkillSyncOptions, Surface,
 };
 use crate::lf::commands::util::find_repo_root;
-use crate::lf::discovery::discover_skill;
+use crate::lf::discovery::{discover_skill, discover_target, Target};
 use crate::lf::output::{column_width, Colors};
 use crate::lf::{
     CronCommand, PmCommand, PmProjectCommand, PmTaskCommand, PrCommand, ReleaseCommand, WtCommand,
@@ -24,8 +24,9 @@ use crate::ops::{
     create_or_update_pr, current_pr, finish_land_after_rebase, finish_submit_after_rebase, land,
     plan_rebase, rebase_class_name, rebase_strategy_name, rebase_with_recovery, recover_rebase,
     release_bump, release_check, release_notes, release_publish, release_run, release_status,
-    release_tag, start_rebase_for_resolution, submit, AbandonOptions, CommitOptions, CronSpec,
-    LandOptions, PrOptions, Progress, RebaseOptions, SystemLaunchctl,
+    release_tag, start_rebase_for_resolution, submit, AbandonOptions, CommitOptions, CronHost,
+    CronOutcome, CronSource, CronSpec, CronTargetKind, LandOptions, PrOptions, Progress,
+    RebaseOptions, SystemLaunchctl,
 };
 use crate::store::RegistryUnavailable;
 use anyhow::{anyhow, Result};
@@ -1105,7 +1106,6 @@ pub fn cron_cmd(cmd: &CronCommand) -> Result<()> {
             flow,
             schedule,
         } => {
-            let repo_root = find_repo_root()?;
             // The one ambient-Wave rule, like every PM arm: `--wave` wins, else
             // `LF_WAVE_ID` (UUID → registry name, hand-set name as fallback). A
             // scheduled invocation needs a concrete wave, so `NoContext` is the
@@ -1117,42 +1117,71 @@ pub fn cron_cmd(cmd: &CronCommand) -> Result<()> {
                     }
                     other => other.into(),
                 })?;
+            require_release_cron_binary()?;
+            let authority = cron_authority(&wave)?;
+            ensure_cron_placement(&wave, &authority)?;
+            let target_kind = cron_target_kind(&authority.repo, flow)?;
             let spec = CronSpec {
                 wave,
                 flow: flow.clone(),
+                target_kind,
                 schedule: crate::ops::parse_schedule(schedule)?,
-                working_directory: repo_root,
+                working_directory: authority.repo,
                 lf_path: crate::ops::resolve_lf_path()?,
+                host: authority.host,
             };
             let cron = crate::ops::add_cron(&launch_agents_dir, &spec, &SystemLaunchctl)?;
             println!("installed {} at {}", cron.label, cron.path.display());
         }
-        CronCommand::List => {
-            let crons = crate::ops::list_crons(&launch_agents_dir)?;
+        CronCommand::List { wave, json } => {
+            let mut crons = crate::ops::list_crons(&launch_agents_dir, &SystemLaunchctl)?;
+            if let Some(wave) = wave {
+                crons.retain(|cron| cron.wave == *wave);
+            }
+            if *json {
+                println!("{}", serde_json::to_string(&crons)?);
+                return Ok(());
+            }
             if crons.is_empty() {
                 println!("no loopflow crons installed");
             } else {
                 for cron in crons {
-                    println!("{} {} {}", cron.label, cron.wave, cron.flow);
+                    let latest = cron
+                        .latest_receipt
+                        .as_ref()
+                        .map(cron_receipt_outcome)
+                        .unwrap_or("never");
+                    println!(
+                        "{}  {}  {}  {}  {}",
+                        cron.flow,
+                        cron.schedule,
+                        if cron.loaded { "loaded" } else { "not-loaded" },
+                        cron.home_id,
+                        latest,
+                    );
                 }
             }
         }
+        CronCommand::Preflight { wave } => {
+            require_release_cron_binary()?;
+            let authority = cron_authority(wave)?;
+            ensure_cron_placement(wave, &authority)?;
+            let specs = cron_specs(&authority, wave)?;
+            crate::ops::validate_cron_specs(wave, &specs)?;
+            println!(
+                "cron preflight passed: {} jobs for Wave {wave} on Home {}",
+                specs.len(),
+                authority.local_home
+            );
+        }
         CronCommand::Sync { wave } => {
-            let repo_root = find_repo_root()?;
-            let declared = crate::engine::wave_config::read_wave_config(&repo_root, wave)
-                .and_then(|config| config.crons)
-                .unwrap_or_default();
-            let lf_path = crate::ops::resolve_lf_path()?;
-            let result = crate::ops::sync_crons(
-                &launch_agents_dir,
-                wave,
-                &declared,
-                &repo_root,
-                &lf_path,
-                &SystemLaunchctl,
-            )?;
-            if result.installed.is_empty() && result.removed.is_empty() && result.skipped.is_empty()
-            {
+            require_release_cron_binary()?;
+            let authority = cron_authority(wave)?;
+            ensure_cron_placement(wave, &authority)?;
+            let specs = cron_specs(&authority, wave)?;
+            let result =
+                crate::ops::sync_crons(&launch_agents_dir, wave, &specs, &SystemLaunchctl)?;
+            if result.installed.is_empty() && result.removed.is_empty() {
                 println!("no crons declared for wave {wave}; nothing to sync");
             }
             for cron in &result.installed {
@@ -1161,8 +1190,135 @@ pub fn cron_cmd(cmd: &CronCommand) -> Result<()> {
             for cron in &result.removed {
                 println!("pruned {} ({})", cron.label, cron.flow);
             }
-            for skip in &result.skipped {
-                eprintln!("skipped {} ({}): {}", skip.flow, skip.schedule, skip.reason);
+        }
+        CronCommand::Run {
+            wave,
+            flow,
+            scheduled,
+        } => {
+            let source = if *scheduled {
+                CronSource::Scheduled
+            } else {
+                CronSource::Manual
+            };
+            let authority = match cron_authority(wave) {
+                Ok(authority) => authority,
+                Err(error) => {
+                    let detail = error.to_string();
+                    return match crate::ops::record_cron_preflight_failure(
+                        &launch_agents_dir,
+                        wave,
+                        flow,
+                        source,
+                        &detail,
+                    ) {
+                        Ok(receipt) => Err(anyhow!(
+                            "cron {wave}/{flow} failed before launch: {}; log {}",
+                            receipt.error.as_deref().unwrap_or(&detail),
+                            receipt.log_path.display()
+                        )),
+                        Err(receipt_error) => Err(anyhow!(
+                            "cron {wave}/{flow} failed before launch: {detail}; receipt persistence also failed: {receipt_error}"
+                        )),
+                    };
+                }
+            };
+            let receipt = crate::ops::run_cron(
+                &launch_agents_dir,
+                wave,
+                flow,
+                &authority.local_home,
+                &authority.placed_home,
+                source,
+            )?;
+            println!(
+                "{} {} {}",
+                receipt.id,
+                receipt.flow,
+                cron_receipt_outcome(&receipt)
+            );
+        }
+        CronCommand::History {
+            wave,
+            flow,
+            days,
+            json,
+        } => {
+            let root = crate::ops::receipt_root(&crate::store::authority_home_dir());
+            let receipts = crate::ops::list_cron_receipts(&root, wave, flow.as_deref(), *days)?;
+            if *json {
+                println!("{}", serde_json::to_string(&receipts)?);
+                return Ok(());
+            }
+            if receipts.is_empty() {
+                println!("no cron receipts for wave {wave} in the last {days} days");
+            }
+            for receipt in receipts {
+                let started = chrono::DateTime::from_timestamp(receipt.started_at, 0)
+                    .map(|time| time.to_rfc3339())
+                    .unwrap_or_else(|| receipt.started_at.to_string());
+                let duration = receipt
+                    .finished_at
+                    .map(|finished| finished.saturating_sub(receipt.started_at))
+                    .map(|seconds| format!("{seconds}s"))
+                    .unwrap_or_else(|| "open".to_string());
+                let exit = receipt
+                    .exit_code
+                    .map(|code| format!("exit={code}"))
+                    .unwrap_or_else(|| "exit=-".to_string());
+                println!(
+                    "{}  {}  {}  {}  {}  {}  {}",
+                    started,
+                    receipt.flow,
+                    cron_source_name(receipt.source),
+                    cron_receipt_outcome(&receipt),
+                    duration,
+                    exit,
+                    receipt.log_path.display(),
+                );
+            }
+        }
+        CronCommand::Trigger {
+            wave,
+            flow,
+            wait,
+            timeout,
+        } => {
+            let authority = cron_authority(wave)?;
+            ensure_cron_placement(wave, &authority)?;
+            let root = crate::ops::receipt_root(&authority.host.lf_home);
+            let prior = crate::ops::cron_receipt_ids(&root, wave, flow)?;
+            let triggered_at = chrono::Utc::now().timestamp();
+            crate::ops::trigger_cron(&SystemLaunchctl, wave, flow)?;
+            println!("triggered {wave}/{flow} through launchd");
+            if *wait {
+                let receipt = crate::ops::wait_for_cron_receipt(
+                    &root,
+                    wave,
+                    flow,
+                    &prior,
+                    triggered_at,
+                    crate::ops::parse_wait_duration(timeout)?,
+                )?;
+                println!(
+                    "{} {} {}",
+                    receipt.id,
+                    receipt.flow,
+                    cron_receipt_outcome(&receipt)
+                );
+                if receipt.outcome == CronOutcome::Failed
+                    || crate::ops::receipt_is_stale(&receipt, chrono::Utc::now().timestamp())
+                {
+                    return Err(anyhow!(
+                        "cron {wave}/{flow} {}: {}; log {}",
+                        cron_receipt_outcome(&receipt),
+                        receipt
+                            .error
+                            .as_deref()
+                            .unwrap_or("no terminal error recorded"),
+                        receipt.log_path.display()
+                    ));
+                }
             }
         }
         CronCommand::Remove { wave, flow } => {
@@ -1173,6 +1329,151 @@ pub fn cron_cmd(cmd: &CronCommand) -> Result<()> {
         }
     }
     Ok(())
+}
+
+#[derive(Debug)]
+struct CronAuthority {
+    host: CronHost,
+    local_home: crate::durable::HomeId,
+    placed_home: crate::durable::HomeId,
+    repo: PathBuf,
+}
+
+fn cron_authority(wave_name: &str) -> Result<CronAuthority> {
+    tokio::runtime::Runtime::new()?.block_on(async {
+        let store = crate::store::open_registry_for_authority()
+            .await
+            .map_err(cron_registry_error)?;
+        let wave = store
+            .get_wave_by_name(wave_name)
+            .await?
+            .ok_or_else(|| anyhow!("Wave '{wave_name}' was not found in the local registry"))?;
+        let placement = store
+            .placement(&crate::durable::WorkRef::Wave(wave.id().clone()))
+            .await?;
+        let local = store.local_home().await?;
+        let repo = main_repo_root(Path::new(wave.repo())).map_err(|error| {
+            anyhow!(
+                "Wave {wave_name} repo {} has no authoritative main checkout: {error}",
+                wave.repo()
+            )
+        })?;
+        let path_env = std::env::var("PATH").map_err(|_| {
+            anyhow!("PATH is absent; cannot install an unattended cron environment")
+        })?;
+        if path_env.is_empty() {
+            return Err(anyhow!(
+                "PATH is empty; cannot install an unattended cron environment"
+            ));
+        }
+        Ok(CronAuthority {
+            host: CronHost {
+                home_id: local.id.clone(),
+                lf_home: crate::store::authority_home_dir(),
+                db_path: crate::store::observability_database_path()?,
+                path_env,
+            },
+            local_home: local.id,
+            placed_home: placement.home_id,
+            repo,
+        })
+    })
+}
+
+fn cron_registry_error(error: RegistryUnavailable) -> anyhow::Error {
+    match error {
+        RegistryUnavailable::MissingFile { path } => anyhow!(
+            "Home registry is missing at {}; initialize or restore it before running cron",
+            path.display()
+        ),
+        RegistryUnavailable::Unresolved { error } => {
+            anyhow!("Home registry path cannot be resolved: {error}")
+        }
+        RegistryUnavailable::Incompatible { path, error } => anyhow!(
+            "Home registry at {} is incompatible: {error}; run `lf doctor`",
+            path.display()
+        ),
+    }
+}
+
+fn ensure_cron_placement(wave: &str, authority: &CronAuthority) -> Result<()> {
+    if authority.local_home == authority.placed_home {
+        return Ok(());
+    }
+    Err(anyhow!(
+        "Wave {wave} is placed on Home {}, not local Home {}; run `lf ssh {} cron sync --wave {wave}`",
+        authority.placed_home,
+        authority.local_home,
+        authority.placed_home,
+    ))
+}
+
+fn cron_target_kind(repo: &Path, name: &str) -> Result<CronTargetKind> {
+    match discover_target(repo, name)? {
+        Target::Flow(_) => Ok(CronTargetKind::Flow),
+        Target::Skill(_) => Ok(CronTargetKind::Skill),
+    }
+}
+
+fn cron_specs(authority: &CronAuthority, wave: &str) -> Result<Vec<CronSpec>> {
+    let lf_path = crate::ops::resolve_lf_path()?;
+    crate::engine::wave_config::try_read_wave_config(&authority.repo, wave)?
+        .ok_or_else(|| {
+            anyhow!(
+                "Wave {wave} has no GOAL.md in {}; refusing to prune installed cron jobs",
+                authority.repo.display()
+            )
+        })?
+        .crons
+        .unwrap_or_default()
+        .into_iter()
+        .map(|cron| {
+            let schedule = crate::ops::parse_schedule(&cron.schedule).map_err(|error| {
+                anyhow!(
+                    "{} ({}) cannot be installed: {error}",
+                    cron.flow,
+                    cron.schedule
+                )
+            })?;
+            let target_kind = cron_target_kind(&authority.repo, &cron.flow)?;
+            Ok(CronSpec {
+                wave: wave.to_string(),
+                flow: cron.flow,
+                target_kind,
+                schedule,
+                working_directory: authority.repo.clone(),
+                lf_path: lf_path.clone(),
+                host: authority.host.clone(),
+            })
+        })
+        .collect()
+}
+
+fn require_release_cron_binary() -> Result<()> {
+    if crate::build_info::provenance().is_release() {
+        return Ok(());
+    }
+    Err(anyhow!(
+        "lf cron installation requires an installed release binary; promote this build before configuring launchd"
+    ))
+}
+
+fn cron_receipt_outcome(receipt: &crate::ops::CronReceipt) -> &'static str {
+    if crate::ops::receipt_is_stale(receipt, chrono::Utc::now().timestamp()) {
+        return "stale";
+    }
+    match receipt.outcome {
+        CronOutcome::Running => "running",
+        CronOutcome::Succeeded => "succeeded",
+        CronOutcome::Failed => "failed",
+    }
+}
+
+fn cron_source_name(source: CronSource) -> &'static str {
+    match source {
+        CronSource::Scheduled => "scheduled",
+        CronSource::Manual => "manual",
+    }
 }
 
 fn release_check_cmd(target_name: Option<&str>) -> Result<()> {

--- a/rust/loopflow/src/lf/mod.rs
+++ b/rust/loopflow/src/lf/mod.rs
@@ -1193,17 +1193,73 @@ pub enum CronCommand {
         /// Flow or skill name to run
         #[arg(long = "flow")]
         flow: String,
-        /// Schedule expression. v0 supports `daily`.
+        /// Fixed-daily cron expression, or the `daily` alias
         #[arg(long = "schedule", default_value = "daily")]
         schedule: String,
     },
     /// List installed loopflow cron jobs
-    List,
+    List {
+        /// Only jobs for this Wave
+        #[arg(short = 'w', long = "wave")]
+        wave: Option<String>,
+        /// Emit machine-readable job state
+        #[arg(long)]
+        json: bool,
+    },
+    /// Validate Home authority and declared jobs without changing launchd
+    Preflight {
+        /// Wave whose GOAL.md `crons:` are validated
+        #[arg(short = 'w', long = "wave")]
+        wave: String,
+    },
     /// Reconcile installed launchd jobs to match a wave's declared `crons:`
     Sync {
         /// Wave whose GOAL.md `crons:` drive the installed jobs
         #[arg(short = 'w', long = "wave")]
         wave: String,
+    },
+    /// Execute one installed cron job and persist its terminal receipt
+    #[command(hide = true)]
+    Run {
+        /// Wave whose installed declaration is executed
+        #[arg(short = 'w', long = "wave")]
+        wave: String,
+        /// Flow or skill name to run
+        #[arg(long = "flow")]
+        flow: String,
+        /// Mark a launchd-owned invocation
+        #[arg(long, hide = true)]
+        scheduled: bool,
+    },
+    /// Show durable cron receipts
+    History {
+        /// Wave whose receipts are shown
+        #[arg(short = 'w', long = "wave")]
+        wave: String,
+        /// Only receipts for this flow or skill
+        #[arg(long = "flow")]
+        flow: Option<String>,
+        /// Receipt window in days
+        #[arg(long, default_value_t = 35)]
+        days: u32,
+        /// Emit machine-readable receipts
+        #[arg(long)]
+        json: bool,
+    },
+    /// Ask launchd to fire an installed job
+    Trigger {
+        /// Wave whose installed job is fired
+        #[arg(short = 'w', long = "wave")]
+        wave: String,
+        /// Flow or skill name to run
+        #[arg(long = "flow")]
+        flow: String,
+        /// Wait for and return the scheduled receipt
+        #[arg(long)]
+        wait: bool,
+        /// Maximum wait for a receipt
+        #[arg(long, default_value = "15m")]
+        timeout: String,
     },
     /// Uninstall a scheduled lf invocation
     Remove {

--- a/rust/loopflow/src/ops/cron.rs
+++ b/rust/loopflow/src/ops/cron.rs
@@ -1,28 +1,130 @@
 use std::collections::HashSet;
-use std::fs;
+use std::fs::{self, OpenOptions};
+use std::io::Write;
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::process::{Command, Stdio};
 use std::str::FromStr;
+use std::time::{Duration, Instant};
 
 use chrono::{TimeZone, Timelike, Utc};
+use serde::{Deserialize, Serialize};
 
-use crate::engine::wave_config::WaveCronDef;
+use crate::durable::{CronReceiptId, HomeId};
 use crate::ops::error::{OpsError, OpsResult};
+
+const RECEIPT_STALE_AFTER: i64 = 6 * 60 * 60;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CronHost {
+    pub home_id: HomeId,
+    pub lf_home: PathBuf,
+    pub db_path: PathBuf,
+    pub path_env: String,
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CronSpec {
     pub wave: String,
     pub flow: String,
-    pub schedule: Schedule,
+    pub target_kind: CronTargetKind,
+    pub schedule: CronSchedule,
     pub working_directory: PathBuf,
     pub lf_path: PathBuf,
+    pub host: CronHost,
+}
+
+impl CronSpec {
+    fn log_path(&self) -> PathBuf {
+        self.working_directory.join(format!(
+            ".lf/logs/cron.{}.{}.log",
+            self.wave,
+            self.flow.replace('/', ".")
+        ))
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CronSchedule {
+    expression: String,
+    hour: u32,
+    minute: u32,
+}
+
+impl CronSchedule {
+    pub fn expression(&self) -> &str {
+        &self.expression
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
 #[non_exhaustive]
-pub enum Schedule {
-    /// Fire once a day at a fixed host-local time.
-    DailyAt { hour: u32, minute: u32 },
+pub enum CronTargetKind {
+    Flow,
+    Skill,
+}
+
+impl CronTargetKind {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Flow => "flow",
+            Self::Skill => "skill",
+        }
+    }
+}
+
+impl FromStr for CronTargetKind {
+    type Err = OpsError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "flow" => Ok(Self::Flow),
+            "skill" => Ok(Self::Skill),
+            _ => Err(OpsError::Parse(format!(
+                "unknown cron target kind {value:?}"
+            ))),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum CronSource {
+    Scheduled,
+    Manual,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum CronOutcome {
+    Running,
+    Succeeded,
+    Failed,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+pub struct CronReceipt {
+    pub schema_version: u32,
+    pub id: CronReceiptId,
+    pub runner_pid: u32,
+    pub home_id: HomeId,
+    pub wave: String,
+    pub flow: String,
+    pub target_kind: CronTargetKind,
+    pub source: CronSource,
+    pub schedule: String,
+    pub repo: PathBuf,
+    pub lf_path: PathBuf,
+    pub log_path: PathBuf,
+    pub started_at: i64,
+    pub finished_at: Option<i64>,
+    pub outcome: CronOutcome,
+    pub exit_code: Option<i32>,
+    pub error: Option<String>,
 }
 
 /// Reconcile summary from [`sync_crons`].
@@ -32,29 +134,28 @@ pub struct CronSyncResult {
     pub installed: Vec<InstalledCron>,
     /// Launchd jobs for this wave pruned because the flow is no longer declared.
     pub removed: Vec<InstalledCron>,
-    /// Declared crons launchd can't run, each with the reason.
-    pub skipped: Vec<SkippedCron>,
 }
 
-/// A declared cron the launchd host can't schedule, and why.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct SkippedCron {
-    pub flow: String,
-    pub schedule: String,
-    pub reason: String,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct InstalledCron {
     pub wave: String,
     pub flow: String,
     pub label: String,
     pub path: PathBuf,
+    pub schedule: String,
+    pub target_kind: CronTargetKind,
+    pub home_id: HomeId,
+    pub repo: PathBuf,
+    pub lf_path: PathBuf,
+    pub loaded: bool,
+    pub latest_receipt: Option<CronReceipt>,
 }
 
 pub trait Launchctl {
     fn load(&self, path: &Path) -> OpsResult<()>;
     fn unload(&self, path: &Path) -> OpsResult<()>;
+    fn is_loaded(&self, label: &str) -> OpsResult<bool>;
+    fn trigger(&self, label: &str) -> OpsResult<()>;
 }
 
 #[derive(Debug)]
@@ -62,11 +163,33 @@ pub struct SystemLaunchctl;
 
 impl Launchctl for SystemLaunchctl {
     fn load(&self, path: &Path) -> OpsResult<()> {
-        run_launchctl("load", path)
+        run_launchctl_path("load", path)
     }
 
     fn unload(&self, path: &Path) -> OpsResult<()> {
-        run_launchctl("unload", path)
+        run_launchctl_path("unload", path)
+    }
+
+    fn is_loaded(&self, label: &str) -> OpsResult<bool> {
+        Ok(Command::new("launchctl")
+            .args(["print", &launchd_service(label)?])
+            .output()?
+            .status
+            .success())
+    }
+
+    fn trigger(&self, label: &str) -> OpsResult<()> {
+        let service = launchd_service(label)?;
+        let output = Command::new("launchctl")
+            .args(["kickstart", "-k", &service])
+            .output()?;
+        if output.status.success() {
+            return Ok(());
+        }
+        Err(OpsError::CommandFailed {
+            command: format!("launchctl kickstart -k {service}"),
+            stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+        })
     }
 }
 
@@ -81,9 +204,9 @@ pub fn add_cron(
     if path.exists() {
         let _ = launchctl.unload(&path);
     }
-    fs::write(&path, render_plist(spec))?;
+    write_private_file(&path, render_plist(spec).as_bytes())?;
     launchctl.load(&path)?;
-    Ok(installed_cron(&path, &spec.wave, &spec.flow))
+    inspect_cron(&path, launchctl)
 }
 
 pub fn remove_cron(
@@ -96,13 +219,16 @@ pub fn remove_cron(
     if !path.exists() {
         return Ok(None);
     }
-    let cron = installed_cron(&path, wave, flow);
+    let cron = inspect_cron(&path, launchctl)?;
     launchctl.unload(&path)?;
     fs::remove_file(&path)?;
     Ok(Some(cron))
 }
 
-pub fn list_crons(launch_agents_dir: &Path) -> OpsResult<Vec<InstalledCron>> {
+pub fn list_crons(
+    launch_agents_dir: &Path,
+    launchctl: &dyn Launchctl,
+) -> OpsResult<Vec<InstalledCron>> {
     let mut crons = Vec::new();
     if !launch_agents_dir.is_dir() {
         return Ok(crons);
@@ -113,39 +239,40 @@ pub fn list_crons(launch_agents_dir: &Path) -> OpsResult<Vec<InstalledCron>> {
         let Some(name) = path.file_name().and_then(|name| name.to_str()) else {
             continue;
         };
-        let Some((wave, flow)) = parse_plist_filename(name) else {
+        if !is_cron_plist(name) {
             continue;
-        };
-        crons.push(installed_cron(&path, &wave, &flow));
+        }
+        crons.push(inspect_cron(&path, launchctl)?);
     }
     crons.sort_by(|a, b| a.label.cmp(&b.label));
     Ok(crons)
 }
 
-pub fn parse_schedule(value: &str) -> OpsResult<Schedule> {
+pub fn parse_schedule(value: &str) -> OpsResult<CronSchedule> {
     match value {
-        "daily" => Ok(Schedule::DailyAt { hour: 3, minute: 0 }),
-        _ => Err(OpsError::Parse(format!(
-            "unsupported cron schedule: {value}"
-        ))),
+        "daily" => schedule_from_cron("0 0 3 * * *"),
+        _ => schedule_from_cron(value),
     }
 }
 
-/// The launchd [`Schedule`] for a declared cron expression, or an error
+/// The launchd [`CronSchedule`] for a declared cron expression, or an error
 /// describing why launchd can't run it.
-pub fn schedule_from_cron(expr: &str) -> OpsResult<Schedule> {
+pub fn schedule_from_cron(expr: &str) -> OpsResult<CronSchedule> {
     let (hour, minute) = daily_time_of(expr)?;
-    Ok(Schedule::DailyAt { hour, minute })
+    Ok(CronSchedule {
+        expression: expr.to_string(),
+        hour,
+        minute,
+    })
 }
 
 /// Classify a cron expression as a fixed daily time for launchd.
 ///
 /// launchd `StartCalendarInterval` expresses a repeating wall-clock time, not an
 /// arbitrary cron expression. We accept only schedules that fire once a day at a
-/// fixed hour:minute — parse with the `cron` crate, take two consecutive fires
-/// from a fixed anchor, and require them exactly 24h apart. Anything else
-/// (sub-daily, weekly, multi-time) is an error so the caller skips it rather than
-/// silently mismapping it onto the wrong launchd interval.
+/// fixed hour:minute. Validate more than a full year of consecutive fires so a
+/// weekday, month-day, or annual gap cannot masquerade as daily merely because
+/// its first two occurrences happen to be 24 hours apart.
 ///
 /// # Errors
 /// Returns [`OpsError::Parse`] for an unparseable expression or one that is not a
@@ -161,58 +288,65 @@ pub fn daily_time_of(expr: &str) -> OpsResult<(u32, u32)> {
     let first = fires
         .next()
         .ok_or_else(|| OpsError::Parse(format!("cron schedule '{expr}' never fires")))?;
-    let second = fires
-        .next()
-        .ok_or_else(|| OpsError::Parse(format!("cron schedule '{expr}' fires only once")))?;
-    if second - first != chrono::Duration::hours(24) {
-        return Err(OpsError::Parse(format!(
-            "cron schedule '{expr}' is not a fixed daily time (launchd host supports daily only)"
-        )));
+    let mut prior = first;
+    for _ in 0..370 {
+        let next = fires.next().ok_or_else(|| {
+            OpsError::Parse(format!("cron schedule '{expr}' does not fire daily"))
+        })?;
+        if next - prior != chrono::Duration::hours(24) {
+            return Err(OpsError::Parse(format!(
+                "cron schedule '{expr}' is not a fixed daily time (launchd host supports daily only)"
+            )));
+        }
+        prior = next;
     }
     Ok((first.hour(), first.minute()))
 }
 
-/// Reconcile the launchd jobs for one wave to match its declared crons.
+/// Validate that every spec belongs to one Wave with one entry per target.
 ///
-/// Installs (or replaces) a launchd job per declared cron whose schedule launchd
-/// can run, prunes jobs for this wave whose flow is no longer declared, and
-/// reports declared crons launchd can't run. Idempotent: running it twice against
-/// the same declaration leaves the same jobs installed.
+/// # Errors
+/// Returns [`OpsError::Parse`] when a spec belongs elsewhere or duplicates a
+/// target.
+pub fn validate_cron_specs(wave: &str, specs: &[CronSpec]) -> OpsResult<()> {
+    let mut flows = HashSet::new();
+    for spec in specs {
+        if spec.wave != wave {
+            return Err(OpsError::Parse(format!(
+                "cron target {} belongs to Wave {}, not {wave}",
+                spec.flow, spec.wave
+            )));
+        }
+        if !flows.insert(&spec.flow) {
+            return Err(OpsError::Parse(format!(
+                "Wave {wave} declares cron target {} more than once",
+                spec.flow
+            )));
+        }
+    }
+    Ok(())
+}
+
+/// Reconcile launchd jobs for one wave to its validated declarations.
 pub fn sync_crons(
     launch_agents_dir: &Path,
     wave: &str,
-    declared: &[WaveCronDef],
-    working_directory: &Path,
-    lf_path: &Path,
+    specs: &[CronSpec],
     launchctl: &dyn Launchctl,
 ) -> OpsResult<CronSyncResult> {
-    let mut installed = Vec::new();
-    let mut skipped = Vec::new();
-    let mut desired_flows = HashSet::new();
+    validate_cron_specs(wave, specs)?;
 
-    for cron in declared {
-        match schedule_from_cron(&cron.schedule) {
-            Ok(schedule) => {
-                let spec = CronSpec {
-                    wave: wave.to_string(),
-                    flow: cron.flow.clone(),
-                    schedule,
-                    working_directory: working_directory.to_path_buf(),
-                    lf_path: lf_path.to_path_buf(),
-                };
-                installed.push(add_cron(launch_agents_dir, &spec, launchctl)?);
-                desired_flows.insert(cron.flow.clone());
-            }
-            Err(err) => skipped.push(SkippedCron {
-                flow: cron.flow.clone(),
-                schedule: cron.schedule.clone(),
-                reason: err.to_string(),
-            }),
-        }
+    let desired_flows = specs
+        .iter()
+        .map(|spec| spec.flow.clone())
+        .collect::<HashSet<_>>();
+    let mut installed = Vec::new();
+    for spec in specs {
+        installed.push(add_cron(launch_agents_dir, spec, launchctl)?);
     }
 
     let mut removed = Vec::new();
-    for existing in list_crons(launch_agents_dir)? {
+    for existing in list_crons(launch_agents_dir, launchctl)? {
         if existing.wave == wave && !desired_flows.contains(&existing.flow) {
             if let Some(cron) =
                 remove_cron(launch_agents_dir, &existing.wave, &existing.flow, launchctl)?
@@ -222,11 +356,219 @@ pub fn sync_crons(
         }
     }
 
-    Ok(CronSyncResult {
-        installed,
-        removed,
-        skipped,
-    })
+    Ok(CronSyncResult { installed, removed })
+}
+
+pub fn run_cron(
+    launch_agents_dir: &Path,
+    wave: &str,
+    flow: &str,
+    current_home: &HomeId,
+    placed_home: &HomeId,
+    source: CronSource,
+) -> OpsResult<CronReceipt> {
+    let path = plist_path(launch_agents_dir, wave, flow);
+    let spec = read_cron_spec(&path)?;
+    validate_installed_spec(&spec, wave, flow)?;
+    let root = receipt_root(&spec.host.lf_home);
+    let mut receipt = new_receipt(&spec, current_home, source);
+    write_receipt(&root, &receipt)?;
+
+    let placement_error = if spec.host.home_id != *placed_home {
+        Some(format!(
+            "installed for Home {}, but Wave {wave} is placed on {placed_home}; run `lf cron sync --wave {wave}` on the placed Home",
+            spec.host.home_id
+        ))
+    } else if *current_home != *placed_home {
+        Some(format!(
+            "current Home is {current_home}, but Wave {wave} is placed on {placed_home}"
+        ))
+    } else {
+        None
+    };
+    if let Some(error) = placement_error {
+        receipt.finished_at = Some(Utc::now().timestamp());
+        receipt.outcome = CronOutcome::Failed;
+        receipt.error = Some(error.clone());
+        write_receipt(&root, &receipt)?;
+        return Err(OpsError::Message(format!(
+            "refusing cron {wave}/{flow}: {error}"
+        )));
+    }
+
+    let result = spawn_cron_target(&spec);
+    receipt.finished_at = Some(Utc::now().timestamp());
+    match result {
+        Ok(status) if status.success() => {
+            receipt.outcome = CronOutcome::Succeeded;
+            receipt.exit_code = status.code();
+            write_receipt(&root, &receipt)?;
+            Ok(receipt)
+        }
+        Ok(status) => {
+            receipt.outcome = CronOutcome::Failed;
+            receipt.exit_code = status.code();
+            receipt.error = Some(format!(
+                "target exited {}; see {}",
+                status_label(&status),
+                receipt.log_path.display()
+            ));
+            write_receipt(&root, &receipt)?;
+            Err(OpsError::CommandFailed {
+                command: format!("cron {wave}/{flow}"),
+                stderr: receipt.error.clone().unwrap_or_default(),
+            })
+        }
+        Err(error) => {
+            receipt.outcome = CronOutcome::Failed;
+            receipt.error = Some(format!(
+                "could not start target: {error}; see {}",
+                receipt.log_path.display()
+            ));
+            write_receipt(&root, &receipt)?;
+            Err(OpsError::CommandFailed {
+                command: format!("cron {wave}/{flow}"),
+                stderr: receipt.error.clone().unwrap_or_default(),
+            })
+        }
+    }
+}
+
+/// Persist a terminal receipt when scheduled execution cannot read its Home
+/// placement authority. The installed plist still supplies the durable receipt
+/// location and non-secret job identity; no target is started.
+pub fn record_cron_preflight_failure(
+    launch_agents_dir: &Path,
+    wave: &str,
+    flow: &str,
+    source: CronSource,
+    error: &str,
+) -> OpsResult<CronReceipt> {
+    let spec = read_cron_spec(&plist_path(launch_agents_dir, wave, flow))?;
+    validate_installed_spec(&spec, wave, flow)?;
+    let root = receipt_root(&spec.host.lf_home);
+    let mut receipt = new_receipt(&spec, &spec.host.home_id, source);
+    write_receipt(&root, &receipt)?;
+    receipt.finished_at = Some(Utc::now().timestamp());
+    receipt.outcome = CronOutcome::Failed;
+    receipt.error = Some(format!("Home placement preflight failed: {error}"));
+    write_receipt(&root, &receipt)?;
+    Ok(receipt)
+}
+
+pub fn receipt_root(lf_home: &Path) -> PathBuf {
+    lf_home.join("cron/receipts")
+}
+
+pub fn list_cron_receipts(
+    root: &Path,
+    wave: &str,
+    flow: Option<&str>,
+    days: u32,
+) -> OpsResult<Vec<CronReceipt>> {
+    let since = Utc::now()
+        .timestamp()
+        .saturating_sub(i64::from(days).saturating_mul(24 * 60 * 60));
+    let mut receipts = read_receipts(root, wave, flow)?;
+    receipts.retain(|receipt| receipt.started_at >= since);
+    receipts.sort_by(|left, right| {
+        right
+            .started_at
+            .cmp(&left.started_at)
+            .then_with(|| right.id.as_str().cmp(left.id.as_str()))
+    });
+    Ok(receipts)
+}
+
+pub fn latest_cron_receipt(root: &Path, wave: &str, flow: &str) -> OpsResult<Option<CronReceipt>> {
+    let mut receipts = read_receipts(root, wave, Some(flow))?;
+    receipts.sort_by_key(|receipt| receipt.started_at);
+    Ok(receipts.pop())
+}
+
+pub(crate) fn cron_receipt_ids(
+    root: &Path,
+    wave: &str,
+    flow: &str,
+) -> OpsResult<Vec<CronReceiptId>> {
+    Ok(read_receipts(root, wave, Some(flow))?
+        .into_iter()
+        .map(|receipt| receipt.id)
+        .collect())
+}
+
+pub fn receipt_is_stale(receipt: &CronReceipt, now: i64) -> bool {
+    receipt.outcome == CronOutcome::Running
+        && (now.saturating_sub(receipt.started_at) >= RECEIPT_STALE_AFTER
+            || !process_alive(receipt.runner_pid))
+}
+
+pub fn trigger_cron(launchctl: &dyn Launchctl, wave: &str, flow: &str) -> OpsResult<()> {
+    launchctl.trigger(&label(wave, flow))
+}
+
+pub fn wait_for_cron_receipt(
+    root: &Path,
+    wave: &str,
+    flow: &str,
+    prior_receipts: &[CronReceiptId],
+    started_after: i64,
+    timeout: Duration,
+) -> OpsResult<CronReceipt> {
+    let deadline = Instant::now() + timeout;
+    loop {
+        let now = Utc::now().timestamp();
+        let mut receipts = read_receipts(root, wave, Some(flow))?;
+        receipts.retain(|receipt| {
+            receipt.source == CronSource::Scheduled
+                && !prior_receipts.contains(&receipt.id)
+                && receipt.started_at >= started_after
+                && (receipt.outcome != CronOutcome::Running || receipt_is_stale(receipt, now))
+        });
+        receipts.sort_by(|left, right| {
+            right
+                .started_at
+                .cmp(&left.started_at)
+                .then_with(|| right.id.as_str().cmp(left.id.as_str()))
+        });
+        if let Some(receipt) = receipts.into_iter().next() {
+            return Ok(receipt);
+        }
+        if Instant::now() >= deadline {
+            return Err(OpsError::Message(format!(
+                "timed out after {}s waiting for cron {wave}/{flow}; inspect `lf cron history --wave {wave} --flow {flow}`",
+                timeout.as_secs()
+            )));
+        }
+        std::thread::sleep(Duration::from_millis(250));
+    }
+}
+
+pub fn parse_wait_duration(value: &str) -> OpsResult<Duration> {
+    let value = value.trim();
+    let (number, multiplier) = if let Some(number) = value.strip_suffix('s') {
+        (number, 1)
+    } else if let Some(number) = value.strip_suffix('m') {
+        (number, 60)
+    } else if let Some(number) = value.strip_suffix('h') {
+        (number, 60 * 60)
+    } else {
+        (value, 1)
+    };
+    let amount: u64 = number.parse().map_err(|_| {
+        OpsError::Parse(format!(
+            "invalid duration {value:?}; use seconds, 10s, 5m, or 1h"
+        ))
+    })?;
+    let seconds = amount
+        .checked_mul(multiplier)
+        .ok_or_else(|| OpsError::Parse(format!("duration {value:?} is larger than 24h")))?;
+    if seconds == 0 || seconds > 24 * 60 * 60 {
+        return Err(OpsError::Parse(format!(
+            "duration {value:?} must be between 1s and 24h"
+        )));
+    }
+    Ok(Duration::from_secs(seconds))
 }
 
 pub fn default_launch_agents_dir() -> OpsResult<PathBuf> {
@@ -239,54 +581,282 @@ pub fn resolve_lf_path() -> OpsResult<PathBuf> {
     std::env::current_exe().map_err(Into::into)
 }
 
-fn plist_path(dir: &Path, wave: &str, flow: &str) -> PathBuf {
-    dir.join(format!("{}.plist", label(wave, flow).replace('/', ".")))
+fn inspect_cron(path: &Path, launchctl: &dyn Launchctl) -> OpsResult<InstalledCron> {
+    let spec = read_cron_spec(path)?;
+    let label = label(&spec.wave, &spec.flow);
+    Ok(InstalledCron {
+        wave: spec.wave.clone(),
+        flow: spec.flow.clone(),
+        label: label.clone(),
+        path: path.to_path_buf(),
+        schedule: spec.schedule.expression().to_string(),
+        target_kind: spec.target_kind,
+        home_id: spec.host.home_id.clone(),
+        repo: spec.working_directory.clone(),
+        lf_path: spec.lf_path.clone(),
+        loaded: launchctl.is_loaded(&label)?,
+        latest_receipt: latest_cron_receipt(
+            &receipt_root(&spec.host.lf_home),
+            &spec.wave,
+            &spec.flow,
+        )?,
+    })
 }
 
-fn installed_cron(path: &Path, wave: &str, flow: &str) -> InstalledCron {
-    InstalledCron {
-        wave: wave.to_string(),
-        flow: flow.to_string(),
-        label: label(wave, flow),
-        path: path.to_path_buf(),
+fn read_cron_spec(path: &Path) -> OpsResult<CronSpec> {
+    let content = fs::read_to_string(path).map_err(|error| {
+        OpsError::Message(format!(
+            "cron is not installed at {}: {error}",
+            path.display()
+        ))
+    })?;
+    let required = |key: &str| {
+        plist_string(&content, key).ok_or_else(|| {
+            OpsError::Parse(format!(
+                "{} is missing required {key} metadata; run `lf cron sync --wave <wave>`",
+                path.display()
+            ))
+        })
+    };
+    Ok(CronSpec {
+        wave: required("LoopflowWave")?,
+        flow: required("LoopflowFlow")?,
+        target_kind: required("LoopflowTargetKind")?.parse()?,
+        schedule: schedule_from_cron(&required("LoopflowSchedule")?)?,
+        working_directory: PathBuf::from(required("LoopflowRepo")?),
+        lf_path: PathBuf::from(required("LoopflowLfPath")?),
+        host: CronHost {
+            home_id: HomeId::parse(&required("LoopflowHomeId")?)
+                .map_err(|error| OpsError::Parse(error.to_string()))?,
+            lf_home: PathBuf::from(required("LoopflowLfHome")?),
+            db_path: PathBuf::from(required("LoopflowDbPath")?),
+            path_env: required("LoopflowPath")?,
+        },
+    })
+}
+
+fn spawn_cron_target(spec: &CronSpec) -> std::io::Result<std::process::ExitStatus> {
+    if let Some(parent) = spec.log_path().parent() {
+        fs::create_dir_all(parent)?;
     }
+    let stdout = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(spec.log_path())?;
+    let stderr = stdout.try_clone()?;
+    let mut command = Command::new(&spec.lf_path);
+    command
+        .args([
+            "--wave",
+            &spec.wave,
+            "--batch",
+            spec.target_kind.as_str(),
+            &spec.flow,
+        ])
+        .current_dir(&spec.working_directory)
+        .env_clear()
+        .env("PATH", &spec.host.path_env)
+        .env("LF_HOME", &spec.host.lf_home)
+        .env("LF_DB_PATH", &spec.host.db_path)
+        .stdout(Stdio::from(stdout))
+        .stderr(Stdio::from(stderr));
+    if let Some(home) = dirs::home_dir() {
+        command.env("HOME", home);
+    }
+    for key in ["USER", "TMPDIR", "LANG", "LC_ALL", "LC_CTYPE"] {
+        if let Some(value) = std::env::var_os(key) {
+            command.env(key, value);
+        }
+    }
+    command.status()
+}
+
+fn validate_installed_spec(spec: &CronSpec, wave: &str, flow: &str) -> OpsResult<()> {
+    if spec.wave == wave && spec.flow == flow {
+        return Ok(());
+    }
+    Err(OpsError::Message(format!(
+        "installed cron metadata names {}/{} instead of {wave}/{flow}",
+        spec.wave, spec.flow
+    )))
+}
+
+fn new_receipt(spec: &CronSpec, home_id: &HomeId, source: CronSource) -> CronReceipt {
+    CronReceipt {
+        schema_version: 1,
+        id: CronReceiptId::new(),
+        runner_pid: std::process::id(),
+        home_id: home_id.clone(),
+        wave: spec.wave.clone(),
+        flow: spec.flow.clone(),
+        target_kind: spec.target_kind,
+        source,
+        schedule: spec.schedule.expression().to_string(),
+        repo: spec.working_directory.clone(),
+        lf_path: spec.lf_path.clone(),
+        log_path: spec.log_path(),
+        started_at: Utc::now().timestamp(),
+        finished_at: None,
+        outcome: CronOutcome::Running,
+        exit_code: None,
+        error: None,
+    }
+}
+
+fn read_receipts(root: &Path, wave: &str, flow: Option<&str>) -> OpsResult<Vec<CronReceipt>> {
+    let wave_root = root.join(safe_component(wave));
+    if !wave_root.is_dir() {
+        return Ok(Vec::new());
+    }
+    let flow_dirs = match flow {
+        Some(flow) => vec![wave_root.join(safe_component(flow))],
+        None => fs::read_dir(&wave_root)?
+            .filter_map(Result::ok)
+            .filter_map(|entry| entry.file_type().ok()?.is_dir().then_some(entry.path()))
+            .collect(),
+    };
+    let mut receipts = Vec::new();
+    for dir in flow_dirs {
+        if !dir.is_dir() {
+            continue;
+        }
+        for entry in fs::read_dir(dir)? {
+            let entry = entry?;
+            if entry.path().extension().and_then(|value| value.to_str()) != Some("json") {
+                continue;
+            }
+            let bytes = fs::read(entry.path())?;
+            let receipt: CronReceipt = serde_json::from_slice(&bytes).map_err(|error| {
+                OpsError::Parse(format!(
+                    "invalid cron receipt {}: {error}",
+                    entry.path().display()
+                ))
+            })?;
+            if receipt.schema_version != 1 {
+                return Err(OpsError::Parse(format!(
+                    "unsupported cron receipt schema {} in {}",
+                    receipt.schema_version,
+                    entry.path().display()
+                )));
+            }
+            if receipt.wave == wave && flow.is_none_or(|flow| receipt.flow == flow) {
+                receipts.push(receipt);
+            }
+        }
+    }
+    Ok(receipts)
+}
+
+fn write_receipt(root: &Path, receipt: &CronReceipt) -> OpsResult<()> {
+    let dir = root
+        .join(safe_component(&receipt.wave))
+        .join(safe_component(&receipt.flow));
+    fs::create_dir_all(&dir)?;
+    #[cfg(unix)]
+    fs::set_permissions(&dir, fs::Permissions::from_mode(0o700))?;
+    let path = dir.join(format!(
+        "{}-{}.json",
+        receipt.started_at,
+        receipt.id.as_str()
+    ));
+    let temporary = dir.join(format!(".{}.tmp", receipt.id.as_str()));
+    let bytes = serde_json::to_vec_pretty(receipt)
+        .map_err(|error| OpsError::Parse(format!("serialize cron receipt: {error}")))?;
+    write_private_file(&temporary, &bytes)?;
+    fs::rename(&temporary, path)?;
+    sync_directory(&dir)?;
+    Ok(())
+}
+
+fn write_private_file(path: &Path, bytes: &[u8]) -> OpsResult<()> {
+    let mut file = OpenOptions::new()
+        .create(true)
+        .truncate(true)
+        .write(true)
+        .open(path)?;
+    #[cfg(unix)]
+    {
+        file.set_permissions(fs::Permissions::from_mode(0o600))?;
+    }
+    file.write_all(bytes)?;
+    file.sync_all()?;
+    Ok(())
+}
+
+fn sync_directory(path: &Path) -> OpsResult<()> {
+    #[cfg(unix)]
+    fs::File::open(path)?.sync_all()?;
+    Ok(())
+}
+
+fn plist_path(dir: &Path, wave: &str, flow: &str) -> PathBuf {
+    dir.join(format!("{}.plist", label(wave, flow).replace('/', ".")))
 }
 
 fn label(wave: &str, flow: &str) -> String {
     format!("loopflow.cron.{wave}.{flow}").replace('/', ".")
 }
 
-fn parse_plist_filename(name: &str) -> Option<(String, String)> {
-    let stem = name
-        .strip_prefix("loopflow.cron.")?
-        .strip_suffix(".plist")?;
-    let mut parts = stem.splitn(2, '.');
-    let wave = parts.next()?.to_string();
-    let flow = parts.next()?.to_string();
-    if wave.is_empty() || flow.is_empty() {
-        None
-    } else {
-        Some((wave, flow))
-    }
+fn is_cron_plist(name: &str) -> bool {
+    name.strip_prefix("loopflow.cron.")
+        .and_then(|name| name.strip_suffix(".plist"))
+        .is_some_and(|name| !name.is_empty())
 }
 
 fn render_plist(spec: &CronSpec) -> String {
-    let interval = match spec.schedule {
-        Schedule::DailyAt { hour, minute } => format!(
-            "    <key>StartCalendarInterval</key>\n    <dict>\n        <key>Hour</key>\n        <integer>{hour}</integer>\n        <key>Minute</key>\n        <integer>{minute}</integer>\n    </dict>"
-        ),
-    };
+    let interval = format!(
+        "    <key>StartCalendarInterval</key>\n    <dict>\n        <key>Hour</key>\n        <integer>{}</integer>\n        <key>Minute</key>\n        <integer>{}</integer>\n    </dict>",
+        spec.schedule.hour, spec.schedule.minute
+    );
     let args = [
         spec.lf_path.to_string_lossy().to_string(),
-        spec.flow.clone(),
+        "cron".to_string(),
+        "run".to_string(),
+        "--scheduled".to_string(),
         "--wave".to_string(),
         spec.wave.clone(),
+        "--flow".to_string(),
+        spec.flow.clone(),
     ];
     let program_args_xml = args
         .iter()
         .map(|arg| format!("        <string>{}</string>", xml_escape(arg)))
         .collect::<Vec<_>>()
         .join("\n");
+    let metadata = [
+        ("LoopflowWave", spec.wave.clone()),
+        ("LoopflowFlow", spec.flow.clone()),
+        ("LoopflowTargetKind", spec.target_kind.as_str().to_string()),
+        ("LoopflowSchedule", spec.schedule.expression.clone()),
+        ("LoopflowHomeId", spec.host.home_id.to_string()),
+        (
+            "LoopflowRepo",
+            spec.working_directory.to_string_lossy().to_string(),
+        ),
+        ("LoopflowLfPath", spec.lf_path.to_string_lossy().to_string()),
+        (
+            "LoopflowLfHome",
+            spec.host.lf_home.to_string_lossy().to_string(),
+        ),
+        (
+            "LoopflowDbPath",
+            spec.host.db_path.to_string_lossy().to_string(),
+        ),
+        ("LoopflowPath", spec.host.path_env.clone()),
+        (
+            "LoopflowLogPath",
+            spec.log_path().to_string_lossy().to_string(),
+        ),
+    ]
+    .iter()
+    .map(|(key, value)| {
+        format!(
+            "    <key>{key}</key>\n    <string>{}</string>",
+            xml_escape(value)
+        )
+    })
+    .collect::<Vec<_>>()
+    .join("\n");
 
     format!(
         r#"<?xml version="1.0" encoding="UTF-8"?>
@@ -295,10 +865,20 @@ fn render_plist(spec: &CronSpec) -> String {
 <dict>
     <key>Label</key>
     <string>{label}</string>
+{metadata}
     <key>ProgramArguments</key>
     <array>
 {program_args_xml}
     </array>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>{path_env}</string>
+        <key>LF_HOME</key>
+        <string>{lf_home}</string>
+        <key>LF_DB_PATH</key>
+        <string>{db_path}</string>
+    </dict>
 {interval}
     <key>WorkingDirectory</key>
     <string>{working_directory}</string>
@@ -310,14 +890,20 @@ fn render_plist(spec: &CronSpec) -> String {
 </plist>
 "#,
         label = xml_escape(&label(&spec.wave, &spec.flow)),
+        path_env = xml_escape(&spec.host.path_env),
+        lf_home = xml_escape(&spec.host.lf_home.to_string_lossy()),
+        db_path = xml_escape(&spec.host.db_path.to_string_lossy()),
         working_directory = xml_escape(&spec.working_directory.to_string_lossy()),
-        log_path = xml_escape(&format!(
-            "{}/.lf/logs/cron.{}.{}.log",
-            spec.working_directory.display(),
-            spec.wave,
-            spec.flow.replace('/', ".")
-        )),
+        log_path = xml_escape(&spec.log_path().to_string_lossy()),
     )
+}
+
+fn plist_string(content: &str, key: &str) -> Option<String> {
+    let marker = format!("<key>{key}</key>");
+    let value = content.split_once(&marker)?.1;
+    let value = value.split_once("<string>")?.1;
+    let value = value.split_once("</string>")?.0;
+    Some(xml_unescape(value))
 }
 
 fn xml_escape(value: &str) -> String {
@@ -329,7 +915,41 @@ fn xml_escape(value: &str) -> String {
         .replace('\'', "&apos;")
 }
 
-fn run_launchctl(action: &str, path: &Path) -> OpsResult<()> {
+fn xml_unescape(value: &str) -> String {
+    value
+        .replace("&apos;", "'")
+        .replace("&quot;", "\"")
+        .replace("&gt;", ">")
+        .replace("&lt;", "<")
+        .replace("&amp;", "&")
+}
+
+fn safe_component(value: &str) -> String {
+    value
+        .chars()
+        .map(|character| {
+            if character.is_ascii_alphanumeric() || matches!(character, '-' | '_' | '.') {
+                character
+            } else {
+                '_'
+            }
+        })
+        .collect()
+}
+
+fn launchd_service(label: &str) -> OpsResult<String> {
+    let output = Command::new("id").arg("-u").output()?;
+    if !output.status.success() {
+        return Err(OpsError::CommandFailed {
+            command: "id -u".to_string(),
+            stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+        });
+    }
+    let uid = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    Ok(format!("gui/{uid}/{label}"))
+}
+
+fn run_launchctl_path(action: &str, path: &Path) -> OpsResult<()> {
     let output = Command::new("launchctl").arg(action).arg(path).output()?;
     if output.status.success() {
         return Ok(());
@@ -340,6 +960,23 @@ fn run_launchctl(action: &str, path: &Path) -> OpsResult<()> {
     })
 }
 
+fn process_alive(pid: u32) -> bool {
+    let Ok(pid) = i32::try_from(pid) else {
+        return false;
+    };
+    // SAFETY: signal 0 does not mutate the target; it only checks whether the
+    // process exists and is signalable by this user.
+    let result = unsafe { libc::kill(pid, 0) };
+    result == 0 || std::io::Error::last_os_error().raw_os_error() == Some(libc::EPERM)
+}
+
+fn status_label(status: &std::process::ExitStatus) -> String {
+    status
+        .code()
+        .map(|code| format!("with status {code}"))
+        .unwrap_or_else(|| "after a signal".to_string())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -347,178 +984,459 @@ mod tests {
 
     #[derive(Debug, Default)]
     struct FakeLaunchctl {
-        calls: RefCell<Vec<String>>,
+        loaded: RefCell<HashSet<String>>,
     }
 
     impl Launchctl for FakeLaunchctl {
         fn load(&self, path: &Path) -> OpsResult<()> {
-            self.calls
-                .borrow_mut()
-                .push(format!("load {}", path.display()));
+            let content = fs::read_to_string(path)?;
+            let wave = plist_string(&content, "LoopflowWave")
+                .ok_or_else(|| OpsError::Parse("missing wave".to_string()))?;
+            let flow = plist_string(&content, "LoopflowFlow")
+                .ok_or_else(|| OpsError::Parse("missing flow".to_string()))?;
+            self.loaded.borrow_mut().insert(label(&wave, &flow));
             Ok(())
         }
 
         fn unload(&self, path: &Path) -> OpsResult<()> {
-            self.calls
-                .borrow_mut()
-                .push(format!("unload {}", path.display()));
+            if let Ok(content) = fs::read_to_string(path) {
+                if let (Some(wave), Some(flow)) = (
+                    plist_string(&content, "LoopflowWave"),
+                    plist_string(&content, "LoopflowFlow"),
+                ) {
+                    self.loaded.borrow_mut().remove(&label(&wave, &flow));
+                }
+            }
             Ok(())
+        }
+
+        fn is_loaded(&self, label: &str) -> OpsResult<bool> {
+            Ok(self.loaded.borrow().contains(label))
+        }
+
+        fn trigger(&self, label: &str) -> OpsResult<()> {
+            if self.loaded.borrow().contains(label) {
+                Ok(())
+            } else {
+                Err(OpsError::Message(format!("{label} is not loaded")))
+            }
+        }
+    }
+
+    fn host(root: &Path) -> CronHost {
+        CronHost {
+            home_id: HomeId::new(),
+            lf_home: root.join("home"),
+            db_path: root.join("home/loopflow.db"),
+            path_env: "/usr/bin:/bin".to_string(),
+        }
+    }
+
+    fn spec(root: &Path, lf_path: &Path) -> CronSpec {
+        named_spec(
+            root,
+            lf_path,
+            "reliability",
+            "wave-report",
+            "0 0 3 * * *",
+            CronTargetKind::Flow,
+        )
+    }
+
+    fn named_spec(
+        root: &Path,
+        lf_path: &Path,
+        wave: &str,
+        flow: &str,
+        schedule: &str,
+        target_kind: CronTargetKind,
+    ) -> CronSpec {
+        CronSpec {
+            wave: wave.to_string(),
+            flow: flow.to_string(),
+            target_kind,
+            schedule: parse_schedule(schedule).unwrap(),
+            working_directory: root.join("repo"),
+            lf_path: lf_path.to_path_buf(),
+            host: host(root),
         }
     }
 
     #[test]
-    fn add_list_remove_round_trips_launchd_plist() {
+    fn add_list_remove_round_trips_loaded_launchd_spec() {
         let temp = tempfile::TempDir::new().unwrap();
         let launchctl = FakeLaunchctl::default();
-        let spec = CronSpec {
-            wave: "reliability".to_string(),
-            flow: "wave-report".to_string(),
-            schedule: Schedule::DailyAt { hour: 3, minute: 0 },
-            working_directory: temp.path().join("repo"),
-            lf_path: PathBuf::from("/bin/lf"),
-        };
+        let spec = spec(temp.path(), Path::new("/usr/bin/true"));
         fs::create_dir_all(&spec.working_directory).unwrap();
 
         let installed = add_cron(temp.path(), &spec, &launchctl).unwrap();
         assert_eq!(installed.label, "loopflow.cron.reliability.wave-report");
-        assert!(installed.path.exists());
-        assert!(spec.working_directory.join(".lf/logs").is_dir());
+        assert!(installed.loaded);
+        assert_eq!(installed.schedule, "0 0 3 * * *");
+        assert_eq!(installed.home_id, spec.host.home_id);
+        assert_eq!(
+            fs::metadata(&installed.path).unwrap().permissions().mode() & 0o777,
+            0o600
+        );
+
+        #[cfg(target_os = "macos")]
+        assert!(Command::new("plutil")
+            .args(["-lint", installed.path.to_str().unwrap()])
+            .output()
+            .unwrap()
+            .status
+            .success());
 
         let content = fs::read_to_string(&installed.path).unwrap();
-        assert!(content.contains("<string>/bin/lf</string>"));
-        assert!(content.contains("<string>wave-report</string>"));
-        assert!(content.contains("<string>--wave</string>"));
-        assert!(content.contains("<string>reliability</string>"));
-        assert!(content.contains("<key>StartCalendarInterval</key>"));
-        assert!(content.contains(&format!(
-            "<string>{}</string>",
-            spec.working_directory.display()
-        )));
+        assert!(content.contains("<string>cron</string>"));
+        assert!(content.contains("<string>run</string>"));
+        assert!(content.contains("<string>--scheduled</string>"));
+        assert!(content.contains("<key>EnvironmentVariables</key>"));
+        assert!(content.contains("<key>PATH</key>"));
+        assert!(content.contains("<key>LF_HOME</key>"));
+        assert!(content.contains("<key>LF_DB_PATH</key>"));
+        assert!(!content.contains("DOPPLER_TOKEN"));
+        assert!(!content.contains("LF_RUN_LEASE"));
 
-        let crons = list_crons(temp.path()).unwrap();
-        assert_eq!(crons, vec![installed.clone()]);
+        assert_eq!(
+            list_crons(temp.path(), &launchctl).unwrap(),
+            vec![installed.clone()]
+        );
 
         let removed = remove_cron(temp.path(), "reliability", "wave-report", &launchctl).unwrap();
         assert_eq!(removed, Some(installed.clone()));
         assert!(!installed.path.exists());
+    }
+
+    #[test]
+    fn list_rejects_a_loopflow_job_without_durable_metadata() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let path = temp.path().join("loopflow.cron.legacy.job.plist");
+        fs::write(
+            path,
+            "<plist><dict><key>Label</key><string>loopflow.cron.legacy.job</string></dict></plist>",
+        )
+        .unwrap();
+
+        let error = list_crons(temp.path(), &FakeLaunchctl::default()).unwrap_err();
+        assert!(error.to_string().contains("missing required LoopflowWave"));
+        assert!(error.to_string().contains("lf cron sync"));
+    }
+
+    #[test]
+    fn parse_schedule_accepts_alias_and_cron_expression() {
         assert_eq!(
-            launchctl.calls.borrow().as_slice(),
-            &[
-                format!("load {}", installed.path.display()),
-                format!("unload {}", installed.path.display())
-            ]
+            parse_schedule("daily").unwrap(),
+            CronSchedule {
+                expression: "0 0 3 * * *".to_string(),
+                hour: 3,
+                minute: 0,
+            }
         );
-    }
-
-    #[test]
-    fn parse_schedule_rejects_unknown_values() {
-        let err = parse_schedule("hourly").unwrap_err();
-        assert!(err.to_string().contains("unsupported cron schedule"));
-    }
-
-    #[test]
-    fn daily_time_of_extracts_fixed_hour_minute() {
-        // sec min hour dom month dow -> 09:00 every day
-        assert_eq!(daily_time_of("0 0 9 * * *").unwrap(), (9, 0));
-        assert_eq!(daily_time_of("0 30 17 * * *").unwrap(), (17, 30));
+        assert_eq!(
+            parse_schedule("0 30 17 * * *").unwrap(),
+            CronSchedule {
+                expression: "0 30 17 * * *".to_string(),
+                hour: 17,
+                minute: 30,
+            }
+        );
     }
 
     #[test]
     fn daily_time_of_rejects_non_daily_schedules() {
-        // Hourly fires 24x/day, not a single daily time.
         assert!(daily_time_of("0 0 * * * *").is_err());
-        // Weekly (only Mondays) is not a fixed daily time either.
         assert!(daily_time_of("0 0 9 * * MON").is_err());
-        // Garbage.
+        assert!(daily_time_of("0 0 9 * * MON-FRI *").is_err());
+        assert!(daily_time_of("0 0 9 1 * * *").is_err());
         assert!(daily_time_of("not a schedule").is_err());
     }
 
     #[test]
-    fn schedule_from_cron_maps_to_daily_at() {
-        assert_eq!(
-            schedule_from_cron("0 0 9 * * *").unwrap(),
-            Schedule::DailyAt { hour: 9, minute: 0 }
+    fn sync_validates_all_specs_before_installing() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let agents = temp.path().join("agents");
+        let launchctl = FakeLaunchctl::default();
+        let misplaced = named_spec(
+            temp.path(),
+            Path::new("/usr/bin/true"),
+            "other",
+            "telemetry-daily",
+            "0 0 9 * * *",
+            CronTargetKind::Flow,
         );
+        let error = sync_crons(&agents, "infra", &[misplaced], &launchctl).unwrap_err();
+        assert!(error.to_string().contains("belongs to Wave other"));
+        assert!(!agents.exists());
+
+        let duplicate = named_spec(
+            temp.path(),
+            Path::new("/usr/bin/true"),
+            "infra",
+            "telemetry-daily",
+            "0 0 9 * * *",
+            CronTargetKind::Flow,
+        );
+        let error = sync_crons(
+            &agents,
+            "infra",
+            &[duplicate.clone(), duplicate],
+            &launchctl,
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("more than once"));
+        assert!(!agents.exists());
     }
 
     #[test]
     fn sync_installs_declared_and_prunes_undeclared() {
         let temp = tempfile::TempDir::new().unwrap();
         let agents = temp.path().join("agents");
-        let repo = temp.path().join("repo");
-        fs::create_dir_all(&repo).unwrap();
         let launchctl = FakeLaunchctl::default();
-        let lf_path = PathBuf::from("/bin/lf");
-
-        // First sync: one declared cron installs one launchd job.
-        let first = sync_crons(
-            &agents,
+        let telemetry = named_spec(
+            temp.path(),
+            Path::new("/usr/bin/true"),
             "infra",
-            &[WaveCronDef {
-                flow: "telemetry-daily".to_string(),
-                schedule: "0 0 9 * * *".to_string(),
-            }],
-            &repo,
-            &lf_path,
-            &launchctl,
-        )
-        .unwrap();
+            "telemetry-daily",
+            "0 0 9 * * *",
+            CronTargetKind::Flow,
+        );
+        let first = sync_crons(&agents, "infra", &[telemetry], &launchctl).unwrap();
         assert_eq!(first.installed.len(), 1);
         assert!(first.removed.is_empty());
-        assert!(first.skipped.is_empty());
-        let installed = &first.installed[0];
-        assert_eq!(installed.flow, "telemetry-daily");
-        let plist = fs::read_to_string(&installed.path).unwrap();
-        assert!(plist.contains("<integer>9</integer>"));
 
-        // Second sync with a different flow: the old job is pruned, the new one installed.
-        let second = sync_crons(
-            &agents,
+        let release = named_spec(
+            temp.path(),
+            Path::new("/usr/bin/true"),
             "infra",
-            &[WaveCronDef {
-                flow: "release-check".to_string(),
-                schedule: "0 0 6 * * *".to_string(),
-            }],
-            &repo,
-            &lf_path,
-            &launchctl,
-        )
-        .unwrap();
-        assert_eq!(second.installed.len(), 1);
-        assert_eq!(second.installed[0].flow, "release-check");
-        assert_eq!(second.removed.len(), 1);
+            "release-run",
+            "0 0 10 * * *",
+            CronTargetKind::Skill,
+        );
+        let second = sync_crons(&agents, "infra", &[release], &launchctl).unwrap();
+        assert_eq!(second.installed[0].flow, "release-run");
         assert_eq!(second.removed[0].flow, "telemetry-daily");
-
-        // Empty declaration prunes everything for the wave.
-        let third = sync_crons(&agents, "infra", &[], &repo, &lf_path, &launchctl).unwrap();
-        assert!(third.installed.is_empty());
-        assert_eq!(third.removed.len(), 1);
-        assert!(list_crons(&agents).unwrap().is_empty());
     }
 
     #[test]
-    fn sync_skips_schedules_launchd_cannot_run() {
+    fn runner_persists_success_and_failure_receipts() {
         let temp = tempfile::TempDir::new().unwrap();
         let agents = temp.path().join("agents");
-        let repo = temp.path().join("repo");
-        fs::create_dir_all(&repo).unwrap();
         let launchctl = FakeLaunchctl::default();
+        let success = spec(temp.path(), Path::new("/usr/bin/true"));
+        fs::create_dir_all(&success.working_directory).unwrap();
+        add_cron(&agents, &success, &launchctl).unwrap();
 
-        let result = sync_crons(
+        let receipt = run_cron(
             &agents,
-            "infra",
-            &[WaveCronDef {
-                flow: "hourly-thing".to_string(),
-                schedule: "0 0 * * * *".to_string(),
-            }],
-            &repo,
-            &PathBuf::from("/bin/lf"),
-            &launchctl,
+            &success.wave,
+            &success.flow,
+            &success.host.home_id,
+            &success.host.home_id,
+            CronSource::Manual,
         )
         .unwrap();
-        assert!(result.installed.is_empty());
-        assert_eq!(result.skipped.len(), 1);
-        assert_eq!(result.skipped[0].flow, "hourly-thing");
-        assert!(list_crons(&agents).unwrap().is_empty());
+        assert_eq!(receipt.outcome, CronOutcome::Succeeded);
+        assert_eq!(receipt.exit_code, Some(0));
+        let prior_receipts = cron_receipt_ids(
+            &receipt_root(&success.host.lf_home),
+            &success.wave,
+            &success.flow,
+        )
+        .unwrap();
+
+        let mut failure = success.clone();
+        failure.lf_path = PathBuf::from("/usr/bin/false");
+        add_cron(&agents, &failure, &launchctl).unwrap();
+        assert!(run_cron(
+            &agents,
+            &failure.wave,
+            &failure.flow,
+            &failure.host.home_id,
+            &failure.host.home_id,
+            CronSource::Scheduled,
+        )
+        .is_err());
+
+        let receipts = list_cron_receipts(
+            &receipt_root(&failure.host.lf_home),
+            &failure.wave,
+            Some(&failure.flow),
+            1,
+        )
+        .unwrap();
+        assert_eq!(receipts.len(), 2);
+        assert!(receipts
+            .iter()
+            .any(|receipt| receipt.outcome == CronOutcome::Succeeded));
+        let failed = receipts
+            .iter()
+            .find(|receipt| receipt.outcome == CronOutcome::Failed)
+            .unwrap();
+        assert_eq!(failed.exit_code, Some(1));
+        assert!(failed.error.as_deref().unwrap().contains("see "));
+        let waited = wait_for_cron_receipt(
+            &receipt_root(&failure.host.lf_home),
+            &failure.wave,
+            &failure.flow,
+            &prior_receipts,
+            failed.started_at,
+            Duration::from_secs(1),
+        )
+        .unwrap();
+        assert_eq!(waited.id, failed.id);
+    }
+
+    #[test]
+    fn runner_uses_the_explicit_target_and_scrubs_task_authority() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let executable = temp.path().join("fake-lf");
+        fs::write(
+            &executable,
+            "#!/bin/sh\nprintf '%s\\n' \"$@\"\nprintf 'LF_RUN_CONTEXT=%s\\n' \"${LF_RUN_CONTEXT-unset}\"\n",
+        )
+        .unwrap();
+        fs::set_permissions(&executable, fs::Permissions::from_mode(0o700)).unwrap();
+
+        let agents = temp.path().join("agents");
+        let launchctl = FakeLaunchctl::default();
+        let cron = spec(temp.path(), &executable);
+        fs::create_dir_all(&cron.working_directory).unwrap();
+        add_cron(&agents, &cron, &launchctl).unwrap();
+        run_cron(
+            &agents,
+            &cron.wave,
+            &cron.flow,
+            &cron.host.home_id,
+            &cron.host.home_id,
+            CronSource::Scheduled,
+        )
+        .unwrap();
+
+        assert_eq!(
+            fs::read_to_string(cron.log_path()).unwrap(),
+            "--wave\nreliability\n--batch\nflow\nwave-report\nLF_RUN_CONTEXT=unset\n"
+        );
+    }
+
+    #[test]
+    fn placement_drift_fails_with_a_terminal_receipt_before_launch() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let agents = temp.path().join("agents");
+        let launchctl = FakeLaunchctl::default();
+        let cron = spec(temp.path(), Path::new("/usr/bin/true"));
+        fs::create_dir_all(&cron.working_directory).unwrap();
+        add_cron(&agents, &cron, &launchctl).unwrap();
+        let placed_home = HomeId::new();
+
+        let error = run_cron(
+            &agents,
+            &cron.wave,
+            &cron.flow,
+            &cron.host.home_id,
+            &placed_home,
+            CronSource::Scheduled,
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("is placed on"));
+
+        let receipts = list_cron_receipts(
+            &receipt_root(&cron.host.lf_home),
+            &cron.wave,
+            Some(&cron.flow),
+            1,
+        )
+        .unwrap();
+        assert_eq!(receipts.len(), 1);
+        assert_eq!(receipts[0].outcome, CronOutcome::Failed);
+        assert!(receipts[0]
+            .error
+            .as_deref()
+            .unwrap()
+            .contains(placed_home.as_str()));
+    }
+
+    #[test]
+    fn registry_preflight_failure_is_durable_without_starting_the_target() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let agents = temp.path().join("agents");
+        let launchctl = FakeLaunchctl::default();
+        let cron = spec(temp.path(), Path::new("/usr/bin/true"));
+        fs::create_dir_all(&cron.working_directory).unwrap();
+        add_cron(&agents, &cron, &launchctl).unwrap();
+
+        let receipt = record_cron_preflight_failure(
+            &agents,
+            &cron.wave,
+            &cron.flow,
+            CronSource::Scheduled,
+            "registry schema is incompatible; run `lf doctor`",
+        )
+        .unwrap();
+        assert_eq!(receipt.outcome, CronOutcome::Failed);
+        assert_eq!(receipt.exit_code, None);
+        assert!(receipt
+            .error
+            .as_deref()
+            .unwrap()
+            .contains("registry schema is incompatible"));
+        assert!(!cron.log_path().exists());
+    }
+
+    #[test]
+    fn stale_running_receipt_is_derived_without_rewriting_it() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let started_at = Utc::now().timestamp();
+        let receipt = CronReceipt {
+            schema_version: 1,
+            id: CronReceiptId::new(),
+            runner_pid: u32::MAX,
+            home_id: HomeId::new(),
+            wave: "infra".to_string(),
+            flow: "telemetry".to_string(),
+            target_kind: CronTargetKind::Flow,
+            source: CronSource::Scheduled,
+            schedule: "0 0 9 * * *".to_string(),
+            repo: PathBuf::from("/repo"),
+            lf_path: PathBuf::from("/bin/lf"),
+            log_path: PathBuf::from("/repo/cron.log"),
+            started_at,
+            finished_at: None,
+            outcome: CronOutcome::Running,
+            exit_code: None,
+            error: None,
+        };
+        let root = receipt_root(temp.path());
+        write_receipt(&root, &receipt).unwrap();
+        let path = root.join("infra/telemetry").join(format!(
+            "{}-{}.json",
+            receipt.started_at,
+            receipt.id.as_str()
+        ));
+        let before = fs::read(&path).unwrap();
+
+        let first = list_cron_receipts(&root, "infra", Some("telemetry"), 1).unwrap();
+        let second = list_cron_receipts(&root, "infra", Some("telemetry"), 1).unwrap();
+
+        assert_eq!(first, vec![receipt.clone()]);
+        assert_eq!(second, first);
+        assert!(receipt_is_stale(&second[0], started_at));
+        assert_eq!(second[0].outcome, CronOutcome::Running);
+        assert_eq!(fs::read(path).unwrap(), before);
+    }
+
+    #[test]
+    fn duration_parser_is_bounded_and_explicit() {
+        assert_eq!(
+            parse_wait_duration("15m").unwrap(),
+            Duration::from_secs(900)
+        );
+        assert_eq!(
+            parse_wait_duration("3h").unwrap(),
+            Duration::from_secs(10_800)
+        );
+        assert!(parse_wait_duration("0s").is_err());
+        assert!(parse_wait_duration("25h").is_err());
+        assert!(parse_wait_duration("later").is_err());
     }
 }

--- a/rust/loopflow/src/ops/mod.rs
+++ b/rust/loopflow/src/ops/mod.rs
@@ -27,10 +27,14 @@ pub use abandon::{abandon_branch, AbandonOptions};
 pub(crate) use ask_comments::publish_pending_ask_comments;
 pub(crate) use child::{ambient_run_lease, required_run_lease};
 pub use commit::{commit_workflow, commit_workflow_traced, CommitOptions};
+pub(crate) use cron::cron_receipt_ids;
 pub use cron::{
-    add_cron, daily_time_of, default_launch_agents_dir, list_crons, parse_schedule, remove_cron,
-    resolve_lf_path, schedule_from_cron, sync_crons, CronSpec, CronSyncResult, InstalledCron,
-    Schedule, SkippedCron, SystemLaunchctl,
+    add_cron, daily_time_of, default_launch_agents_dir, latest_cron_receipt, list_cron_receipts,
+    list_crons, parse_schedule, parse_wait_duration, receipt_is_stale, receipt_root,
+    record_cron_preflight_failure, remove_cron, resolve_lf_path, run_cron, schedule_from_cron,
+    sync_crons, trigger_cron, validate_cron_specs, wait_for_cron_receipt, CronHost, CronOutcome,
+    CronReceipt, CronSchedule, CronSource, CronSpec, CronSyncResult, CronTargetKind, InstalledCron,
+    SystemLaunchctl,
 };
 pub use error::{OpsError, OpsResult};
 pub use flow::execute_flow_ops;

--- a/rust/loopflow/tests/wave_resolution_matrix.rs
+++ b/rust/loopflow/tests/wave_resolution_matrix.rs
@@ -86,7 +86,19 @@ const AMBIENT_ONLY: &[&[&str]] = &[];
 /// Commands whose optional `--wave` narrows a machine-wide result instead of
 /// selecting ambient Wave context. These must not inherit `LF_WAVE_ID` or
 /// reject names absent from the registry.
-const FILTER_ONLY: &[&[&str]] = &[&["activity"], &["ci"], &["runs"]];
+const FILTER_ONLY: &[&[&str]] = &[&["activity"], &["ci"], &["cron", "list"], &["runs"]];
+
+/// Commands that require a Wave on the command line and therefore never
+/// resolve ambient context. Cron keeps these explicit because scheduled host
+/// operations must name the installed Wave whose authority they validate.
+const EXPLICIT_WAVE_ONLY: &[&[&str]] = &[
+    &["cron", "preflight"],
+    &["cron", "sync"],
+    &["cron", "run"],
+    &["cron", "history"],
+    &["cron", "trigger"],
+    &["cron", "remove"],
+];
 
 const COMMANDS: &[Cmd] = &[
     // ── Reads ────────────────────────────────────────────────────────────
@@ -711,10 +723,11 @@ fn find_clap_command<'a>(root: &'a clap::Command, path: &[&str]) -> Option<&'a c
 }
 
 /// The registry is complete: every `wave`-bearing clap leaf is classified as
-/// either a resolver or a machine-wide filter, every ambient-only command
-/// exists as a real clap leaf, and every registry entry maps to a real clap
-/// leaf. Adding a new `--wave`-bearing command without classifying it fails CI;
-/// removing a command leaves a stale entry that also fails.
+/// either a resolver or a machine-wide filter, every cron leaf has exactly one
+/// Wave-context classification, every ambient/explicit-only command exists as
+/// a real clap leaf, and every registry entry maps to a real clap leaf. Adding
+/// a new `--wave`-bearing command without classifying it fails CI; removing a
+/// command leaves a stale entry that also fails.
 #[test]
 fn registry_is_complete() {
     let root = Cli::command();
@@ -734,6 +747,10 @@ fn registry_is_complete() {
         .iter()
         .map(|path| path.iter().map(|s| s.to_string()).collect())
         .collect();
+    let explicit_paths: HashSet<Vec<String>> = EXPLICIT_WAVE_ONLY
+        .iter()
+        .map(|path| path.iter().map(|s| s.to_string()).collect())
+        .collect();
 
     // 3. Every wave-arg clap command must be classified.
     for path in &found {
@@ -745,8 +762,24 @@ fn registry_is_complete() {
         );
     }
 
-    // 4. Every ambient-only and filter-only command must exist as a real clap
-    //    leaf.
+    // 4. Every cron leaf must be classified exactly once. Required-wave cron
+    //    commands do not appear in the optional-wave discovery above.
+    let cron = root
+        .find_subcommand("cron")
+        .expect("cron command must exist");
+    for subcommand in cron.get_subcommands() {
+        let path = vec!["cron".to_string(), subcommand.get_name().to_string()];
+        let classifications = usize::from(registry_paths.contains(&path))
+            + usize::from(filter_paths.contains(&path))
+            + usize::from(explicit_paths.contains(&path));
+        assert_eq!(
+            classifications, 1,
+            "cron command {path:?} must have exactly one Wave-context classification"
+        );
+    }
+
+    // 5. Every ambient-only, filter-only, and explicit-only command must exist
+    //    as a real clap leaf. Explicit-only commands must require `wave`.
     for path in AMBIENT_ONLY.iter().chain(FILTER_ONLY) {
         assert!(
             find_clap_command(&root, path).is_some(),
@@ -754,8 +787,21 @@ fn registry_is_complete() {
             path
         );
     }
+    for path in EXPLICIT_WAVE_ONLY {
+        let command = find_clap_command(&root, path).unwrap_or_else(|| {
+            panic!("classified command {path:?} does not exist in the clap tree")
+        });
+        assert!(
+            command.get_arguments().any(|arg| {
+                (arg.get_long() == Some("wave") || arg.get_id() == "wave")
+                    && arg.is_required_set()
+                    && !matches!(arg.get_action(), ArgAction::Append)
+            }),
+            "explicit-only command {path:?} must require one `wave` argument"
+        );
+    }
 
-    // 5. Every registry entry must map to a real clap command (no stale
+    // 6. Every registry entry must map to a real clap command (no stale
     //    entries). Ambient-only commands are checked above.
     let ambient_set: HashSet<Vec<String>> = AMBIENT_ONLY
         .iter()
@@ -778,12 +824,12 @@ fn registry_is_complete() {
 
 // ─── Mutation targeting ─────────────────────────────────────────────────
 
-/// Cache-only mutations target exactly the resolved Wave. Seed two waves
-/// ("alpha" and "beta"); run `lf cron add` resolving to alpha; assert the
-/// plist names alpha, not beta. `cron add` writes the plist before calling
-/// `launchctl load`, so the file is on disk even when `launchctl` fails.
+/// Cron installation refuses a development binary before writing host state.
+/// The matrix above already proves the command resolves an ambient Wave; this
+/// boundary proves that successful resolution cannot leave a disposable binary
+/// in launchd.
 #[test]
-fn cache_mutations_target_the_resolved_wave() {
+fn cron_add_rejects_a_development_binary_before_mutation() {
     let tmp = tempfile::tempdir().expect("tempdir");
     let home = tmp.path().join("home");
     let repo = tmp.path().join("repo");
@@ -812,19 +858,10 @@ fn cache_mutations_target_the_resolved_wave() {
         "alpha".to_string(),
         repo.display().to_string(),
     );
-    let beta = Wave::new(
-        WaveId::new(),
-        "beta".to_string(),
-        repo.display().to_string(),
-    );
     store.create_wave(&alpha).expect("register alpha");
-    store.create_wave(&beta).expect("register beta");
 
     let alpha_uuid = alpha.id().as_str();
 
-    // `lf cron add` with alpha's UUID → plist names alpha, not beta.
-    // `launchctl load` may fail (no launchd on CI); the plist is written
-    // before that call, so we can read it regardless.
     let cron = Command::new(env!("CARGO_BIN_EXE_lf"))
         .args([
             "cron",
@@ -841,28 +878,17 @@ fn cache_mutations_target_the_resolved_wave() {
         .output()
         .expect("run cron add");
 
-    let launch_agents = home.join("Library/LaunchAgents");
-    let alpha_plist = launch_agents.join("loopflow.cron.alpha.mutation-test.plist");
-    let beta_plist = launch_agents.join("loopflow.cron.beta.mutation-test.plist");
-
     assert!(
-        alpha_plist.exists(),
-        "alpha plist should exist (cron add exit: {}, stderr: {})",
-        cron.status,
-        String::from_utf8_lossy(&cron.stderr).trim()
+        !cron.status.success(),
+        "development cron installation should fail"
+    );
+    let stderr = String::from_utf8_lossy(&cron.stderr);
+    assert!(
+        stderr.contains("requires an installed release binary"),
+        "unexpected cron add error: {stderr}"
     );
     assert!(
-        !beta_plist.exists(),
-        "beta plist should NOT exist — mutation targeted the wrong wave"
-    );
-
-    let plist = std::fs::read_to_string(&alpha_plist).expect("read plist");
-    assert!(
-        plist.contains("<string>alpha</string>"),
-        "plist should contain the resolved wave name 'alpha':\n{plist}"
-    );
-    assert!(
-        !plist.contains("<string>beta</string>"),
-        "plist must not contain 'beta':\n{plist}"
+        !home.join("Library/LaunchAgents").exists(),
+        "development cron installation must not create launchd state"
     );
 }

--- a/scripts/bootstrap-cron-host.sh
+++ b/scripts/bootstrap-cron-host.sh
@@ -1,38 +1,137 @@
 #!/usr/bin/env bash
+# Bootstrap repo-owned cron jobs on the Wave's placed Home.
 #
-# Bootstrap a maintained lf cron host.
+# Run this from the placed Home after promoting a release `lf`. The script
+# reconstructs the unattended environment from non-secret host-local paths;
+# Doppler injects publisher secrets only into its read-only preflight.
 #
-# Probes reachability + auth over bounded SSH, verifies lf and Doppler are
-# present, syncs the wave's repo-owned schedules onto the host, and lists the
-# result. Idempotent and secret-free — re-run any time to reconcile.
-#
-# Usage: scripts/bootstrap-cron-host.sh <ssh-host-or-alias> [wave]
-#   scripts/bootstrap-cron-host.sh mini-heart infrastructure
-#
-# Secrets are configured out of band via `doppler setup` on the host; this
-# script never reads, prints, or forwards a value.
+# Usage: scripts/bootstrap-cron-host.sh [wave]
+#   scripts/bootstrap-cron-host.sh infrastructure
 set -euo pipefail
 
-host="${1:?usage: bootstrap-cron-host.sh <ssh-host-or-alias> [wave]}"
-wave="${2:-infrastructure}"
+wave="${1:-infrastructure}"
+repo_root="$(git rev-parse --show-toplevel)"
+main_repo="$(dirname "$(git rev-parse --path-format=absolute --git-common-dir)")"
+if [ "$repo_root" != "$main_repo" ]; then
+  printf 'run bootstrap from the authoritative main checkout %s, not %s\n' \
+    "$main_repo" "$repo_root" >&2
+  exit 1
+fi
+cd "$repo_root"
 
 step() { printf '\n== %s ==\n' "$1"; }
 
-step "reachability + auth ($host)"
-# Bounded lf ssh: an unreachable host fails in ~10s instead of hanging.
-lf ssh "$host" --version
+step "placed Home"
+local_home="$(lf home id)"
+placed_home="$(lf status "$wave" --json | jq -er '.wave.home.id')"
+if [ "$local_home" != "$placed_home" ]; then
+  printf 'Wave %s is placed on %s, not local Home %s\n' \
+    "$wave" "$placed_home" "$local_home" >&2
+  exit 1
+fi
+printf '%s\n' "$local_home"
 
-step "host prerequisites"
-ssh -o BatchMode=yes -o ConnectTimeout=10 "$host" doppler --version
+lf_home="${LF_CONTROL_HOME:-${LF_HOME:-$HOME/.lf}}"
+lf_db_path="${LF_CONTROL_DB_PATH:-${LF_DB_PATH:-$lf_home/loopflow.db}}"
+minimal_env=(
+  env -i
+  "HOME=$HOME"
+  "USER=${USER:-}"
+  "PATH=$PATH"
+  "LF_HOME=$lf_home"
+  "LF_DB_PATH=$lf_db_path"
+  "TMPDIR=${TMPDIR:-/tmp}"
+  "LANG=${LANG:-C}"
+)
 
-step "release publisher preflight"
-ssh -o BatchMode=yes -o ConnectTimeout=10 "$host" \
-  doppler run -- uv run python scripts/publish_release.py check
+step "installed binary + declared jobs"
+"${minimal_env[@]}" lf cron preflight --wave "$wave"
 
-step "sync repo-owned schedules (wave: $wave)"
-lf ssh "$host" cron sync --wave "$wave"
+step "unattended tool path"
+"${minimal_env[@]}" sh -c '
+  missing=0
+  for tool in lf doppler uv gh cargo flyctl security swift xcrun jq; do
+    if ! command -v "$tool" >/dev/null 2>&1; then
+      printf "missing: %s\n" "$tool" >&2
+      missing=1
+    fi
+  done
+  if ! command -v codex >/dev/null 2>&1 && ! command -v claude >/dev/null 2>&1; then
+    printf "missing: codex or claude provider CLI\n" >&2
+    missing=1
+  fi
+  exit "$missing"
+'
+step "host-local provider authority"
+auth_status="$("${minimal_env[@]}" lf auth accounts --verify)"
+printf '%s\n' "$auth_status"
+if ! grep -q 'live active' <<<"$auth_status"; then
+  printf 'no managed provider account verified live from the Home store\n' >&2
+  exit 1
+fi
 
-step "installed schedules"
-lf ssh "$host" cron list
+step "Doppler publisher authority"
+"${minimal_env[@]}" doppler run \
+  --project loopflow \
+  --config prd \
+  -- \
+  uv run python scripts/publish_release.py check
 
-printf '\nbootstrap complete: %s runs wave %s schedules via launchd\n' "$host" "$wave"
+step "sync repo-owned schedules"
+"${minimal_env[@]}" lf cron sync --wave "$wave"
+
+step "prove GOAL.md matches loaded launchd jobs"
+cron_json="$("${minimal_env[@]}" lf cron list --wave "$wave" --json)"
+"${minimal_env[@]}" \
+  "CRON_LIST_JSON=$cron_json" \
+  "EXPECTED_HOME_ID=$local_home" \
+  uv run python - "$wave" <<'PY'
+import json
+import os
+import sys
+from pathlib import Path
+
+import yaml
+
+wave = sys.argv[1]
+goal = Path("wave") / wave / "GOAL.md"
+frontmatter = yaml.safe_load(goal.read_text().split("---", 2)[1])
+expected = [
+    (entry["flow"], entry["schedule"])
+    for entry in frontmatter.get("crons", [])
+]
+installed = json.loads(os.environ["CRON_LIST_JSON"])
+actual = [(entry["flow"], entry["schedule"]) for entry in installed]
+if sorted(actual) != sorted(expected):
+    raise SystemExit(f"cron drift: GOAL.md={sorted(expected)!r} installed={sorted(actual)!r}")
+for entry in installed:
+    if entry["wave"] != wave:
+        raise SystemExit(f"wrong Wave in installed cron: {entry!r}")
+    if not entry["loaded"]:
+        raise SystemExit(f"cron is not loaded: {entry['flow']}")
+    if entry["home_id"] != os.environ["EXPECTED_HOME_ID"]:
+        raise SystemExit(f"wrong Home in installed cron: {entry!r}")
+print(f"{len(installed)}/{len(expected)} jobs loaded and exact")
+PY
+
+step "configured-path telemetry receipt"
+result=0
+if ! "${minimal_env[@]}" lf cron trigger \
+  --wave "$wave" --flow telemetry-daily --wait --timeout 15m; then
+  result=1
+fi
+
+step "configured-path release receipt"
+if ! "${minimal_env[@]}" lf cron trigger \
+  --wave "$wave" --flow release-run --wait --timeout 3h; then
+  result=1
+fi
+
+step "35-day durable receipt window"
+"${minimal_env[@]}" lf cron history --wave "$wave" --days 35
+
+if [ "$result" -ne 0 ]; then
+  printf '\nbootstrap installed the jobs, but a configured-path run is red; inspect the receipt and log above\n' >&2
+  exit "$result"
+fi
+printf '\nbootstrap complete: %s owns Wave %s cron receipts\n' "$local_home" "$wave"


### PR DESCRIPTION
## Usage

```bash
scripts/bootstrap-cron-host.sh infrastructure
lf cron list --wave infrastructure --json
lf cron history --wave infrastructure --days 35
```

## Summary

Bootstraps the infrastructure Wave’s declared telemetry and release schedules on the Home that owns its placement. Cron installation now validates the installed release binary, authoritative checkout, target catalog, and fixed-daily schedules before mutating launchd, then runs jobs with a minimal secret-free environment and durable receipts so host drift and failures remain observable.

## Changes

- Added `cron preflight`, filtered/JSON `list`, launchd-backed `trigger`, and durable `history` commands
- Persisted atomic running, succeeded, and failed receipts under `LF_HOME`, including stale-run detection and configured log paths
- Refused installation or execution when the binary, checkout, target, or Wave placement is not authoritative
- Reworked the bootstrap to run locally on the placed Home, verify provider and publisher authority, reconcile exact schedules, and exercise both configured jobs
- Updated the release workflow dispatch to match its input-free contract and documented the maintained Home workflow