### PR TITLE
task workflow: make human review focused and durable

### DIFF
--- a/rust/loopflow/src/bin/lf.rs
+++ b/rust/loopflow/src/bin/lf.rs
@@ -1015,11 +1015,24 @@ fn run_project_command(repo: &Path, command: &ProjectCommand) -> anyhow::Result<
     }
 }
 
+fn task_cycle(fix: bool, feature: bool) -> Option<loopflow::ops::task::TaskCycle> {
+    // clap conflicts_with guarantees at most one flag is set.
+    if fix {
+        Some(loopflow::ops::task::TaskCycle::Fix)
+    } else if feature {
+        Some(loopflow::ops::task::TaskCycle::Feature)
+    } else {
+        None
+    }
+}
+
 fn run_task_command(repo: &Path, command: &TaskCommand) -> anyhow::Result<()> {
     match command {
         TaskCommand::Run {
             issue,
             name,
+            fix,
+            feature,
             first,
             loop_,
             finally,
@@ -1032,11 +1045,12 @@ fn run_task_command(repo: &Path, command: &TaskCommand) -> anyhow::Result<()> {
                 issue,
                 loopflow::ops::task::TaskLaunchOptions {
                     name: name.clone(),
-                    flows: loopflow::ops::task::TaskFlowOverrides {
-                        first: first.clone(),
-                        loop_: loop_.clone(),
-                        finally: finally.clone(),
-                    },
+                    flows: loopflow::ops::task::TaskFlowOverrides::for_cycle(
+                        task_cycle(*fix, *feature),
+                        first.clone(),
+                        loop_.clone(),
+                        finally.clone(),
+                    ),
                     stack_on: stack_on.clone(),
                     directive: directive.clone(),
                 },
@@ -1047,6 +1061,8 @@ fn run_task_command(repo: &Path, command: &TaskCommand) -> anyhow::Result<()> {
             project_id,
             title,
             name,
+            fix,
+            feature,
             first,
             loop_,
             finally,
@@ -1061,11 +1077,12 @@ fn run_task_command(repo: &Path, command: &TaskCommand) -> anyhow::Result<()> {
                 piped_task_report()?,
                 loopflow::ops::task::TaskLaunchOptions {
                     name: name.clone(),
-                    flows: loopflow::ops::task::TaskFlowOverrides {
-                        first: first.clone(),
-                        loop_: loop_.clone(),
-                        finally: finally.clone(),
-                    },
+                    flows: loopflow::ops::task::TaskFlowOverrides::for_cycle(
+                        task_cycle(*fix, *feature),
+                        first.clone(),
+                        loop_.clone(),
+                        finally.clone(),
+                    ),
                     stack_on: stack_on.clone(),
                     directive: directive.clone(),
                 },

--- a/rust/loopflow/src/engine/builtins/ops/skill/loopflow.md
+++ b/rust/loopflow/src/engine/builtins/ops/skill/loopflow.md
@@ -31,3 +31,33 @@ only when the User explicitly withdraws the request.
 Normal Loopflow inspection commands remain available here. Questions for this
 present User stay in this conversation; never enqueue an Ask merely to reach
 the human already speaking with you.
+
+## Launching work
+
+When the User asks to file or launch a Task, there are two kinds of work,
+distinguished by where the human gate sits:
+
+- **Fix** — behavior is wrong: a bug, a regression, live breakage. The Task
+  opens with the incident cycle (restore stops the bleeding, 5whys finds the
+  cause), fix work proceeds in the loop, and the human gates at a working
+  demo — never a design doc:
+
+  ```text
+  lf task start <project> "<title>" --fix
+  ```
+
+- **Feature** — behavior should be different than designed. The human shapes
+  the design before code exists:
+
+  ```text
+  lf task start <project> "<title>" --feature
+  ```
+
+Prefer routing by Project: a Project can pin its cycle in its description
+(`## Flows` with `cycle: fix` or explicit `first:`/`loop:`/`finally:`
+lines), and every Task filed into it inherits the right gate with no flags
+at all. Reach for per-task flags only for the mismatched case — a
+product-shaped bug, a risky fix that wants a design review. State which
+gate the Task got and why in one sentence when you launch. When unsure
+whether work is a fix or a feature, ask the User — the wrong gate wastes
+either their attention or their trust.

--- a/rust/loopflow/src/engine/builtins/task/flow/ship-demo.yaml
+++ b/rust/loopflow/src/engine/builtins/task/flow/ship-demo.yaml
@@ -1,0 +1,8 @@
+# Prove the result, demo it to the human, then settle the Task.
+- task-gate
+- step:
+    id: review_demo
+    name: demo
+    human: true
+- record-learnings
+- op: pr land -c

--- a/rust/loopflow/src/engine/builtins/task/skill/review-design.md
+++ b/rust/loopflow/src/engine/builtins/task/skill/review-design.md
@@ -38,17 +38,41 @@ Kickoff took a fuzzy task and fleshed it out. That elaboration is the AI's best 
 
 ## Voice
 
+Assume the human is walking in cold. This task may have been filed by an
+incident flow, another agent, or a PM sync they never read — do not assume
+they know what it is, why it exists, or what has happened since. The
+session's first job is context transfer: give them everything they need to
+own the decisions before asking for any. A question posed before the human
+has the context to answer it is a wasted question.
+
 Come prepared, not opinionated. You've read the wave context, the task, and the kickoff output. Present your understanding and let the human reshape it. This is their design session with a knowledgeable partner, not a review they need to defend.
 
-Don't open with evaluation ("The strongest part of this design...", "One concern is..."). Open with what you think they meant. Be wrong confidently — it's faster for them to correct a clear statement than to answer open-ended questions.
+Don't open with evaluation ("The strongest part of this design...", "One concern is..."). Open with where they are and the wins the task is chasing. Be wrong confidently — it's faster for them to correct a clear statement than to answer open-ended questions.
 
 ## Opening
 
-Present your understanding of the design, not an assessment of it:
+Brief first, then interpret. Four movements, in order:
 
-1. **What I think you want** — the problem and the approach, stated as your interpretation. Plain language, not quoting the doc back. Make it easy for the human to say "yes" or "no, more like..."
-2. **Key decisions** — the choices in the design that everything else depends on. State them as decisions, not questions. "The design puts X in Y" — not "should X go in Y?"
-3. **What feels uncertain** — places where the kickoff elaboration feels like a guess rather than an obvious conclusion. Flag these honestly.
+0. **Where you are** — one short paragraph situating the human: what this
+   task is in plain language, what filed it and why (incident, backlog,
+   another agent's finding), and what happens after this session (the design
+   drives implementation without further input). No jargon, no internal ids
+   without explanation. Written for someone who has never seen this task.
+1. **What I learned** — what the kickoff investigation found about the
+   system: how the affected code actually behaves, what the real cause or
+   constraint turned out to be, anything that would surprise someone who
+   hasn't read the code recently. Teach it; don't reference it. This is
+   where the human integrates the work so far into their own model of the
+   system.
+2. **The wins we're shooting for, and the key decisions** — the concrete
+   improvements this task should produce, stated in plain language, then
+   the choices everything else depends on. State them as decisions, not
+   questions. "The design puts X in Y" — not "should X go in Y?" Make it
+   easy for the human to say "yes" or "no, more like..."
+3. **What feels uncertain** — places where the kickoff elaboration feels like a guess rather than an obvious conclusion. Flag these honestly, and say what context would resolve each one.
+
+Movements 0 and 1 are the briefing; keep them tight but never skip them —
+even a human who filed the task yesterday has swapped it out by now.
 
 ## Session flow
 

--- a/rust/loopflow/src/lf/commands/ask.rs
+++ b/rust/loopflow/src/lf/commands/ask.rs
@@ -389,6 +389,7 @@ async fn release_command(
 ) -> anyhow::Result<()> {
     let invocation_id = ambient_invocation_id()?;
     let ask = store.release_ask(ask_id, &invocation_id, reason).await?;
+    crate::ops::ask::checkpoint_origin_task(store, &ask, "release").await;
     if json {
         println!("{}", serde_json::to_string_pretty(&ask)?);
     } else {
@@ -546,7 +547,16 @@ async fn open_shared_store() -> anyhow::Result<Arc<Store>> {
 
 fn present_in_external_terminal(surface: &InvocationSurface) -> anyhow::Result<()> {
     let attach = exact_attach_argv(surface)?;
-    let terminal = std::env::var("LF_EXTERNAL_TERMINAL")
+    let terminal = resolve_external_terminal();
+    if let Some(ask_session) = local_tmux_attach_session(&attach) {
+        return present_in_asks_hub(&ask_session, &terminal);
+    }
+    let presentation = external_terminal_command(&terminal, &attach)?;
+    run_presentation(&presentation)
+}
+
+fn resolve_external_terminal() -> String {
+    std::env::var("LF_EXTERNAL_TERMINAL")
         .ok()
         .or_else(|| {
             crate::engine::config::load_global_config()
@@ -554,9 +564,116 @@ fn present_in_external_terminal(surface: &InvocationSurface) -> anyhow::Result<(
                 .flatten()
                 .and_then(|config| config.session.terminal)
         })
-        .unwrap_or_else(default_external_terminal);
-    let presentation = external_terminal_command(&terminal, &attach)?;
-    run_presentation(&presentation)
+        .unwrap_or_else(default_external_terminal)
+}
+
+/// Session that collects every locally presented Ask as a tmux window, so the
+/// user reviews all Asks from one terminal window instead of one per Ask.
+const ASKS_HUB_SESSION: &str = "lf-asks";
+
+fn local_tmux_attach_session(attach_argv: &[String]) -> Option<String> {
+    let program = std::path::Path::new(attach_argv.first()?)
+        .file_name()?
+        .to_str()?;
+    if program != "tmux" {
+        return None;
+    }
+    if !matches!(
+        attach_argv.get(1)?.as_str(),
+        "attach-session" | "attach" | "a"
+    ) {
+        return None;
+    }
+    let mut args = attach_argv[2..].iter();
+    while let Some(arg) = args.next() {
+        if arg == "-t" {
+            return args.next().cloned();
+        }
+    }
+    None
+}
+
+fn present_in_asks_hub(ask_session: &str, terminal: &str) -> anyhow::Result<()> {
+    let hub = format!("={ASKS_HUB_SESSION}");
+    // Trailing colon targets the session's current window; bare `=session`
+    // resolves to an empty window id for display-message.
+    let ask = format!("={ask_session}:");
+    if !tmux_succeeds(&["has-session", "-t", &hub]) {
+        tmux_output(&["new-session", "-d", "-s", ASKS_HUB_SESSION, "-n", "asks"])?;
+    }
+    let window_id = tmux_output(&["display-message", "-p", "-t", &ask, "#{window_id}"])?
+        .trim()
+        .to_string();
+    // link-window appends the same window again on every call; link only once.
+    let windows = tmux_output(&[
+        "list-windows",
+        "-t",
+        &hub,
+        "-F",
+        "#{window_index} #{window_id}",
+    ])?;
+    let hub_index = windows.lines().find_map(|line| {
+        let (index, id) = line.trim().split_once(' ')?;
+        (id == window_id).then(|| index.to_string())
+    });
+    let hub_index = match hub_index {
+        Some(index) => index,
+        None => {
+            tmux_output(&["link-window", "-s", &ask, "-t", &hub])?;
+            tmux_output(&[
+                "list-windows",
+                "-t",
+                &hub,
+                "-F",
+                "#{window_index} #{window_id}",
+            ])?
+            .lines()
+            .find_map(|line| {
+                let (index, id) = line.trim().split_once(' ')?;
+                (id == window_id).then(|| index.to_string())
+            })
+            .ok_or_else(|| anyhow!("linked Ask window {window_id} missing from hub"))?
+        }
+    };
+    let has_client = !tmux_output(&["list-clients", "-t", &hub, "-F", "#{client_tty}"])?
+        .trim()
+        .is_empty();
+    if !has_client {
+        // Only steer the hub when no one is watching it; never yank an
+        // attached reviewer away from the Ask they are working on.
+        tmux_output(&["select-window", "-t", &format!("{hub}:{hub_index}")])?;
+        let attach = vec![
+            "tmux".to_string(),
+            "attach-session".to_string(),
+            "-t".to_string(),
+            ASKS_HUB_SESSION.to_string(),
+        ];
+        run_presentation(&external_terminal_command(terminal, &attach)?)?;
+    }
+    Ok(())
+}
+
+fn tmux_output(args: &[&str]) -> anyhow::Result<String> {
+    let output = Command::new("tmux")
+        .args(args)
+        .output()
+        .context("run tmux for Ask presentation")?;
+    if !output.status.success() {
+        bail!(
+            "tmux {:?} failed: {}",
+            args,
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+}
+
+fn tmux_succeeds(args: &[&str]) -> bool {
+    Command::new("tmux")
+        .args(args)
+        .output()
+        .map(|output| output.status.success())
+        .unwrap_or(false)
 }
 
 fn run_presentation(presentation: &PresentationCommand) -> anyhow::Result<()> {
@@ -586,10 +703,13 @@ fn external_terminal_command(
 ) -> anyhow::Result<PresentationCommand> {
     if cfg!(target_os = "macos") {
         let launcher = write_terminal_launcher(attach_argv)?;
+        // No -n: route the launcher into the running terminal instance so each
+        // Ask presents as a window there instead of spawning a whole new app
+        // instance (which multiplies Cmd-Tab entries and restored windows).
         Ok(PresentationCommand {
             program: "open".to_string(),
             args: vec![
-                "-na".to_string(),
+                "-a".to_string(),
                 terminal.to_string(),
                 launcher.display().to_string(),
             ],
@@ -699,6 +819,42 @@ mod tests {
             assert_eq!(command.args[0], "-e");
             assert_eq!(&command.args[1..], attach);
         }
+    }
+
+    #[test]
+    fn local_tmux_attach_routes_to_the_asks_hub() {
+        let attach = vec![
+            "tmux".to_string(),
+            "attach-session".to_string(),
+            "-t".to_string(),
+            "lf-ask-proof".to_string(),
+        ];
+        assert_eq!(
+            super::local_tmux_attach_session(&attach).as_deref(),
+            Some("lf-ask-proof")
+        );
+    }
+
+    #[test]
+    fn remote_and_non_attach_routes_keep_direct_presentation() {
+        let ssh = vec![
+            "ssh".to_string(),
+            "jack@mini".to_string(),
+            "--".to_string(),
+            "tmux".to_string(),
+            "attach-session".to_string(),
+            "-t".to_string(),
+            "lf-ask-proof".to_string(),
+        ];
+        assert_eq!(super::local_tmux_attach_session(&ssh), None);
+
+        let new_session = vec![
+            "tmux".to_string(),
+            "new-session".to_string(),
+            "-t".to_string(),
+            "lf-ask-proof".to_string(),
+        ];
+        assert_eq!(super::local_tmux_attach_session(&new_session), None);
     }
 
     #[test]

--- a/rust/loopflow/src/lf/mod.rs
+++ b/rust/loopflow/src/lf/mod.rs
@@ -1069,6 +1069,12 @@ pub enum TaskCommand {
         issue: String,
         #[arg(long)]
         name: Option<String>,
+        /// Fix cycle: first task-fix, finally ship-demo (human gates at the demo)
+        #[arg(long, conflicts_with = "feature")]
+        fix: bool,
+        /// Feature cycle: first task-design, finally ship (human gates at the design)
+        #[arg(long, alias = "feat", conflicts_with = "fix")]
+        feature: bool,
         /// Override the Project's first flow for a new Task
         #[arg(long, value_name = "FLOW")]
         first: Option<String>,
@@ -1094,6 +1100,12 @@ pub enum TaskCommand {
         title: Option<String>,
         #[arg(long)]
         name: Option<String>,
+        /// Fix cycle: first task-fix, finally ship-demo (human gates at the demo)
+        #[arg(long, conflicts_with = "feature")]
+        fix: bool,
+        /// Feature cycle: first task-design, finally ship (human gates at the design)
+        #[arg(long, alias = "feat", conflicts_with = "fix")]
+        feature: bool,
         /// Override the Project's first flow
         #[arg(long, value_name = "FLOW")]
         first: Option<String>,

--- a/rust/loopflow/src/ops/ask.rs
+++ b/rust/loopflow/src/ops/ask.rs
@@ -249,6 +249,7 @@ pub(crate) async fn settle(
     result: AskResult,
 ) -> Result<Ask> {
     let ask = store.settle_ask(ask_id, invocation_id, result).await?;
+    checkpoint_origin_task(store, &ask, "settle").await;
     resume_flow_step(store, &ask).await?;
     Ok(ask)
 }
@@ -260,8 +261,30 @@ pub(crate) async fn cancel(
     reason: &str,
 ) -> Result<Ask> {
     let ask = store.cancel_ask(context, ask_id, reason).await?;
+    checkpoint_origin_task(store, &ask, "cancel").await;
     resume_flow_step(store, &ask).await?;
     Ok(ask)
+}
+
+/// Push whatever the Ask session left in the origin Task worktree before the
+/// Task resumes or the session's product waits for another machine.
+pub(crate) async fn checkpoint_origin_task(store: &SharedStore, ask: &Ask, action: &str) {
+    let WorkRef::Task(task_id) = &ask.origin.work else {
+        return;
+    };
+    let task = match store.get_task(task_id).await {
+        Ok(Some(task)) => task,
+        _ => return,
+    };
+    if let Err(error) = crate::ops::checkpoint_task_worktree(
+        task.worktree.clone(),
+        task.plan.identifier.clone(),
+        format!("checkpoint: {action} Ask {}", ask.id),
+    )
+    .await
+    {
+        tracing::warn!(ask = %ask.id, action, %error, "Ask settled without a pushed checkpoint");
+    }
 }
 
 async fn resume_flow_step(store: &SharedStore, ask: &Ask) -> Result<()> {

--- a/rust/loopflow/src/ops/commit.rs
+++ b/rust/loopflow/src/ops/commit.rs
@@ -9,7 +9,7 @@ use crate::engine::git::{commit, current_branch, is_clean, push, push_with_upstr
 use crate::engine::load_skill;
 
 use crate::ops::error::{OpsError, OpsResult};
-use crate::ops::progress::Progress;
+use crate::ops::progress::{NullProgress, Progress};
 use crate::ops::trace::{MockResponses, Tracer};
 
 #[derive(Debug, Clone)]
@@ -35,6 +35,31 @@ impl CommitOptions {
             agent: None,
         }
     }
+}
+
+/// Stage, commit, and push a Task worktree so its state survives this
+/// machine. Runs off the async worker thread because commit_workflow drives
+/// its own runtime for the push settlement fence.
+pub(crate) async fn checkpoint_task_worktree(
+    worktree: std::path::PathBuf,
+    task_identifier: String,
+    message: String,
+) -> anyhow::Result<()> {
+    let outcome = tokio::task::spawn_blocking(move || {
+        let options = CommitOptions {
+            add: true,
+            push: true,
+            create_draft_pr: false,
+            task: task_identifier,
+            flow_parents: Vec::new(),
+            message: Some(message),
+            agent: None,
+        };
+        commit_workflow(&worktree, &options, &NullProgress).map(|_| ())
+    })
+    .await
+    .map_err(|join_error| anyhow::anyhow!("Task worktree checkpoint panicked: {join_error}"))?;
+    outcome.map_err(anyhow::Error::from)
 }
 
 pub fn commit_workflow(

--- a/rust/loopflow/src/ops/mod.rs
+++ b/rust/loopflow/src/ops/mod.rs
@@ -29,6 +29,7 @@ pub(crate) use ask_comments::publish_pending_ask_comments;
 #[doc(hidden)]
 pub use child::ambient_run_lease;
 pub(crate) use child::required_run_lease;
+pub(crate) use commit::checkpoint_task_worktree;
 pub use commit::{commit_workflow, commit_workflow_traced, CommitOptions};
 pub(crate) use cron::cron_receipt_ids;
 pub use cron::{

--- a/rust/loopflow/src/ops/task.rs
+++ b/rust/loopflow/src/ops/task.rs
@@ -52,6 +52,55 @@ pub struct TaskFlowOverrides {
     pub finally: Option<String>,
 }
 
+/// Named lifecycle presets: where the human gate sits, in one word.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TaskCycle {
+    /// Behavior is wrong. Opens with the incident cycle (restore → 5whys)
+    /// and the human gates at the demo, not a design doc.
+    Fix,
+    /// Behavior should change; the human shapes the design before code.
+    Feature,
+}
+
+impl TaskCycle {
+    pub fn parse(name: &str) -> Option<Self> {
+        match name {
+            "fix" => Some(Self::Fix),
+            "feature" | "feat" => Some(Self::Feature),
+            _ => None,
+        }
+    }
+
+    /// The (first, finally) flows this cycle stands for.
+    pub fn flows(self) -> (&'static str, &'static str) {
+        match self {
+            Self::Fix => ("incident", "ship-demo"),
+            Self::Feature => ("task-design", "ship"),
+        }
+    }
+}
+
+impl TaskFlowOverrides {
+    /// Expand a cycle preset into flow overrides. Explicit flow flags win
+    /// over the preset; both win over the Project's pinned flows.
+    pub fn for_cycle(
+        cycle: Option<TaskCycle>,
+        first: Option<String>,
+        loop_: Option<String>,
+        finally: Option<String>,
+    ) -> Self {
+        let (cycle_first, cycle_finally) = match cycle.map(TaskCycle::flows) {
+            Some((first, finally)) => (Some(first), Some(finally)),
+            None => (None, None),
+        };
+        Self {
+            first: first.or_else(|| cycle_first.map(str::to_string)),
+            loop_,
+            finally: finally.or_else(|| cycle_finally.map(str::to_string)),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct TaskLaunchOptions {
     pub name: Option<String>,
@@ -5460,6 +5509,46 @@ mod tests {
         .all(|step| {
             !matches!(step, crate::engine::ConcreteStep::Skill(skill) if skill.policy.human)
         }));
+    }
+
+    #[test]
+    fn fix_cycle_moves_the_only_human_gate_to_the_demo() {
+        let repo = tempfile::tempdir().expect("temp repo");
+        let plan = resolve_task_lifecycle(
+            repo.path(),
+            &ProjectFlowPlan::empty(),
+            &TaskFlowOverrides::for_cycle(Some(super::TaskCycle::Fix), None, None, None),
+        )
+        .expect("resolve fix lifecycle");
+        assert_eq!(plan.first.flow, "incident");
+        assert_eq!(plan.loop_.flow, "slice");
+        assert_eq!(plan.finally.flow, "ship-demo");
+
+        let human = [&plan.first.flow, &plan.loop_.flow, &plan.finally.flow]
+            .into_iter()
+            .flat_map(|flow| {
+                let flow = crate::engine::load_flow(flow, repo.path()).unwrap();
+                crate::engine::expand_flow(&flow, repo.path()).unwrap()
+            })
+            .filter(
+                |step| matches!(step, crate::engine::ConcreteStep::Skill(skill) if skill.policy.human),
+            )
+            .collect::<Vec<_>>();
+        assert_eq!(human.len(), 1);
+        assert!(matches!(
+            &human[0],
+            crate::engine::ConcreteStep::Skill(skill)
+                if skill.policy.id.as_deref() == Some("review_demo")
+        ));
+
+        let explicit_wins = TaskFlowOverrides::for_cycle(
+            Some(super::TaskCycle::Fix),
+            Some("task-design".to_string()),
+            None,
+            None,
+        );
+        assert_eq!(explicit_wins.first.as_deref(), Some("task-design"));
+        assert_eq!(explicit_wins.finally.as_deref(), Some("ship-demo"));
     }
 
     #[test]

--- a/rust/loopflow/src/pm/mod.rs
+++ b/rust/loopflow/src/pm/mod.rs
@@ -372,6 +372,7 @@ pub fn parse_project_content(content: &str) -> ProjectContent {
     let mut section = Section::None;
     let mut definition = Vec::new();
     let mut flows = ProjectFlowPlan::empty();
+    let mut cycle = None;
     let mut krs = Vec::new();
     let mut current_kr: Option<PmKr> = None;
     for line in content.lines() {
@@ -423,6 +424,11 @@ pub fn parse_project_content(content: &str) -> ProjectContent {
                     "first" => flows.first = value,
                     "loop" => flows.loop_ = value,
                     "finally" => flows.finally = value,
+                    "cycle" => {
+                        cycle = value
+                            .as_deref()
+                            .and_then(crate::ops::task::TaskCycle::parse)
+                    }
                     _ => {}
                 }
             }
@@ -459,6 +465,14 @@ pub fn parse_project_content(content: &str) -> ProjectContent {
     }
     if let Some(kr) = current_kr {
         krs.push(kr);
+    }
+
+    // `cycle:` is sugar for the preset's flows; explicit keys win, and
+    // writeback normalizes the sugar into explicit first/finally lines.
+    if let Some(cycle) = cycle {
+        let (first, finally) = cycle.flows();
+        flows.first = flows.first.or_else(|| Some(first.to_string()));
+        flows.finally = flows.finally.or_else(|| Some(finally.to_string()));
     }
 
     ProjectContent {
@@ -668,6 +682,22 @@ mod tests {
         .expect("legacy project snapshot");
 
         assert_eq!(project.flows, None);
+    }
+
+    #[test]
+    fn project_cycle_is_sugar_for_preset_flows() {
+        let content = parse_project_content(
+            "## Definition\n\nFix things.\n\n## Flows\n\ncycle: fix\n\n## KRs\n\n- [ ] holds\n",
+        );
+        assert_eq!(content.flows.first.as_deref(), Some("incident"));
+        assert_eq!(content.flows.loop_, None);
+        assert_eq!(content.flows.finally.as_deref(), Some("ship-demo"));
+
+        let explicit = parse_project_content(
+            "## Definition\n\nFix things.\n\n## Flows\n\ncycle: fix\nfirst: task-design\n",
+        );
+        assert_eq!(explicit.flows.first.as_deref(), Some("task-design"));
+        assert_eq!(explicit.flows.finally.as_deref(), Some("ship-demo"));
     }
 
     #[test]

--- a/rust/loopflow/src/task/runner.rs
+++ b/rust/loopflow/src/task/runner.rs
@@ -1024,6 +1024,7 @@ async fn prepare_task_flow_step(
             .node_id
             .clone()
             .ok_or_else(|| anyhow!("human Task flow step has no stable node id"))?;
+        checkpoint_worktree_before_human(task, &node_id).await;
         store
             .set_flow_position(lease, prepared.position.clone())
             .await?;
@@ -1279,6 +1280,21 @@ async fn finish_parked(
     }
     store.finish_task_run(task, lease, outcome).await?;
     Ok(())
+}
+
+/// A human Ask can outlive this machine's uptime; nothing the Task produced
+/// may exist only in the local worktree while it waits. Failure to checkpoint
+/// (offline, no remote) must never block the park itself.
+async fn checkpoint_worktree_before_human(task: &Task, node_id: &str) {
+    if let Err(error) = crate::ops::checkpoint_task_worktree(
+        task.worktree.clone(),
+        task.plan.identifier.clone(),
+        format!("checkpoint: park at human node {node_id}"),
+    )
+    .await
+    {
+        tracing::warn!(task = %task.id, %error, "Task parks at a human node without a pushed checkpoint");
+    }
 }
 
 async fn park_task_at_human(
@@ -2165,6 +2181,31 @@ mod planning_tests {
         let repository =
             std::fs::canonicalize(std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("../.."))
                 .unwrap();
+        // The Task worktree must never be the real checkout: parking at a
+        // human node checkpoint-commits the worktree, and a test must not
+        // commit or push the developer's repo.
+        let worktree = tempfile::tempdir().unwrap().keep();
+        let git = |args: &[&str]| {
+            assert!(std::process::Command::new("git")
+                .current_dir(&worktree)
+                .args(args)
+                .output()
+                .unwrap()
+                .status
+                .success());
+        };
+        git(&["init", "-q"]);
+        git(&[
+            "-c",
+            "user.email=test@loopflow.dev",
+            "-c",
+            "user.name=Loopflow Test",
+            "commit",
+            "--allow-empty",
+            "-q",
+            "-m",
+            "init",
+        ]);
         let database = tempfile::tempdir().unwrap().keep();
         let store = std::sync::Arc::new(
             open_store(&StorageConfig::sqlite(database.join("registry.db")))
@@ -2209,7 +2250,7 @@ mod planning_tests {
             pm_writeback: PmWritebackState::Current,
             wave_id: wave.id().clone(),
             project_id: project.id.clone(),
-            worktree: repository.clone(),
+            worktree: worktree.clone(),
             workspace_slug: "human-task-proof".to_string(),
             lifecycle: TaskLifecyclePlan::defaults(),
             lifecycle_phase: TaskLifecyclePhase::First,
@@ -2260,7 +2301,7 @@ mod planning_tests {
                     containment: Containment::Tmux {
                         name: "human-task-proof".to_string(),
                     },
-                    cwd: repository,
+                    cwd: worktree.clone(),
                 },
             )
             .await


### PR DESCRIPTION
## Usage

```bash
lf ask open <ask-id>
lf task start <project> "Fix broken behavior" --fix
lf task start <project> "Add new behavior" --feature
```

Projects can also pin the cycle inherited by their tasks:

```markdown
## Flows

cycle: fix
```

## Summary

This PR makes human Task gates easier to review and safer to leave parked. Local Asks now collect in one terminal-backed tmux hub, design reviews brief humans who arrive without prior context, and Task work is committed and pushed at every Ask boundary. It also introduces fix and feature cycle presets so human attention lands at a working demo for fixes and at design review for features.

## Changes

- Link local Ask sessions into one deduplicated `lf-asks` hub while preserving direct presentation for remote sessions
- Checkpoint and push Task work before parking and after Ask resolution, cancellation, or release; failures warn without blocking the transition
- Add `--fix` and `--feature` task presets, plus Project-level `cycle: fix|feature` inheritance
- Add `ship-demo`, which gates fixes on a human demo before landing
- Expand `review-design` to transfer context before requesting decisions
- Keep explicit `--first`, `--loop`, and `--finally` overrides authoritative over cycle presets