### PR TITLE
lf: honor terminal control launch options

### DIFF
--- a/rust/loopflow/src/bin/lf.rs
+++ b/rust/loopflow/src/bin/lf.rs
@@ -1219,8 +1219,7 @@ fn main() -> anyhow::Result<()> {
         .init();
 
     // Reorder args so flags can appear after the skill name
-    let raw_args: Vec<String> = std::env::args().collect();
-    let args = reorder_args(normalize_ssh_args(raw_args.clone()));
+    let args = reorder_args(normalize_ssh_args(std::env::args().collect()));
 
     let mut cli = Cli::parse_from(args.clone());
     ctrlc::set_handler(|| {
@@ -1449,9 +1448,9 @@ fn main() -> anyhow::Result<()> {
             }) => in_repo_runtime(&args, |repo| {
                 loopflow::lf::commands::home::start(waves, wave_ids, *json, repo)
             }),
-            Some(Commands::Stop { name }) => in_repo_runtime(&args, |repo| {
-                loopflow::lf::commands::home::stop(name, repo)
-            }),
+            Some(Commands::Stop { name }) => {
+                in_repo_runtime(&args, |repo| loopflow::lf::commands::home::stop(name, repo))
+            }
             Some(Commands::Pause { name, json }) => in_repo_runtime(&args, |repo| {
                 loopflow::lf::commands::wave_intent::run(name, true, *json, repo)
             }),
@@ -1473,13 +1472,11 @@ fn main() -> anyhow::Result<()> {
                 )
                 .map(|wave| wave.name().to_string())
                 .map_err(|err| match err {
-                            loopflow::engine::wave_context::WaveResolveError::NoContext => {
-                                anyhow::anyhow!(
-                                    "cannot determine parent wave; pass --wave <name>"
-                                )
-                            }
-                            other => anyhow::Error::from(other),
-                        })?;
+                    loopflow::engine::wave_context::WaveResolveError::NoContext => {
+                        anyhow::anyhow!("cannot determine parent wave; pass --wave <name>")
+                    }
+                    other => anyhow::Error::from(other),
+                })?;
                 let message = format!(
                     "Promote project '{slug}' from parent wave '{parent}'. Complete the authored migration, PM move, parent link, and residency checks."
                 );
@@ -1537,15 +1534,8 @@ fn main() -> anyhow::Result<()> {
                 wave,
                 repo,
                 json,
-            }) => loopflow::lf::commands::ci::run(
-                since,
-                wave.as_deref(),
-                repo.as_deref(),
-                *json,
-            ),
-            Some(Commands::Ps { json, sort }) => {
-                loopflow::lf::commands::top::run_ps(*json, *sort)
-            }
+            }) => loopflow::lf::commands::ci::run(since, wave.as_deref(), repo.as_deref(), *json),
+            Some(Commands::Ps { json, sort }) => loopflow::lf::commands::top::run_ps(*json, *sort),
             Some(Commands::Top { json, sort }) => {
                 loopflow::lf::commands::top::run_top(*json, *sort)
             }
@@ -1695,9 +1685,9 @@ fn main() -> anyhow::Result<()> {
             ),
             Some(Commands::Flow { name, args: rest }) => {
                 if matches!(name.as_str(), "show" | "validate") {
-                    let target = rest.first().ok_or_else(|| {
-                        anyhow::anyhow!("usage: lf flow {name} FLOW")
-                    })?;
+                    let target = rest
+                        .first()
+                        .ok_or_else(|| anyhow::anyhow!("usage: lf flow {name} FLOW"))?;
                     if rest.len() != 1 {
                         return Err(anyhow::anyhow!("usage: lf flow {name} FLOW"));
                     }
@@ -1749,12 +1739,9 @@ fn main() -> anyhow::Result<()> {
                     Err(err) => Err(err),
                 }
             }
-            None if raw_args.len() == 1 => in_repo_runtime(&args, |_| {
+            None => in_repo_runtime(&args, |_| {
                 loopflow::lf::commands::run::run(Some("loopflow"), None, &cli)
             }),
-            None => anyhow::bail!(
-                "no command specified; run bare `lf` for terminal control, `lf desktop` for the optional app, or name a skill or flow"
-            ),
         }
     };
 

--- a/rust/loopflow/tests/terminal_control_tests.rs
+++ b/rust/loopflow/tests/terminal_control_tests.rs
@@ -1,0 +1,31 @@
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::process::Command;
+
+#[test]
+fn terminal_control_accepts_a_model_option() {
+    let temp = tempfile::tempdir().unwrap();
+    let bin = temp.path().join("bin");
+    fs::create_dir(&bin).unwrap();
+    let claude = bin.join("claude");
+    fs::write(&claude, "#!/bin/sh\nexit 0\n").unwrap();
+    fs::set_permissions(&claude, fs::Permissions::from_mode(0o755)).unwrap();
+
+    let path = std::env::join_paths(std::iter::once(bin).chain(std::env::split_paths(
+        &std::env::var_os("PATH").unwrap_or_default(),
+    )))
+    .unwrap();
+    let output = Command::new(env!("CARGO_BIN_EXE_lf"))
+        .args(["-m", "claude"])
+        .current_dir(env!("CARGO_MANIFEST_DIR"))
+        .env("LF_HOME", temp.path().join("home"))
+        .env("PATH", path)
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}


### PR DESCRIPTION
## Usage

    lf -m claude

## Summary

Launch terminal control whenever the CLI parses a valid no-subcommand invocation, preserving global launch options such as the provider selection. Add an isolated end-to-end regression test for the reported path.