### PR TITLE
tests: keep maintainer topology out of public fixtures

### DIFF
--- a/rust/loopflow/src/engine/wave_config.rs
+++ b/rust/loopflow/src/engine/wave_config.rs
@@ -384,7 +384,7 @@ mod tests {
         fs::create_dir_all(&dir).expect("create dir");
         fs::write(
             dir.join("GOAL.md"),
-            "---\nchat:\n  provider: discord\n  home_id: home_39860354aaca640c2ccb50bf6ca609d8\n  guild_id: guild\n  channel_id: channel\n---\nDrive the work.\n",
+            "---\nchat:\n  provider: discord\n  home_id: home_11111111111111111111111111111111\n  guild_id: guild\n  channel_id: channel\n---\nDrive the work.\n",
         )
         .expect("write");
         let config = try_read_wave_config(temp.path(), "scan")
@@ -393,7 +393,7 @@ mod tests {
         assert!(matches!(
             config.chat,
             Some(WaveChatConfig::Discord { home_id, guild_id, channel_id })
-                if home_id.as_str() == "home_39860354aaca640c2ccb50bf6ca609d8"
+                if home_id.as_str() == "home_11111111111111111111111111111111"
                     && guild_id == "guild"
                     && channel_id == "channel"
         ));

--- a/rust/loopflow/src/lfd/service.rs
+++ b/rust/loopflow/src/lfd/service.rs
@@ -359,8 +359,8 @@ mod tests {
             lf_home: Some(PathBuf::from("/home/op/.lf")),
             db_path: None,
             path_env: Some("/opt/homebrew/bin:/usr/bin:/bin".to_string()),
-            doppler_project: Some("loopflow".to_string()),
-            doppler_config: Some("dev".to_string()),
+            doppler_project: Some("example-project".to_string()),
+            doppler_config: Some("example-config".to_string()),
         }
     }
 
@@ -380,9 +380,9 @@ mod tests {
         assert!(plist.contains("<key>PATH</key>"));
         assert!(plist.contains("/opt/homebrew/bin:/usr/bin:/bin"));
         assert!(plist.contains("<key>DOPPLER_PROJECT</key>"));
-        assert!(plist.contains("<string>loopflow</string>"));
+        assert!(plist.contains("<string>example-project</string>"));
         assert!(plist.contains("<key>DOPPLER_CONFIG</key>"));
-        assert!(plist.contains("<string>dev</string>"));
+        assert!(plist.contains("<string>example-config</string>"));
         assert_eq!(plist.matches("<string>/dev/null</string>").count(), 2);
         // Secrets must never appear in the file.
         assert!(!plist.contains("WEBHOOK_SECRET"));
@@ -402,8 +402,8 @@ mod tests {
         assert!(unit.contains("StandardError=null"));
         assert!(unit.contains("Environment=LF_HOME=/home/op/.lf"));
         assert!(unit.contains("Environment=PATH=/opt/homebrew/bin:/usr/bin:/bin"));
-        assert!(unit.contains("Environment=DOPPLER_PROJECT=loopflow"));
-        assert!(unit.contains("Environment=DOPPLER_CONFIG=dev"));
+        assert!(unit.contains("Environment=DOPPLER_PROJECT=example-project"));
+        assert!(unit.contains("Environment=DOPPLER_CONFIG=example-config"));
         assert!(unit.contains("WantedBy=default.target"));
         assert!(!unit.contains("WEBHOOK_SECRET"));
     }


### PR DESCRIPTION
## Try it!

```bash
cargo test -p loopflow discord_chat_config_is_typed_and_invalid_bindings_fail_closed
cargo test -p loopflow lfd::service::tests
```

The Wave-config test still parses a typed Discord binding, and the daemon tests
still render the configured non-secret environment into launchd and systemd.
Their fixture identities are now synthetic and safe to copy from the public
repository.

The changed-aware gate also passed rustfmt, clippy, and all 1,819
release-equivalent Rust tests after materializing the draft migration.

## Intent

Keep public source focused on the logical publisher and service contracts. Test
fixtures should demonstrate required shape, propagation, preflight, and
fail-closed behavior without publishing a maintainer's Home or provider
topology.

## Assumptions

- The fixture identities need valid shape, not a real account or environment.
- The product Wave's Discord `chat.home_id` is a live runtime binding, separate
  from release-publisher authority.
- Private publisher selection remains Home-local or arrives through scoped
  runtime authority.

## Key decisions

- Replace only the maintainer-shaped test values; keep every behavioral
  assertion intact.
- Leave production configuration and public APIs unchanged.
- Do not add a generic provider or deployment abstraction for a fixture
  correction.

## Durable invariant

Tracked release and cron source may name the logical publisher role and the
authority it requires, but never a maintainer's Home id, provider
project/config, or secret selector. The public-contract Python test rejects
provider selectors in the tracked config, bootstrap, and host docs; Rust
release tests require the logical role and fail closed when it is absent; the
Wave and daemon fixtures now exercise valid shapes with synthetic identities.

## Not included

This PR does not claim completion of LOO-214. The supported installed binary
still predates the cron implementation, so installing the Infrastructure Home
and collecting real `list`, waited-trigger, and `history` receipts remains the
next serial increment after a schema-complete release is available.
