### PR TITLE
task: keep initialization readable before worktree placement

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -46,6 +46,10 @@ agent. It refuses while another executor is still writing; interrupt that
 boundary first. A Steer is durable before live delivery is attempted. Provider
 acceptance is not incorporation; the Basis of a later successful boundary is.
 
+During new-Task placement, status reports the declared worktree as initializing.
+If creation does not finish, status keeps the Task identity and names the exact
+path and branch to restore before resuming.
+
 ## Rate limits
 
 **Symptom:** Tasks fail with rate limit errors.

--- a/rust/loopflow/src/chat/turns.rs
+++ b/rust/loopflow/src/chat/turns.rs
@@ -269,6 +269,11 @@ struct ActivityFields {
 
 fn task_activity_fields(event: &TaskEventKind) -> ActivityFields {
     match event {
+        TaskEventKind::WorktreeInitializing { path, branch, .. } => activity(
+            ChildActivityKind::StateChanged,
+            "Task worktree initializing",
+            &format!("{path} on {branch}"),
+        ),
         TaskEventKind::Started => activity(ChildActivityKind::StateChanged, "Task started", ""),
         TaskEventKind::BodyHandedOff { handoff } => activity(
             ChildActivityKind::StateChanged,

--- a/rust/loopflow/src/lf/commands/waves.rs
+++ b/rust/loopflow/src/lf/commands/waves.rs
@@ -1504,7 +1504,17 @@ async fn snapshot_task_detail(
         },
     };
     let process = task_process_evidence(runtime.as_ref(), liveness);
-    let local_progress = task_local_progress(task, runtime.as_ref(), active, &process);
+    let worktree_blocker = match task {
+        Some(task) => crate::ops::task::task_worktree_blocker(store, task).await?,
+        None => None,
+    };
+    let local_progress = task_local_progress(
+        task,
+        runtime.as_ref(),
+        active,
+        &process,
+        worktree_blocker.as_ref(),
+    );
     let completion_refusal = match (task, runtime.as_ref()) {
         (Some(task), Some(runtime)) if !work_status_is_terminal(&runtime.status) => {
             crate::ops::task::task_completion_gate(store, task)
@@ -1513,9 +1523,14 @@ async fn snapshot_task_detail(
         }
         _ => None,
     };
-    let resume_refusal = task.and_then(|task| {
-        crate::ops::task::no_active_pr_resume_refusal(&task.plan.identifier, active, latest)
-    });
+    let resume_refusal = worktree_blocker
+        .as_ref()
+        .map(|blocker| blocker.reason.clone())
+        .or_else(|| {
+            task.and_then(|task| {
+                crate::ops::task::no_active_pr_resume_refusal(&task.plan.identifier, active, latest)
+            })
+        });
     let (action_evidence, user_ask) = match task {
         Some(task) => {
             let predecessor_phase = match active.and_then(|pr| pr.parent_pr_id.as_ref()) {
@@ -1627,6 +1642,7 @@ fn task_local_progress(
     runtime: Option<&TaskRuntimeSnapshot>,
     active_pr: Option<&TaskPr>,
     process: &TaskProcessEvidence,
+    worktree_blocker: Option<&crate::ops::task::TaskWorktreeBlocker>,
 ) -> LocalProgressEvidence {
     let Some(task) = task else {
         return LocalProgressEvidence {
@@ -1645,6 +1661,7 @@ fn task_local_progress(
         &task.worktree,
         active_pr.map(|pr| pr.base_commit.as_str()),
         process,
+        worktree_blocker,
     )
 }
 
@@ -1653,12 +1670,23 @@ fn inspect_task_local_progress(
     worktree: &Path,
     active_pr_base: Option<&str>,
     process: &TaskProcessEvidence,
+    worktree_blocker: Option<&crate::ops::task::TaskWorktreeBlocker>,
 ) -> LocalProgressEvidence {
     let recovery_required = if work_status_is_running(status) {
         process.alive.map(|alive| !alive)
     } else {
         Some(false)
     };
+    if let Some(blocker) = worktree_blocker {
+        return LocalProgressEvidence {
+            state: LocalProgressEvidenceState::Missing,
+            unsettled: Some(!blocker.initializing),
+            dirty: None,
+            authored_commits: None,
+            recovery_required: Some(!blocker.initializing),
+            reason: Some(blocker.reason.clone()),
+        };
+    }
     if !worktree.exists() {
         if work_status_is_terminal(status) && active_pr_base.is_none() {
             return LocalProgressEvidence {
@@ -1763,6 +1791,16 @@ fn derive_task_attention(
                 .reason
                 .clone()
                 .unwrap_or_else(|| "Task body evidence is unavailable".into()),
+        )
+    } else if local_progress.state == LocalProgressEvidenceState::Missing
+        && local_progress.recovery_required == Some(false)
+    {
+        (
+            TaskAttentionLevel::Black,
+            local_progress
+                .reason
+                .clone()
+                .unwrap_or_else(|| "Task worktree is initializing".into()),
         )
     } else if local_progress.unsettled == Some(true) {
         let reason = if local_progress.dirty == Some(true) {

--- a/rust/loopflow/src/ops/task.rs
+++ b/rust/loopflow/src/ops/task.rs
@@ -664,6 +664,20 @@ pub fn task_run(repo: &Path, issue: &str, options: TaskLaunchOptions) -> OpsResu
             Err(error) => return Err(task_error(format!("failed to reserve task: {error}"))),
         };
 
+        if let Err(error) = create_from_placement_plan(&main_repo, &plan) {
+            store
+                .fail_task_run(&task.id, &lease, &error.to_string())
+                .await
+                .map_err(|settle_error| {
+                    task_error(format!(
+                        "worktree creation failed ({error}); failed to settle reserved Run: {settle_error}"
+                    ))
+                })?;
+            return Err(task_error(format!(
+                "failed to create task worktree: {error}"
+            )));
+        }
+
         if let Err(error) = store
             .append_task_event(
                 &task.id,
@@ -685,20 +699,6 @@ pub fn task_run(repo: &Path, issue: &str, options: TaskLaunchOptions) -> OpsResu
                     ))
                 })?;
             return Err(task_error(error.to_string()));
-        }
-
-        if let Err(error) = create_from_placement_plan(&main_repo, &plan) {
-            store
-                .fail_task_run(&task.id, &lease, &error.to_string())
-                .await
-                .map_err(|settle_error| {
-                    task_error(format!(
-                        "worktree creation failed ({error}); failed to settle reserved Run: {settle_error}"
-                    ))
-                })?;
-            return Err(task_error(format!(
-                "failed to create task worktree: {error}"
-            )));
         }
 
         launch_reserved_task_process(&store, &mut task, &run, &lease).await?;
@@ -872,6 +872,65 @@ fn validate_task_lifecycle(task: &Task) -> OpsResult<()> {
         })?;
     }
     Ok(())
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct TaskWorktreeBlocker {
+    pub initializing: bool,
+    pub reason: String,
+}
+
+const TASK_WORKTREE_INITIALIZATION_GRACE: time::Duration = time::Duration::minutes(5);
+
+pub(crate) async fn task_worktree_blocker(
+    store: &SharedStore,
+    task: &Task,
+) -> OpsResult<Option<TaskWorktreeBlocker>> {
+    let event = store
+        .latest_task_event(&task.id)
+        .await
+        .map_err(|error| task_error(format!("failed to read Task worktree state: {error}")))?;
+    if let Some(event) = event {
+        if let TaskEventKind::WorktreeInitializing { branch, path, .. } = &event.kind {
+            let initializing = event.created_at + TASK_WORKTREE_INITIALIZATION_GRACE
+                > time::OffsetDateTime::now_utc();
+            let reason = if initializing {
+                format!(
+                    "Task {} is initializing worktree {path} on branch {branch:?}; no body is expected until placement completes",
+                    task.plan.identifier
+                )
+            } else {
+                format!(
+                    "Task {} worktree initialization did not complete at {path} on branch {branch:?}; finish or restore that exact path before `lf task resume {}`; Task identity and PR history are unchanged",
+                    task.plan.identifier, task.plan.identifier
+                )
+            };
+            return Ok(Some(TaskWorktreeBlocker {
+                initializing,
+                reason,
+            }));
+        }
+    }
+    if task.worktree.exists() {
+        return Ok(None);
+    }
+    let active = store
+        .active_task_pr(&task.id)
+        .await
+        .map_err(|error| task_error(format!("failed to read active Task PR: {error}")))?;
+    let branch = active
+        .as_ref()
+        .map(|pr| format!(" on branch {:?}", pr.branch))
+        .unwrap_or_default();
+    Ok(Some(TaskWorktreeBlocker {
+        initializing: false,
+        reason: format!(
+            "Task {} worktree {} is missing; restore that exact path{branch} before `lf task resume {}`; Task identity and PR history are unchanged",
+            task.plan.identifier,
+            task.worktree.display(),
+            task.plan.identifier,
+        ),
+    }))
 }
 
 fn resolve_task_flow(repo: &Path, requested: &str, allow_ops: bool) -> OpsResult<String> {
@@ -2610,6 +2669,12 @@ pub(crate) async fn reconcile_project_tasks(
         ) {
             continue;
         }
+        if task_worktree_blocker(store, task)
+            .await?
+            .is_some_and(|blocker| blocker.initializing)
+        {
+            continue;
+        }
         if let Err(error) = task_recovery_adoption(store, task).await {
             tracing::warn!(
                 task = %task.plan.identifier,
@@ -3975,9 +4040,11 @@ pub fn task_status(issue: &str) -> OpsResult<Task> {
             .await
             .map_err(|error| task_error(format!("failed to read task status: {error}")))?
             .ok_or_else(|| task_error(format!("no Task exists for {issue:?}")))?;
-        reconcile_task_pr(&store, &mut task).await?;
-        reconcile_process_liveness(&store, &mut task).await?;
-        reconcile_task_completion(&store, &mut task, None).await?;
+        if task_worktree_blocker(&store, &task).await?.is_none() {
+            reconcile_task_pr(&store, &mut task).await?;
+            reconcile_process_liveness(&store, &mut task).await?;
+            reconcile_task_completion(&store, &mut task, None).await?;
+        }
         Ok(task)
     })
 }
@@ -4337,6 +4404,11 @@ pub(crate) async fn task_completion_gate(
         blockers: Vec::new(),
         discardable_successor: None,
     };
+    if let Some(blocker) = task_worktree_blocker(store, task).await? {
+        gate.satisfied = false;
+        gate.blockers.push(blocker.reason);
+        return Ok(gate);
+    }
     let work_done = task_work_status(store, task).await? == WorkStatus::Done;
 
     // Work committed past the tip GitHub merged is owned by no PR; completing
@@ -4566,7 +4638,11 @@ pub fn task_snapshot(task: &Task) -> OpsResult<TaskSnapshot> {
         };
         let completion_gate = task_completion_gate(&store, &task).await?;
         let completion_refusal = completion_gate.refusal(&task.plan.identifier);
-        let resume_refusal = no_active_pr_resume_refusal(&task.plan.identifier, active, latest);
+        let worktree_blocker = task_worktree_blocker(&store, &task).await?;
+        let resume_refusal = worktree_blocker
+            .as_ref()
+            .map(|blocker| blocker.reason.clone())
+            .or_else(|| no_active_pr_resume_refusal(&task.plan.identifier, active, latest));
         let work_status = store
             .work_status(&work)
             .await

--- a/rust/loopflow/src/store/mod.rs
+++ b/rust/loopflow/src/store/mod.rs
@@ -2251,6 +2251,21 @@ mod tests {
             store.current_run(&task_work).await.unwrap().unwrap().id,
             child_run.id
         );
+        assert_eq!(
+            store
+                .latest_task_event(&task.id)
+                .await
+                .unwrap()
+                .expect("initial Task publication records placement")
+                .kind,
+            TaskEventKind::WorktreeInitializing {
+                pr_id: pr.id.clone(),
+                sequence: pr.sequence,
+                branch: pr.branch.clone(),
+                path: task.worktree.display().to_string(),
+                base_commit: pr.base_commit.clone(),
+            }
+        );
         assert_eq!(durable_child_rows(&database_path), (1, 1, 1, 1, 1));
         assert!(!task.worktree.exists());
     }

--- a/rust/loopflow/src/store/sqlite/children.rs
+++ b/rust/loopflow/src/store/sqlite/children.rs
@@ -63,6 +63,17 @@ impl SqliteStore {
         super::durable::validate_control_caller(&transaction, caller, &work)?;
         let author = caller.map_or(Author::User, |lease| Author::Run(lease.run_id.clone()));
         let steer = Self::append_steer_in(&transaction, &work, &author, text)?;
+        insert_task_event_in(
+            &transaction,
+            task,
+            &TaskEventKind::WorktreeInitializing {
+                pr_id: pr.id.clone(),
+                sequence: pr.sequence,
+                branch: pr.branch.clone(),
+                path: task.worktree.display().to_string(),
+                base_commit: pr.base_commit.clone(),
+            },
+        )?;
         let reservation = super::durable::reserve_run_in(
             &transaction,
             &work,

--- a/rust/loopflow/src/task/actions.rs
+++ b/rust/loopflow/src/task/actions.rs
@@ -67,7 +67,8 @@ pub fn derive_task_actions(evidence: &TaskActionEvidence) -> TaskActionModel {
     } else {
         phase_action(evidence)
     };
-    apply_predecessor(model, evidence.predecessor_phase)
+    let model = apply_predecessor(model, evidence.predecessor_phase);
+    apply_resume_refusal(model, evidence.resume_refusal)
 }
 
 fn phase_action(evidence: &TaskActionEvidence) -> TaskActionModel {
@@ -162,6 +163,19 @@ fn apply_predecessor(model: TaskActionModel, predecessor: Option<PrPhase>) -> Ta
     }
 }
 
+fn apply_resume_refusal(model: TaskActionModel, refusal: Option<&str>) -> TaskActionModel {
+    if !matches!(
+        model.recommended,
+        Some(TaskAction::Resume | TaskAction::Recover)
+    ) {
+        return model;
+    }
+    match refusal {
+        Some(refusal) => action(TaskAction::NoAction, refusal),
+        None => model,
+    }
+}
+
 fn action(recommended: TaskAction, reason: impl Into<String>) -> TaskActionModel {
     TaskActionModel {
         recommended: Some(recommended),
@@ -236,6 +250,18 @@ mod tests {
 
         assert_eq!(model.recommended, Some(TaskAction::Resume));
         assert_eq!(model.reason, "resume the parked Task");
+    }
+
+    #[test]
+    fn resume_refusal_suppresses_recovery_during_a_working_pr() {
+        let mut evidence = evidence(PrPhase::Working, None, None);
+        evidence.process_alive = Some(false);
+        evidence.resume_refusal = Some("Task worktree is still initializing");
+
+        let model = derive_task_actions(&evidence);
+
+        assert_eq!(model.recommended, Some(TaskAction::NoAction));
+        assert_eq!(model.reason, "Task worktree is still initializing");
     }
 
     #[test]

--- a/rust/loopflow/src/task/mod.rs
+++ b/rust/loopflow/src/task/mod.rs
@@ -935,6 +935,13 @@ impl Task {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum TaskEventKind {
+    WorktreeInitializing {
+        pr_id: TaskPrId,
+        sequence: u32,
+        branch: String,
+        path: String,
+        base_commit: String,
+    },
     Started,
     BodyHandedOff {
         handoff: crate::child::ChildBodyHandoff,
@@ -973,7 +980,10 @@ pub enum TaskEventKind {
 impl TaskEventKind {
     /// Whether the event crosses the required Task → Project boundary.
     pub fn is_project_observable(&self) -> bool {
-        !matches!(self, Self::Started | Self::Progress { .. })
+        !matches!(
+            self,
+            Self::WorktreeInitializing { .. } | Self::Started | Self::Progress { .. }
+        )
     }
 
     /// Whether a Project-observable Task event also belongs in the root Wave.

--- a/rust/loopflow/tests/task_initialization_tests.rs
+++ b/rust/loopflow/tests/task_initialization_tests.rs
@@ -1,0 +1,233 @@
+mod support;
+
+use std::process::Command;
+
+use loopflow::child::ChildRef;
+use loopflow::ops::task::{task_snapshot, task_status};
+use loopflow::store::PmSnapshotRow;
+use loopflow::task::actions::TaskAction;
+use loopflow::task::TaskEventKind;
+use loopflow_test_support::TestRepo;
+use support::{register_unrun_task, EnvGuard};
+
+#[test]
+fn initializing_worktree_keeps_status_wait_and_roadmap_readable() {
+    let home = tempfile::tempdir().expect("Task home");
+    let _env = EnvGuard::with_lf_home(&[], home.path());
+    let repo = TestRepo::new();
+    let base = repo.head_sha();
+    let branch = "jack/initializing-task";
+    repo.create_branch(branch);
+    let mut task = register_unrun_task(home.path(), repo.path(), branch, &base);
+    let missing_worktree = home.path().join("not-yet-created-worktree");
+    task.task.worktree = missing_worktree.clone();
+    let runtime = tokio::runtime::Runtime::new().expect("initialization fixture runtime");
+    runtime
+        .block_on(task.store.update_task(&task.task))
+        .expect("publish declared Task worktree");
+    runtime
+        .block_on(task.store.append_task_event(
+            &task.task.id,
+            &TaskEventKind::WorktreeInitializing {
+                pr_id: task.pr.id.clone(),
+                sequence: task.pr.sequence,
+                branch: task.pr.branch.clone(),
+                path: missing_worktree.display().to_string(),
+                base_commit: task.pr.base_commit.clone(),
+            },
+        ))
+        .expect("publish initialization marker");
+    std::fs::create_dir_all(&missing_worktree)
+        .expect("simulate a partially created worktree directory");
+    let project = runtime
+        .block_on(task.store.get_project(&task.task.project_id))
+        .expect("read owning Project")
+        .expect("owning Project exists");
+    let payload = serde_json::json!({
+        "projects": [{
+            "id": project.plan.id.as_str(),
+            "slug": project.plan.slug,
+            "name": project.plan.name,
+            "summary": project.plan.prompt_context,
+            "definition": project.plan.prompt_context,
+            "flows": {"first": null, "loop": null, "finally": null},
+            "krs": [],
+            "initiative_ids": ["initialization-initiative"],
+            "team_ids": ["initialization-team"]
+        }],
+        "items": [{
+            "id": task.task.plan.id.as_str(),
+            "identifier": task.task.plan.identifier,
+            "url": null,
+            "name": task.task.plan.title,
+            "description": task.task.plan.description,
+            "rank": 1,
+            "completed": false,
+            "project_id": project.plan.id.as_str(),
+            "project": project.plan.slug,
+            "team_id": "initialization-team",
+            "assignee": null
+        }]
+    });
+    runtime
+        .block_on(task.store.put_pm_snapshot(PmSnapshotRow {
+            wave_id: task.task.wave_id.clone(),
+            provider: "linear".to_string(),
+            initiative: "initialization-initiative".to_string(),
+            synced_at: time::OffsetDateTime::now_utc().unix_timestamp(),
+            payload: serde_json::to_string(&payload).expect("serialize PM snapshot"),
+        }))
+        .expect("seed roadmap planning");
+    let run_lf = |args: &[&str]| {
+        Command::new(env!("CARGO_BIN_EXE_lf"))
+            .args(args)
+            .env("LF_DB_PATH", home.path().join("loopflow.db"))
+            .env_remove("LF_WAVE_ID")
+            .current_dir(repo.path())
+            .output()
+            .expect("run lf read surface")
+    };
+    let status = run_lf(&["task", "status", "INF-123", "--json"]);
+    assert!(
+        status.status.success(),
+        "status stays readable: {}",
+        String::from_utf8_lossy(&status.stderr)
+    );
+    let status: serde_json::Value = serde_json::from_slice(&status.stdout).expect("status JSON");
+    assert_eq!(status["actions"]["recommended"], "no_action");
+    assert!(status["actions"]["reason"]
+        .as_str()
+        .expect("status action reason")
+        .contains("is initializing worktree"));
+
+    let wait = run_lf(&["task", "wait", "INF-123", "--timeout", "0s", "--json"]);
+    assert!(
+        wait.status.success(),
+        "wait stays readable: {}",
+        String::from_utf8_lossy(&wait.stderr)
+    );
+    let wait: serde_json::Value = serde_json::from_slice(&wait.stdout).expect("wait JSON");
+    assert_eq!(wait["actions"], status["actions"]);
+
+    let roadmap = run_lf(&["roadmap", "--wave", "task-pr-tests", "--json"]);
+    assert!(
+        roadmap.status.success(),
+        "roadmap stays readable: {}",
+        String::from_utf8_lossy(&roadmap.stderr)
+    );
+    let roadmap: serde_json::Value = serde_json::from_slice(&roadmap.stdout).expect("roadmap JSON");
+    let wave = &roadmap["waves"][0];
+    assert_eq!(wave["projects"]["state"], "ok", "roadmap wave: {wave:#}");
+    let roadmap_task = &wave["projects"]["items"][0]["tasks"][0];
+    assert_eq!(roadmap_task["task"]["identifier"], "INF-123");
+    assert_eq!(
+        roadmap_task["attention"]["actions"]["recommended"],
+        "no_action"
+    );
+    assert!(roadmap_task["attention"]["reason"]
+        .as_str()
+        .expect("roadmap attention reason")
+        .contains("is initializing worktree"));
+    let work = runtime
+        .block_on(
+            task.store
+                .work_for_child(&ChildRef::Task(task.task.id.clone())),
+        )
+        .expect("resolve initializing Task Work");
+    assert!(runtime
+        .block_on(task.store.current_run(&work))
+        .expect("read initializing Task Run")
+        .is_none());
+
+    let projected =
+        task_snapshot(&task_status("INF-123").expect("read Task")).expect("project Task status");
+    assert_eq!(projected.actions.recommended, Some(TaskAction::NoAction));
+
+    rusqlite::Connection::open(home.path().join("loopflow.db"))
+        .expect("open stale initialization fixture")
+        .execute(
+            "UPDATE task_events SET created_at=?2 WHERE task_id=?1",
+            rusqlite::params![
+                task.task.id.as_str(),
+                time::OffsetDateTime::now_utc().unix_timestamp() - 301,
+            ],
+        )
+        .expect("age the initialization marker");
+    let stale = run_lf(&["task", "status", "INF-123", "--json"]);
+    assert!(
+        stale.status.success(),
+        "stale initialization stays readable"
+    );
+    let stale: serde_json::Value =
+        serde_json::from_slice(&stale.stdout).expect("stale status JSON");
+    assert_eq!(stale["actions"]["recommended"], "no_action");
+    assert!(stale["actions"]["reason"]
+        .as_str()
+        .expect("stale action reason")
+        .contains("initialization did not complete"));
+    let stale_roadmap = run_lf(&["roadmap", "--wave", "task-pr-tests", "--json"]);
+    assert!(
+        stale_roadmap.status.success(),
+        "stale roadmap stays readable"
+    );
+    let stale_roadmap: serde_json::Value =
+        serde_json::from_slice(&stale_roadmap.stdout).expect("stale roadmap JSON");
+    let stale_attention =
+        &stale_roadmap["waves"][0]["projects"]["items"][0]["tasks"][0]["attention"];
+    assert_eq!(stale_attention["level"], "red");
+    assert!(stale_attention["reason"]
+        .as_str()
+        .expect("stale roadmap reason")
+        .contains("initialization did not complete"));
+}
+
+#[test]
+fn missing_worktree_status_is_actionable_and_read_only() {
+    let home = tempfile::tempdir().expect("Task home");
+    let _env = EnvGuard::with_lf_home(&[], home.path());
+    let (task, missing_path, branch) = {
+        let repo = TestRepo::new();
+        let base = repo.head_sha();
+        let branch = "jack/missing-worktree";
+        repo.create_branch(branch);
+        let task = register_unrun_task(home.path(), repo.path(), branch, &base);
+        (task, repo.path().to_path_buf(), branch.to_string())
+    };
+    assert!(!missing_path.exists(), "fixture worktree is absent");
+    let runtime = tokio::runtime::Runtime::new().expect("missing Task runtime");
+    let before_task = runtime
+        .block_on(task.store.get_task(&task.task.id))
+        .expect("read Task before status")
+        .expect("Task exists before status");
+    let before_prs = runtime
+        .block_on(task.store.task_prs(&task.task.id))
+        .expect("read PRs before status");
+
+    let status = task_status("INF-123").expect("status survives the absent worktree");
+    let snapshot = task_snapshot(&status).expect("project missing-worktree status");
+
+    assert_eq!(snapshot.actions.recommended, Some(TaskAction::NoAction));
+    assert!(snapshot
+        .actions
+        .reason
+        .contains(&missing_path.display().to_string()));
+    assert!(snapshot.actions.reason.contains(&branch));
+    assert!(snapshot.actions.reason.contains("lf task resume INF-123"));
+    assert!(snapshot
+        .actions
+        .reason
+        .contains("identity and PR history are unchanged"));
+    assert_eq!(
+        runtime
+            .block_on(task.store.get_task(&task.task.id))
+            .expect("reread Task after status")
+            .expect("Task remains registered"),
+        before_task
+    );
+    assert_eq!(
+        runtime
+            .block_on(task.store.task_prs(&task.task.id))
+            .expect("reread PRs after status"),
+        before_prs
+    );
+}


### PR DESCRIPTION
## Usage

```bash
lf task status INF-123 --json
lf task wait INF-123 --timeout 0s --json
lf roadmap --wave product --json
```

These reads now keep a newly published Task visible while its worktree is still being placed.

## Summary

Publish a durable `WorktreeInitializing` event in the same transaction as the Task, PR, Steer, and reserved Run. `PrStarted` now closes that state only after placement completes. Status, wait, roadmap, chat, completion, and supervision distinguish active placement from a stale or genuinely missing worktree without touching invalid Git state.

## Verification

- `cargo test -p loopflow --test task_initialization_tests`
- `cargo test -p loopflow newer_parent_steer_rolls_back_initial_child_creation_before_files_exist`
- `cargo test -p loopflow resume_refusal_suppresses_recovery_during_a_working_pr`
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`