### PR TITLE
wave: reset stale playheads when flow definitions change

### DIFF
--- a/rust/loopflow/src/flowloop/wave.rs
+++ b/rust/loopflow/src/flowloop/wave.rs
@@ -1467,9 +1467,11 @@ mod tests {
 
     use crate::chat::turns::{ChatRole, ChatTurn};
     use crate::chat::types::TurnUsage;
+    use crate::engine::OccurrencePolicy;
     use crate::wave::journal::{
         journal_path, DiscordChatBinding, DiscordMessageSource, EventKind, Journal,
     };
+    use crate::wave::playhead::{Playhead, PlayheadEvent, QueuedInvocation, StepPlan};
     use crate::wave::runtime::WaveRuntime;
     use crate::wave::server::{self, ResidentDoor};
     use crate::wave::state::LoopState;
@@ -1741,6 +1743,54 @@ mod tests {
         accepts_current_send: bool,
     }
 
+    struct CompletingHarness {
+        events: mpsc::UnboundedSender<ConversationEvent>,
+        inputs: Arc<Mutex<Vec<String>>>,
+    }
+
+    #[async_trait]
+    impl Harness for CompletingHarness {
+        async fn start(&mut self, _config: &crate::engine::AgentConfig) -> Result<()> {
+            Ok(())
+        }
+
+        async fn send_input(&mut self, content: &str) -> Result<()> {
+            self.inputs
+                .lock()
+                .expect("inputs lock")
+                .push(content.into());
+            let turn_id = "recovery-turn".to_string();
+            let _ = self.events.send(ConversationEvent::TurnStarted {
+                turn_id: turn_id.clone(),
+            });
+            let _ = self.events.send(ConversationEvent::TextDelta {
+                turn_id: turn_id.clone(),
+                content: "recovered".to_string(),
+            });
+            let _ = self.events.send(ConversationEvent::TurnCompleted {
+                turn_id,
+                status: Lifecycle::Completed,
+            });
+            Ok(())
+        }
+
+        async fn send_current(&mut self, _content: &str) -> SendCurrentOutcome {
+            SendCurrentOutcome::NotSteerable
+        }
+
+        async fn interrupt(&mut self) -> Result<()> {
+            Ok(())
+        }
+
+        async fn stop(&mut self) -> Result<()> {
+            Ok(())
+        }
+
+        fn provider_session_id(&self) -> Option<String> {
+            None
+        }
+    }
+
     #[async_trait]
     impl Harness for SteeringHarness {
         async fn start(&mut self, _config: &crate::engine::AgentConfig) -> Result<()> {
@@ -1808,6 +1858,157 @@ mod tests {
             (!self.inputs.lock().expect("inputs lock").is_empty())
                 .then(|| "vendor-session".to_string())
         }
+    }
+
+    #[tokio::test]
+    async fn stale_wave_definition_resets_before_running_the_fresh_flow() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let status = std::process::Command::new("git")
+            .args(["init", "--quiet"])
+            .current_dir(tmp.path())
+            .status()
+            .expect("git init");
+        assert!(status.success());
+
+        let (mut journal, _) =
+            Journal::open(&journal_path(tmp.path(), "ship")).expect("open journal");
+        let root = QueuedInvocation {
+            id: "wave-root".to_string(),
+            flow: "wave".to_string(),
+            steps: ["wave_clarify", "wave_pursue", "wave_mutate"]
+                .into_iter()
+                .map(|name| StepPlan {
+                    name: name.to_string(),
+                    kind: StepKind::Skill,
+                    policy: OccurrencePolicy::default(),
+                })
+                .collect(),
+        };
+        let (playhead, event) = Playhead::resume_root(root, 2, 7).expect("legacy playhead");
+        journal.append(|_| EventKind::PlayheadChanged {
+            event,
+            playhead: Box::new(playhead),
+        });
+        drop(journal);
+
+        let attempts = Arc::new(Mutex::new(Vec::new()));
+        let prepare_attempts = attempts.clone();
+        let inputs = Arc::new(Mutex::new(Vec::new()));
+        let harness_inputs = inputs.clone();
+        let backend = BodyBackend::Harness {
+            prepare: Box::new(move |skill, seed, _wave, max_turns| {
+                prepare_attempts
+                    .lock()
+                    .expect("attempts lock")
+                    .push(skill.to_string());
+                Ok(crate::lf::commands::run::PreparedHarnessTurn {
+                    config: crate::engine::AgentConfig {
+                        agent: Some("fake".to_string()),
+                        max_turns,
+                        ..crate::engine::AgentConfig::default()
+                    },
+                    input: format!("{skill}\n{seed}"),
+                    context: crate::trace::PreparedTurnContext::from_prompts(
+                        "",
+                        &format!("{skill}\n{seed}"),
+                    ),
+                    harness: "fake".to_string(),
+                    model: None,
+                    context_gather_ms: 0,
+                    context_render_ms: 0,
+                })
+            }),
+            create: Box::new(move |_name, _approval, events| {
+                Ok(Box::new(CompletingHarness {
+                    events,
+                    inputs: harness_inputs.clone(),
+                }))
+            }),
+        };
+        let loop_ = boot_backend(
+            tmp,
+            test_config(Duration::from_secs(600)),
+            backend,
+            Arc::new(Mutex::new(Vec::new())),
+            mpsc::unbounded_channel().1,
+            None,
+        )
+        .await;
+        let user_turn = loop_
+            .runtime
+            .deliver(MessageOp::Message, "recover".into())
+            .expect("recovery wake");
+
+        wait_for("fresh Wave iteration completed", || {
+            loop_.runtime.thread_snapshot().iter().any(|turn| {
+                turn.role == ChatRole::Assistant
+                    && turn.status == Lifecycle::Completed
+                    && turn.text == "recovered"
+            })
+        })
+        .await;
+        wait_for("next Wave iteration is idle", || {
+            loop_.runtime.loop_state() == LoopState::Idle
+                && loop_
+                    .runtime
+                    .playhead()
+                    .and_then(|playhead| playhead.now)
+                    .is_some_and(|step| step.step == "wave/clarify" && step.iteration == 1)
+        })
+        .await;
+
+        assert_eq!(
+            *attempts.lock().expect("attempts lock"),
+            vec!["wave/clarify", "wave/pursue", "wave/mutate"]
+        );
+        assert_eq!(inputs.lock().expect("inputs lock").len(), 3);
+        let events = loop_.journal_events();
+        assert_eq!(
+            events
+                .iter()
+                .filter(|event| matches!(
+                    event,
+                    EventKind::PlayheadChanged {
+                        event: PlayheadEvent::DefinitionReset,
+                        ..
+                    }
+                ))
+                .count(),
+            1
+        );
+        assert_eq!(
+            events
+                .iter()
+                .filter(|event| matches!(
+                    event,
+                    EventKind::PlayheadChanged {
+                        event: PlayheadEvent::StepStarted { .. },
+                        ..
+                    }
+                ))
+                .count(),
+            3,
+            "reset itself never opens a body; the fresh three-step flow does"
+        );
+        assert!(!events.iter().any(|event| matches!(
+            event,
+            EventKind::PlayheadChanged {
+                event: PlayheadEvent::StepFinished {
+                    outcome: StepOutcome::Failed,
+                    ..
+                },
+                ..
+            }
+        )));
+        assert_eq!(
+            started_answers(&events),
+            vec![vec![message_id(&user_turn)], Vec::new(), Vec::new()]
+        );
+        assert!(!loop_
+            .runtime
+            .thread_snapshot()
+            .iter()
+            .any(|turn| turn.role == ChatRole::Assistant && turn.status == Lifecycle::Failed));
     }
 
     #[tokio::test]
@@ -2289,6 +2490,47 @@ mod tests {
             .expect("loop task not cancelled");
         let err = outcome.expect_err("loop failure is an error exit");
         assert!(err.to_string().contains("consecutive wave failures"));
+    }
+
+    #[tokio::test]
+    async fn non_catalog_harness_prepare_failure_counts_toward_cap() {
+        let attempts = Arc::new(Mutex::new(0_u32));
+        let prepare_attempts = attempts.clone();
+        let backend = BodyBackend::Harness {
+            prepare: Box::new(move |_skill, _seed, _wave, _max_turns| {
+                *prepare_attempts.lock().expect("attempts lock") += 1;
+                Err(anyhow!("provider configuration is invalid"))
+            }),
+            create: Box::new(|_name, _approval, _events| {
+                Err(anyhow!("prepare failure must not create a harness"))
+            }),
+        };
+        let mut loop_ = boot_backend(
+            tempfile::tempdir().expect("tempdir"),
+            test_config(Duration::from_millis(30)),
+            backend,
+            Arc::new(Mutex::new(Vec::new())),
+            mpsc::unbounded_channel().1,
+            None,
+        )
+        .await;
+
+        wait_for("prepare failures exhaust the cap", || {
+            matches!(loop_.runtime.loop_state(), LoopState::Failed { .. })
+        })
+        .await;
+        assert_eq!(
+            *attempts.lock().expect("attempts lock"),
+            MAX_CONSECUTIVE_PASS_FAILURES
+        );
+        let outcome = tokio::time::timeout(Duration::from_secs(5), &mut loop_.loop_task)
+            .await
+            .expect("loop task ends")
+            .expect("loop task not cancelled");
+        let error = outcome.expect_err("failure cap ends the resident");
+        assert!(error
+            .to_string()
+            .contains("provider configuration is invalid"));
     }
 
     /// A pass overrunning its timeout is killed and finishes its turn

--- a/rust/loopflow/src/wave/README.md
+++ b/rust/loopflow/src/wave/README.md
@@ -43,6 +43,14 @@ The journal rebuilds the thread, playhead, and loop state after restart. The
 endpoint and resident token exist only while the listener owns that boot and
 are removed on shutdown.
 
+Expanded Wave plans stay pinned across restarts while their definitions remain
+unchanged. Before opening a body, the listener compares every journaled stack
+and queued plan with the current catalog. Any name, kind, order, policy, or
+shape change appends one reset snapshot and starts the current root at step
+zero. The reset drops cursors, iterations, nested invocations, and queued flow
+continuations; pending chat and inbox messages remain available to the fresh
+flow. An active body finishes against its pinned plan before this check runs.
+
 Wave Chat is local when `GOAL.md` has no `chat` block. A Discord channel binding
 replaces that backing on the next listener start. Each change appends one
 conversation epoch; reopening the same backing resumes its epoch. The listener

--- a/rust/loopflow/src/wave/journal.rs
+++ b/rust/loopflow/src/wave/journal.rs
@@ -642,6 +642,9 @@ impl Narrator {
                 PlayheadEvent::InvocationCompleted { flow, .. } => {
                     info(format!("playhead completed · {flow}"))
                 }
+                PlayheadEvent::DefinitionReset => {
+                    info("playhead reset · definition changed".to_string())
+                }
                 PlayheadEvent::StepStarted { step, .. } => {
                     info(format!("playhead now · {} / {}", step.flow, step.step))
                 }

--- a/rust/loopflow/src/wave/playhead.rs
+++ b/rust/loopflow/src/wave/playhead.rs
@@ -83,6 +83,10 @@ impl QueuedInvocation {
             queue: Vec::new(),
         }
     }
+
+    fn matches_definition(&self, flow: &str, steps: &[StepPlan]) -> bool {
+        self.flow == flow && self.steps == steps
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -95,8 +99,7 @@ pub struct InvocationState {
     pub queue: Vec<QueuedInvocation>,
 }
 
-/// One logical step, keyed by `invocation_id` + `index` — repeated invocations
-/// of the same flow name stay distinguishable, and the name is display only.
+/// One logical step selected from the journaled flow expansion.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct StepRef {
     pub invocation_id: String,
@@ -216,6 +219,7 @@ pub enum PlayheadEvent {
         invocation_id: String,
         flow: String,
     },
+    DefinitionReset,
     StepStarted {
         step: StepRef,
         body_id: String,
@@ -268,6 +272,36 @@ impl Playhead {
         frame.cursor = cursor;
         frame.iteration = iteration;
         Ok((playhead, event))
+    }
+
+    pub fn reset(root: QueuedInvocation) -> (Self, PlayheadEvent) {
+        (
+            Self {
+                stack: vec![root.start()],
+                active: None,
+            },
+            PlayheadEvent::DefinitionReset,
+        )
+    }
+
+    pub fn definitions_match(&self, repo: &Path, root: &QueuedInvocation) -> bool {
+        let Some(root_frame) = self.stack.first() else {
+            return false;
+        };
+        if !root.matches_definition(&root_frame.flow, &root_frame.steps) {
+            return false;
+        }
+        self.stack.iter().skip(1).all(|frame| {
+            QueuedInvocation::load(repo, &frame.flow)
+                .is_ok_and(|current| current.matches_definition(&frame.flow, &frame.steps))
+        }) && self
+            .stack
+            .iter()
+            .flat_map(|frame| &frame.queue)
+            .all(|queued| {
+                QueuedInvocation::load(repo, &queued.flow)
+                    .is_ok_and(|current| current.matches_definition(&queued.flow, &queued.steps))
+            })
     }
 
     pub fn current(&self) -> Option<StepRef> {
@@ -559,6 +593,51 @@ mod tests {
     fn root_rejects_a_cursor_past_its_current_definition() {
         let error = Playhead::resume_root(invocation("task", &["clarify"]), 1, 0).unwrap_err();
         assert!(error.to_string().contains("cannot resume at step 2 of 1"));
+    }
+
+    #[test]
+    fn playhead_definition_comparison_covers_root_and_queued_shape() {
+        let tmp = tempfile::tempdir().unwrap();
+        let flows = tmp.path().join(".lf/flows");
+        std::fs::create_dir_all(&flows).unwrap();
+        std::fs::write(flows.join("wave.yaml"), "- current\n- next\n").unwrap();
+        std::fs::write(flows.join("queued.yaml"), "- queued-current\n").unwrap();
+
+        let root = QueuedInvocation::load(tmp.path(), "wave").unwrap();
+        let (mut playhead, _) = Playhead::new(root.clone());
+        assert!(playhead.definitions_match(tmp.path(), &root));
+
+        let mut renamed = playhead.clone();
+        renamed.stack[0].steps[0].name = "old-name".to_string();
+        assert!(!renamed.definitions_match(tmp.path(), &root));
+
+        let mut changed_kind = playhead.clone();
+        changed_kind.stack[0].steps[0].kind = StepKind::Op;
+        assert!(!changed_kind.definitions_match(tmp.path(), &root));
+
+        let mut changed_policy = playhead.clone();
+        changed_policy.stack[0].steps[0].policy.id = Some("old-policy".to_string());
+        assert!(!changed_policy.definitions_match(tmp.path(), &root));
+
+        let mut reordered = playhead.clone();
+        reordered.stack[0].steps.reverse();
+        assert!(!reordered.definitions_match(tmp.path(), &root));
+
+        let mut shortened = playhead.clone();
+        shortened.stack[0].steps.pop();
+        assert!(!shortened.definitions_match(tmp.path(), &root));
+
+        playhead.stack[0]
+            .queue
+            .push(invocation("queued", &["queued-old"]));
+        assert!(!playhead.definitions_match(tmp.path(), &root));
+
+        let (reset, event) = Playhead::reset(root);
+        assert_eq!(event, PlayheadEvent::DefinitionReset);
+        assert_eq!(reset.stack.len(), 1);
+        assert_eq!(reset.stack[0].cursor, 0);
+        assert_eq!(reset.stack[0].iteration, 0);
+        assert!(reset.stack[0].queue.is_empty());
     }
 
     #[test]

--- a/rust/loopflow/src/wave/runtime.rs
+++ b/rust/loopflow/src/wave/runtime.rs
@@ -792,27 +792,47 @@ impl WaveRuntime {
         self.inner().playhead.as_ref().map(Playhead::view)
     }
 
-    /// Initialize the default wave invocation once. Replay wins over code:
-    /// after restart the journaled cursor is reused even if definitions moved.
+    /// Initialize the default Wave invocation, or reset stale execution state
+    /// once no body is active. Inbox messages live outside the playhead and
+    /// remain pending for the fresh root.
     pub fn ensure_playhead(&self) -> anyhow::Result<PlayheadView> {
         let mut inner = self.inner();
-        if let Some(playhead) = inner.playhead.as_ref() {
-            return Ok(playhead.view());
+        if inner
+            .playhead
+            .as_ref()
+            .is_some_and(|playhead| playhead.active.is_some())
+        {
+            return Ok(inner
+                .playhead
+                .as_ref()
+                .expect("active body belongs to an initialized playhead")
+                .view());
         }
         let root = QueuedInvocation::load(&self.repo_root, "wave")?;
-        let (playhead, event) = Playhead::new(root);
-        let view = playhead.view();
-        inner.journal.append(|_| EventKind::PlayheadChanged {
-            event,
-            playhead: Box::new(playhead.clone()),
-        });
+        if inner
+            .playhead
+            .as_ref()
+            .is_some_and(|playhead| playhead.definitions_match(&self.repo_root, &root))
+        {
+            return Ok(inner
+                .playhead
+                .as_ref()
+                .expect("matching playhead is initialized")
+                .view());
+        }
+        if inner.playhead.is_none() {
+            let (playhead, event) = Playhead::new(root);
+            inner.playhead = Some(playhead);
+            return self.journal_playhead_locked(&mut inner, vec![event]);
+        }
+
+        let (playhead, event) = Playhead::reset(root);
         inner.playhead = Some(playhead);
-        let _ = self.playhead_tx.send(view.clone());
-        Ok(view)
+        self.journal_playhead_locked(&mut inner, vec![event])
     }
 
-    /// Enqueue a flow at the innermost active invocation. The flow is
-    /// resolved now, so the queue carries stable step names and paths.
+    /// Enqueue a flow at the innermost active invocation. The queue keeps the
+    /// expanded plan until a definition change resets the playhead.
     pub fn enqueue_flow(&self, flow: &str) -> anyhow::Result<PlayheadView> {
         self.ensure_playhead()?;
         let invocation = QueuedInvocation::load(&self.repo_root, flow)?;
@@ -1875,6 +1895,9 @@ mod tests {
     use super::*;
     use std::path::Path;
 
+    use crate::engine::OccurrencePolicy;
+    use crate::wave::playhead::{StepKind, StepPlan};
+
     /// Parse the sequence out of a `"turn-<n>"` id; panics on a malformed one
     /// (ids are always minted from journal seqs).
     fn turn_seq(id: &str) -> u64 {
@@ -1912,6 +1935,108 @@ mod tests {
             ChatBacking::discord(binding),
         )
         .expect("open Discord runtime")
+    }
+
+    #[test]
+    fn stale_wave_definition_resets_once_and_preserves_pending_input() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let path = journal_path(tmp.path(), "ship");
+        let (mut journal, _) = Journal::open(&path).expect("open journal");
+        let mut root = QueuedInvocation {
+            id: "wave-root".to_string(),
+            flow: "wave".to_string(),
+            steps: ["wave_clarify", "wave_pursue", "wave_mutate"]
+                .into_iter()
+                .map(|name| StepPlan {
+                    name: name.to_string(),
+                    kind: StepKind::Skill,
+                    policy: OccurrencePolicy::default(),
+                })
+                .collect(),
+        };
+        root.steps[1].kind = StepKind::Op;
+        let (playhead, event) = Playhead::resume_root(root, 2, 7).expect("legacy playhead");
+        journal.append(|_| EventKind::PlayheadChanged {
+            event,
+            playhead: Box::new(playhead),
+        });
+        drop(journal);
+
+        let rt = open_runtime(tmp.path());
+        rt.deliver(MessageOp::Message, "recover".to_string())
+            .expect("pending recovery message");
+        let reset = rt.ensure_playhead().expect("reset stale definition");
+        let current = reset.now.as_ref().expect("fresh root step");
+        assert_eq!(current.step, "wave/clarify");
+        assert_eq!(current.index, 0);
+        assert_eq!(current.iteration, 0);
+        assert_eq!(reset.stack.len(), 1);
+        assert!(reset.stack[0].queue.is_empty());
+        assert_ne!(reset.stack[0].id, "wave-root");
+        assert_eq!(rt.pending_messages().len(), 1);
+
+        let repeated = rt.ensure_playhead().expect("idempotent definition check");
+        assert_eq!(repeated, reset);
+        drop(rt);
+
+        let reopened = open_runtime(tmp.path());
+        let current = reopened
+            .playhead()
+            .expect("replayed reset playhead")
+            .now
+            .expect("selected fresh step");
+        assert_eq!(current.step, "wave/clarify");
+        assert_eq!(current.iteration, 0);
+        assert_eq!(reopened.pending_messages().len(), 1);
+        drop(reopened);
+
+        let (_, events) = Journal::open(&path).expect("read reset journal");
+        let resets = events
+            .iter()
+            .filter(|event| {
+                matches!(
+                    &event.kind,
+                    EventKind::PlayheadChanged {
+                        event: PlayheadEvent::DefinitionReset,
+                        ..
+                    }
+                )
+            })
+            .count();
+        assert_eq!(resets, 1);
+    }
+
+    #[test]
+    fn stale_wave_definition_waits_for_the_active_body_to_close() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let rt = open_runtime(tmp.path());
+        let playhead = rt.ensure_playhead().expect("initialize playhead");
+        let body = BodyProvenance::for_step(&playhead.now.expect("current step"), tmp.path());
+        let body_id = body.body_id.clone();
+        rt.start_body(body).expect("start body");
+
+        let flows = tmp.path().join(".lf/flows");
+        std::fs::create_dir_all(&flows).expect("flow directory");
+        std::fs::write(flows.join("wave.yaml"), "- replacement\n").expect("replacement flow");
+
+        assert_eq!(
+            rt.ensure_playhead()
+                .expect("active body stays pinned")
+                .now
+                .expect("original step remains")
+                .step,
+            "wave/clarify"
+        );
+        rt.finish_body(&body_id, StepOutcome::Failed, "body ended")
+            .expect("close active body");
+        assert_eq!(
+            rt.ensure_playhead()
+                .expect("reset after body closes")
+                .now
+                .expect("fresh root")
+                .step,
+            "replacement"
+        );
     }
 
     // -- Wire delta builders (the resident door's vocabulary) --


### PR DESCRIPTION
## Usage

```bash
lf wave product
# Edit the Wave flow definition while the resident is idle
lf chat --wave product "continue"
```

## Summary

Wave residents now reconcile journaled playheads with current flow definitions before opening the next body. When a persisted plan is stale, the runtime records one durable reset and restarts from the current root instead of replaying an obsolete cursor, preventing renamed, reordered, or otherwise changed steps from running incorrectly.

## Changes

- Compare root, nested, and queued plans by step name, kind, order, policy, and shape
- Reset cursors, iterations, nested invocations, and queued continuations while preserving pending chat and inbox input
- Keep active bodies pinned to their original plan until they finish
- Journal and narrate definition resets so recovery remains visible and replayable
- Add behavioral coverage for end-to-end recovery, restart idempotence, active-body deferral, and harness preparation failure limits