### PR TITLE
lf: scope shared reads to the current repository

### DIFF
--- a/rust/loopflow/src/bin/lf.rs
+++ b/rust/loopflow/src/bin/lf.rs
@@ -1585,12 +1585,12 @@ fn main() -> anyhow::Result<()> {
             Some(Commands::List) => {
                 in_repo_runtime(&args, |_| loopflow::lf::commands::list::show_all())
             }
-            Some(Commands::Ls { json }) => loopflow::lf::commands::waves::ls(*json),
+            Some(Commands::Ls { json, all }) => loopflow::lf::commands::waves::ls(*json, *all),
             Some(Commands::Status { wave, json }) => {
                 loopflow::lf::commands::waves::status(wave.as_deref(), *json)
             }
-            Some(Commands::Roadmap { wave, json }) => {
-                loopflow::lf::commands::waves::roadmap(wave.as_deref(), *json)
+            Some(Commands::Roadmap { wave, json, all }) => {
+                loopflow::lf::commands::waves::roadmap(wave.as_deref(), *json, *all)
             }
             Some(Commands::Activity {
                 since,

--- a/rust/loopflow/src/engine/builtins/ops/skill/loopflow.md
+++ b/rust/loopflow/src/engine/builtins/ops/skill/loopflow.md
@@ -16,6 +16,12 @@ lf ask list --user --json
 Treat that command as the only current attention state. Never rely on queue
 content remembered from an earlier turn or embedded in the launch prompt.
 
+The list is scoped to the repository this conversation runs in: worktrees
+collapse to their main checkout, and Asks from other repositories are hidden.
+Add `--all` to see every repository's User Asks on this machine. The same
+repository scope governs `lf ls` and `lf roadmap` (both take `--all`); `lf
+status` is already single-Wave and repo-resolved.
+
 When the User selects a queued Ask, run `lf ask open <ask-id>`. It opens or
 reattaches one detached Ask session in a sibling external terminal while
 this control conversation remains open. Explain queued, claimed,

--- a/rust/loopflow/src/lf/commands/ask.rs
+++ b/rust/loopflow/src/lf/commands/ask.rs
@@ -34,7 +34,8 @@ async fn run_async(args: &AskArgs) -> anyhow::Result<()> {
             user,
             outgoing,
             json,
-        }) => list_command(&store, *user, *outgoing, *json).await,
+            all,
+        }) => list_command(&store, *user, *outgoing, *json, *all).await,
         Some(AskCommand::Open {
             ask_id,
             prepare,
@@ -193,11 +194,31 @@ fn select_default_wait(
         .cloned()
 }
 
+/// Keep only Asks whose origin cwd resolves to the current repository,
+/// collapsing worktrees to their main checkout. `all` (or a cwd outside any git
+/// repo, where there is nothing to scope to) returns every Ask unchanged.
+fn scope_attention_to_repo(
+    attention: Vec<crate::ops::ask::AskAttention>,
+    all: bool,
+) -> Vec<crate::ops::ask::AskAttention> {
+    if all {
+        return attention;
+    }
+    let Some(scope) = crate::repository::CanonicalRepo::current() else {
+        return attention;
+    };
+    attention
+        .into_iter()
+        .filter(|item| scope.contains(&item.ask.origin.cwd))
+        .collect()
+}
+
 async fn list_command(
     store: &Arc<Store>,
     user: bool,
     outgoing: bool,
     json: bool,
+    all: bool,
 ) -> anyhow::Result<()> {
     if outgoing {
         let lease = crate::ops::required_run_lease(store)
@@ -231,8 +252,13 @@ async fn list_command(
     }
     let attention = if user {
         let request = AuthenticatedRequest::cli();
-        crate::ops::ask::pending_attention(store, &ControlCtx::User(&request), &AskTarget::User)
-            .await?
+        let attention = crate::ops::ask::pending_attention(
+            store,
+            &ControlCtx::User(&request),
+            &AskTarget::User,
+        )
+        .await?;
+        scope_attention_to_repo(attention, all)
     } else {
         let lease = crate::ops::required_run_lease(store)
             .await

--- a/rust/loopflow/src/lf/commands/waves.rs
+++ b/rust/loopflow/src/lf/commands/waves.rs
@@ -536,7 +536,23 @@ pub struct RoadmapTask {
 }
 
 /// `lf ls` — every wave the registry knows, running and stopped alike.
-pub fn ls(json: bool) -> Result<()> {
+/// Keep only Waves whose repository matches the current working directory,
+/// collapsing worktrees to their main checkout. `all` (or a cwd outside any git
+/// repo, where there is nothing to scope to) returns every Wave unchanged.
+fn scope_waves_to_repo(waves: Vec<Wave>, all: bool) -> Vec<Wave> {
+    if all {
+        return waves;
+    }
+    let Some(scope) = crate::repository::CanonicalRepo::current() else {
+        return waves;
+    };
+    waves
+        .into_iter()
+        .filter(|wave| scope.contains(Path::new(wave.repo())))
+        .collect()
+}
+
+pub fn ls(json: bool, all: bool) -> Result<()> {
     let rt = tokio::runtime::Runtime::new()?;
     rt.block_on(async {
         let Some(store) = open_existing_store().await.map(std::sync::Arc::new) else {
@@ -546,6 +562,7 @@ pub fn ls(json: bool) -> Result<()> {
             .list_waves(None)
             .await
             .map_err(|err| anyhow!("failed to read wave registry: {err}"))?;
+        let waves = scope_waves_to_repo(waves, all);
         let mut snapshots = Vec::with_capacity(waves.len());
         for wave in waves {
             snapshots.push(snapshot_wave(&store, &wave).await?);
@@ -635,7 +652,7 @@ pub fn status(wave: Option<&str>, json: bool) -> Result<()> {
 /// read, bounded Git probes for Task Work, and no network. `lf status`
 /// answers "is it healthy"; this answers "what is being worked on and what
 /// could be".
-pub fn roadmap(wave: Option<&str>, json: bool) -> Result<()> {
+pub fn roadmap(wave: Option<&str>, json: bool, all: bool) -> Result<()> {
     let rt = tokio::runtime::Runtime::new()?;
     rt.block_on(async {
         let Some(store) = open_existing_store().await.map(std::sync::Arc::new) else {
@@ -665,10 +682,13 @@ pub fn roadmap(wave: Option<&str>, json: bool) -> Result<()> {
         .await
         {
             Ok(wave) => vec![wave],
-            Err(crate::engine::wave_context::WaveResolveError::NoContext) => store
-                .list_waves(None)
-                .await
-                .map_err(|err| anyhow!("failed to read wave registry: {err}"))?,
+            Err(crate::engine::wave_context::WaveResolveError::NoContext) => {
+                let waves = store
+                    .list_waves(None)
+                    .await
+                    .map_err(|err| anyhow!("failed to read wave registry: {err}"))?;
+                scope_waves_to_repo(waves, all)
+            }
             Err(other) => return Err(anyhow!(other)),
         };
         // One tmux reading for every Work process on the machine, taken once.

--- a/rust/loopflow/src/lf/mod.rs
+++ b/rust/loopflow/src/lf/mod.rs
@@ -486,6 +486,10 @@ pub enum Commands {
         /// Emit the wave snapshot as JSON (Loopflow's dashboard snapshot)
         #[arg(long)]
         json: bool,
+        /// List Waves from every repository on this machine, not just the
+        /// current repository (worktrees collapse to their main checkout).
+        #[arg(long)]
+        all: bool,
     },
     /// Show one wave's Project/Task hierarchy, runs, attention, and live loop
     /// state from the registry. Defaults to the ambient wave (`LF_WAVE_ID`).
@@ -496,16 +500,20 @@ pub enum Commands {
         #[arg(long)]
         json: bool,
     },
-    /// Show the machine-wide roadmap: every open Task across every Wave, joined
-    /// to live evidence and bucketed into Now / Needs attention / Available /
-    /// Later. Global by default; `--wave` scopes it. Local-only, deterministic.
+    /// Show the current repository's roadmap: every open Task across the repo's
+    /// Waves, joined to live evidence and bucketed into Now / Needs attention /
+    /// Available / Later. `--wave` scopes it; `--all` spans every repository on
+    /// this machine. Local-only, deterministic.
     Roadmap {
-        /// Scope to one Wave (default: every Wave on this machine)
+        /// Scope to one Wave (default: every Wave in the current repository)
         #[arg(long)]
         wave: Option<String>,
         /// Emit the roadmap snapshot as JSON
         #[arg(long)]
         json: bool,
+        /// Span every repository on this machine, not just the current one.
+        #[arg(long)]
+        all: bool,
     },
     /// Show one ordered record of durable Work, Run, PR, and Steer facts
     Activity {
@@ -720,6 +728,10 @@ pub enum AskCommand {
         outgoing: bool,
         #[arg(long)]
         json: bool,
+        /// Include Asks from every repository on this machine, not just the
+        /// current repository (worktrees collapse to their main checkout).
+        #[arg(long)]
+        all: bool,
     },
     /// Claim or reopen an Ask and present its session in a sibling terminal
     Open {
@@ -1978,7 +1990,13 @@ mod tests {
         assert!(flag.list);
 
         let waves = Cli::try_parse_from(["lf", "ls", "--json"]).expect("parse wave list");
-        assert!(matches!(waves.command, Some(Commands::Ls { json: true })));
+        assert!(matches!(
+            waves.command,
+            Some(Commands::Ls {
+                json: true,
+                all: false
+            })
+        ));
     }
 
     #[test]
@@ -3014,7 +3032,8 @@ mod tests {
                     Some(AskCommand::List {
                         outgoing: true,
                         user: false,
-                        json: true
+                        json: true,
+                        all: false
                     })
                 )
         ));

--- a/rust/loopflow/src/repository.rs
+++ b/rust/loopflow/src/repository.rs
@@ -41,6 +41,21 @@ impl CanonicalRepo {
     pub fn as_path(&self) -> &Path {
         &self.0
     }
+
+    /// The repository scope of the current working directory, or `None` when the
+    /// cwd is outside any git checkout (nothing to scope to).
+    pub fn current() -> Option<Self> {
+        Self::discover(&std::env::current_dir().ok()?).ok()
+    }
+
+    /// Whether `path` resolves to this same repository, collapsing worktrees to
+    /// their main checkout. A path that no longer exists on disk is not "this
+    /// repo" and returns `false`.
+    pub fn contains(&self, path: &Path) -> bool {
+        Self::discover(path)
+            .map(|other| &other == self)
+            .unwrap_or(false)
+    }
 }
 
 impl fmt::Display for CanonicalRepo {
@@ -139,6 +154,56 @@ impl From<RepoId> for String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::process::Command;
+
+    fn git(dir: &Path, args: &[&str]) {
+        let output = Command::new("git")
+            .arg("-C")
+            .arg(dir)
+            .args(args)
+            .output()
+            .expect("run git");
+        assert!(output.status.success(), "git {args:?} failed");
+    }
+
+    fn init_repo() -> tempfile::TempDir {
+        let dir = tempfile::tempdir().expect("temp repo");
+        git(dir.path(), &["init", "-b", "main"]);
+        git(dir.path(), &["config", "user.name", "tester"]);
+        git(dir.path(), &["config", "user.email", "t@example.com"]);
+        std::fs::write(dir.path().join("README.md"), "base").expect("seed file");
+        git(dir.path(), &["add", "README.md"]);
+        git(dir.path(), &["commit", "-m", "base"]);
+        dir
+    }
+
+    #[test]
+    fn canonical_repo_collapses_worktree_and_separates_distinct_repo() {
+        let repo_a = init_repo();
+        let repo_b = init_repo();
+
+        // A linked worktree of A collapses to A's main checkout.
+        let wt_parent = tempfile::tempdir().expect("worktree parent");
+        let worktree = wt_parent.path().join("a.child");
+        git(
+            repo_a.path(),
+            &["worktree", "add", "-b", "child", worktree.to_str().unwrap()],
+        );
+
+        let scope_a = CanonicalRepo::discover(repo_a.path()).expect("discover A");
+        assert_eq!(
+            CanonicalRepo::discover(&worktree).expect("discover worktree"),
+            scope_a,
+            "worktree should resolve to its main checkout"
+        );
+        assert!(scope_a.contains(&worktree));
+
+        // A distinct repository is a different scope.
+        assert!(!scope_a.contains(repo_b.path()));
+
+        // A path outside any checkout is not this repo.
+        assert!(!scope_a.contains(Path::new("/nonexistent/path")));
+    }
 
     #[test]
     fn repo_id_name_returns_repo_portion() {

--- a/rust/loopflow/tests/wave_repository_ownership.rs
+++ b/rust/loopflow/tests/wave_repository_ownership.rs
@@ -319,10 +319,23 @@ async fn repositories_own_same_named_waves_and_relocation_preserves_identity() {
         Err(WaveResolveError::RepositoryMismatch { .. })
     ));
 
-    let list = lf(&home, &repo_a, &["ls", "--json"]);
-    let listed = list.as_array().unwrap();
+    // `lf ls` is scoped to the invoking repository: from repo_a only alpha's
+    // infrastructure Wave is listed, not repo_b's same-named beta.
+    let scoped = lf(&home, &repo_a, &["ls", "--json"]);
+    let scoped_infra: Vec<_> = scoped
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter(|wave| wave["name"] == "infrastructure")
+        .collect();
+    assert_eq!(scoped_infra.len(), 1);
+    assert_eq!(scoped_infra[0]["id"], alpha.id().as_str());
+
+    // `--all` restores the machine-wide view: both same-named Waves appear.
+    let all = lf(&home, &repo_a, &["ls", "--all", "--json"]);
     assert_eq!(
-        listed
+        all.as_array()
+            .unwrap()
             .iter()
             .filter(|wave| wave["name"] == "infrastructure")
             .count(),
@@ -341,7 +354,13 @@ async fn repositories_own_same_named_waves_and_relocation_preserves_identity() {
     assert!(human_list
         .lines()
         .any(|line| { line.contains("infrastructure") && line.contains("alpha") }));
-    assert!(human_list
+    // repo_b's beta is out of scope from repo_a's checkout.
+    assert!(!human_list
+        .lines()
+        .any(|line| { line.contains("infrastructure") && line.contains("beta") }));
+    // `--all` brings beta's repository back into the human listing.
+    let human_all = String::from_utf8(lf_output(&home, &repo_a, &["ls", "--all"]).stdout).unwrap();
+    assert!(human_all
         .lines()
         .any(|line| { line.contains("infrastructure") && line.contains("beta") }));
 


### PR DESCRIPTION
## Usage

```bash
lf ls
lf roadmap
lf ask list --user --json

# Restore the machine-wide view
lf ls --all
lf roadmap --all
lf ask list --user --all --json
```

## Summary

Scopes Wave listings, roadmaps, and User Ask attention to the invoking repository by default, keeping unrelated repositories out of normal terminal control workflows. Linked worktrees resolve to their main checkout, while `--all` preserves access to the previous machine-wide view.

## Changes

- Added canonical repository matching for current checkouts and linked worktrees
- Applied repository filtering to `lf ls`, `lf roadmap`, and `lf ask list --user`
- Added `--all` flags for explicit machine-wide reads
- Updated Loopflow control guidance and repository-ownership coverage for scoped and global listings