### PR TITLE
release: make publisher authority host-local

### DIFF
--- a/.lf/config.yaml
+++ b/.lf/config.yaml
@@ -17,13 +17,7 @@ release:
       - uv run python scripts/canonicalize_migrations.py {version} --release-cut
       completion: github-release
       publisher:
-      - doppler
-      - run
-      - --project
-      - loopflow
-      - --config
-      - prd
-      - --
+      - loopflow-release-publisher
       - uv
       - run
       - python

--- a/python/tests/test_release_automation.py
+++ b/python/tests/test_release_automation.py
@@ -245,13 +245,7 @@ def test_infrastructure_cron_runs_the_host_release_after_telemetry():
 
     config = yaml.safe_load((ROOT / ".lf/config.yaml").read_text())
     assert config["release"]["targets"]["default"]["publisher"] == [
-        "doppler",
-        "run",
-        "--project",
-        "loopflow",
-        "--config",
-        "prd",
-        "--",
+        "loopflow-release-publisher",
         "uv",
         "run",
         "python",
@@ -272,12 +266,29 @@ def test_infrastructure_cron_runs_the_host_release_after_telemetry():
     assert 'lf cron history --wave "$wave" --days 35' in bootstrap
     assert "env -i" in bootstrap
     assert "DOPPLER_TOKEN" not in bootstrap
+    assert "loopflow-release-publisher" in bootstrap
     assert bootstrap.index('lf cron preflight --wave "$wave"') < bootstrap.index(
         "scripts/publish_release.py check"
     )
     assert bootstrap.index("scripts/publish_release.py check") < bootstrap.index(
         'lf cron sync --wave "$wave"'
     )
+
+    public_contract = "\n".join(
+        [
+            (ROOT / ".lf/config.yaml").read_text(),
+            bootstrap,
+            (ROOT / "release/CRON_HOST.md").read_text(),
+        ]
+    )
+    for private_selector in (
+        "doppler",
+        "--project",
+        "--config",
+        "DOPPLER_PROJECT",
+        "DOPPLER_CONFIG",
+    ):
+        assert private_selector not in public_contract
 
 
 def test_release_installer_uses_the_promotion_boundary_to_activate_the_binary():

--- a/release/CRON_HOST.md
+++ b/release/CRON_HOST.md
@@ -20,10 +20,12 @@ launchd when they differ.
   task-worktree binaries.
 - Keep the repository's authoritative checkout on the placed Home.
 - Configure at least one managed Claude or Codex account in the Home store.
-- Install `doppler`, `uv`, `gh`, `cargo`, `flyctl`, `security`, `swift`,
-  `xcrun`, and `jq` on the host path.
-- Configure Doppler project `loopflow`, config `prd`, without storing or
-  printing secret values in the repository or launchd plist.
+- Install `uv`, `gh`, `cargo`, `flyctl`, `security`, `swift`, `xcrun`, and
+  `jq` on the host path.
+- Install an executable named `loopflow-release-publisher` on the Home's PATH.
+  It must inject the host's private publisher authority, then execute the argv
+  it receives. Keep its implementation and provider selectors outside the
+  checkout.
 - Install the Developer ID signing identity and host-native GitHub, registry,
   R2, notarization, and Fly authority required by the release publisher.
 
@@ -32,13 +34,14 @@ Home/store paths, and basic locale/temp settings. It verifies a managed provider
 account live, then runs the publisher's read-only check through:
 
 ```bash
-doppler run --project loopflow --config prd -- \
+loopflow-release-publisher \
   uv run python scripts/publish_release.py check
 ```
 
-Doppler injects values only into that process. The script never reads or prints
-a secret and never forwards a Task lease, provider lease, GitHub token, PM
-token, or invocation context.
+The logical command is the public contract; its Home-local implementation owns
+the private provider binding. The bootstrap never reads or prints a secret and
+never forwards a Task lease, provider lease, GitHub token, PM token, or
+invocation context. A missing command or failed check stops before cron sync.
 
 ## Repo-owned schedules
 

--- a/release/README.md
+++ b/release/README.md
@@ -38,6 +38,11 @@ repository owns migration checks and preparation in `.lf/config.yaml`, plus
 package builds, signing, notarization, uploads, deployment, smoke tests, and
 secrets in its workflows and scripts.
 
+The repository names the logical `loopflow-release-publisher` command. The
+maintained Home supplies that executable on PATH and keeps its credential
+provider and selectors untracked. `lf release run` invokes its read-only
+`check` before changing release state, so missing host authority fails closed.
+
 | Path | What it does |
 |------|--------------|
 | `release/unreleased/DECISIONS.md` | Append-only ledger for release-worthy intent and policy decisions during the current cycle |

--- a/rust/loopflow/tests/release_tests.rs
+++ b/rust/loopflow/tests/release_tests.rs
@@ -21,7 +21,7 @@ fn write_gh_script(pr_list: &str) -> String {
 
 fn write_gh_status_script(run_list: &str, release_view: &str) -> String {
     format!(
-        "#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then\n  echo 'gh version 2.0.0'\n  exit 0\nfi\ncase \"$1 $2\" in\n  'run list')\n    case \"$*\" in *databaseId*) ;; *) echo 'databaseId was not requested' >&2; exit 1;; esac\n    cat <<'JSON'\n{run_list}\nJSON\n    exit 0;;\n  'release view')\n    cat <<'JSON'\n{release_view}\nJSON\n    exit 0;;\nesac\necho \"unexpected gh invocation: $@\" >&2\nexit 1\n"
+        "#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then\n  echo 'gh version 2.0.0'\n  exit 0\nfi\ncase \"$1 $2\" in\n  'run list')\n    case \"$*\" in *databaseId*) ;; *) echo 'databaseId was not requested' >&2; exit 1;; esac\n    cat <<'JSON'\n{run_list}\nJSON\n    exit 0;;\n  'release view')\n    cat <<'JSON'\n{release_view}\nJSON\n    exit 0;;\n  'pr list') echo '[]'; exit 0;;\nesac\necho \"unexpected gh invocation: $@\" >&2\nexit 1\n"
     )
 }
 
@@ -581,6 +581,73 @@ fn release_run_is_a_green_noop_without_merged_changes() {
             latest_tag: Some("v0.9.1".to_string()),
         }
     );
+}
+
+#[test]
+fn release_run_checks_the_host_local_publisher_role() {
+    let gh_script = write_gh_status_script("[]", r#"{"isDraft":false}"#);
+    let _env = EnvGuard::new(&[("gh", gh_script.as_str())]);
+
+    let repo = TestRepo::new();
+    let checked = repo.path().join("publisher-checked");
+    let publisher = repo.path().join("publisher.sh");
+    fs::write(
+        &publisher,
+        format!(
+            "#!/bin/sh\n[ \"$1\" = check ] || exit 19\n: > '{}'\n",
+            checked.display()
+        ),
+    )
+    .expect("write publisher");
+    fs::create_dir_all(repo.path().join(".lf")).expect("create config dir");
+    fs::write(
+        repo.path().join(".lf/config.yaml"),
+        "release:\n  targets:\n    default:\n      publisher: [\"sh\", \"{repo}/publisher.sh\"]\n",
+    )
+    .expect("write config");
+    git(&repo, &["add", ".lf/config.yaml", "publisher.sh"]);
+    git(&repo, &["commit", "-m", "Configure publisher role"]);
+    git(&repo, &["push", "origin", "HEAD"]);
+    git(&repo, &["tag", "v0.9.1"]);
+
+    let outcome = release_run(repo.path(), "patch", None, &NullProgress)
+        .expect("configured publisher should pass preflight");
+
+    assert!(checked.exists());
+    assert_eq!(
+        outcome,
+        ReleaseRunOutcome::NoChanges {
+            target: "default".to_string(),
+            latest_tag: Some("v0.9.1".to_string()),
+        }
+    );
+}
+
+#[test]
+fn release_run_fails_closed_when_the_publisher_role_is_missing() {
+    let gh_script = write_gh_script("[]");
+    let _env = EnvGuard::new(&[("gh", gh_script.as_str())]);
+
+    let repo = TestRepo::new();
+    fs::create_dir_all(repo.path().join(".lf")).expect("create config dir");
+    fs::write(
+        repo.path().join(".lf/config.yaml"),
+        "release:\n  targets:\n    default:\n      publisher: [\"missing-release-publisher-role\"]\n",
+    )
+    .expect("write config");
+    git(&repo, &["add", ".lf/config.yaml"]);
+    git(&repo, &["commit", "-m", "Require publisher role"]);
+    git(&repo, &["push", "origin", "HEAD"]);
+    git(&repo, &["tag", "v0.9.1"]);
+    let head_before = git_output(&repo, &["rev-parse", "HEAD"]);
+    let tags_before = git_output(&repo, &["tag", "--list"]);
+
+    let error = release_run(repo.path(), "patch", None, &NullProgress)
+        .expect_err("missing publisher authority must stop release");
+
+    assert!(error.to_string().contains("missing-release-publisher-role"));
+    assert_eq!(git_output(&repo, &["rev-parse", "HEAD"]), head_before);
+    assert_eq!(git_output(&repo, &["tag", "--list"]), tags_before);
 }
 
 #[test]

--- a/scripts/bootstrap-cron-host.sh
+++ b/scripts/bootstrap-cron-host.sh
@@ -3,7 +3,7 @@
 #
 # Run this from the placed Home after promoting a release `lf`. The script
 # reconstructs the unattended environment from non-secret host-local paths;
-# Doppler injects publisher secrets only into its read-only preflight.
+# the Home-local publisher command injects authority only into its child.
 #
 # Usage: scripts/bootstrap-cron-host.sh [wave]
 #   scripts/bootstrap-cron-host.sh infrastructure
@@ -50,7 +50,7 @@ step "installed binary + declared jobs"
 step "unattended tool path"
 "${minimal_env[@]}" sh -c '
   missing=0
-  for tool in lf doppler uv gh cargo flyctl security swift xcrun jq; do
+  for tool in lf loopflow-release-publisher uv gh cargo flyctl security swift xcrun jq; do
     if ! command -v "$tool" >/dev/null 2>&1; then
       printf "missing: %s\n" "$tool" >&2
       missing=1
@@ -70,11 +70,8 @@ if ! grep -q 'live active' <<<"$auth_status"; then
   exit 1
 fi
 
-step "Doppler publisher authority"
-"${minimal_env[@]}" doppler run \
-  --project loopflow \
-  --config prd \
-  -- \
+step "configured publisher authority"
+"${minimal_env[@]}" loopflow-release-publisher \
   uv run python scripts/publish_release.py check
 
 step "sync repo-owned schedules"


### PR DESCRIPTION
## Usage

```bash
command -v loopflow-release-publisher
scripts/bootstrap-cron-host.sh infrastructure
lf cron history --wave infrastructure --days 35
```

## Summary

Moves release credential injection behind the logical `loopflow-release-publisher` command supplied by the maintained Home. This keeps provider-specific selectors and secret authority outside the repository while preserving the release publisher’s existing interface.

## Changes

- Replaced the repository’s Doppler-specific publisher command with the host-local role
- Made cron bootstrap verify the role and run its read-only check before syncing schedules
- Documented the Home-owned credential boundary and fail-closed behavior
- Added coverage proving configured roles run and missing roles cannot mutate release state