### PR TITLE
install: pin refresh before asset redirects

### DIFF
--- a/python/tests/test_install_script.py
+++ b/python/tests/test_install_script.py
@@ -203,13 +203,11 @@ def test_published_refresh_pins_and_verifies_the_external_installer(
         downloads.append(url)
         if destination.name == "SHA256SUMS":
             destination.write_text(f"{digest}  install.sh\n")
-            return (
-                "https://github.com/loopflowstudio/loopflow/releases/"
-                "download/v9.9.9/SHA256SUMS"
-            )
+            return "https://release-assets.githubusercontent.com/signed-checksums"
         destination.write_bytes(installer_payload)
-        return url
+        return "https://release-assets.githubusercontent.com/signed-installer"
 
+    monkeypatch.setattr(install, "_latest_release_tag", lambda: "v9.9.9")
     monkeypatch.setattr(install, "_download_release_asset", download)
     monkeypatch.setattr(
         install,
@@ -221,8 +219,8 @@ def test_published_refresh_pins_and_verifies_the_external_installer(
 
     assert tag == "v9.9.9"
     assert downloads == [
-        f"{install.LATEST_RELEASE_BASE}/SHA256SUMS",
-        "https://github.com/loopflowstudio/loopflow/releases/download/v9.9.9/install.sh",
+        f"{install.RELEASE_DOWNLOAD_BASE}/v9.9.9/SHA256SUMS",
+        f"{install.RELEASE_DOWNLOAD_BASE}/v9.9.9/install.sh",
     ]
     assert runs[0][0][0] == "sh"
     assert runs[0][0][-2:] == ["--version", "v9.9.9"]
@@ -235,13 +233,11 @@ def test_published_refresh_rejects_an_installer_digest_mismatch(
     def download(url: str, destination: Path) -> str:
         if destination.name == "SHA256SUMS":
             destination.write_text(f"{'0' * 64}  install.sh\n")
-            return (
-                "https://github.com/loopflowstudio/loopflow/releases/"
-                "download/v9.9.9/SHA256SUMS"
-            )
+            return "https://release-assets.githubusercontent.com/signed-checksums"
         destination.write_text("different")
-        return url
+        return "https://release-assets.githubusercontent.com/signed-installer"
 
+    monkeypatch.setattr(install, "_latest_release_tag", lambda: "v9.9.9")
     monkeypatch.setattr(install, "_download_release_asset", download)
     monkeypatch.setattr(
         install,

--- a/scripts/install.py
+++ b/scripts/install.py
@@ -35,7 +35,8 @@ APP_NAME = "Loopflow"
 # app binary is built as `LoopflowMac` and renamed to APP_NAME inside the bundle.
 SWIFT_APP_PRODUCT = "LoopflowMac"
 BUILD_STAGES = ("cargo", "swift")
-LATEST_RELEASE_BASE = "https://github.com/loopflowstudio/loopflow/releases/latest/download"
+LATEST_RELEASE_URL = "https://github.com/loopflowstudio/loopflow/releases/latest"
+RELEASE_DOWNLOAD_BASE = "https://github.com/loopflowstudio/loopflow/releases/download"
 
 
 # --- Bundle spec (single source of truth for Loopflow.app layout) ---
@@ -275,14 +276,23 @@ def _download_release_asset(url: str, destination: Path) -> str:
         raise StageError(f"download failed: {url}: {exc}") from exc
 
 
-def _release_tag_from_manifest_url(url: str) -> str:
-    marker = "/releases/download/"
+def _release_tag_from_latest_url(url: str) -> str:
+    marker = "/releases/tag/"
     if marker not in url:
         raise StageError(f"latest release did not resolve to a pinned tag: {url}")
     tag = url.split(marker, 1)[1].split("/", 1)[0]
     if not tag.startswith("v") or len(tag) == 1:
         raise StageError(f"latest release resolved to an invalid tag: {tag}")
     return tag
+
+
+def _latest_release_tag() -> str:
+    request = urllib.request.Request(LATEST_RELEASE_URL, method="HEAD")
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            return _release_tag_from_latest_url(response.geturl())
+    except OSError as exc:
+        raise StageError(f"latest release lookup failed: {exc}") from exc
 
 
 def _manifest_digest(manifest: Path, asset: str) -> str:
@@ -304,14 +314,10 @@ def _verify_release_asset(path: Path, expected: str) -> None:
 def _install_published_release(install_dir: Path) -> str:
     with tempfile.TemporaryDirectory(prefix="loopflow-release-") as temp:
         directory = Path(temp)
+        tag = _latest_release_tag()
+        pinned_base = f"{RELEASE_DOWNLOAD_BASE}/{tag}"
         manifest = directory / "SHA256SUMS"
-        effective = _download_release_asset(
-            f"{LATEST_RELEASE_BASE}/SHA256SUMS", manifest
-        )
-        tag = _release_tag_from_manifest_url(effective)
-        pinned_base = (
-            f"https://github.com/loopflowstudio/loopflow/releases/download/{tag}"
-        )
+        _download_release_asset(f"{pinned_base}/SHA256SUMS", manifest)
         installer = directory / "install.sh"
         _download_release_asset(f"{pinned_base}/install.sh", installer)
         _verify_release_asset(installer, _manifest_digest(manifest, "install.sh"))


### PR DESCRIPTION
## Summary

- Resolve the latest GitHub Release tag before downloading any assets.
- Download both SHA256SUMS and install.sh from that immutable tag.
- Cover signed release-assets redirects so CDN URLs cannot be mistaken for release tags.

## Verification

- uv run pytest -q python/tests/test_install_script.py
- uv run ruff check scripts/install.py python/tests/test_install_script.py
- uv run ruff format --check scripts/install.py python/tests/test_install_script.py
- live latest-release lookup resolves v0.12.7