### PR TITLE
mac app: run agent activity through the bundled lf

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,6 +151,11 @@ jobs:
     runs-on: macos-15
     steps:
       - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: loopflow-ui-test
+          workspaces: . -> target/dev-app-control
       - name: Install XcodeGen
         run: brew install xcodegen
       - name: Generate Xcode project

--- a/scripts/loopflow-dev.py
+++ b/scripts/loopflow-dev.py
@@ -22,6 +22,8 @@ Streaming logs (long-running commands):
     ~/.lf/logs/dev/<repo>.loopflow-run-debug.log
 """
 
+from __future__ import annotations
+
 import argparse
 import os
 import shutil
@@ -443,7 +445,7 @@ def _install_dev_app() -> None:
     _apply_dev_identity(app_dir / "Info.plist")
     shutil.copy(SWIFT_DIR / "LoopflowMac" / "Loopflow.sdef", app_dir / "Resources")
     shutil.copy(SWIFT_DIR / "LoopflowMac" / "AppIcon.icns", app_dir / "Resources")
-    _copy_bundled_tools(app_dir / "MacOS", profile="debug")
+    _copy_bundled_tools(app_dir / "MacOS")
 
     identity = _ensure_dev_signing_identity()
     entitlements = SWIFT_DIR / "LoopflowMac" / "Loopflow.entitlements"
@@ -461,40 +463,27 @@ def _apply_dev_identity(plist: Path) -> None:
     run(["plutil", "-replace", "CFBundleDisplayName", "-string", "Loopflow Dev", str(plist)])
 
 
-def _copy_bundled_tools(app_macos_dir: Path, profile: str) -> None:
-    if profile == "release":
-        cargo_cmd = [
-            "cargo",
-            "build",
-            "--locked",
-            "--release",
-            "--bin",
-            "lf",
-            "--bin",
-            "lfd",
-        ]
-        bin_dir = REPO_ROOT / "target" / "release"
-    else:
-        # The app is a live operator surface even when its Swift shell is a dev
-        # build. Compile its bundled control binary against the installed Home,
-        # but never grant it migration authority. Ordinary development binaries
-        # keep their isolated `.lf-dev` stores.
-        target_dir = REPO_ROOT / "target" / "dev-app-control"
-        cargo_cmd = [
-            "/usr/bin/env",
-            "LOOPFLOW_BUILD_PROVENANCE=release",
-            "LOOPFLOW_MIGRATION_AUTHORITY=validation_only",
-            "cargo",
-            "build",
-            "--locked",
-            "--bin",
-            "lf",
-            "--bin",
-            "lfd",
-            "--target-dir",
-            str(target_dir),
-        ]
-        bin_dir = target_dir / "debug"
+def _copy_bundled_tools(app_macos_dir: Path) -> None:
+    # The app is a live operator surface even when its Swift shell is a dev
+    # build. Compile its bundled control binary against the installed Home,
+    # but never grant it migration authority. Ordinary development binaries
+    # keep their isolated `.lf-dev` stores.
+    target_dir = REPO_ROOT / "target" / "dev-app-control"
+    cargo_cmd = [
+        "/usr/bin/env",
+        "LOOPFLOW_BUILD_PROVENANCE=release",
+        "LOOPFLOW_MIGRATION_AUTHORITY=validation_only",
+        "cargo",
+        "build",
+        "--locked",
+        "--bin",
+        "lf",
+        "--bin",
+        "lfd",
+        "--target-dir",
+        str(target_dir),
+    ]
+    bin_dir = target_dir / "debug"
 
     result = run(cargo_cmd, cwd=REPO_ROOT, check=False)
     if result.returncode != 0:
@@ -505,6 +494,13 @@ def _copy_bundled_tools(app_macos_dir: Path, profile: str) -> None:
         if not source.exists():
             raise RuntimeError(f"Missing built binary: {source}")
         shutil.copy(source, app_macos_dir / binary)
+
+
+def cmd_bundle_control_tools(output: Path) -> int:
+    """Build validation-only control tools into an Xcode app bundle."""
+    output.mkdir(parents=True, exist_ok=True)
+    _copy_bundled_tools(output)
+    return 0
 
 
 # --- Screenshots ---
@@ -530,6 +526,10 @@ COMMANDS = {
     "clean": (cmd_clean, "Remove dev app and reset permissions"),
     "xcode": (cmd_xcode, "Open in Xcode"),
     "logs": (cmd_logs, "Tail the app logs"),
+    "bundle-control-tools": (
+        cmd_bundle_control_tools,
+        "Build validation-only control tools into an app bundle",
+    ),
     "agent-image": (cmd_agent_image, "Build the Docker agent image"),
     "screenshots": (cmd_screenshots, "Generate app screenshots"),
 }
@@ -562,6 +562,13 @@ def main() -> int:
                 action="store_true",
                 help="print what would be installed",
             )
+        if name == "bundle-control-tools":
+            sub.add_argument(
+                "--output",
+                type=lambda p: Path(p).expanduser().resolve(),
+                required=True,
+                help="Contents/MacOS directory that receives lf and lfd",
+            )
     args = parser.parse_args()
 
     if not args.command:
@@ -573,6 +580,8 @@ def main() -> int:
         return func(repo=args.repo)
     if args.command == "setup":
         return func(install=args.install, dry_run=args.dry_run)
+    if args.command == "bundle-control-tools":
+        return func(output=args.output)
     return func()
 
 

--- a/swift/Loopflow/Services/RegistryQuery.swift
+++ b/swift/Loopflow/Services/RegistryQuery.swift
@@ -10,7 +10,7 @@
 // This runs `lf ls/status/roadmap/ps/activity --json` as a subprocess and decodes the wire
 // snapshots (mirrors of the Rust types in `lf/commands/waves.rs` and
 // `lf/commands/runs.rs`) into the app models the stores hold. The subprocess
-// runner is injected: on macOS it resolves and execs a local `lf`. There is no
+// runner is injected: on macOS it execs the `lf` shipped inside the app. There is no
 // HTTP fallback for reads; remote reads need to become proxied `lf` queries.
 
 import Foundation

--- a/swift/LoopflowMac/MacLocalWaveAgentLauncher.swift
+++ b/swift/LoopflowMac/MacLocalWaveAgentLauncher.swift
@@ -7,18 +7,8 @@
 import Foundation
 import Loopflow
 
-enum WaveLaunchError: LocalizedError, Equatable {
-    case noUsableLf(String)
-    case launchFailed(String)
-
-    var errorDescription: String? {
-        switch self {
-        case .noUsableLf(let detail):
-            return detail
-        case .launchFailed(let detail):
-            return detail
-        }
-    }
+struct LocalLfError: LocalizedError {
+    let errorDescription: String?
 }
 
 struct TaskStartReceipt: Decodable, Sendable, Equatable {
@@ -28,13 +18,11 @@ struct TaskStartReceipt: Decodable, Sendable, Equatable {
 }
 
 enum LocalWaveAgentLauncher {
-    private static let resolutionCache = ResolvedLfCache()
-
     /// Stop the listener through the same `lf` lifecycle surface the CLI uses.
     /// The server performs resident, registry, and discovery-file cleanup.
     static func stopWave(repoPath: String, waveName: String) throws {
         let origin = WaveOrigin.resolve(repoPath)
-        let lfPath = try resolveWaveCapableLf(originRepo: origin)
+        let lfPath = try bundledLfPath()
         try runChecked(waveStopCommand(lfPath: lfPath, waveName: waveName), cwd: origin)
     }
 
@@ -47,7 +35,7 @@ enum LocalWaveAgentLauncher {
     /// Task process; the app does not reproduce any of those decisions.
     static func runTask(repoPath: String, issue: String) throws {
         let origin = WaveOrigin.resolve(repoPath)
-        let lfPath = try resolveWaveCapableLf(originRepo: origin)
+        let lfPath = try bundledLfPath()
         try runChecked(taskRunCommand(lfPath: lfPath, issue: issue), cwd: origin)
     }
 
@@ -59,7 +47,7 @@ enum LocalWaveAgentLauncher {
         directive: String
     ) throws -> TaskStartReceipt {
         let origin = WaveOrigin.resolve(repoPath)
-        let lfPath = try resolveWaveCapableLf(originRepo: origin)
+        let lfPath = try bundledLfPath()
         let stdout = try runCheckedOutput(
             taskStartCommand(
                 lfPath: lfPath,
@@ -76,7 +64,7 @@ enum LocalWaveAgentLauncher {
     /// status record.
     static func resumeTask(repoPath: String, issue: String) throws {
         let origin = WaveOrigin.resolve(repoPath)
-        let lfPath = try resolveWaveCapableLf(originRepo: origin)
+        let lfPath = try bundledLfPath()
         try runChecked(taskResumeCommand(lfPath: lfPath, issue: issue), cwd: origin)
     }
 
@@ -84,7 +72,7 @@ enum LocalWaveAgentLauncher {
     /// provider turn is stopped and records the receipt in the shared store.
     static func interruptTask(repoPath: String, issue: String) throws {
         let origin = WaveOrigin.resolve(repoPath)
-        let lfPath = try resolveWaveCapableLf(originRepo: origin)
+        let lfPath = try bundledLfPath()
         try runChecked(taskInterruptCommand(lfPath: lfPath, issue: issue), cwd: origin)
     }
 
@@ -94,8 +82,7 @@ enum LocalWaveAgentLauncher {
     /// honored in one place. Only an explicit user review action calls this;
     /// background app work publishes with `lf pr publish`.
     static func reviewPullRequest(worktree: String) throws {
-        let origin = WaveOrigin.resolve(worktree)
-        let lfPath = try resolveWaveCapableLf(originRepo: origin)
+        let lfPath = try bundledLfPath()
         try runChecked(pullRequestReviewCommand(lfPath: lfPath), cwd: worktree)
     }
 
@@ -126,8 +113,8 @@ enum LocalWaveAgentLauncher {
         do {
             return try decoder.decode(TaskStartReceipt.self, from: Data(stdout.utf8))
         } catch {
-            throw WaveLaunchError.launchFailed(
-                "lf task start returned an invalid receipt: \(error.localizedDescription)"
+            throw LocalLfError(
+                errorDescription: "lf task start returned an invalid receipt: \(error.localizedDescription)"
             )
         }
     }
@@ -140,99 +127,32 @@ enum LocalWaveAgentLauncher {
         [lfPath, "task", "interrupt", issue]
     }
 
-    /// Candidate lf binaries in trust order: the lf bundled inside Loopflow.app,
-    /// each `lf` on the enriched PATH, then
-    /// `<origin>/target/release/lf` — the dev-tree build, for a Loopflow pointed
-    /// at a loopflow checkout where the freshest lf is the one just compiled.
-    static func lfCandidates(
-        originRepo: String,
-        bundled: URL?,
-        pathEnv: String,
-        isExecutableFile: (String) -> Bool
-    ) -> [String] {
-        var candidates: [String] = []
-        if let bundled {
-            candidates.append(bundled.path)
-        }
-        for dir in pathEnv.split(separator: ":") where !dir.isEmpty {
-            let candidate = "\(dir)/lf"
-            if isExecutableFile(candidate), !candidates.contains(candidate) {
-                candidates.append(candidate)
-            }
-        }
-        let devBuild = "\(originRepo)/target/release/lf"
-        if isExecutableFile(devBuild), !candidates.contains(devBuild) {
-            candidates.append(devBuild)
-        }
-        return candidates
-    }
-
-    /// First candidate that has the Wave lifecycle and turn-intent commands. Resolving `lf`
-    /// from PATH can find a build that predates one of them; treating an
-    /// unknown lifecycle verb as a skill would launch the wrong work, so every
-    /// candidate is capability-probed before it's trusted.
+    /// Return the control binary shipped with this exact Mac client build.
     ///
-    /// The probes use `lf help <verb>`, not `<verb> --help`: lf's arg reorderer
-    /// may treat an unknown lifecycle verb as a skill name. Clap's help command
-    /// answers without touching wave state.
-    static func resolveWaveCapableLf(
-        originRepo: String,
-        bundled: URL? = Bundle.main.url(forAuxiliaryExecutable: "lf"),
-        pathEnv: String = GUIProcessEnvironment.enrichedPath(from: ProcessInfo.processInfo.environment["PATH"]),
-        isExecutableFile: (String) -> Bool = { FileManager.default.isExecutableFile(atPath: $0) },
-        probe: (String) -> Bool = hasWaveCommands,
-        useCache: Bool = true
+    /// A missing or stale bundled helper is a malformed app, not permission to
+    /// borrow a different wire contract from PATH or a checkout build.
+    static func bundledLfPath(
+        bundled: URL? = Bundle.main.url(forAuxiliaryExecutable: "lf")
     ) throws -> String {
-        let cacheKey = "\(originRepo)|\(bundled?.path ?? "")|\(pathEnv)"
-        if useCache,
-           let cached = resolutionCache.get(cacheKey),
-           isExecutableFile(cached) {
-            return cached
-        }
-
-        let candidates = lfCandidates(
-            originRepo: originRepo,
-            bundled: bundled,
-            pathEnv: pathEnv,
-            isExecutableFile: isExecutableFile
-        )
-        guard !candidates.isEmpty else {
-            throw WaveLaunchError.noUsableLf(
-                "Can't find an lf binary — not bundled with Loopflow and not on PATH."
+        guard let bundled, FileManager.default.isExecutableFile(atPath: bundled.path) else {
+            throw LocalLfError(
+                errorDescription: "Loopflow.app is missing its executable bundled lf helper at Contents/MacOS/lf. "
+                    + "Rebuild or reinstall Loopflow; PATH fallback is disabled."
             )
         }
-        for candidate in candidates where probe(candidate) {
-            if useCache {
-                resolutionCache.set(candidate, for: cacheKey)
-            }
-            return candidate
-        }
-        throw WaveLaunchError.noUsableLf(
-            "No lf with the Wave control commands. Rejected (each failed at least one of "
-                + "`lf help start`, `lf help stop`, `lf help pause`, or `lf help resume`): "
-                + candidates.joined(separator: ", ")
-        )
-    }
-
-    /// Help probes parse without touching wave state.
-    static func hasWaveCommands(lfPath: String) -> Bool {
-        run([lfPath, "help", "start"])?.status == 0
-            && run([lfPath, "help", "stop"])?.status == 0
-            && run([lfPath, "help", "pause"])?.status == 0
-            && run([lfPath, "help", "resume"])?.status == 0
+        return bundled.path
     }
 
     /// Run an `lf` query verb (`ls`, `status`, `runs`, …) and return its
     /// stdout. Backs `RegistryQuery` on macOS: the wave dashboard reads durable
-    /// facts by shelling the daemonless `lf` over the local store, not by streaming
-    /// a center. Resolves the same wave-capable `lf` the launcher trusts (a build
-    /// old enough to lack `lf start` also lacks these verbs), then execs it with
-    /// the enriched GUI PATH. Throws on a spawn failure or a non-zero exit.
+    /// facts by shelling the daemonless bundled `lf` over the local store, not
+    /// by streaming a center. Throws on a spawn failure or a non-zero exit.
     static func queryLf(_ subargs: [String], cwd: String?) throws -> String {
-        let origin = cwd.map(WaveOrigin.resolve) ?? FileManager.default.currentDirectoryPath
-        let lfPath = try resolveWaveCapableLf(originRepo: origin)
+        let lfPath = try bundledLfPath()
         guard let result = run([lfPath] + subargs, cwd: cwd) else {
-            throw WaveLaunchError.launchFailed("Failed to spawn: lf \(subargs.joined(separator: " "))")
+            throw LocalLfError(
+                errorDescription: "Failed to spawn: lf \(subargs.joined(separator: " "))"
+            )
         }
         // `lf doctor --json` exits 1 when a check fails, but its stdout is the
         // report the telemetry dashboard must show. A red monitor cannot hide
@@ -242,9 +162,10 @@ enum LocalWaveAgentLauncher {
         }
         guard result.status == 0 else {
             let detail = result.stderr.trimmingCharacters(in: .whitespacesAndNewlines)
-            throw WaveLaunchError.launchFailed(
-                detail.isEmpty ? "lf \(subargs.joined(separator: " ")) failed (\(result.status))" : detail
-            )
+            let message = detail.isEmpty
+                ? "lf \(subargs.joined(separator: " ")) failed (\(result.status))"
+                : detail
+            throw LocalLfError(errorDescription: message)
         }
         return result.stdout
     }
@@ -258,13 +179,16 @@ enum LocalWaveAgentLauncher {
     private static func runCheckedOutput(_ args: [String], cwd: String) throws -> String {
         let result = run(args, cwd: cwd)
         guard let result else {
-            throw WaveLaunchError.launchFailed("Failed to spawn: \(args.joined(separator: " "))")
+            throw LocalLfError(
+                errorDescription: "Failed to spawn: \(args.joined(separator: " "))"
+            )
         }
         guard result.status == 0 else {
             let detail = result.stderr.trimmingCharacters(in: .whitespacesAndNewlines)
-            throw WaveLaunchError.launchFailed(
-                detail.isEmpty ? "Command failed (\(result.status)): \(args.joined(separator: " "))" : detail
-            )
+            let message = detail.isEmpty
+                ? "Command failed (\(result.status)): \(args.joined(separator: " "))"
+                : detail
+            throw LocalLfError(errorDescription: message)
         }
         return result.stdout
     }
@@ -329,24 +253,4 @@ private final class OutputCollector: @unchecked Sendable {
     func setStderr(_ data: Data) { lock.withLock { err = data } }
 }
 
-private final class ResolvedLfCache: @unchecked Sendable {
-    private let lock = NSLock()
-    private var resolvedLfByKey: [String: String] = [:]
-
-    func get(_ key: String) -> String? {
-        withLock { resolvedLfByKey[key] }
-    }
-
-    func set(_ value: String, for key: String) {
-        withLock {
-            resolvedLfByKey[key] = value
-        }
-    }
-
-    private func withLock<T>(_ body: () -> T) -> T {
-        lock.lock()
-        defer { lock.unlock() }
-        return body()
-    }
-}
 #endif

--- a/swift/LoopflowTests/LocalWaveAgentLauncherTests.swift
+++ b/swift/LoopflowTests/LocalWaveAgentLauncherTests.swift
@@ -91,17 +91,6 @@ struct LocalWaveAgentLauncherTests {
         #expect(!command.contains { $0.hasPrefix("http") })
     }
 
-    private func loadFixtureData(_ name: String, sourceFile: String = #filePath) throws -> Data {
-        let testFile = URL(fileURLWithPath: sourceFile)
-        let fixtures = testFile
-            .deletingLastPathComponent()
-            .deletingLastPathComponent()
-            .deletingLastPathComponent()
-            .appendingPathComponent("tests/fixtures/dto")
-            .appendingPathComponent(name)
-        return try Data(contentsOf: fixtures)
-    }
-
     @Test("Task start uses the exact CLI receipt as workspace identity")
     func taskStartReceiptDecodes() throws {
         let receipt = try LocalWaveAgentLauncher.taskStartReceipt("""
@@ -119,99 +108,35 @@ struct LocalWaveAgentLauncherTests {
         ))
     }
 
-    // MARK: - Binary resolution + capability probe
+    // MARK: - Bundled binary boundary
 
-    @Test("candidate order: bundled, PATH hits in order, dev-tree build last")
-    func candidateOrder() {
-        let candidates = LocalWaveAgentLauncher.lfCandidates(
-            originRepo: "/Users/jack/src/loopflow",
-            bundled: URL(fileURLWithPath: "/Applications/Loopflow.app/Contents/MacOS/lf"),
-            pathEnv: "/missing/bin:/opt/homebrew/bin:/usr/local/bin",
-            isExecutableFile: { $0 != "/missing/bin/lf" }
-        )
-
-        #expect(candidates == [
-            "/Applications/Loopflow.app/Contents/MacOS/lf",
-            "/opt/homebrew/bin/lf",
-            "/usr/local/bin/lf",
-            "/Users/jack/src/loopflow/target/release/lf",
-        ])
-    }
-
-    @Test("probe passes: the first candidate wins")
-    func probePassesFirstCandidate() throws {
-        let resolved = try LocalWaveAgentLauncher.resolveWaveCapableLf(
-            originRepo: "/Users/jack/src/loopflow",
-            bundled: URL(fileURLWithPath: "/Applications/Loopflow.app/Contents/MacOS/lf"),
-            pathEnv: "/usr/local/bin",
-            isExecutableFile: { _ in true },
-            probe: { _ in true },
-            useCache: false
-        )
-
-        #expect(resolved == "/Applications/Loopflow.app/Contents/MacOS/lf")
-    }
-
-    @Test("a stale PATH lf is rejected by the probe; the dev-tree build wins")
-    func staleLfFallsThroughToDevBuild() throws {
-        var probed: [String] = []
-        let resolved = try LocalWaveAgentLauncher.resolveWaveCapableLf(
-            originRepo: "/Users/jack/src/loopflow",
-            bundled: nil,
-            pathEnv: "/Users/jack/.local/bin",
-            isExecutableFile: { _ in true },
-            probe: { candidate in
-                probed.append(candidate)
-                return candidate == "/Users/jack/src/loopflow/target/release/lf"
-            },
-            useCache: false
-        )
-
-        #expect(resolved == "/Users/jack/src/loopflow/target/release/lf")
-        #expect(probed == [
-            "/Users/jack/.local/bin/lf",
-            "/Users/jack/src/loopflow/target/release/lf",
-        ], "walks candidates in order, probing each")
-    }
-
-    @Test("every candidate rejected: the error names what was found and why")
-    func allCandidatesRejected() {
+    @Test("a missing bundled helper never falls through to PATH")
+    func missingBundledHelperFails() {
         #expect {
-            try LocalWaveAgentLauncher.resolveWaveCapableLf(
-                originRepo: "/Users/jack/src/loopflow",
-                bundled: nil,
-                pathEnv: "/Users/jack/.local/bin",
-                isExecutableFile: { _ in true },
-                probe: { _ in false },
-                useCache: false
-            )
+            try LocalWaveAgentLauncher.bundledLfPath(bundled: nil)
         } throws: { error in
-            guard case let WaveLaunchError.noUsableLf(detail) = error else { return false }
-            return detail.contains("/Users/jack/.local/bin/lf")
-                && detail.contains("/Users/jack/src/loopflow/target/release/lf")
-                && detail.contains("lf help start")
-                && detail.contains("lf help stop")
-                && detail.contains("lf help pause")
-                && detail.contains("lf help resume")
+            guard error is LocalLfError else { return false }
+            return error.localizedDescription.contains("missing its executable bundled lf helper")
+                && error.localizedDescription.contains("PATH fallback is disabled")
         }
     }
 
-    @Test("nothing bundled, nothing on PATH, no dev build: a clear error")
-    func nothingResolves() {
-        #expect {
-            try LocalWaveAgentLauncher.resolveWaveCapableLf(
-                originRepo: "/Users/jack/src/loopflow",
-                bundled: nil,
-                pathEnv: "/usr/local/bin:/usr/bin",
-                isExecutableFile: { _ in false },
-                probe: { _ in true },
-                useCache: false
-            )
-        } throws: { error in
-            guard case let WaveLaunchError.noUsableLf(detail) = error else { return false }
-            return detail.contains("not bundled") && detail.contains("not on PATH")
+    #if !SWIFT_PACKAGE
+    @Test("the hosted app executes and decodes its bundled process activity")
+    func hostedBundleProcessActivityDecodes() async throws {
+        let helper = try #require(Bundle.main.url(forAuxiliaryExecutable: "lf"))
+        #expect(FileManager.default.isExecutableFile(atPath: helper.path))
+        let query = RegistryQuery { args, cwd in
+            #expect(args == ["ps", "--json"])
+            #expect(cwd == nil)
+            return try LocalWaveAgentLauncher.queryLf(args, cwd: cwd)
         }
+
+        let snapshot = try await query.processActivity()
+        #expect(snapshot.schemaVersion == 1)
+        #expect(snapshot.usage.windows == [5, 300, 3_600, 86_400])
     }
+    #endif
 
     // MARK: - Not-running copy
 

--- a/swift/README.md
+++ b/swift/README.md
@@ -153,6 +153,10 @@ xcodebuild -project LoopflowSwift.xcodeproj \
   build
 ```
 
+The generated app target builds validation-only `lf` and `lfd` helpers from
+the same checkout into `Loopflow.app/Contents/MacOS`. A runnable app never
+borrows a different `lf` from PATH.
+
 Keep `Package.swift` and `project.yml` in sync.
 
 ## Shared-library boundary

--- a/swift/project.yml
+++ b/swift/project.yml
@@ -42,6 +42,21 @@ targets:
           - Info.plist
     dependencies:
       - target: Loopflow
+    postBuildScripts:
+      - name: Bundle Loopflow control tools
+        script: |
+          set -eu
+          export PATH="$HOME/.cargo/bin:/opt/homebrew/bin:/usr/local/bin:$PATH"
+          /usr/bin/python3 "$SRCROOT/../scripts/loopflow-dev.py" bundle-control-tools \
+            --output "$TARGET_BUILD_DIR/$EXECUTABLE_FOLDER_PATH"
+          if [ "${CODE_SIGNING_ALLOWED:-NO}" = "YES" ]; then
+            signing_identity="${EXPANDED_CODE_SIGN_IDENTITY:--}"
+            for helper in lf lfd; do
+              /usr/bin/codesign --force --sign "$signing_identity" \
+                "$TARGET_BUILD_DIR/$EXECUTABLE_FOLDER_PATH/$helper"
+            done
+          fi
+        basedOnDependencyAnalysis: false
     settings:
       base:
         PRODUCT_NAME: Loopflow


### PR DESCRIPTION
## Usage

```bash
uv run python scripts/loopflow-dev.py run-debug
```

Open **Go → Telemetry** to verify the Mac app loads process activity through its bundled helper.

## Summary

The Mac app now builds and ships validation-only `lf` and `lfd` helpers from the same checkout, then uses that exact `lf` for local activity queries and agent controls. This prevents wire-format drift when PATH or a development checkout contains a stale or incompatible CLI build.

## Changes

- Bundle and sign the Rust control tools during generated Xcode app builds
- Remove PATH lookup, capability probing, and binary resolution caching
- Fail clearly when the app bundle is missing its executable `lf` helper
- Add a hosted test proving bundled `lf ps --json` activity decodes successfully
- Prepare the macOS CI job with Rust and cache the dedicated helper build target