### PR TITLE
project: adopt Linear plans at phase boundaries

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -147,7 +147,7 @@ Intentional copies stay read projections:
 <!-- architecture-projections:start -->
 | Projection | Authority copied | Freshness and consumer |
 | --- | --- | --- |
-| [`PmSnapshotRow`](../rust/loopflow/src/store/mod.rs) / `pm_snapshots` | Linear planning | Atomic sync/webhook replacement; `lf status`, `lf roadmap`, and the Mac app read it but never author through it. |
+| [`PmSnapshotRow`](../rust/loopflow/src/store/mod.rs) / `pm_snapshots` | Linear planning | Atomic sync or Project-phase refresh replacement; `lf status`, `lf roadmap`, and the Mac app read it but never author through it. |
 | [`TaskLinearObservation`](../rust/loopflow/src/task/mod.rs) / `task_linear_observations` | Linear Issue state | Reconciliation records provider evidence before applying lifecycle changes. |
 | [`GithubObservation`](../rust/loopflow/src/task/mod.rs) / `task_prs`, `ci_incidents` | GitHub PR/check state | Webhook or foreground reads update Task delivery evidence; GitHub remains merge truth. |
 | `tests/fixtures/dto/` | Rust `lf --json` DTOs | Rust and Swift fixture tests reject required-field or enum drift. |
@@ -199,6 +199,9 @@ and current runtime source do not.
   locators are unique, and bare slugs are never mutation authority.
 - Linear owns current Project/Task planning; SQLite projections never become an
   authoring fallback.
+- Active Project Work adopts one complete refreshed Linear plan between provider
+  turns; a refresh or ownership failure stops before the next turn rather than
+  serving the prior plan.
 - One non-ended Run exists per Epoch; only its current opaque lease writes as
   Work.
 - Run containment, not invocation ordering, is the interrupt and recovery

--- a/docs/lf.md
+++ b/docs/lf.md
@@ -294,6 +294,10 @@ Bare `lf start` is the automatic form: it starts only repo Waves whose optional
 placement is local and enabled. The named form is the explicit override.
 `lf wave <name>` runs that Wave listener and resident in the foreground for
 development. Project Work pursues one Linear Project's KRs without a worktree.
+Each Project phase refreshes Linear before it starts. Definition, Task-flow, and
+KR edits take effect together on the next phase without replacing the Project
+Work or its direction; an unavailable or invalid plan stops before another
+provider turn and status prints the restart reason.
 Each Linear Project has at most one current Work; terminal Work remains readable
 history and the next pursuit creates a successor. Every Task requires the
 current Project Work; `task start/run` ensures it before reserving the Task.

--- a/rust/loopflow/src/bin/lf.rs
+++ b/rust/loopflow/src/bin/lf.rs
@@ -815,7 +815,7 @@ fn print_project(project: &loopflow::project::Project, json: bool) -> anyhow::Re
             project.id,
             body,
             project.iteration,
-            work_status_label(&snapshot.status),
+            snapshot.reason,
         );
     }
     Ok(())

--- a/rust/loopflow/src/lf/commands/waves.rs
+++ b/rust/loopflow/src/lf/commands/waves.rs
@@ -1163,21 +1163,24 @@ async fn snapshot_project_runtime(
             .map_err(|err| anyhow!("failed to read Project observation outbox: {err}"))?
             .len() as u32
     };
-    let latest_event_at = store
-        .latest_project_event_at(&project.id)
+    let latest_event = store
+        .latest_project_event(&project.id)
         .await
         .map_err(|err| anyhow!("failed to read Project event log: {err}"))?;
+    let latest_event_at = latest_event.as_ref().map(|event| event.created_at);
+    let reason =
+        crate::project::status_reason(&status, latest_event.as_ref().map(|event| &event.kind));
     let evidence = BodyEvidence {
         intent: work_status_body_intent(&status),
         observable: liveness.liveness() == Liveness::Observable,
         process_alive,
         progress_age: body_progress_age(latest_event_at, project.updated_at, now),
         step: Some(format!("iteration {}", project.iteration)),
-        reason: work_status_reason(&status),
+        reason: reason.clone(),
     };
     Ok(ProjectRuntimeSnapshot {
         work_id: project.id.to_string(),
-        reason: work_status_reason(&status),
+        reason,
         status,
         updated_at: format_time(project.updated_at).unwrap_or_default(),
         iteration: project.iteration,

--- a/rust/loopflow/src/ops/project.rs
+++ b/rust/loopflow/src/ops/project.rs
@@ -28,6 +28,7 @@ pub struct ProjectSnapshot {
     pub project_name: String,
     pub wave: String,
     pub status: WorkStatus,
+    pub reason: String,
     pub iteration: u32,
     pub observation_cursor: i64,
     pub pending_observations: u32,
@@ -203,20 +204,13 @@ pub(crate) fn reserve_project(
                 ))
             })?;
         let now = time::OffsetDateTime::now_utc();
-        let context = crate::ops::task::project_context(&resolved.project);
+        let plan = project_plan(&resolved.project, resolved.snapshot.synced_at)?;
         let project = Project {
             id: predecessor
                 .as_ref()
                 .map(|project| project.id.clone())
                 .unwrap_or_else(ProjectId::new),
-            plan: ProjectPlan {
-                id: LinearProjectId::new(resolved.project.id.clone())
-                    .map_err(|error| project_error(error.to_string()))?,
-                slug: resolved.project.slug,
-                name: resolved.project.name,
-                prompt_context: context,
-                pm_snapshot_synced_at: resolved.snapshot.synced_at,
-            },
+            plan,
             wave_id: wave.id().clone(),
             iteration: 0,
             observation_cursor: 0,
@@ -255,6 +249,20 @@ pub(crate) fn reserve_project(
             return Err(project_error(format!("failed to reserve Project: {error}")));
         }
         Ok(project)
+    })
+}
+
+pub(crate) fn project_plan(
+    project: &crate::pm::PmProject,
+    pm_snapshot_synced_at: i64,
+) -> OpsResult<ProjectPlan> {
+    Ok(ProjectPlan {
+        id: LinearProjectId::new(project.id.clone())
+            .map_err(|error| project_error(error.to_string()))?,
+        slug: project.slug.clone(),
+        name: project.name.clone(),
+        prompt_context: crate::ops::task::project_context(project),
+        pm_snapshot_synced_at,
     })
 }
 
@@ -507,11 +515,9 @@ pub fn project_snapshot(project: &Project) -> OpsResult<ProjectSnapshot> {
             None => false,
         };
         let latest_event = store
-            .project_events_after(&project.id, 0)
+            .latest_project_event(&project.id)
             .await
-            .map_err(|error| project_error(error.to_string()))?
-            .into_iter()
-            .last();
+            .map_err(|error| project_error(error.to_string()))?;
         let pending_observations = store
             .pending_project_observations(&project.id)
             .await
@@ -521,6 +527,8 @@ pub fn project_snapshot(project: &Project) -> OpsResult<ProjectSnapshot> {
             .work_status(&work)
             .await
             .map_err(|error| project_error(error.to_string()))?;
+        let reason =
+            crate::project::status_reason(&status, latest_event.as_ref().map(|event| &event.kind));
         Ok(ProjectSnapshot {
             id: project.id.to_string(),
             external_project_id: project.plan.id.as_str().to_string(),
@@ -528,6 +536,7 @@ pub fn project_snapshot(project: &Project) -> OpsResult<ProjectSnapshot> {
             project_name: project.plan.name,
             wave: wave.name().to_string(),
             status,
+            reason,
             iteration: project.iteration,
             observation_cursor: project.observation_cursor,
             pending_observations,

--- a/rust/loopflow/src/ops/task_pm.rs
+++ b/rust/loopflow/src/ops/task_pm.rs
@@ -132,6 +132,27 @@ pub fn resolve_project(
     Ok(ResolvedProject { snapshot, project })
 }
 
+pub(crate) async fn refresh_project(
+    repo: &Path,
+    wave: &str,
+    project_id: &str,
+) -> OpsResult<ResolvedProject> {
+    let team_id = crate::ops::pm::repository_team_id(repo)?;
+    let snapshot = load_wave_async(repo, wave, PmRefresh::Force).await?;
+    let project = snapshot
+        .projects
+        .iter()
+        .find(|project| project.id == project_id)
+        .cloned()
+        .ok_or_else(|| {
+            OpsError::Message(format!(
+                "Linear Project {project_id} is absent from the refreshed wave/{wave} snapshot; it was removed, archived, or moved out of the Wave"
+            ))
+        })?;
+    validate_project_ownership(&snapshot, &project, &team_id)?;
+    Ok(ResolvedProject { snapshot, project })
+}
+
 fn repository_snapshots(repo: &Path, team_id: &str) -> OpsResult<Vec<PmShowResult>> {
     let mut snapshots = Vec::new();
     let mut ownership = PmPortfolioValidator::default();

--- a/rust/loopflow/src/planning.rs
+++ b/rust/loopflow/src/planning.rs
@@ -50,6 +50,15 @@ pub struct ProjectPlan {
     pub pm_snapshot_synced_at: i64,
 }
 
+impl ProjectPlan {
+    pub(crate) fn has_same_content(&self, other: &Self) -> bool {
+        self.id == other.id
+            && self.slug == other.slug
+            && self.name == other.name
+            && self.prompt_context == other.prompt_context
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct TaskPlan {
     pub id: LinearIssueId,

--- a/rust/loopflow/src/project/mod.rs
+++ b/rust/loopflow/src/project/mod.rs
@@ -9,6 +9,7 @@ use time::OffsetDateTime;
 
 use crate::child::{AbandonIntent, ChildRef, ObservationRecipient};
 pub use crate::durable::ProjectId;
+use crate::durable::WorkStatus;
 use crate::id::WaveId;
 use crate::planning::ProjectPlan;
 use crate::task::{TaskEventKind, TaskId};
@@ -91,6 +92,31 @@ pub enum ProjectEventKind {
 impl ProjectEventKind {
     pub fn is_wave_observable(&self) -> bool {
         !matches!(self, Self::Started | Self::TaskObserved { .. })
+    }
+
+    fn resumable_failure_reason(&self) -> Option<&str> {
+        match self {
+            Self::Failed {
+                error,
+                resumable: true,
+            } => Some(error),
+            _ => None,
+        }
+    }
+}
+
+pub(crate) fn status_reason(status: &WorkStatus, latest: Option<&ProjectEventKind>) -> String {
+    if matches!(status, WorkStatus::Ready | WorkStatus::Waiting { .. }) {
+        if let Some(reason) = latest.and_then(ProjectEventKind::resumable_failure_reason) {
+            return reason.to_string();
+        }
+    }
+    match status {
+        WorkStatus::Running { run_id } => format!("Run {run_id} is active"),
+        WorkStatus::Waiting { .. } => "waiting for input or an event".to_string(),
+        WorkStatus::Ready => "ready".to_string(),
+        WorkStatus::Done => "done".to_string(),
+        WorkStatus::Abandoned => "abandoned".to_string(),
     }
 }
 

--- a/rust/loopflow/src/project/runner.rs
+++ b/rust/loopflow/src/project/runner.rs
@@ -36,6 +36,7 @@ const TASK_SUPERVISION_INTERVAL: Duration = Duration::from_secs(5);
 struct PreparedProjectStep {
     turn: crate::lf::commands::run::PreparedHarnessTurn,
     basis: Basis,
+    planning: crate::ops::task_pm::ResolvedProject,
 }
 
 pub(crate) async fn run(store: SharedStore, project_id: ProjectId, lease: &RunLease) -> Result<()> {
@@ -125,6 +126,7 @@ async fn run_project_inner(
     let (mut flow, _) = Playhead::new(QueuedInvocation::load(Path::new(wave.repo()), "project")?);
     let prepared =
         prepare_project_flow_step(&store, &mut project, lease, &wave, &flow, &observations).await?;
+    let mut active_planning = prepared.planning.clone();
     let (harness_name, _) = crate::engine::config::parse_agent(&project.agent);
     let (event_tx, mut event_rx) = mpsc::unbounded_channel();
     let mut harness = default_create_harness(&harness_name, ApprovalPolicy::AutoApprove, event_tx)?;
@@ -420,6 +422,7 @@ async fn run_project_inner(
                                 &[],
                             )
                             .await?;
+                            active_planning = prepared.planning.clone();
                             active_basis = prepared.basis.clone();
                             start_project_flow_turn(
                                 &store,
@@ -447,7 +450,7 @@ async fn run_project_inner(
                                 },
                             ).await?;
                         }
-                        let mut outcome = inspect_outcome(&store, &project, &wave).await?;
+                        let mut outcome = inspect_outcome(&store, &project, &active_planning).await?;
                         if status == Lifecycle::Interrupted {
                             outcome.disposition = ProjectDisposition::Wait;
                         }
@@ -465,6 +468,7 @@ async fn run_project_inner(
                                 &[],
                             )
                             .await?;
+                            active_planning = prepared.planning.clone();
                             active_basis = prepared.basis.clone();
                             start_project_flow_turn(
                                 &store,
@@ -717,6 +721,7 @@ async fn prepare_project_flow_step(
     flow: &Playhead,
     observations: &[String],
 ) -> Result<PreparedProjectStep> {
+    let planning = refresh_project_plan(store, project, lease, wave).await?;
     let work = store
         .work_for_child(&ChildRef::Project(project.id.clone()))
         .await?;
@@ -731,7 +736,6 @@ async fn prepare_project_flow_step(
             step.kind
         );
     }
-    store.update_project_for_run(project, lease).await?;
     let seed = project_seed(project, wave.name(), &boundary, observations);
     let mut prepared =
         crate::lf::commands::run::prepare_harness_turn(&step.step, &seed, wave.name(), None)?;
@@ -739,7 +743,50 @@ async fn prepare_project_flow_step(
     Ok(PreparedProjectStep {
         turn: prepared,
         basis: boundary.basis,
+        planning,
     })
+}
+
+async fn refresh_project_plan(
+    store: &SharedStore,
+    project: &mut Project,
+    lease: &RunLease,
+    wave: &Wave,
+) -> Result<crate::ops::task_pm::ResolvedProject> {
+    let planning = crate::ops::task_pm::refresh_project(
+        Path::new(wave.repo()),
+        wave.name(),
+        project.plan.id.as_str(),
+    )
+    .await
+    .map_err(|error| {
+        anyhow!(
+            "Project plan refresh blocked before the next phase: {error}. Project Work {} did not continue on its stale plan; repair Linear planning, then restart it with `lf project run {}`",
+            project.id,
+            project.plan.id.as_str()
+        )
+    })?;
+    let plan = crate::ops::project::project_plan(&planning.project, planning.snapshot.synced_at)
+        .map_err(|error| anyhow!(error.to_string()))?;
+    let (adopted, changed) = store
+        .adopt_project_plan_for_run(&project.id, &plan, lease)
+        .await
+        .map_err(|error| {
+            anyhow!(
+                "Project plan refresh could not be adopted safely: {error}. Project Work {} did not continue on its stale plan; restart it after repairing the planning conflict",
+                project.id
+            )
+        })?;
+    if changed {
+        tracing::info!(
+            project = %project.id,
+            linear_project = %project.plan.id.as_str(),
+            snapshot = adopted.plan.pm_snapshot_synced_at,
+            "adopted refreshed Project planning at a phase boundary"
+        );
+    }
+    *project = adopted;
+    Ok(planning)
 }
 
 fn open_project_flow_body(flow: &mut Playhead, control_repo: &str) -> Result<()> {
@@ -869,27 +916,16 @@ struct ProjectOutcome {
 async fn inspect_outcome(
     store: &SharedStore,
     project: &Project,
-    wave: &Wave,
+    planning: &crate::ops::task_pm::ResolvedProject,
 ) -> Result<ProjectOutcome> {
-    let repo = wave.repo().to_string();
-    let project_id = project.plan.id.as_str().to_string();
-    let resolved = tokio::task::spawn_blocking(move || {
-        crate::ops::task_pm::resolve_project(
-            std::path::Path::new(&repo),
-            &project_id,
-            crate::ops::pm::PmRefresh::Never,
-        )
-    })
-    .await
-    .map_err(|error| anyhow!(error.to_string()))??;
     let tasks = crate::ops::task::reconcile_project_tasks(store, project)
         .await
         .map_err(|error| anyhow!(error.to_string()))?;
-    let pm_tasks = resolved
+    let pm_tasks = planning
         .snapshot
         .items
         .iter()
-        .filter(|item| item.project == project.plan.slug)
+        .filter(|item| item.project_id == project.plan.id.as_str())
         .collect::<Vec<_>>();
     let mut task_states = Vec::with_capacity(tasks.len());
     for task in &tasks {
@@ -903,12 +939,12 @@ async fn inspect_outcome(
         ));
     }
     let fingerprint_payload = serde_json::json!({
-        "project": resolved.project,
+        "project": planning.project,
         "pm_tasks": pm_tasks,
         "tasks": &task_states,
     });
     let fingerprint = hex::encode(Sha256::digest(serde_json::to_vec(&fingerprint_payload)?));
-    if !resolved.project.krs.is_empty() && resolved.project.krs.iter().all(|kr| kr.holds) {
+    if !planning.project.krs.is_empty() && planning.project.krs.iter().all(|kr| kr.holds) {
         return Ok(ProjectOutcome {
             disposition: ProjectDisposition::Done,
             fingerprint,
@@ -1264,9 +1300,10 @@ mod tests {
     use time::OffsetDateTime;
 
     use crate::child::ChildRef;
-    use crate::durable::{BoundaryState, RunAdvance, RunLease, WorkStatus};
+    use crate::durable::{Author, BoundaryState, RunAdvance, RunLease, WorkStatus};
     use crate::id::WaveId;
     use crate::planning::{LinearProjectId, ProjectPlan};
+    use crate::pm::{PmKr, PmProject, ProjectFlowPlan};
     use crate::project::{Project, ProjectEventKind, ProjectId};
     use crate::store::{open_store, SharedStore, StorageConfig};
     use crate::wave::Wave;
@@ -1337,6 +1374,95 @@ mod tests {
             super::bounded_summary(&"x".repeat(2_500)).chars().count(),
             2_000
         );
+    }
+
+    #[tokio::test]
+    async fn project_plan_refresh_reaches_the_next_boundary_once_with_all_krs() {
+        let (_directory, _database, store, mut project, lease, _invocation) =
+            project_fixture().await;
+        let work = store
+            .work_for_child(&ChildRef::Project(project.id.clone()))
+            .await
+            .unwrap();
+        store
+            .append_steer(
+                &work,
+                Author::User,
+                "Preserve this direction across planning refresh.",
+                None,
+            )
+            .await
+            .unwrap();
+        project.observation_cursor = 17;
+        store
+            .update_project_for_run(&project, &lease)
+            .await
+            .unwrap();
+        let prior_event = store
+            .append_project_event_for_run(
+                &project.id,
+                &lease,
+                &ProjectEventKind::IterationCompleted {
+                    iteration: 0,
+                    summary: "prior evidence remains durable".to_string(),
+                },
+            )
+            .await
+            .unwrap();
+        let prior_basis = store.boundary_seed(&work).await.unwrap();
+        let prior_epoch = store.current_epoch(&work).await.unwrap();
+        let prior_id = project.id.clone();
+        let refreshed = PmProject {
+            id: project.plan.id.as_str().to_string(),
+            slug: project.plan.slug.clone(),
+            name: "Incident Prevention".to_string(),
+            summary: "Prevent recurrence after restoring service.".to_string(),
+            definition: "Prevent repeated incidents with evidence from production.".to_string(),
+            flows: Some(ProjectFlowPlan::empty()),
+            krs: (1..=6)
+                .map(|number| PmKr {
+                    text: format!("proof {number} holds"),
+                    holds: number == 6,
+                })
+                .collect(),
+            initiative_ids: vec!["initiative-1".to_string()],
+            team_ids: vec!["team-1".to_string()],
+        };
+        let refreshed_plan =
+            crate::ops::project::project_plan(&refreshed, project.plan.pm_snapshot_synced_at + 1)
+                .unwrap();
+
+        let (adopted, changed) = store
+            .adopt_project_plan_for_run(&project.id, &refreshed_plan, &lease)
+            .await
+            .unwrap();
+        let (same_plan, changed_again) = store
+            .adopt_project_plan_for_run(&project.id, &refreshed_plan, &lease)
+            .await
+            .unwrap();
+
+        assert!(changed);
+        assert!(!changed_again);
+        assert_eq!(same_plan.plan, adopted.plan);
+        assert_eq!(adopted.id, prior_id);
+        assert_eq!(adopted.observation_cursor, 17);
+        assert_eq!(store.current_epoch(&work).await.unwrap(), prior_epoch);
+        assert_eq!(store.boundary_seed(&work).await.unwrap(), prior_basis);
+        let events = store.project_events_after(&adopted.id, 0).await.unwrap();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0], prior_event);
+
+        let seed = super::project_seed(&adopted, "incident-management", &prior_basis, &[]);
+        assert!(seed.contains("Prevent repeated incidents with evidence from production."));
+        assert!(!seed.contains("Restore incidents before prevention."));
+        assert!(seed.contains("Preserve this direction across planning refresh."));
+        for number in 1..=6 {
+            let line = format!(
+                "- [{}] proof {number} holds",
+                if number == 6 { "x" } else { " " }
+            );
+            assert_eq!(seed.matches(&line).count(), 1, "missing or repeated {line}");
+        }
     }
 
     #[tokio::test]
@@ -1434,7 +1560,9 @@ mod tests {
             &store,
             &project.id,
             &lease,
-            &anyhow!("Linear project snapshot is unavailable"),
+            &anyhow!(
+                "Project plan refresh blocked before the next phase: Linear Project was archived; restore it before restarting Project Work"
+            ),
         )
         .await;
 
@@ -1444,8 +1572,12 @@ mod tests {
         assert!(matches!(
             &events[0].kind,
             ProjectEventKind::Failed { error, resumable: true }
-                if error == "project runner failed: Linear project snapshot is unavailable"
+                if error == "project runner failed: Project plan refresh blocked before the next phase: Linear Project was archived; restore it before restarting Project Work"
         ));
+        assert_eq!(
+            crate::project::status_reason(&WorkStatus::Ready, Some(&events[0].kind)),
+            "project runner failed: Project plan refresh blocked before the next phase: Linear Project was archived; restore it before restarting Project Work"
+        );
 
         let connection = rusqlite::Connection::open(database).unwrap();
         let run_state: String = connection

--- a/rust/loopflow/src/store/children.rs
+++ b/rust/loopflow/src/store/children.rs
@@ -377,6 +377,17 @@ impl Store {
         .await
     }
 
+    pub async fn latest_project_event(
+        &self,
+        project_id: &ProjectId,
+    ) -> StoreResult<Option<ProjectEvent>> {
+        let project_id = project_id.clone();
+        run_sqlite(&self.sqlite, move |store| {
+            store.latest_project_event(&project_id)
+        })
+        .await
+    }
+
     pub async fn get_task_pr(&self, pr_id: &TaskPrId) -> StoreResult<Option<TaskPr>> {
         let pr_id = pr_id.clone();
         run_sqlite(&self.sqlite, move |store| store.task_pr(&pr_id)).await
@@ -715,6 +726,21 @@ impl Store {
         let lease = lease.clone();
         run_sqlite(&self.sqlite, move |store| {
             store.update_project_for_run(&project, &lease)
+        })
+        .await
+    }
+
+    pub(crate) async fn adopt_project_plan_for_run(
+        &self,
+        project_id: &ProjectId,
+        plan: &crate::planning::ProjectPlan,
+        lease: &RunLease,
+    ) -> StoreResult<(Project, bool)> {
+        let project_id = project_id.clone();
+        let plan = plan.clone();
+        let lease = lease.clone();
+        run_sqlite(&self.sqlite, move |store| {
+            store.adopt_project_plan_for_run(&project_id, &plan, &lease)
         })
         .await
     }

--- a/rust/loopflow/src/store/sqlite/children.rs
+++ b/rust/loopflow/src/store/sqlite/children.rs
@@ -1105,6 +1105,58 @@ impl SqliteStore {
         Ok(())
     }
 
+    pub(crate) fn adopt_project_plan_for_run(
+        &self,
+        project_id: &ProjectId,
+        plan: &ProjectPlan,
+        lease: &RunLease,
+    ) -> StoreResult<(Project, bool)> {
+        let mut conn = self.conn.lock().expect("store mutex poisoned");
+        let transaction = conn.transaction_with_behavior(TransactionBehavior::Immediate)?;
+        require_run_owns_child(&transaction, &ChildRef::Project(project_id.clone()), lease)?;
+        let mut project = transaction.query_row(
+            PROJECT_SELECT,
+            params![project_id.as_str()],
+            map_project_row,
+        )?;
+        if plan.id != project.plan.id {
+            return Err(StoreError::InvalidData(format!(
+                "Project {} cannot adopt planning for Linear Project {}",
+                project.id,
+                plan.id.as_str()
+            )));
+        }
+        if plan.pm_snapshot_synced_at < project.plan.pm_snapshot_synced_at {
+            return Err(StoreError::InvalidData(format!(
+                "Project {} cannot move its PM snapshot backward from {} to {}",
+                project.id, project.plan.pm_snapshot_synced_at, plan.pm_snapshot_synced_at
+            )));
+        }
+        let changed = !project.plan.has_same_content(plan);
+        if project.plan == *plan {
+            transaction.commit()?;
+            return Ok((project, false));
+        }
+        project.plan = plan.clone();
+        if changed {
+            project.updated_at = OffsetDateTime::now_utc();
+        }
+        validate_project(&project)?;
+        let parameters = project_params(&project);
+        if transaction.execute(
+            PROJECT_RUN_UPDATE,
+            rusqlite::params_from_iter(parameters.iter().map(|value| value.as_ref())),
+        )? == 0
+        {
+            return Err(StoreError::InvalidAuthority(format!(
+                "Run {} cannot adopt planning for Project {}",
+                lease.run_id, project.id
+            )));
+        }
+        transaction.commit()?;
+        Ok((project, changed))
+    }
+
     pub(crate) fn finish_project_run(
         &self,
         project: &Project,
@@ -1397,6 +1449,21 @@ impl SqliteStore {
             |row| row.get(0),
         )?;
         Ok(seconds.map(crate::store::rows::unix_to_datetime))
+    }
+
+    pub fn latest_project_event(
+        &self,
+        project_id: &ProjectId,
+    ) -> StoreResult<Option<ProjectEvent>> {
+        let conn = self.conn.lock().expect("store mutex poisoned");
+        conn.query_row(
+            "SELECT id, project_id, kind_json, created_at
+             FROM project_events WHERE project_id=?1 ORDER BY id DESC LIMIT 1",
+            params![project_id.as_str()],
+            map_project_event_row,
+        )
+        .optional()
+        .map_err(StoreError::from)
     }
 
     pub fn pending_observations(

--- a/rust/loopflow/tests/status_tests.rs
+++ b/rust/loopflow/tests/status_tests.rs
@@ -268,7 +268,7 @@ fn prepend_test_bin(command: &mut Command, home: &Path) {
     command.env("PATH", std::env::join_paths(paths).expect("test PATH"));
 }
 
-fn seed_stale_project_work(home: &Path) {
+fn seed_stale_project_work(home: &Path, abandon_stale_project: bool) {
     const STALE_WORK_ID: &str = "proj_e972b70272fbb5e91c096ebe657f9f9b";
     const STALE_PROJECT_ID: &str = "f56c583c-c360-4dc4-ba12-4b5a02268623";
     const STALE_TASK_WORK_ID: &str = "task_40fbeeaadfbca5367aa7391432ae84ff";
@@ -350,20 +350,22 @@ fn seed_stale_project_work(home: &Path) {
     store
         .insert_task(&stale_task, &stale_pr)
         .expect("seed orphaned Task");
-    let stale_work = store
-        .work_for_child(&ChildRef::Project(stale.id.clone()))
-        .expect("resolve stale Project Work");
-    let stale_basis = store
-        .current_epoch(&stale_work)
-        .expect("read stale Project epoch")
-        .current_basis;
-    store
-        .abandon(
-            &stale_work,
-            "Project is absent from the current PM snapshot",
-            &stale_basis,
-        )
-        .expect("retire stale Project Work");
+    if abandon_stale_project {
+        let stale_work = store
+            .work_for_child(&ChildRef::Project(stale.id.clone()))
+            .expect("resolve stale Project Work");
+        let stale_basis = store
+            .current_epoch(&stale_work)
+            .expect("read stale Project epoch")
+            .current_basis;
+        store
+            .abandon(
+                &stale_work,
+                "Project is absent from the current PM snapshot",
+                &stale_basis,
+            )
+            .expect("retire stale Project Work");
+    }
 
     let current = Project {
         id: ProjectId::new(),
@@ -701,7 +703,7 @@ fn a_wave_with_no_runs_reports_an_empty_reading_not_a_missing_one() {
 #[test]
 fn orphaned_task_work_preserves_status_and_roadmap_evidence() {
     let home = tempfile::tempdir().expect("tempdir");
-    seed_stale_project_work(home.path());
+    seed_stale_project_work(home.path(), true);
 
     let status = status_json(home.path(), &["product"], None);
     let status_projects = status["projects"].as_array().expect("status projects");
@@ -780,4 +782,35 @@ fn orphaned_task_work_preserves_status_and_roadmap_evidence() {
         "PRD-52"
     );
     assert_eq!(wave["unavailable_projects"], status["unavailable_projects"]);
+}
+
+#[test]
+fn active_project_removed_from_planning_reports_truthful_recovery() {
+    let home = tempfile::tempdir().expect("tempdir");
+    seed_stale_project_work(home.path(), false);
+
+    let status = status_json(home.path(), &["product"], None);
+    let unavailable = status["unavailable_projects"]
+        .as_array()
+        .expect("status unavailable Projects");
+
+    assert_eq!(unavailable.len(), 1);
+    assert_eq!(unavailable[0]["project_slug"], "technical-architecture");
+    assert_eq!(unavailable[0]["status"], "ready");
+    assert_eq!(unavailable[0]["owner"], "wave");
+    assert_eq!(
+        unavailable[0]["reason"],
+        "Project is absent from the current PM snapshot"
+    );
+    assert_eq!(
+        unavailable[0]["recovery"],
+        "lf project abandon technical-architecture --reason \"Project is absent from the current PM snapshot\""
+    );
+    assert_eq!(
+        unavailable[0]["tasks"]
+            .as_array()
+            .expect("preserved Task evidence")
+            .len(),
+        1
+    );
 }


### PR DESCRIPTION
## Try it

```bash
uv run python scripts/materialize_rust_tests.py -- \
  cargo test -p loopflow --lib project_plan_refresh_reaches_the_next_boundary_once_with_all_krs

uv run python scripts/materialize_rust_tests.py -- \
  cargo test -p loopflow --test status_tests active_project_removed_from_planning_reports_truthful_recovery
```

## Intent

Make active Project Work adopt authoritative Linear definition and KR edits at
the next safe phase boundary without changing Work identity or losing durable
direction and evidence.

## Changes

- Force an atomic Wave PM refresh before each Project provider turn and resolve
  the Project by stable Linear id.
- Replace the existing Project row's complete plan through the active Run lease;
  equal content is idempotent and all KRs are preserved.
- Use the plan that seeded a turn for its completion judgment, preventing
  mid-turn cache races.
- Fail closed before the next provider turn when refresh or adoption is unsafe,
  and expose the exact durable restart reason in Project and Wave status.
- Preserve removed/archived Project Work as unavailable current planning with
  explicit recovery and intact historical Tasks.
- Document the Linear-to-projection-to-Work freshness boundary in the architecture
  map and CLI guide.

## Assumptions

- Linear Project edits need bounded consistency at Project phase boundaries, not
  mid-turn interruption.
- A forced full Wave snapshot is the correctness path because updating only one
  Project would leave status and runtime on different local representations.

## Verification

- `uv run python scripts/check_architecture.py`
- `uv run python scripts/check_migrations.py`
- affected gate: rustfmt, clippy with warnings denied, 1,822 Rust tests, and 69
  website tests

## Not included

- Project webhooks, Task live-edit ingestion, Wave planning changes, and
  unrelated historical W2 cleanup.
