### PR TITLE
release: rebuild stale release PRs before publishing

### DIFF
--- a/python/tests/test_release_automation.py
+++ b/python/tests/test_release_automation.py
@@ -267,6 +267,10 @@ def test_infrastructure_cron_runs_the_host_release_after_telemetry():
     assert "env -i" in bootstrap
     assert "DOPPLER_TOKEN" not in bootstrap
     assert "loopflow-release-publisher" in bootstrap
+    assert "not local Home %s" not in bootstrap
+    assert "printf '%s\\n' \"$local_home\"" not in bootstrap
+    assert "bootstrap complete: %s owns" not in bootstrap
+    assert "wrong Home in installed cron: {entry!r}" not in bootstrap
     assert bootstrap.index('lf cron preflight --wave "$wave"') < bootstrap.index(
         "scripts/publish_release.py check"
     )

--- a/rust/loopflow/src/ops/land.rs
+++ b/rust/loopflow/src/ops/land.rs
@@ -489,7 +489,7 @@ fn finalize_remote(
                 )
             })?;
             progress.status("Enabling auto-merge...");
-            enable_auto_merge(repo_root, number, pr_title, pr_body, head_sha)?;
+            crate::ops::pr::enable_auto_merge(repo_root, number, pr_title, pr_body, head_sha)?;
         }
         Finalize::UserMerge => {
             progress.status("Assigning PR for you to merge...");
@@ -641,45 +641,6 @@ fn update_pr_message(repo: &Path, title: &str, body: &str) -> OpsResult<()> {
 pub fn mark_ready(repo: &Path) -> OpsResult<()> {
     let mut cmd = Command::new("gh");
     cmd.arg("pr").arg("ready").current_dir(repo);
-    if let Err(err) = run_command(&mut cmd) {
-        return Err(OpsError::CommandFailed {
-            command: err.command_line(),
-            stderr: err.stderr,
-        });
-    }
-    Ok(())
-}
-
-fn enable_auto_merge(
-    repo: &Path,
-    number: u64,
-    title: Option<&str>,
-    body: Option<&str>,
-    head_sha: &str,
-) -> OpsResult<()> {
-    if crate::ops::pr::auto_merge_enabled(repo, number)? {
-        let number = u32::try_from(number).map_err(|_| {
-            OpsError::Message(format!("pull request #{number} exceeds supported range"))
-        })?;
-        // A pre-existing remote arm carries no durable Loopflow head binding.
-        // Replace it so every accepted Auto request crosses our exact-head
-        // command boundary, even when GitHub already reports auto-merge.
-        crate::ops::pr::disable_auto_merge(repo, number)?;
-    }
-    let mut cmd = Command::new("gh");
-    cmd.arg("pr")
-        .arg("merge")
-        .arg("--squash")
-        .arg("--auto")
-        .arg("--match-head-commit")
-        .arg(head_sha);
-    if let Some(title) = title {
-        cmd.arg("--subject").arg(title);
-    }
-    if let Some(body) = body.filter(|b| !b.trim().is_empty()) {
-        cmd.arg("--body").arg(body);
-    }
-    cmd.current_dir(repo);
     if let Err(err) = run_command(&mut cmd) {
         return Err(OpsError::CommandFailed {
             command: err.command_line(),

--- a/rust/loopflow/src/ops/pr.rs
+++ b/rust/loopflow/src/ops/pr.rs
@@ -507,6 +507,49 @@ pub(crate) fn disable_auto_merge(repo: &Path, number: u32) -> OpsResult<()> {
     })
 }
 
+pub(crate) fn enable_auto_merge(
+    repo: &Path,
+    number: u64,
+    title: Option<&str>,
+    body: Option<&str>,
+    head_sha: &str,
+) -> OpsResult<()> {
+    if auto_merge_enabled(repo, number)? {
+        let number = u32::try_from(number).map_err(|_| {
+            OpsError::Message(format!("pull request #{number} exceeds supported range"))
+        })?;
+        // A pre-existing remote arm carries no durable Loopflow head binding.
+        // Replace it so every accepted Auto request crosses our exact-head
+        // command boundary, even when GitHub already reports auto-merge.
+        disable_auto_merge(repo, number)?;
+    }
+
+    let number_arg = number.to_string();
+    let mut command = Command::new("gh");
+    command
+        .arg("pr")
+        .arg("merge")
+        .arg(&number_arg)
+        .arg("--squash")
+        .arg("--auto")
+        .arg("--match-head-commit")
+        .arg(head_sha);
+    if let Some(title) = title {
+        command.arg("--subject").arg(title);
+    }
+    if let Some(body) = body.filter(|body| !body.trim().is_empty()) {
+        command.arg("--body").arg(body);
+    }
+    let output = command.current_dir(repo).output()?;
+    if output.status.success() {
+        return Ok(());
+    }
+    Err(OpsError::CommandFailed {
+        command: format!("gh pr merge {number} --squash --auto --match-head-commit {head_sha}"),
+        stderr: stderr_from_output(&output),
+    })
+}
+
 /// The outcome of a bounded, single-PR remote observation. GitHub is a
 /// reconciliation input, never the Task's store of record: a transport, quota,
 /// or network failure must leave the cached Task/PR row standing rather than

--- a/rust/loopflow/src/ops/release.rs
+++ b/rust/loopflow/src/ops/release.rs
@@ -1,4 +1,5 @@
 use std::collections::HashSet;
+use std::ffi::OsString;
 use std::fs;
 use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
@@ -14,14 +15,14 @@ use crate::engine::config::{
     load_config_or_default, Config, ReleaseCompletion, ReleaseTargetConfig,
 };
 use crate::engine::git::{
-    acquire_worktree_lease, delete_local_branch, get_default_branch, sync_main, worktree_remove,
-    worktree_remove_owned, WorktreeLease,
+    acquire_worktree_lease, delete_local_branch, fetch, get_default_branch, sync_main,
+    worktree_remove, worktree_remove_owned, WorktreeLease,
 };
 use crate::engine::naming::{git_user, sanitize_for_branch};
 use crate::engine::worktrees::{create_named_worktree, main_repo_root, worktree_path};
 use crate::ops::commit::{commit_workflow, CommitOptions};
 use crate::ops::error::{OpsError, OpsResult};
-use crate::ops::land::{land, LandOptions};
+use crate::ops::land::{finish_land_after_rebase, LandOptions};
 use crate::ops::pr::PrCopy;
 use crate::ops::progress::Progress;
 use crate::ops::util::command_exists;
@@ -42,6 +43,42 @@ const RELEASE_NOTES_MAX_BYTES: usize = 60 * 1024;
 const FALLBACK_NOTES_MAX_COMMITS: usize = 50;
 const FALLBACK_NOTES_MAX_PRS: usize = 50;
 const RELEASE_NOTES_STATUS_PREFIX: &str = "<!-- loopflow:release-notes=";
+const RELEASE_WORKTREE_CONTEXT_ENV: [&str; 5] = [
+    crate::durable::RUN_CONTEXT_ENV,
+    "LF_RUN_ID",
+    crate::durable::RUN_LEASE_ENV,
+    crate::durable::AGENT_INVOCATION_ENV,
+    crate::engine::wave_context::WAVE_ID_ENV,
+];
+
+struct ReleaseWorktreeContext {
+    previous: Vec<(&'static str, Option<OsString>)>,
+}
+
+impl ReleaseWorktreeContext {
+    fn enter() -> Self {
+        let previous = RELEASE_WORKTREE_CONTEXT_ENV
+            .iter()
+            .map(|name| {
+                let value = std::env::var_os(name);
+                std::env::remove_var(name);
+                (*name, value)
+            })
+            .collect();
+        Self { previous }
+    }
+}
+
+impl Drop for ReleaseWorktreeContext {
+    fn drop(&mut self) {
+        for (name, value) in &self.previous {
+            match value {
+                Some(value) => std::env::set_var(name, value),
+                None => std::env::remove_var(name),
+            }
+        }
+    }
+}
 
 /// A merged PR with enough context for release notes.
 #[derive(Debug, Clone, Serialize)]
@@ -117,11 +154,6 @@ struct GhRunListEntry {
 }
 
 #[derive(Debug, Deserialize)]
-struct GhPrSummary {
-    number: u64,
-}
-
-#[derive(Debug, Deserialize)]
 struct GhPrMergeCommit {
     oid: String,
 }
@@ -129,6 +161,8 @@ struct GhPrMergeCommit {
 #[derive(Debug, Deserialize)]
 struct GhPrView {
     state: String,
+    #[serde(rename = "mergeStateStatus")]
+    merge_state_status: String,
     #[serde(default, rename = "mergeCommit")]
     merge_commit: Option<GhPrMergeCommit>,
     #[serde(default)]
@@ -143,6 +177,8 @@ struct GhReleasePr {
     merge_commit: Option<GhPrMergeCommit>,
     #[serde(default)]
     url: Option<String>,
+    #[serde(default, rename = "headRefOid")]
+    head_ref_oid: Option<String>,
 }
 
 impl From<GhMergedPr> for MergedPr {
@@ -652,8 +688,25 @@ pub fn release_run(
                 ))
             })?,
             "OPEN" => {
+                let head_sha = pr.head_ref_oid.as_deref().ok_or_else(|| {
+                    OpsError::Message(format!(
+                        "open release PR #{} has no observable head commit",
+                        pr.number
+                    ))
+                })?;
                 progress.status(&format!("Resuming release PR #{}...", pr.number));
-                wait_for_pr_merge(&main_repo, pr.number, progress)?
+                finish_release_pr(
+                    &main_repo,
+                    &wt_name,
+                    &branch,
+                    PreparedRelease {
+                        pr_number: pr.number,
+                        head_sha: head_sha.to_string(),
+                    },
+                    &target,
+                    &version,
+                    progress,
+                )?
             }
             _ => {
                 let url = pr.url.unwrap_or_else(|| format!("PR #{}", pr.number));
@@ -682,7 +735,9 @@ pub fn release_run(
         let prepared = prepared?;
 
         progress.status("Waiting for release PR to merge...");
-        wait_for_pr_merge(&main_repo, prepared.pr_number, progress)?
+        finish_release_pr(
+            &main_repo, &wt_name, &branch, prepared, &target, &version, progress,
+        )?
     };
 
     progress.status(&format!("Tagging {}...", target_tag(&target, &version)));
@@ -843,6 +898,7 @@ fn expand_publisher_command(repo: &Path, publisher: &[String]) -> Vec<String> {
 #[derive(Debug)]
 struct PreparedRelease {
     pr_number: u64,
+    head_sha: String,
 }
 
 fn prepare_release_in_worktree(
@@ -854,6 +910,9 @@ fn prepare_release_in_worktree(
     target: &ReleaseTarget,
     progress: &impl Progress,
 ) -> OpsResult<PreparedRelease> {
+    // Release preparation owns its branch independently of whichever Work
+    // launched the controller. Provider/account authority remains available.
+    let _context = ReleaseWorktreeContext::enter();
     progress.status(&format!(
         "Bumping manifests for {}...",
         target_tag(target, version)
@@ -893,30 +952,111 @@ fn prepare_release_in_worktree(
         progress,
     )?;
 
-    let pr = current_pr_summary(wt_path)?;
-    let pr_copy = release_pr_copy(wt_path, target, version)?;
-
     progress.status("Enqueuing release PR for merge...");
-    land(
-        wt_path,
-        &LandOptions {
-            strict: true,
-            local: false,
-            create_pr: false,
-            complete: false,
-            next_slug: None,
-            worktree: None,
-            commit_message: None,
-            pr_title: Some(pr_copy.title),
-            pr_body: Some(pr_copy.body),
-            agent: None,
-        },
-        progress,
-    )?;
+    let pr_copy = release_pr_copy(wt_path, target, version)?;
+    let options = LandOptions {
+        strict: true,
+        local: false,
+        create_pr: false,
+        complete: false,
+        next_slug: None,
+        worktree: None,
+        commit_message: None,
+        pr_title: Some(pr_copy.title),
+        pr_body: Some(pr_copy.body),
+        agent: None,
+    };
+    let pr = finish_land_after_rebase(wt_path, &options, progress)?.ok_or_else(|| {
+        OpsError::Message("release land completed without a pull request".to_string())
+    })?;
+    let head_sha = pr.head_sha.ok_or_else(|| {
+        OpsError::Message(format!(
+            "release pull request #{} has no observable head commit",
+            pr.number
+        ))
+    })?;
 
     Ok(PreparedRelease {
         pr_number: pr.number,
+        head_sha,
     })
+}
+
+fn finish_release_pr(
+    main_repo: &Path,
+    worktree_name: &str,
+    release_branch: &str,
+    mut prepared: PreparedRelease,
+    target: &ReleaseTarget,
+    version: &str,
+    progress: &impl Progress,
+) -> OpsResult<String> {
+    loop {
+        match wait_for_pr_merge(main_repo, prepared.pr_number, &prepared.head_sha, progress)? {
+            ReleasePrWait::Merged(commit) => return Ok(commit),
+            ReleasePrWait::NeedsIntegration(state) => {
+                progress.status(&format!(
+                    "Release PR #{} is {state}; rebuilding on current main...",
+                    prepared.pr_number
+                ));
+                fetch_release_branch(main_repo, release_branch, &prepared.head_sha)?;
+                let wt = create_named_worktree(main_repo, worktree_name, None, true)?;
+                let refreshed = rebuild_release_pr(
+                    main_repo,
+                    &wt.path,
+                    &prepared.head_sha,
+                    target,
+                    version,
+                    progress,
+                );
+                cleanup_release_worktree(main_repo, &wt.path, &wt.branch, None, progress);
+                prepared = refreshed?;
+            }
+        }
+    }
+}
+
+fn fetch_release_branch(repo: &Path, branch: &str, expected_head: &str) -> OpsResult<()> {
+    let remote_ref = format!("refs/remotes/origin/{branch}");
+    let refspec = format!("+refs/heads/{branch}:{remote_ref}");
+    fetch(repo, "origin", &refspec)?;
+    let remote_head = crate::engine::git::rev_parse(repo, &remote_ref)?;
+    if remote_head != expected_head {
+        return Err(OpsError::Message(format!(
+            "release PR head changed while recovery was fetching it: expected {expected_head}, found {remote_head}"
+        )));
+    }
+    Ok(())
+}
+
+fn rebuild_release_pr(
+    main_repo: &Path,
+    worktree: &Path,
+    expected_head: &str,
+    target: &ReleaseTarget,
+    version: &str,
+    progress: &impl Progress,
+) -> OpsResult<PreparedRelease> {
+    let current_head = crate::engine::git::rev_parse(worktree, "HEAD")?;
+    if current_head != expected_head {
+        return Err(OpsError::Message(format!(
+            "release PR head changed while recovery was materializing it: expected {expected_head}, found {current_head}"
+        )));
+    }
+
+    let main_branch = get_default_branch(main_repo)?;
+    let main_ref = format!("origin/{main_branch}");
+    run_stdout(worktree, "git", &["reset", "--hard", &main_ref])?;
+    let changes = collect_release_changes(main_repo, target)?;
+    prepare_release_in_worktree(
+        worktree,
+        version,
+        changes.previous_tag.as_deref(),
+        &changes.commits,
+        &changes.merged_prs,
+        target,
+        progress,
+    )
 }
 
 #[derive(Debug, Serialize)]
@@ -1549,12 +1689,6 @@ fn release_pr_copy(repo: &Path, target: &ReleaseTarget, version: &str) -> OpsRes
     })
 }
 
-fn current_pr_summary(repo: &Path) -> OpsResult<GhPrSummary> {
-    let output = run_stdout(repo, "gh", &["pr", "view", "--json", "number"])?;
-    serde_json::from_str(&output)
-        .map_err(|err| OpsError::Parse(format!("failed to parse PR summary: {err}")))
-}
-
 fn release_branch_name(repo: &Path, worktree_name: &str) -> OpsResult<String> {
     let author = git_user(repo)?;
     Ok(format!("{author}/{}", sanitize_for_branch(worktree_name)))
@@ -1572,7 +1706,7 @@ fn find_release_pr(repo: &Path, branch: &str) -> OpsResult<Option<GhReleasePr>> 
             "--state",
             "all",
             "--json",
-            "number,state,mergeCommit,url",
+            "number,state,mergeCommit,url,headRefOid",
             "--limit",
             "1",
         ],
@@ -1582,7 +1716,17 @@ fn find_release_pr(repo: &Path, branch: &str) -> OpsResult<Option<GhReleasePr>> 
     Ok(prs.pop())
 }
 
-fn wait_for_pr_merge(repo: &Path, pr_number: u64, progress: &impl Progress) -> OpsResult<String> {
+enum ReleasePrWait {
+    Merged(String),
+    NeedsIntegration(String),
+}
+
+fn wait_for_pr_merge(
+    repo: &Path,
+    pr_number: u64,
+    head_sha: &str,
+    progress: &impl Progress,
+) -> OpsResult<ReleasePrWait> {
     let started = Instant::now();
     let timeout = Duration::from_secs(60 * 60);
     let poll = Duration::from_secs(10);
@@ -1598,7 +1742,7 @@ fn wait_for_pr_merge(repo: &Path, pr_number: u64, progress: &impl Progress) -> O
                 "view",
                 &pr_number_arg,
                 "--json",
-                "state,mergeCommit,url",
+                "state,mergeStateStatus,mergeCommit,url",
             ],
         )?;
         let view: GhPrView = serde_json::from_str(&output)
@@ -1611,7 +1755,7 @@ fn wait_for_pr_merge(repo: &Path, pr_number: u64, progress: &impl Progress) -> O
                         "PR #{pr_number} is merged but merge commit is unavailable"
                     ))
                 })?;
-                return Ok(commit.oid);
+                return Ok(ReleasePrWait::Merged(commit.oid));
             }
             "CLOSED" => {
                 let url = view.url.unwrap_or_else(|| format!("PR #{pr_number}"));
@@ -1622,14 +1766,30 @@ fn wait_for_pr_merge(repo: &Path, pr_number: u64, progress: &impl Progress) -> O
             _ => {}
         }
 
+        if matches!(view.merge_state_status.as_str(), "BEHIND" | "DIRTY") {
+            return Ok(ReleasePrWait::NeedsIntegration(
+                view.merge_state_status.to_ascii_lowercase(),
+            ));
+        }
+
         if started.elapsed() >= timeout {
             return Err(OpsError::Message(format!(
                 "timed out waiting for PR #{pr_number} to merge"
             )));
         }
 
+        if !crate::ops::pr::auto_merge_enabled(repo, pr_number)? {
+            progress.status(&format!(
+                "Re-arming release PR #{pr_number} for exact-head auto-merge..."
+            ));
+            crate::ops::pr::enable_auto_merge(repo, pr_number, None, None, head_sha)?;
+        }
+
         if attempt.is_multiple_of(6) {
-            progress.status(&format!("PR #{pr_number} still in merge queue..."));
+            progress.status(&format!(
+                "PR #{pr_number} is open ({}) and awaiting GitHub auto-merge...",
+                view.merge_state_status.to_ascii_lowercase()
+            ));
         }
         attempt += 1;
         thread::sleep(poll);

--- a/rust/loopflow/tests/land_tests.rs
+++ b/rust/loopflow/tests/land_tests.rs
@@ -915,7 +915,7 @@ fn land_clears_the_durable_request_when_auto_arm_fails() {
         "a failed Auto handoff must not leave GitHub as a false owner"
     );
     let log = fs::read_to_string(log_path).expect("read gh log");
-    assert!(log.contains("pr merge --squash --auto --match-head-commit"));
+    assert!(log.contains("pr merge 912 --squash --auto --match-head-commit"));
 }
 
 #[test]
@@ -1026,13 +1026,13 @@ fn latest_land_disposition_wins_before_merge() {
     assert_eq!(merge.next_slug.as_deref(), Some("follow-up-proof"));
     let log = fs::read_to_string(&log_path).expect("read gh log");
     assert!(log.contains(&format!(
-        "pr merge --squash --auto --match-head-commit {revised_head}"
+        "pr merge 912 --squash --auto --match-head-commit {revised_head}"
     )));
     let first_disable = log
         .find("pr merge 912 --disable-auto")
         .expect("pre-existing Auto is replaced");
     let first_arm = log
-        .find("pr merge --squash --auto --match-head-commit")
+        .find("pr merge 912 --squash --auto --match-head-commit")
         .expect("land arms the exact prepared head");
     assert!(
         first_disable < first_arm,
@@ -1211,7 +1211,7 @@ fn non_task_land_leaves_the_merge_queue_before_pushing_a_new_head() {
         .expect("queued Auto is revoked");
     let push = log.find("git-push").expect("prepared head is pushed");
     let arm = log
-        .rfind("pr merge --squash --auto --match-head-commit")
+        .rfind("pr merge 912 --squash --auto --match-head-commit")
         .expect("prepared head is re-armed");
     assert!(
         disable < push && push < arm,

--- a/rust/loopflow/tests/release_tests.rs
+++ b/rust/loopflow/tests/release_tests.rs
@@ -33,6 +33,107 @@ fn write_gh_failed_release_script() -> &'static str {
     "#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then\n  echo 'gh version 2.0.0'\n  exit 0\nfi\ncase \"$1 $2\" in\n  'release view') exit 1;;\n  'run list') cat <<'JSON'\n[{\"databaseId\":42,\"headBranch\":\"v0.9.1\",\"status\":\"completed\",\"conclusion\":\"failure\",\"url\":\"https://example.com/run/42\"}]\nJSON\n    exit 0;;\n  'pr list') echo '[]'; exit 0;;\nesac\necho \"unexpected gh invocation: $@\" >&2\nexit 1\n"
 }
 
+fn write_gh_dropped_auto_merge_script(log_path: &str) -> String {
+    format!(
+        r#"#!/bin/sh
+log="{log_path}"
+armed="{log_path}.armed"
+if [ "$1" = "--version" ]; then
+  exit 0
+fi
+printf '%s\n' "$*" >> "$log"
+case "$1 $2" in
+  'pr list')
+    case " $* " in
+      *' --head '*)
+        head="$(git rev-parse HEAD)"
+        printf '[{{"number":1176,"state":"OPEN","mergeCommit":null,"url":"https://example.com/pr/1176","headRefOid":"%s"}}]\n' "$head"
+        ;;
+      *) echo '[]' ;;
+    esac
+    exit 0;;
+  'pr view')
+    head="$(git rev-parse HEAD)"
+    if [ -f "$armed" ]; then
+      printf '{{"state":"MERGED","mergeStateStatus":"UNKNOWN","mergeCommit":{{"oid":"%s"}},"url":"https://example.com/pr/1176"}}\n' "$head"
+    else
+      printf '{{"state":"OPEN","mergeStateStatus":"CLEAN","mergeCommit":null,"url":"https://example.com/pr/1176"}}\n'
+    fi
+    exit 0;;
+  'api graphql')
+    if [ -f "$armed" ]; then echo 'true'; else echo 'false'; fi
+    exit 0;;
+  'pr merge')
+    touch "$armed"
+    exit 0;;
+  'release view') exit 1;;
+esac
+echo "unexpected gh invocation: $*" >&2
+exit 1
+"#
+    )
+}
+
+fn write_gh_dirty_release_script(
+    log_path: &str,
+    release_branch: &str,
+    main_branch: &str,
+) -> String {
+    format!(
+        r#"#!/bin/sh
+log="{log_path}"
+integrated="{log_path}.integrated"
+seen="{log_path}.seen"
+release_branch="{release_branch}"
+main_branch="{main_branch}"
+if [ "$1" = "--version" ]; then
+  exit 0
+fi
+printf '%s\n' "$*" >> "$log"
+case "$1 $2" in
+  'pr list')
+    case " $* " in
+      *' --head '*)
+        head="$(git ls-remote origin "refs/heads/$release_branch" | cut -f1)"
+        printf '[{{"number":1176,"state":"OPEN","isDraft":false,"mergeCommit":null,"url":"https://example.com/pr/1176","headRefOid":"%s"}}]\n' "$head"
+        ;;
+      *) echo '[]' ;;
+    esac
+    exit 0;;
+  'pr view')
+    release_head="$(git ls-remote origin "refs/heads/$release_branch" | cut -f1)"
+    if [ -f "$integrated" ]; then
+      printf '{{"state":"MERGED","mergeStateStatus":"UNKNOWN","mergeCommit":{{"oid":"%s"}},"url":"https://example.com/pr/1176"}}\n' "$release_head"
+    elif [ ! -f "$seen" ]; then
+      touch "$seen"
+      printf '{{"state":"OPEN","mergeStateStatus":"DIRTY","mergeCommit":null,"url":"https://example.com/pr/1176"}}\n'
+    else
+      main_head="$(git ls-remote origin "refs/heads/$main_branch" | cut -f1)"
+      if git merge-base --is-ancestor "$main_head" "$release_head"; then
+        merge_state=CLEAN
+      else
+        merge_state=BEHIND
+      fi
+      printf '{{"state":"OPEN","mergeStateStatus":"%s","mergeCommit":null,"url":"https://example.com/pr/1176"}}\n' "$merge_state"
+    fi
+    exit 0;;
+  'api graphql') echo 'false'; exit 0;;
+  'pr merge')
+    release_head="$(git ls-remote origin "refs/heads/$release_branch" | cut -f1)"
+    main_head="$(git ls-remote origin "refs/heads/$main_branch" | cut -f1)"
+    if git merge-base --is-ancestor "$main_head" "$release_head"; then
+      touch "$integrated"
+    fi
+    exit 0;;
+  'pr ready'|'pr edit') exit 0;;
+  'release view') exit 1;;
+esac
+echo "unexpected gh invocation: $*" >&2
+exit 1
+"#
+    )
+}
+
 fn git(repo: &TestRepo, args: &[&str]) {
     let _ = git_output(repo, args);
 }
@@ -621,6 +722,163 @@ fn release_run_checks_the_host_local_publisher_role() {
             latest_tag: Some("v0.9.1".to_string()),
         }
     );
+}
+
+#[test]
+fn release_run_rearms_a_dropped_auto_merge_for_the_exact_head() {
+    let repo = TestRepo::new();
+    git(&repo, &["tag", "v0.9.1"]);
+    git(&repo, &["push", "origin", "v0.9.1"]);
+    fs::write(repo.path().join("feature.txt"), "release me\n").unwrap();
+    git(&repo, &["add", "feature.txt"]);
+    git(&repo, &["commit", "-m", "Add release change"]);
+    git(&repo, &["push", "origin", "HEAD"]);
+    let head = git_output(&repo, &["rev-parse", "HEAD"]);
+    let state = tempfile::tempdir().expect("release state");
+    let log_path = state.path().join("gh.log");
+    let gh_script = write_gh_dropped_auto_merge_script(&log_path.to_string_lossy());
+    let _env = EnvGuard::new(&[("gh", gh_script.as_str())]);
+
+    let outcome = release_run(repo.path(), "patch", None, &NullProgress)
+        .expect("release should re-arm and resume");
+
+    let ReleaseRunOutcome::Released(receipt) = outcome else {
+        panic!("expected a released receipt");
+    };
+    assert_eq!(receipt.version, "0.9.2");
+    assert_eq!(receipt.tag, "v0.9.2");
+    assert_eq!(receipt.commit, head);
+    let log = fs::read_to_string(log_path).expect("read gh log");
+    assert!(log.contains("api graphql"));
+    assert!(log.contains(&format!(
+        "pr merge 1176 --squash --auto --match-head-commit {head}"
+    )));
+}
+
+#[test]
+fn release_run_reintegrates_a_dirty_existing_pr() {
+    let repo = TestRepo::new();
+    let main_branch = git_output(&repo, &["branch", "--show-current"]);
+    let state = tempfile::tempdir().expect("release state");
+    let log_path = state.path().join("gh.log");
+    let prepare_runs = state.path().join("prepare-runs");
+    let advance_once = state.path().join("advance-once");
+    git(&repo, &["tag", "v0.9.1"]);
+    git(&repo, &["push", "origin", "v0.9.1"]);
+    fs::write(repo.path().join("feature.txt"), "release me\n").unwrap();
+    git(&repo, &["add", "feature.txt"]);
+    git(&repo, &["commit", "-m", "Add release change"]);
+    git(&repo, &["push", "origin", "HEAD"]);
+
+    let release_branch = "jack/release-default-v0-9-2";
+    git(&repo, &["checkout", "-b", release_branch]);
+    fs::write(
+        repo.path().join("RELEASE_NOTES.md"),
+        "# v0.9.2\n\nRelease notes.\n",
+    )
+    .unwrap();
+    git(&repo, &["add", "RELEASE_NOTES.md"]);
+    git(&repo, &["commit", "-m", "release: v0.9.2"]);
+    git(&repo, &["push", "-u", "origin", release_branch]);
+    git(&repo, &["checkout", &main_branch]);
+    git(&repo, &["branch", "-D", release_branch]);
+    git(
+        &repo,
+        &[
+            "update-ref",
+            "-d",
+            &format!("refs/remotes/origin/{release_branch}"),
+        ],
+    );
+    fs::write(
+        repo.path().join("RELEASE_NOTES.md"),
+        "# v0.9.1\n\nCorrected prior release notes.\n",
+    )
+    .unwrap();
+    fs::create_dir_all(repo.path().join(".lf")).unwrap();
+    fs::write(
+        repo.path().join(".lf/config.yaml"),
+        "release:\n  targets:\n    default:\n      prepare:\n      - sh prepare.sh {version}\n",
+    )
+    .unwrap();
+    fs::write(
+        repo.path().join("prepare.sh"),
+        format!(
+            "#!/bin/sh\nprintf 'run\\n' >> '{}'\nprintf '%s\\n' \"$1\" > prepared-version.txt\ngit -C '{}' rev-parse 'origin/{}' > prepared-main.txt\nif [ ! -f '{}' ]; then\n  : > '{}'\n  printf 'late main change\\n' > '{}/late-main.txt'\n  git -C '{}' add late-main.txt\n  git -C '{}' commit -m 'Advance main during release preparation'\n  git -C '{}' push origin HEAD\nfi\n",
+            prepare_runs.display(),
+            repo.path().display(),
+            main_branch,
+            advance_once.display(),
+            advance_once.display(),
+            repo.path().display(),
+            repo.path().display(),
+            repo.path().display(),
+            repo.path().display(),
+        ),
+    )
+    .unwrap();
+    git(
+        &repo,
+        &["add", "RELEASE_NOTES.md", ".lf/config.yaml", "prepare.sh"],
+    );
+    git(&repo, &["commit", "-m", "Correct prior release notes"]);
+    git(&repo, &["push", "origin", "HEAD"]);
+
+    let gh_script =
+        write_gh_dirty_release_script(&log_path.to_string_lossy(), release_branch, &main_branch);
+    let lf_script = "#!/bin/sh\ncat > RELEASE_NOTES.md <<'EOF'\n# v0.9.2\n\n<!-- loopflow:release-notes=narrative;gate=safe -->\n\nRegenerated release notes.\nEOF\n";
+    let _env = EnvGuard::new(&[("gh", gh_script.as_str()), ("lf", lf_script)]);
+    std::env::set_var("LF_RUN_CONTEXT", "agent");
+    std::env::set_var("LF_RUN_ID", "run_stale");
+    std::env::set_var("LF_RUN_LEASE", "stale-lease");
+    std::env::set_var("LF_AGENT_INVOCATION_ID", "invocation_stale");
+    std::env::set_var("LF_WAVE_ID", "wave_stale");
+
+    let outcome = release_run(repo.path(), "patch", None, &NullProgress)
+        .expect("release should reintegrate without inheriting Task authority");
+
+    let ReleaseRunOutcome::Released(receipt) = outcome else {
+        panic!("expected a released receipt");
+    };
+    let integrated_head = git_output_bare(
+        &repo,
+        &["rev-parse", &format!("refs/heads/{release_branch}")],
+    );
+    let integrated_parent = git_output_bare(&repo, &["rev-parse", &format!("{integrated_head}^")]);
+    assert_eq!(receipt.commit, integrated_head);
+    assert_eq!(
+        fs::read_to_string(&prepare_runs)
+            .expect("read preparation runs")
+            .lines()
+            .count(),
+        2,
+        "a main advance after preparation must rerun preparation"
+    );
+    assert_eq!(
+        git_output_bare(
+            &repo,
+            &["show", &format!("{integrated_head}:prepared-main.txt")],
+        ),
+        integrated_parent
+    );
+    assert_eq!(
+        git_output_bare(
+            &repo,
+            &["show", &format!("{integrated_head}:RELEASE_NOTES.md")],
+        ),
+        "# v0.9.2\n\n<!-- loopflow:release-notes=narrative;gate=safe -->\n\nRegenerated release notes."
+    );
+    assert_eq!(
+        git_output_bare(
+            &repo,
+            &["show", &format!("{integrated_head}:prepared-version.txt")],
+        ),
+        "0.9.2"
+    );
+    let log = fs::read_to_string(log_path).expect("read gh log");
+    assert!(log.contains(&format!(
+        "pr merge 1176 --squash --auto --match-head-commit {integrated_head}"
+    )));
 }
 
 #[test]

--- a/scripts/bootstrap-cron-host.sh
+++ b/scripts/bootstrap-cron-host.sh
@@ -25,11 +25,10 @@ step "placed Home"
 local_home="$(lf home id)"
 placed_home="$(lf status "$wave" --json | jq -er '.wave.home.id')"
 if [ "$local_home" != "$placed_home" ]; then
-  printf 'Wave %s is placed on %s, not local Home %s\n' \
-    "$wave" "$placed_home" "$local_home" >&2
+  printf 'Wave %s is not placed on this Home\n' "$wave" >&2
   exit 1
 fi
-printf '%s\n' "$local_home"
+printf 'Wave %s is placed on this Home\n' "$wave"
 
 lf_home="${LF_CONTROL_HOME:-${LF_HOME:-$HOME/.lf}}"
 lf_db_path="${LF_CONTROL_DB_PATH:-${LF_DB_PATH:-$lf_home/loopflow.db}}"
@@ -45,7 +44,8 @@ minimal_env=(
 )
 
 step "installed binary + declared jobs"
-"${minimal_env[@]}" lf cron preflight --wave "$wave"
+"${minimal_env[@]}" lf cron preflight --wave "$wave" >/dev/null
+printf 'installed cron preflight passed for Wave %s\n' "$wave"
 
 step "unattended tool path"
 "${minimal_env[@]}" sh -c '
@@ -103,11 +103,11 @@ if sorted(actual) != sorted(expected):
     raise SystemExit(f"cron drift: GOAL.md={sorted(expected)!r} installed={sorted(actual)!r}")
 for entry in installed:
     if entry["wave"] != wave:
-        raise SystemExit(f"wrong Wave in installed cron: {entry!r}")
+        raise SystemExit(f"wrong Wave in installed cron: {entry['flow']}")
     if not entry["loaded"]:
         raise SystemExit(f"cron is not loaded: {entry['flow']}")
     if entry["home_id"] != os.environ["EXPECTED_HOME_ID"]:
-        raise SystemExit(f"wrong Home in installed cron: {entry!r}")
+        raise SystemExit(f"wrong Home in installed cron: {entry['flow']}")
 print(f"{len(installed)}/{len(expected)} jobs loaded and exact")
 PY
 
@@ -131,4 +131,4 @@ if [ "$result" -ne 0 ]; then
   printf '\nbootstrap installed the jobs, but a configured-path run is red; inspect the receipt and log above\n' >&2
   exit "$result"
 fi
-printf '\nbootstrap complete: %s owns Wave %s cron receipts\n' "$local_home" "$wave"
+printf '\nbootstrap complete: this Home owns Wave %s cron receipts\n' "$wave"


### PR DESCRIPTION
## Try it!

```bash
cargo test -p loopflow --test release_tests release_run_rearms_a_dropped_auto_merge_for_the_exact_head -- --exact
cargo test -p loopflow --test release_tests release_run_reintegrates_a_dirty_existing_pr -- --exact
uv run python scripts/materialize_rust_tests.py -- cargo test -p loopflow --test land_tests latest_land_disposition_wins_before_merge -- --exact
uv run pytest python/tests/test_release_automation.py -k infrastructure_cron_runs_the_host_release_after_telemetry
```

The dirty-PR test starts without a cached release branch and advances main
during preparation. It observes two complete preparation passes and proves the
recorded preparation base is the final release parent. PR #1187's hosted checks
pass every implementation job; `scratch-clear` remains the intentional
land-time cleanup check.

## Intent

Release recovery previously integrated newer main after preparing a release
artifact. That published v0.12.6 with draft migrations, and installed promotion
correctly refused it. This change makes recovery rebuild generated release
state on current main and prevents any rebase after preparation, while keeping
the cron bootstrap output free of private Home topology.

## Assumptions

- A release branch is controller-owned generated state. It may be reset only
  after the fetched remote head exactly matches GitHub's observed PR head.
- A dirty or behind release PR must be prepared again; its existing artifacts
  are not reusable.
- Publisher authority is bound through Home-local configuration. The public
  repository names only the logical role and its fail-closed contract.
- The final flow owns scratch cleanup, current-main integration, merge, and any
  later serial PR. LOO-214 stays open after this source PR.

## Key decisions

- Reuse one exact-head auto-merge owner in `ops::pr` for ordinary and release
  PRs.
- Fetch the explicit release branch before creating the temporary worktree, so
  recovery works on a clean cron host.
- Finalize an already-integrated prepared head without rebasing. If main moves,
  let GitHub report the PR behind and run preparation again.
- Remove only Work authority while preparing the release; preserve configured
  provider authority for publish preflight.

## Learned invariant

A prepared release head is immutable relative to its source frontier. If main
advances or the existing release PR is dirty or behind, rebuild the generated
branch from current main and rerun every preparation step; never transparently
rebase already-prepared migrations, manifests, or notes.

v0.12.6 is the evidence: recovery rebased after preparation and installed
promotion found three draft migrations. `finish_release_pr` and
`prepare_release_in_worktree` now enforce exact-head fetch, reset, preparation,
and completed-integration finalization. The
`release_run_reintegrates_a_dirty_existing_pr` test advances main during
preparation and requires a second pass whose recorded main is the final release
parent.

## Not included

- Installing or triggering the Infrastructure Wave's cron jobs.
- Durable `telemetry-daily` or `release-run` receipts and endurance windows.
- Bypassing installed promotion or changing the unrelated persisted Work it
  reports.
- Public provider selectors or a generic deployment abstraction.
