### PR TITLE
prompt caching: improve reuse and expose hit rates

### DIFF
--- a/rust/loopflow/src/engine/flow.rs
+++ b/rust/loopflow/src/engine/flow.rs
@@ -206,6 +206,10 @@ pub fn wave_memory_section(memory: &str) -> Option<String> {
     Some(format!("<lf:wave-memory>\n{trimmed}\n</lf:wave-memory>"))
 }
 
+/// Sections run stable → volatile so providers can prefix-cache the front of
+/// the seed: goal prompt and flow list rarely change between passes, while
+/// MEMORY.md is rewritten every pass — it goes last so a memory edit doesn't
+/// invalidate the cacheable bytes ahead of it.
 pub fn render_goal(goal: &Goal, ctx: &GoalRenderContext) -> String {
     let flows = if ctx.flows.is_empty() {
         "No flows are available.".to_string()
@@ -221,10 +225,10 @@ pub fn render_goal(goal: &Goal, ctx: &GoalRenderContext) -> String {
     });
 
     format!(
-        "{}\n\n{}\n\n<lf:goal-context>\nAvailable flows:\n{}\n</lf:goal-context>",
+        "{}\n\n<lf:goal-context>\nAvailable flows:\n{}\n</lf:goal-context>\n\n{}",
         goal.prompt.trim(),
-        memory,
         flows,
+        memory,
     )
 }
 
@@ -1201,6 +1205,11 @@ mod tests {
         assert!(rendered.contains("Last loop found the docs drift."));
         assert!(rendered.contains("- build"));
         assert!(rendered.contains("- qa"));
+        // Stable → volatile: memory is rewritten between passes, so it must
+        // trail the stable goal and flow list to keep the prefix cacheable.
+        let memory_at = rendered.find("<lf:wave-memory>").expect("memory section");
+        let flows_at = rendered.find("<lf:goal-context>").expect("flow section");
+        assert!(flows_at < memory_at, "memory renders after the flow list");
     }
 
     #[test]

--- a/rust/loopflow/src/flowloop/wave.rs
+++ b/rust/loopflow/src/flowloop/wave.rs
@@ -174,17 +174,21 @@ pub fn path_for_children() -> OsString {
     std::env::join_paths(paths).unwrap_or(inherited)
 }
 
-/// One pass's seed: the rendered goal seed, the orchestration discipline,
-/// the shared loopflow operating document (pass seeds bypass context
-/// assembly, so the `<lf:loopflow>` section is appended here), and the
-/// wake that opened the pass. Reads GOAL.md and MEMORY.md from the ORIGIN
-/// repo (reads are free; writes go through the listener's doors).
+/// One pass's seed: the shared loopflow operating document (pass seeds
+/// bypass context assembly, so the `<lf:loopflow>` section is emitted here),
+/// the orchestration discipline, the rendered goal seed, and the wake that
+/// opened the pass. Reads GOAL.md and MEMORY.md from the ORIGIN repo (reads
+/// are free; writes go through the listener's doors).
+///
+/// Order is stable → volatile so providers can prefix-cache fresh sessions:
+/// the doctrine and discipline are byte-identical every pass, the goal seed
+/// ends with rewritten-every-pass memory, and the wake is unique per pass.
 fn wave_pass_seed(origin_repo: &Path, wave: &str, wake: &str) -> String {
     let seed = build_goal_seed(origin_repo, wave);
     format!(
-        "{seed}\n\n{}\n\n{}\n\n<wake>\n{wake}\n</wake>",
+        "{}\n\n{}\n\n{seed}\n\n<wake>\n{wake}\n</wake>",
+        crate::engine::prompt::loopflow_section(),
         orchestration_discipline(wave),
-        crate::engine::prompt::loopflow_section()
     )
 }
 
@@ -2049,6 +2053,13 @@ mod tests {
         assert!(seed.contains("Ship the thing."));
         assert!(seed.contains("<lf:loopflow>"));
         assert!(seed.contains("<wake>\nhello from chat\n</wake>"));
+        // Stable → volatile: the byte-identical doctrine leads so fresh
+        // sessions prefix-cache it; per-pass memory and wake trail it.
+        let doctrine_at = seed.find("<lf:loopflow>").expect("doctrine");
+        let goal_at = seed.find("Ship the thing.").expect("goal");
+        let wake_at = seed.find("<wake>").expect("wake");
+        assert!(doctrine_at < goal_at, "doctrine precedes the goal seed");
+        assert!(goal_at < wake_at, "wake closes the seed");
         assert_eq!(
             LoopConfig::default().heartbeat_idle,
             Duration::from_secs(4 * 60 * 60)

--- a/rust/loopflow/src/harness/opencode.rs
+++ b/rust/loopflow/src/harness/opencode.rs
@@ -131,12 +131,21 @@ impl OpenCodeHarness {
             return Err(err);
         }
 
-        let provider_session_id = match create_provider_session(&self.client, &base_url).await {
-            Ok(provider_session_id) => provider_session_id,
-            Err(err) => {
-                shutdown_child(&mut child).await;
-                return Err(err);
-            }
+        // Resume the stored session when this serve instance still has it —
+        // a resumed session keeps its conversation history, which providers
+        // serve from prompt cache. Any probe failure falls back to fresh.
+        let resumed =
+            resume_provider_session(&self.client, &base_url, self.provider_session_id.as_deref())
+                .await;
+        let provider_session_id = match resumed {
+            Some(provider_session_id) => provider_session_id,
+            None => match create_provider_session(&self.client, &base_url).await {
+                Ok(provider_session_id) => provider_session_id,
+                Err(err) => {
+                    shutdown_child(&mut child).await;
+                    return Err(err);
+                }
+            },
         };
 
         let event_tx = self.events.clone();
@@ -466,13 +475,14 @@ impl Harness for OpenCodeHarness {
         if let (Some(base_url), Some(provider_session_id)) =
             (&self.server_base_url, &self.provider_session_id)
         {
+            // Abort any in-flight turn but leave the session in opencode's
+            // storage — the persisted id lets the next launch resume the
+            // conversation (and its provider-side prompt cache) instead of
+            // starting cold, matching the claude/codex harnesses.
             let abort_url = format!("{base_url}/session/{provider_session_id}/abort");
             let _ =
                 send_request_with_retry(&self.client, Method::POST, &abort_url, Some(json!({})))
                     .await;
-
-            let delete_url = format!("{base_url}/session/{provider_session_id}");
-            let _ = send_request_with_retry(&self.client, Method::DELETE, &delete_url, None).await;
         }
 
         let opencode_pid = self.child.as_ref().and_then(|child| child.id());
@@ -507,7 +517,8 @@ impl Harness for OpenCodeHarness {
         }
 
         self.turn_in_progress.store(false, Ordering::SeqCst);
-        self.provider_session_id = None;
+        // Keep `provider_session_id`: the runner persists it after stop so the
+        // next launch can resume the session (see `resume_provider_session`).
         self.server_base_url = None;
 
         Ok(())
@@ -530,6 +541,25 @@ impl Harness for OpenCodeHarness {
 async fn shutdown_child(child: &mut Child) {
     let _ = child.start_kill();
     let _ = child.wait().await;
+}
+
+/// Probe a previously stored session id against this serve instance. opencode
+/// persists sessions in its project storage, so a new serve can pick up a
+/// session an earlier one created. `None` (missing id, dead session, or any
+/// transport error) means "create a fresh session instead" — resume is an
+/// optimization, never a failure.
+async fn resume_provider_session(
+    client: &reqwest::Client,
+    base_url: &str,
+    stored: Option<&str>,
+) -> Option<String> {
+    let session_id = stored?;
+    let session_url = format!("{base_url}/session/{session_id}");
+    let response = client.get(&session_url).send().await.ok()?;
+    response
+        .status()
+        .is_success()
+        .then(|| session_id.to_string())
 }
 
 async fn create_provider_session(client: &reqwest::Client, base_url: &str) -> Result<String> {
@@ -1036,6 +1066,46 @@ mod tests {
     use crate::chat::types::ConversationItem;
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
     use tokio::net::TcpListener;
+
+    /// A stored session id is reused when the serve instance still has it and
+    /// dropped when it's gone — resume is an optimization, never a failure.
+    #[tokio::test]
+    async fn resume_probe_reuses_live_sessions_and_drops_dead_ones() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let base_url = format!("http://127.0.0.1:{port}");
+
+        tokio::spawn(async move {
+            loop {
+                let Ok((mut socket, _)) = listener.accept().await else {
+                    return;
+                };
+                let mut buf = vec![0u8; 4096];
+                let n = socket.read(&mut buf).await.unwrap_or(0);
+                let request = String::from_utf8_lossy(&buf[..n]).to_string();
+                let response = if request.starts_with("GET /session/live") {
+                    "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\n{}"
+                } else {
+                    "HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\n\r\n"
+                };
+                let _ = socket.write_all(response.as_bytes()).await;
+            }
+        });
+
+        let client = reqwest::Client::new();
+        assert_eq!(
+            resume_provider_session(&client, &base_url, Some("live")).await,
+            Some("live".to_string())
+        );
+        assert_eq!(
+            resume_provider_session(&client, &base_url, Some("gone")).await,
+            None
+        );
+        assert_eq!(
+            resume_provider_session(&client, &base_url, None).await,
+            None
+        );
+    }
 
     /// Where the fake SSE stream dies relative to the turn lifecycle.
     #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/rust/loopflow/src/lf/commands/runs.rs
+++ b/rust/loopflow/src/lf/commands/runs.rs
@@ -1832,6 +1832,7 @@ mod tests {
             input_tokens: Some(input),
             output_tokens: Some(0),
             cache_read_tokens: None,
+            cache_write_tokens: None,
             cost_usd: Some(cost),
         }
     }

--- a/rust/loopflow/src/lf/commands/usage.rs
+++ b/rust/loopflow/src/lf/commands/usage.rs
@@ -296,6 +296,7 @@ struct Totals {
     input: u64,
     output: u64,
     cache: u64,
+    cache_write: u64,
 }
 
 impl Totals {
@@ -303,17 +304,27 @@ impl Totals {
         self.input += row.input_tokens;
         self.output += row.output_tokens;
         self.cache += row.cache_read_tokens;
+        self.cache_write += row.cache_write_tokens;
     }
 
     fn total(&self) -> u64 {
         self.input + self.output
     }
 
-    fn cells(&self, grand_total: u64) -> [String; 5] {
+    /// Share of the full prompt served from provider cache. Stored `input` is
+    /// the uncached remainder on every harness (codex is normalized net of
+    /// cache reads at capture), so the denominator is the whole prompt.
+    fn hit_percent(&self) -> String {
+        format_share(self.cache, self.input + self.cache + self.cache_write)
+    }
+
+    fn cells(&self, grand_total: u64) -> [String; 7] {
         [
             format_int(self.input),
             format_int(self.output),
             format_int(self.cache),
+            format_int(self.cache_write),
+            self.hit_percent(),
             format_int(self.total()),
             format_share(self.total(), grand_total),
         ]
@@ -344,6 +355,7 @@ struct UsageRow {
     input_tokens: u64,
     output_tokens: u64,
     cache_read_tokens: u64,
+    cache_write_tokens: u64,
 }
 
 fn aggregate_spend(spend: &[TurnSpendRow]) -> Vec<UsageRow> {
@@ -352,7 +364,8 @@ fn aggregate_spend(spend: &[TurnSpendRow]) -> Vec<UsageRow> {
         let input = turn.input_tokens.unwrap_or(0).max(0) as u64;
         let output = turn.output_tokens.unwrap_or(0).max(0) as u64;
         let cache = turn.cache_read_tokens.unwrap_or(0).max(0) as u64;
-        if input == 0 && output == 0 && cache == 0 {
+        let cache_write = turn.cache_write_tokens.unwrap_or(0).max(0) as u64;
+        if input == 0 && output == 0 && cache == 0 && cache_write == 0 {
             continue;
         }
         let totals = rows
@@ -361,6 +374,7 @@ fn aggregate_spend(spend: &[TurnSpendRow]) -> Vec<UsageRow> {
         totals.input += input;
         totals.output += output;
         totals.cache += cache;
+        totals.cache_write += cache_write;
     }
     rows.into_iter()
         .map(|((repo, provider), totals)| UsageRow {
@@ -369,6 +383,7 @@ fn aggregate_spend(spend: &[TurnSpendRow]) -> Vec<UsageRow> {
             input_tokens: totals.input,
             output_tokens: totals.output,
             cache_read_tokens: totals.cache,
+            cache_write_tokens: totals.cache_write,
         })
         .collect()
 }
@@ -426,7 +441,19 @@ fn print_report(rows: &[UsageRow], days: u32) {
 /// distribution across repos, deliberately not a subscription measure (a repo
 /// can burn through many subscriptions' worth; subscription state lives in
 /// the ACCOUNTS section, always as percent *used*).
-const HEADINGS: [&str; 5] = ["INPUT", "OUTPUT", "CACHE READ", "TOTAL", "% TOKENS"];
+///
+/// `HIT %` is cache reads over the full prompt (input + cache read + cache
+/// write) — the canary for prefix-breaking regressions: a drop means agents
+/// stopped reusing their prompt prefixes.
+const HEADINGS: [&str; 7] = [
+    "INPUT",
+    "OUTPUT",
+    "CACHE READ",
+    "CACHE WRITE",
+    "HIT %",
+    "TOTAL",
+    "% TOKENS",
+];
 
 fn repo_lead(repo: &str, provider: &str) -> String {
     format!("{repo:<REPO_WIDTH$}  {provider:<PROVIDER_WIDTH$}")
@@ -436,18 +463,18 @@ fn provider_lead(provider: &str) -> String {
     format!("{provider:<PROVIDER_WIDTH$}")
 }
 
-/// Both tables are the same five columns behind a label; only the label differs,
+/// Both tables are the same seven columns behind a label; only the label differs,
 /// so one printer serves headers, rows, and totals.
-fn print_row(lead: &str, cells: [String; 5], bold: bool) {
+fn print_row(lead: &str, cells: [String; 7], bold: bool) {
     let colors = Colors::default();
     let (on, off) = if bold {
         (colors.bold, colors.reset)
     } else {
         ("", "")
     };
-    let [input, output, cache, total, share] = cells;
+    let [input, output, cache, cache_write, hit, total, share] = cells;
     println!(
-        "{on}{lead}  {input:>num_w$}  {output:>num_w$}  {cache:>num_w$}  {total:>num_w$}  {share:>share_w$}{off}",
+        "{on}{lead}  {input:>num_w$}  {output:>num_w$}  {cache:>num_w$}  {cache_write:>num_w$}  {hit:>share_w$}  {total:>num_w$}  {share:>share_w$}{off}",
         num_w = NUM_WIDTH,
         share_w = SHARE_WIDTH,
     );
@@ -507,9 +534,11 @@ mod tests {
         assert_eq!(turns.len(), 2);
         assert_eq!(turns[0].turn_id, "turn-1");
         assert_eq!(turns[0].invocation_id, "invocation-1");
+        assert_eq!(turns[0].cache_write_tokens, Some(100));
         assert_eq!(turns[1].input_tokens, None);
         assert_eq!(turns[1].output_tokens, Some(0));
         assert_eq!(turns[1].cache_read_tokens, Some(150));
+        assert_eq!(turns[1].cache_write_tokens, None);
         assert_eq!(turns[1].cost_usd, None);
         assert_eq!(
             serde_json::to_value(&turns).expect("serialize turn spend"),
@@ -554,6 +583,7 @@ mod tests {
         invocation: &AgentInvocationRow,
         output: Option<i64>,
         cache_read: Option<i64>,
+        cache_write: Option<i64>,
     ) -> AgentTurnRow {
         AgentTurnRow {
             id: invocation.id.replacen("invocation", "turn", 1),
@@ -578,7 +608,7 @@ mod tests {
             provider_output_tokens: output,
             reasoning_tokens: None,
             cache_read_tokens: cache_read,
-            cache_write_tokens: None,
+            cache_write_tokens: cache_write,
             cost_usd: None,
             context_gather_ms: 0,
             context_render_ms: 0,
@@ -594,13 +624,14 @@ mod tests {
     fn spend_query_keeps_zero_and_cache_only_but_omits_absent_usage() {
         let directory = tempfile::tempdir().expect("tempdir");
         let store = SqliteStore::new(&directory.path().join("loopflow.db")).expect("store");
-        for (id, output, cache_read) in [
-            ("absent", None, None),
-            ("zero", Some(0), None),
-            ("cache", None, Some(150)),
+        for (id, output, cache_read, cache_write) in [
+            ("absent", None, None, None),
+            ("zero", Some(0), None, None),
+            ("cache", None, Some(150), None),
+            ("write", None, None, Some(75)),
         ] {
             let invocation = invocation(id);
-            let turn = measured_turn(&invocation, output, cache_read);
+            let turn = measured_turn(&invocation, output, cache_read, cache_write);
             store
                 .insert_trace_capture(&invocation, &turn, &[], &[])
                 .expect("insert capture");
@@ -608,7 +639,7 @@ mod tests {
 
         let rows = store.turn_spend_since(0).expect("turn spend");
 
-        assert_eq!(rows.len(), 2);
+        assert_eq!(rows.len(), 3);
         assert!(rows.iter().all(|row| row.turn_id != "turn-absent"));
         let zero = rows
             .iter()
@@ -622,6 +653,11 @@ mod tests {
         assert_eq!(cache.input_tokens, None);
         assert_eq!(cache.output_tokens, None);
         assert_eq!(cache.cache_read_tokens, Some(150));
+        let write = rows
+            .iter()
+            .find(|row| row.turn_id == "turn-write")
+            .expect("cache-write-only report");
+        assert_eq!(write.cache_write_tokens, Some(75));
     }
 
     fn row(repo: &str, provider: &str, input: u64) -> UsageRow {
@@ -631,6 +667,7 @@ mod tests {
             input_tokens: input,
             output_tokens: 1,
             cache_read_tokens: 2,
+            cache_write_tokens: 3,
         }
     }
 
@@ -662,6 +699,26 @@ mod tests {
 
         assert_eq!(claude.input, 150);
         assert_eq!(grand.input, 157);
+    }
+
+    /// Hit % is cache reads over the whole prompt: uncached input + cache
+    /// reads + cache writes. A fully cold turn is 0%, a fully warm one
+    /// approaches 100%.
+    #[test]
+    fn hit_percent_is_cache_reads_over_full_prompt() {
+        let mut totals = Totals::default();
+        totals.add(&UsageRow {
+            repo: "/src/loopflow".to_string(),
+            provider: "claude".to_string(),
+            input_tokens: 100,
+            output_tokens: 500,
+            cache_read_tokens: 800,
+            cache_write_tokens: 100,
+        });
+
+        // 800 / (100 + 800 + 100) = 80%; output never enters the ratio.
+        assert_eq!(totals.hit_percent(), "80%");
+        assert_eq!(Totals::default().hit_percent(), "-");
     }
 
     #[test]
@@ -709,6 +766,7 @@ mod tests {
             input_tokens: Some(input),
             output_tokens: Some(0),
             cache_read_tokens: Some(0),
+            cache_write_tokens: None,
             cost_usd: Some(input as f64 / 100.0),
         }
     }

--- a/rust/loopflow/src/store/mod.rs
+++ b/rust/loopflow/src/store/mod.rs
@@ -71,6 +71,7 @@ pub struct TurnSpendRow {
     pub input_tokens: Option<i64>,
     pub output_tokens: Option<i64>,
     pub cache_read_tokens: Option<i64>,
+    pub cache_write_tokens: Option<i64>,
     pub cost_usd: Option<f64>,
 }
 

--- a/rust/loopflow/src/store/sqlite.rs
+++ b/rust/loopflow/src/store/sqlite.rs
@@ -1535,13 +1535,14 @@ impl SqliteStore {
         let mut stmt = conn.prepare(
             "SELECT t.id, l.id, l.run_id, l.process_id, l.repo, l.wave, l.flow, l.skill,
                     l.provider, l.model, COALESCE(t.ended_at, t.started_at), t.provider_input_tokens,
-                    t.provider_output_tokens, t.cache_read_tokens, t.cost_usd
+                    t.provider_output_tokens, t.cache_read_tokens, t.cache_write_tokens, t.cost_usd
              FROM agent_turns t
              JOIN agent_invocations l ON l.id = t.invocation_id
              WHERE COALESCE(t.ended_at, t.started_at) >= ?1
                AND (t.provider_input_tokens IS NOT NULL
                     OR t.provider_output_tokens IS NOT NULL
                     OR t.cache_read_tokens IS NOT NULL
+                    OR t.cache_write_tokens IS NOT NULL
                     OR t.cost_usd IS NOT NULL)
              ORDER BY COALESCE(t.ended_at, t.started_at), l.process_id, t.ordinal",
         )?;
@@ -1561,7 +1562,8 @@ impl SqliteStore {
                 input_tokens: row.get(11)?,
                 output_tokens: row.get(12)?,
                 cache_read_tokens: row.get(13)?,
-                cost_usd: row.get(14)?,
+                cache_write_tokens: row.get(14)?,
+                cost_usd: row.get(15)?,
             })
         })?;
         rows.collect::<rusqlite::Result<Vec<_>>>()

--- a/swift/Loopflow/Services/RegistryQuery.swift
+++ b/swift/Loopflow/Services/RegistryQuery.swift
@@ -677,6 +677,7 @@ public struct TurnSpend: Codable, Equatable, Sendable, Identifiable {
     public let inputTokens: Int?
     public let outputTokens: Int?
     public let cacheReadTokens: Int?
+    public let cacheWriteTokens: Int?
     public let costUsd: Double?
 
     /// `provider:model` — the harness and the model it drove.
@@ -698,6 +699,7 @@ public struct TurnSpend: Codable, Equatable, Sendable, Identifiable {
         case inputTokens = "input_tokens"
         case outputTokens = "output_tokens"
         case cacheReadTokens = "cache_read_tokens"
+        case cacheWriteTokens = "cache_write_tokens"
         case costUsd = "cost_usd"
     }
 }

--- a/swift/LoopflowTests/DTOFixtureTests.swift
+++ b/swift/LoopflowTests/DTOFixtureTests.swift
@@ -37,9 +37,11 @@ struct DTOFixtureTests {
         #expect(turns[0].execId == "exec-1")
         #expect(turns[0].totalTokens == 1200)
         #expect(turns[0].agent == "claude:opus")
+        #expect(turns[0].cacheWriteTokens == 100)
         #expect(turns[1].inputTokens == nil)
         #expect(turns[1].outputTokens == 0)
         #expect(turns[1].cacheReadTokens == 150)
+        #expect(turns[1].cacheWriteTokens == nil)
         #expect(turns[1].costUsd == nil)
 
         let encoded = try JSONEncoder().encode(turns)

--- a/tests/fixtures/dto/README.md
+++ b/tests/fixtures/dto/README.md
@@ -27,9 +27,10 @@ current source-file hash used to reject a stale Task worktree without
 reimplementing prompt transformations in Swift.
 
 `turn_spend.json` is the additive `lf usage --json` wire. Each row names its
-Turn, AgentInvocation, trace, and exec; the second row proves a cache-only measurement
-survives while absent token and cost fields remain explicit nulls. Rust and
-Swift both round-trip it.
+Turn, AgentInvocation, trace, and exec, and carries both cache directions
+(read and write); the second row proves a cache-only measurement survives
+while absent token and cost fields remain explicit nulls. Rust and Swift both
+round-trip it.
 
 `activity_snapshot.json` pins `lf ps --json`: Exec and provider nodes retain
 their existing Work attribution, working/stalled state, and exact token rates, while a registered

--- a/tests/fixtures/dto/turn_spend.json
+++ b/tests/fixtures/dto/turn_spend.json
@@ -14,6 +14,7 @@
     "input_tokens": 1000,
     "output_tokens": 200,
     "cache_read_tokens": 800,
+    "cache_write_tokens": 100,
     "cost_usd": 0.25
   },
   {
@@ -31,6 +32,7 @@
     "input_tokens": null,
     "output_tokens": 0,
     "cache_read_tokens": 150,
+    "cache_write_tokens": null,
     "cost_usd": null
   }
 ]


### PR DESCRIPTION
## Usage

```bash
lf usage --cached --days 7
lf usage --days 7 --json
```

## Summary

Improves prompt-cache reuse for Wave agents and makes cache performance visible in `lf usage`. Stable prompt sections now precede frequently changing memory and wake content, while OpenCode sessions survive harness restarts when their stored conversation remains available.

## Changes

- Order Wave seeds from stable doctrine and goals to volatile memory and wake content
- Resume persisted OpenCode sessions, falling back cleanly when a session is unavailable
- Carry cache-write tokens through SQLite and the shared Rust/Swift usage DTO
- Report cache writes and prompt-cache hit percentage by repository and provider