### PR TITLE
release: identify production health probes

### DIFF
--- a/python/tests/test_deploy_website.py
+++ b/python/tests/test_deploy_website.py
@@ -1,4 +1,6 @@
 import subprocess
+import urllib.error
+import urllib.request
 from pathlib import Path
 
 import pytest
@@ -8,6 +10,35 @@ from scripts import deploy_website
 
 def _completed(stdout: str = "") -> subprocess.CompletedProcess[str]:
     return subprocess.CompletedProcess([], 0, stdout, "")
+
+
+def test_health_probe_identifies_itself_to_production(monkeypatch: pytest.MonkeyPatch):
+    class Response:
+        status = 200
+
+        def __init__(self, body: bytes):
+            self._body = body
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            return None
+
+        def read(self) -> bytes:
+            return self._body
+
+    def production(request: urllib.request.Request, timeout: int) -> Response:
+        if request.get_header("User-agent") is None:
+            raise urllib.error.HTTPError(request.full_url, 403, "Forbidden", {}, None)
+        body = (
+            b'{"status":"ok","release":"v1.2.3"}' if request.full_url.endswith("healthz") else b""
+        )
+        return Response(body)
+
+    monkeypatch.setattr(deploy_website.urllib.request, "urlopen", production)
+
+    assert deploy_website._release_is_healthy("v1.2.3")
 
 
 def test_deploy_is_a_green_noop_when_the_tag_is_already_live(

--- a/scripts/deploy_website.py
+++ b/scripts/deploy_website.py
@@ -17,6 +17,7 @@ from typing import Literal, NoReturn
 
 APP = "loopflow-website"
 PRODUCTION_URL = "https://loopflow.studio"
+HEALTH_USER_AGENT = "loopflow-release-health/1"
 
 
 @dataclass(frozen=True)
@@ -46,7 +47,8 @@ def _run(
 
 def _fetch_json(url: str) -> dict[str, object] | None:
     try:
-        with urllib.request.urlopen(url, timeout=10) as response:
+        request = urllib.request.Request(url, headers={"User-Agent": HEALTH_USER_AGENT})
+        with urllib.request.urlopen(request, timeout=10) as response:
             if response.status != 200:
                 return None
             value = json.loads(response.read())
@@ -57,7 +59,10 @@ def _fetch_json(url: str) -> dict[str, object] | None:
 
 def _root_is_healthy() -> bool:
     try:
-        with urllib.request.urlopen(f"{PRODUCTION_URL}/", timeout=10) as response:
+        request = urllib.request.Request(
+            f"{PRODUCTION_URL}/", headers={"User-Agent": HEALTH_USER_AGENT}
+        )
+        with urllib.request.urlopen(request, timeout=10) as response:
             return response.status == 200
     except (OSError, urllib.error.HTTPError):
         return False


### PR DESCRIPTION
## Usage

```bash
lf release run patch
```

## Summary

Identifies release health requests explicitly so loopflow.studio accepts the exact-tag proof. Python urllib defaults receive HTTP 403 at the production edge; the release-specific User-Agent receives the v0.12.5 health body and root HTTP 200, allowing the landed health-before-rollback gate to observe reality.

## Proof

- six deploy behavior tests pass, including the 403-without-identity fixture
- the real probe returns `{status: ok, release: v0.12.5}`, root healthy, and exact-tag proof true