### PR TITLE
discord: harden binding ownership and restart reconciliation

### DIFF
--- a/docs/waves.md
+++ b/docs/waves.md
@@ -172,9 +172,10 @@ journal event or Discord message source.
 
 Loopflow retains source-linked inputs until the resident consumes them,
 execution turns, deterministic send intents, cursors, and provider receipts as
-Run evidence. `home_id` is the binding's durable owner (`lf home id`). Another
-Home fails before contacting Discord, while an OS-held lease prevents another
-checkout on the owner Home from consuming the same channel.
+Run evidence. `home_id` is the portable binding owner (`lf home id`) and must
+match the Wave's durable placement. Another Home fails before contacting
+Discord, while an OS-held lease prevents another checkout on the owner Home
+from consuming the same channel.
 
 Read the active epoch or an earlier one explicitly:
 

--- a/rust/loopflow/src/engine/wave_config.rs
+++ b/rust/loopflow/src/engine/wave_config.rs
@@ -46,7 +46,8 @@ pub struct WavePmConfig {
 
 /// One existing Discord guild text channel bound to this Wave's chat.
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
-#[serde(tag = "provider", rename_all = "snake_case")]
+#[serde(tag = "provider", rename_all = "snake_case", deny_unknown_fields)]
+#[non_exhaustive]
 pub enum WaveChatConfig {
     Local,
     Discord {
@@ -124,6 +125,38 @@ pub(crate) fn try_read_wave_config(
             .map_err(|source| WaveConfigError::Parse { path, source })?,
         None => WaveConfig::default(),
     }))
+}
+
+/// Read only the external chat binding, so malformed unrelated Wave policy
+/// cannot turn listener startup into a new validation boundary.
+pub(crate) fn try_read_wave_chat_config(
+    repo: &Path,
+    name: &str,
+) -> Result<Option<WaveChatConfig>, WaveConfigError> {
+    let path = goal_path(repo, name);
+    let content = match std::fs::read_to_string(&path) {
+        Ok(content) => content,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(source) => return Err(WaveConfigError::Read { path, source }),
+    };
+    let Some((frontmatter, _)) = split_frontmatter(&content) else {
+        return Ok(None);
+    };
+    let value = serde_yaml_ng::from_str::<Value>(&frontmatter).map_err(|source| {
+        WaveConfigError::Parse {
+            path: path.clone(),
+            source,
+        }
+    })?;
+    let Some(chat) = value
+        .as_mapping()
+        .and_then(|mapping| mapping.get(Value::String("chat".to_string())))
+    else {
+        return Ok(None);
+    };
+    serde_yaml_ng::from_value(chat.clone())
+        .map(Some)
+        .map_err(|source| WaveConfigError::Parse { path, source })
 }
 
 /// One-line Wave objective for status, PM, and API projections.
@@ -387,9 +420,7 @@ mod tests {
             "---\nchat:\n  provider: discord\n  home_id: home_11111111111111111111111111111111\n  guild_id: guild\n  channel_id: channel\n---\nDrive the work.\n",
         )
         .expect("write");
-        let config = try_read_wave_config(temp.path(), "scan")
-            .expect("valid config")
-            .expect("config");
+        let config = read_wave_config(temp.path(), "scan").expect("config should parse");
         assert!(matches!(
             config.chat,
             Some(WaveChatConfig::Discord { home_id, guild_id, channel_id })
@@ -397,14 +428,21 @@ mod tests {
                     && guild_id == "guild"
                     && channel_id == "channel"
         ));
+        assert!(matches!(
+            try_read_wave_chat_config(temp.path(), "scan"),
+            Ok(Some(WaveChatConfig::Discord { home_id, guild_id, channel_id }))
+                if home_id.as_str() == "home_11111111111111111111111111111111"
+                    && guild_id == "guild"
+                    && channel_id == "channel"
+        ));
 
         fs::write(
             dir.join("GOAL.md"),
-            "---\nchat:\n  provider: discord\n  guild_id: guild\n---\nDrive the work.\n",
+            "---\nchat:\n  provider: discord\n  home_id: home_39860354aaca640c2ccb50bf6ca609d8\n  guild_id: guild\n---\nDrive the work.\n",
         )
         .expect("write invalid");
         assert!(matches!(
-            try_read_wave_config(temp.path(), "scan"),
+            try_read_wave_chat_config(temp.path(), "scan"),
             Err(WaveConfigError::Parse { .. })
         ));
 
@@ -426,8 +464,18 @@ mod tests {
         )
         .expect("write invalid HomeId");
         assert!(matches!(
-            try_read_wave_config(temp.path(), "scan"),
+            try_read_wave_chat_config(temp.path(), "scan"),
             Err(WaveConfigError::Parse { .. })
+        ));
+
+        fs::write(
+            dir.join("GOAL.md"),
+            "---\npaused: not-a-boolean\n---\nDrive the work.\n",
+        )
+        .expect("write unrelated invalid policy");
+        assert!(matches!(
+            try_read_wave_chat_config(temp.path(), "scan"),
+            Ok(None)
         ));
     }
 

--- a/rust/loopflow/src/wave/README.md
+++ b/rust/loopflow/src/wave/README.md
@@ -50,8 +50,8 @@ preflights Discord before reserving a Run or opening the journal, then polls
 after the committed cursor, journals external inputs before advancing it, and
 journals deterministic send intents before posting. The resident receives only
 source-tagged authored input and never inherits `LF_DISCORD_TOKEN`. Binding
-ownership is explicit: the configured Home is the only Home allowed to attach,
-and an OS-held lease prevents concurrent listeners across its checkouts.
+ownership is explicit and must agree with the Wave's durable Home placement;
+an OS-held lease prevents concurrent listeners across its checkouts.
 
 The shared `~/.lf/loopflow.db` stores the Wave UUID, its repository-scoped
 locator, and typed Project and Task observations. Human commands resolve the

--- a/rust/loopflow/src/wave/discord.rs
+++ b/rust/loopflow/src/wave/discord.rs
@@ -58,14 +58,16 @@ pub enum DiscordError {
     #[error("Discord messages are limited to {limit} characters; this message has {actual}")]
     MessageTooLong { limit: usize, actual: usize },
     #[error("Discord chat binding is owned by Home {owner}; current Home is {current}")]
-    WrongHome { owner: String, current: String },
+    WrongHome { owner: HomeId, current: HomeId },
+    #[error("Discord chat binding Home {configured} does not match Wave placement {placed}")]
+    PlacementMismatch { configured: HomeId, placed: HomeId },
     #[error(
         "Discord chat binding {guild_id}/{channel_id} already has a live listener on Home {home_id}"
     )]
     AlreadyOwned {
         guild_id: String,
         channel_id: String,
-        home_id: String,
+        home_id: HomeId,
     },
     #[error("failed to claim Discord chat binding: {0}")]
     Lease(#[from] std::io::Error),
@@ -80,9 +82,10 @@ impl DiscordError {
 
 /// Process-held ownership for one Discord binding on its configured Home.
 ///
-/// The configured Home prevents a second Home from competing. The advisory
-/// lock prevents a second checkout or store on that Home from competing. The
-/// file may outlive the process; only the held OS lock carries authority.
+/// The authored Home stays portable when another store observes the repo. It
+/// must agree with Wave placement; the advisory lock then prevents a second
+/// checkout or store on that Home from competing. The file may outlive the
+/// process; only the held OS lock carries authority.
 #[derive(Debug)]
 struct DiscordBindingLease {
     _file: File,
@@ -91,13 +94,20 @@ struct DiscordBindingLease {
 impl DiscordBindingLease {
     fn acquire(
         binding: &DiscordChatBinding,
-        owner_home_id: &HomeId,
+        configured_home_id: &HomeId,
+        placed_home_id: &HomeId,
         local_home_id: &HomeId,
     ) -> Result<Self, DiscordError> {
-        if owner_home_id != local_home_id {
+        if configured_home_id != placed_home_id {
+            return Err(DiscordError::PlacementMismatch {
+                configured: configured_home_id.clone(),
+                placed: placed_home_id.clone(),
+            });
+        }
+        if configured_home_id != local_home_id {
             return Err(DiscordError::WrongHome {
-                owner: owner_home_id.to_string(),
-                current: local_home_id.to_string(),
+                owner: configured_home_id.clone(),
+                current: local_home_id.clone(),
             });
         }
         Self::acquire_at(
@@ -131,7 +141,7 @@ impl DiscordBindingLease {
                 Err(DiscordError::AlreadyOwned {
                     guild_id: binding.guild_id.clone(),
                     channel_id: binding.channel_id.clone(),
-                    home_id: local_home_id.to_string(),
+                    home_id: local_home_id.clone(),
                 })
             }
             Err(error) => Err(DiscordError::Lease(error)),
@@ -266,11 +276,17 @@ pub(crate) struct DiscordProjection {
 impl DiscordAdapter {
     pub async fn preflight(
         binding: DiscordChatBinding,
-        owner_home_id: &HomeId,
+        configured_home_id: &HomeId,
+        placed_home_id: &HomeId,
         local_home_id: &HomeId,
         token: Option<SecretString>,
     ) -> Result<Self, DiscordError> {
-        let lease = DiscordBindingLease::acquire(&binding, owner_home_id, local_home_id)?;
+        let lease = DiscordBindingLease::acquire(
+            &binding,
+            configured_home_id,
+            placed_home_id,
+            local_home_id,
+        )?;
         let client = match token {
             Some(token) => DiscordClient::from_secret(Some(token), API_BASE)?,
             None => DiscordClient::from_env()?,
@@ -503,7 +519,7 @@ impl DiscordAdapter {
             if delivery
                 .confirmed
                 .values()
-                .any(|provider_id| provider_id == &message.id)
+                .any(|provider_message_id| provider_message_id == &message.id)
             {
                 return Ok(true);
             }
@@ -1240,11 +1256,23 @@ mod tests {
         let local = HomeId::new();
         let owner = HomeId::new();
 
-        let error = DiscordAdapter::preflight(binding(), &owner, &local, None)
+        let error = DiscordAdapter::preflight(binding(), &owner, &owner, &local, None)
             .await
             .expect_err("another Home must not reach token or Discord preflight");
 
         assert!(matches!(error, DiscordError::WrongHome { .. }));
+    }
+
+    #[tokio::test]
+    async fn discord_chat_rejects_binding_placement_drift_before_provider_access() {
+        let configured = HomeId::new();
+        let placed = HomeId::new();
+
+        let error = DiscordAdapter::preflight(binding(), &configured, &placed, &configured, None)
+            .await
+            .expect_err("binding ownership and Wave placement must agree");
+
+        assert!(matches!(error, DiscordError::PlacementMismatch { .. }));
     }
 
     #[tokio::test]
@@ -1342,6 +1370,89 @@ mod tests {
             "self echo is not input"
         );
         server.abort();
+    }
+
+    #[test]
+    fn discord_chat_reconciliation_does_not_reuse_a_confirmed_echo() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let runtime = WaveRuntime::open_with_backing(
+            "ship".into(),
+            temp.path().to_path_buf(),
+            crate::wave::chat::ChatBacking::discord(&binding()),
+        )
+        .expect("runtime");
+        runtime
+            .try_attach_discord(binding(), "bot".into(), None)
+            .expect("attach");
+        runtime
+            .try_deliver_discord(
+                "question".into(),
+                DiscordMessageSource {
+                    binding: binding(),
+                    message_id: "101".into(),
+                    author_id: "human".into(),
+                },
+            )
+            .expect("deliver");
+        let answer = runtime.pending_messages()[0].id.0.clone();
+        runtime.apply_resident_delta(ResidentDelta::TurnOpened {
+            answers: vec![answer],
+        });
+        runtime.apply_resident_delta(ResidentDelta::TurnText {
+            text: "x".repeat(4_000),
+        });
+        runtime.apply_resident_delta(ResidentDelta::TurnFinished {
+            status: Lifecycle::Completed,
+            reason: None,
+        });
+        let delivery = runtime.discord_snapshot().deliveries[0].clone();
+        assert_eq!(delivery.parts.len(), 2);
+        assert_eq!(delivery.parts[0].content, delivery.parts[1].content);
+        runtime
+            .try_confirm_discord_part(
+                &delivery.delivery_id,
+                &delivery.parts[0].part_id,
+                "provider-1".into(),
+            )
+            .expect("confirm first part");
+
+        let client = DiscordClient::from_token(Some("fixture-token".into()), "http://unused")
+            .expect("fixture client");
+        let (health, _) = watch::channel(ChatBackingHealth::Ready);
+        let adapter = DiscordAdapter {
+            client,
+            binding: binding(),
+            bot_user_id: "bot".into(),
+            initial_head: None,
+            health,
+            _lease: None,
+        };
+        let echo = |id: &str| Message {
+            id: id.into(),
+            author: User {
+                id: "bot".into(),
+                bot: Some(true),
+            },
+            content: delivery.parts[1].content.clone(),
+            kind: 0,
+            webhook_id: None,
+            message_reference: Some(ReturnedMessageReference {
+                message_id: Some("101".into()),
+            }),
+        };
+
+        adapter
+            .reconcile_echo(&runtime, &echo("provider-1"))
+            .expect("ignore already confirmed echo");
+        assert_eq!(runtime.discord_snapshot().deliveries[0].confirmed.len(), 1);
+        adapter
+            .reconcile_echo(&runtime, &echo("provider-2"))
+            .expect("confirm second echo");
+        let resumed = &runtime.discord_snapshot().deliveries[0];
+        assert_eq!(
+            resumed.confirmed.get(&delivery.parts[1].part_id),
+            Some(&"provider-2".to_string())
+        );
     }
 
     #[tokio::test]

--- a/rust/loopflow/src/wave/mod.rs
+++ b/rust/loopflow/src/wave/mod.rs
@@ -75,7 +75,7 @@ use anyhow::{anyhow, Result};
 use secrecy::SecretString;
 
 use crate::engine::repo::find_repo_root;
-use crate::engine::wave_config::{try_read_wave_config, WaveChatConfig};
+use crate::engine::wave_config::{try_read_wave_chat_config, WaveChatConfig};
 use crate::engine::worktrees::main_repo_root;
 use crate::ops::util::normalize_wave_name;
 use crate::store::{open_existing_store, SharedStore};
@@ -401,33 +401,35 @@ where
         .then(crate::engine::process::resolve_current_home_lf_binary_checked)
         .transpose()?;
 
-    let (chat_backing, discord_adapter) =
-        match try_read_wave_config(&repo_root, &wave)?.and_then(|config| config.chat) {
-            Some(WaveChatConfig::Discord {
-                home_id,
+    let (chat_backing, discord_adapter) = match try_read_wave_chat_config(&repo_root, &wave)? {
+        Some(WaveChatConfig::Discord {
+            home_id,
+            guild_id,
+            channel_id,
+        }) => {
+            let registry = registry_config.as_ref().ok_or_else(|| {
+                anyhow!("Discord chat requires the local registry to verify its owner Home")
+            })?;
+            let work = crate::durable::WorkRef::Wave(registry.wave.id().clone());
+            let placement = registry.store.placement(&work).await?;
+            let local_home = registry.store.local_home().await?;
+            let binding = journal::DiscordChatBinding {
                 guild_id,
                 channel_id,
-            }) => {
-                let registry = registry_config.as_ref().ok_or_else(|| {
-                    anyhow!("Discord chat requires the local registry to verify its owner Home")
-                })?;
-                let local_home = registry.store.local_home().await?;
-                let binding = journal::DiscordChatBinding {
-                    guild_id,
-                    channel_id,
-                };
-                let backing = ChatBacking::discord(&binding);
-                let adapter = discord::DiscordAdapter::preflight(
-                    binding,
-                    &home_id,
-                    &local_home.id,
-                    discord_token,
-                )
-                .await?;
-                (backing, Some(adapter))
-            }
-            Some(WaveChatConfig::Local) | None => (ChatBacking::Local, None),
-        };
+            };
+            let backing = ChatBacking::discord(&binding);
+            let adapter = discord::DiscordAdapter::preflight(
+                binding,
+                &home_id,
+                &placement.home_id,
+                &local_home.id,
+                discord_token,
+            )
+            .await?;
+            (backing, Some(adapter))
+        }
+        Some(WaveChatConfig::Local) | None => (ChatBacking::Local, None),
+    };
 
     let registered = registry_config
         .as_ref()


### PR DESCRIPTION
## Usage

```bash
lf home id
doppler run -- lf wave <name>
cargo test -p loopflow discord_chat
```

Set `chat.home_id` to the Wave’s placed Home before starting its Discord listener.

## Summary

This PR prevents copied repositories and stale placement data from starting competing Discord listeners. A binding now starts only when its configured Home, durable Wave placement, and local Home agree, while preserving the process-held lease that excludes concurrent listeners on that Home. It also makes restart reconciliation distinguish repeated delivery parts so one confirmed provider echo cannot satisfy another identical part.

## Changes

- Validate Discord ownership and Wave placement before token or provider access
- Parse chat configuration independently so malformed unrelated Wave policy does not block listener startup
- Reject unknown Discord binding fields and retain typed `HomeId` values in ownership errors
- Ignore already-confirmed provider messages when reconciling repeated delivery content
- Document the portable ownership model and add focused regression coverage