### PR TITLE
lf land: require final approval for direct task completion

### DIFF
--- a/rust/loopflow/src/ops/land.rs
+++ b/rust/loopflow/src/ops/land.rs
@@ -73,16 +73,12 @@ fn prepare_pr(
     crate::ops::pr::reject_control_plane_pr(&repo_root)?;
     if options.complete && (!options.strict || is_clean(&repo_root)?) {
         if let Some(issue) = crate::ops::task::find_discardable_final_task(&repo_root)? {
-            // The final flow reviewed work that already landed, and rotation left
-            // one unpublished branch at its recorded base. Reuse the Task completion
-            // gate instead of manufacturing an empty GitHub PR. Pre-final Tasks do
-            // not match the query and continue through the ordinary range refusal.
+            // The final flow approved work that already landed, and rotation left
+            // one unpublished branch at its recorded base. Consume that approval
+            // instead of manufacturing either an empty GitHub PR or a new outcome.
+            // Pre-final Tasks continue through the ordinary range refusal.
             clear_scratch(&repo_root, progress)?;
-            crate::ops::task::task_complete(
-                &issue,
-                "Final Task flow approved completion after its prior pull request merged"
-                    .to_string(),
-            )?;
+            crate::ops::task::task_complete_approved(&issue)?;
             progress.status("Completed Task over its merged pull request.");
             return Ok(None);
         }

--- a/rust/loopflow/src/ops/task.rs
+++ b/rust/loopflow/src/ops/task.rs
@@ -4017,8 +4017,11 @@ pub(crate) fn find_discardable_final_task(repo: &Path) -> OpsResult<Option<Strin
             return Ok(None);
         }
         let gate = task_completion_gate(&store, &task).await?;
-        Ok((gate.satisfied && gate.discardable_successor.is_some())
-            .then(|| task.plan.identifier.clone()))
+        if !gate.satisfied || gate.discardable_successor.is_none() {
+            return Ok(None);
+        }
+        require_approved_task_completion(&task)?;
+        Ok(Some(task.plan.identifier.clone()))
     })
 }
 
@@ -4027,6 +4030,19 @@ pub fn task_complete(issue: &str, summary: String) -> OpsResult<Task> {
     if summary.is_empty() {
         return Err(task_error("completion summary cannot be empty"));
     }
+    complete_task(issue, TaskCompletionAuthority::Explicit { summary })
+}
+
+pub(crate) fn task_complete_approved(issue: &str) -> OpsResult<Task> {
+    complete_task(issue, TaskCompletionAuthority::Approved)
+}
+
+enum TaskCompletionAuthority {
+    Explicit { summary: String },
+    Approved,
+}
+
+fn complete_task(issue: &str, authority: TaskCompletionAuthority) -> OpsResult<Task> {
     block_on_task(async move {
         let store = task_store().await?;
         let mut task = store
@@ -4067,6 +4083,9 @@ pub fn task_complete(issue: &str, summary: String) -> OpsResult<Task> {
                 "Task worktree has uncommitted changes; publish or explicitly abandon them first",
             ));
         }
+        if matches!(&authority, TaskCompletionAuthority::Approved) {
+            require_approved_task_completion(&task)?;
+        }
         // The completion gate requires every active PR to be settled. Do not
         // bypass that fact or infer merge from a green head.
         let gate = task_completion_gate(&store, &task).await?;
@@ -4076,7 +4095,9 @@ pub fn task_complete(issue: &str, summary: String) -> OpsResult<Task> {
             // provoked.
             return Err(task_error(refusal));
         }
-        propose_task_done(&mut task, summary.clone())?;
+        if let TaskCompletionAuthority::Explicit { summary } = authority {
+            propose_task_done(&mut task, summary)?;
+        }
         // Every other condition is now proven, so the rotation's empty artifact
         // is dropped as part of completing — one transaction that deletes the row
         // and writes the terminal status together. There is no instant at which
@@ -4099,6 +4120,19 @@ pub fn task_complete(issue: &str, summary: String) -> OpsResult<Task> {
         }
         Ok(task)
     })
+}
+
+fn require_approved_task_completion(task: &Task) -> OpsResult<()> {
+    let proposal = task
+        .approved_gate_proposal()
+        .map_err(|error| task_error(error.to_string()))?;
+    if proposal.done {
+        return Ok(());
+    }
+    Err(task_error(format!(
+        "Task {} final gate did not approve completion: {}",
+        task.plan.identifier, proposal.reason
+    )))
 }
 
 fn propose_task_done(task: &mut Task, summary: String) -> OpsResult<()> {
@@ -4280,7 +4314,7 @@ pub(crate) struct CompletionGate {
     /// recorded base. It is the rotation's artifact, not work, so it does not
     /// block completion; it must not outlive one either.
     ///
-    /// Classification only, and exactly one thing acts on it: [`task_complete`]
+    /// Classification only, and exactly one thing acts on it: [`complete_task`]
     /// passes it as the completion transaction's `skipped_pr`, which drops the
     /// row and writes the terminal status together. Discarding it any earlier
     /// would leave a non-terminal Task with no active PR — the state

--- a/rust/loopflow/tests/pr_tests.rs
+++ b/rust/loopflow/tests/pr_tests.rs
@@ -556,7 +556,7 @@ fn merged_continue_task_rotates_to_a_working_pr_without_review_state() {
 }
 
 #[test]
-fn completing_land_discards_an_empty_successor_only_in_finally() {
+fn completing_land_requires_an_approved_final_gate_for_an_empty_successor() {
     let home = tempfile::TempDir::new().expect("temp home");
     let log_path = home.path().join("gh.log");
     let script = gh_merged_pr_logging_script(log_path.to_string_lossy().as_ref());
@@ -656,6 +656,45 @@ fn completing_land_discards_an_empty_successor_only_in_finally() {
         .expect("write final evidence");
     let calls_before = fs::read_to_string(&log_path).expect("read setup calls");
 
+    let refusal = land(repo.path(), &options, &NullProgress)
+        .expect_err("a continue proposal must not complete the Task");
+    assert!(
+        refusal
+            .to_string()
+            .contains("final gate did not approve completion"),
+        "expected an actionable completion-authority refusal, got: {refusal}"
+    );
+    assert!(
+        repo.path().join("scratch/review.md").exists(),
+        "refused completion must preserve final review evidence"
+    );
+    assert!(!matches!(
+        runtime.block_on(task.store.work_status(&work)).unwrap(),
+        WorkStatus::Done
+    ));
+    let refused = runtime
+        .block_on(task.store.get_task(&task.task.id))
+        .expect("read refused Task")
+        .expect("refused Task exists");
+    assert!(refused
+        .gate_proposal
+        .as_ref()
+        .is_some_and(|gate| !gate.done));
+
+    let approved_reason = "final review approved the merged slice";
+    final_task.gate_proposal = Some(TaskGateProposal {
+        done: true,
+        reason: approved_reason.to_string(),
+    });
+    conn.execute(
+        "UPDATE tasks SET gate_proposal_json=?2 WHERE id=?1",
+        rusqlite::params![
+            final_task.id.as_str(),
+            serde_json::to_string(&final_task.gate_proposal).expect("serialize approval")
+        ],
+    )
+    .expect("persist approved proposal");
+
     let result = land(repo.path(), &options, &NullProgress).expect("complete final Task");
 
     assert!(result.is_none(), "no empty GitHub PR should be created");
@@ -677,10 +716,14 @@ fn completing_land_discards_an_empty_successor_only_in_finally() {
         .block_on(task.store.get_task(&task.task.id))
         .expect("read completed Task")
         .expect("completed Task exists");
-    assert!(completed
-        .gate_proposal
-        .as_ref()
-        .is_some_and(|gate| gate.done));
+    assert_eq!(
+        completed.gate_proposal,
+        Some(TaskGateProposal {
+            done: true,
+            reason: approved_reason.to_string(),
+        }),
+        "completion must preserve the reviewed proposal"
+    );
     let prs = runtime
         .block_on(task.store.task_prs(&task.task.id))
         .expect("read completed PR chain");


### PR DESCRIPTION
## Usage

```bash
lf pr land --complete
```

## Summary

Requires an approved final gate before completing a Task whose prior PR has merged and whose only remaining PR is an empty rotated successor. `lf pr land --complete` now consumes the reviewed approval instead of synthesizing a new completion outcome, preserving the final gate as the source of authority while avoiding an empty GitHub PR.

## Changes

- Refuse direct completion when the final gate proposes continuing, preserving scratch evidence and Task state
- Separate explicit-summary completion from completion authorized by an existing approved gate
- Preserve the reviewed approval reason when completing the Task
- Verify the empty successor is removed atomically without additional GitHub mutations