### PR TITLE
LOO-222: Keep managed browser login alive without taking over the Mac

### DIFF
--- a/rust/loopflow/src/lf/commands/auth.rs
+++ b/rust/loopflow/src/lf/commands/auth.rs
@@ -1,5 +1,6 @@
 use std::fs;
 use std::fs::OpenOptions;
+use std::future::Future;
 use std::path::Path;
 use std::path::PathBuf;
 use std::process::Command;
@@ -26,7 +27,8 @@ use crate::provider_auth::{
     capture_claude_authorization_code_from_chrome, capture_claude_profile_credentials,
     disconnect_provider_account_auth, import_ambient_claude_profile_credentials, no_event_sink,
     prepare_provider_account_access_token, provider_account_auth_status,
-    start_provider_account_auth, AuthStatus, Provider, ProviderAuthService, ProviderAuthSnapshot,
+    start_provider_account_auth, AuthError, AuthStatus, Provider, ProviderAuthService,
+    ProviderAuthSnapshot,
 };
 use crate::store::{
     open_store, CredentialState, CredentialType, ProviderAccount, ProviderAccountId, ProviderToken,
@@ -35,6 +37,7 @@ use crate::store::{
 
 const AUTH_STATUS_POLL_TIMEOUT: Duration = Duration::from_secs(180);
 const AUTH_STATUS_POLL_INTERVAL: Duration = Duration::from_secs(1);
+const AUTH_BROWSER_HEARTBEAT_INTERVAL: Duration = Duration::from_secs(30);
 // Authorization-code flows wait on a human finishing a browser login; give
 // them the ~10 minutes the OAuth authorization itself stays valid.
 const AUTH_CODE_FLOW_TIMEOUT_SECS: u64 = 600;
@@ -367,7 +370,7 @@ async fn connect_managed_account(
         .await?
         {
             Some(code) => code,
-            None => capture_claude_authorization_code_visibly().await?,
+            None => prompt_for_claude_authorization_code().await?,
         };
         handle
             .submit_authorization_code(code.expose_secret())
@@ -376,15 +379,13 @@ async fn connect_managed_account(
         println!("Complete authorization in the browser.");
         open_chrome_profile(&chrome_profile, &verification_url)?;
     }
-    tokio::time::timeout(AUTH_STATUS_POLL_TIMEOUT, handle.wait())
-        .await
-        .map_err(|_| {
-            anyhow!(
-                "timed out waiting for {} account '{}' browser confirmation",
-                provider.display_name(),
-                account_login(account)
-            )
-        })??;
+    wait_for_browser_confirmation(
+        handle.wait(),
+        flow.expires_in,
+        provider,
+        account_login(account),
+    )
+    .await?;
 
     match provider {
         Provider::Claude => {
@@ -426,6 +427,47 @@ async fn connect_managed_account(
         profile.id
     );
     Ok(())
+}
+
+async fn wait_for_browser_confirmation<F>(
+    confirmation: F,
+    expires_in: Option<u64>,
+    provider: Provider,
+    login: &str,
+) -> Result<()>
+where
+    F: Future<Output = std::result::Result<(), AuthError>>,
+{
+    let timeout = Duration::from_secs(expires_in.unwrap_or(AUTH_CODE_FLOW_TIMEOUT_SECS));
+    let started_at = tokio::time::Instant::now();
+    let deadline = tokio::time::sleep_until(started_at + timeout);
+    let mut heartbeat = tokio::time::interval_at(
+        started_at + AUTH_BROWSER_HEARTBEAT_INTERVAL,
+        AUTH_BROWSER_HEARTBEAT_INTERVAL,
+    );
+    heartbeat.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+    tokio::pin!(confirmation);
+    tokio::pin!(deadline);
+
+    loop {
+        tokio::select! {
+            biased;
+            result = &mut confirmation => return result.map_err(anyhow::Error::from),
+            _ = &mut deadline => {
+                return Err(anyhow!(
+                    "timed out waiting for {} account '{}' browser confirmation",
+                    provider.display_name(),
+                    login
+                ));
+            }
+            _ = heartbeat.tick() => {
+                println!(
+                    "Still waiting for browser approval ({}s elapsed); the login listener is still running. Press Ctrl-C to cancel.",
+                    started_at.elapsed().as_secs()
+                );
+            }
+        }
+    }
 }
 
 async fn bootstrap_access_profile(
@@ -789,100 +831,15 @@ fn open_chrome_profile(profile: &LocalChromeProfile, url: &str) -> Result<()> {
     Ok(())
 }
 
-#[cfg(target_os = "macos")]
-fn visible_claude_prompt_script(socket: &Path) -> String {
-    let socket = socket.to_string_lossy().replace('\'', "'\\''");
-    format!(
-        "#!/bin/zsh\n\
-         echo 'Claude authorization needs a visible handoff.'\n\
-         echo 'Approve the Chrome page, then paste its one-time code here.'\n\
-         read -r -s 'code?One-time code: '\n\
-         print\n\
-         if [[ -z \"$code\" ]]; then\n\
-           echo 'No code entered; close this window and rerun lf auth connect.'\n\
-           exit 1\n\
-         fi\n\
-         printf '%s' \"$code\" | /usr/bin/nc -U '{socket}'\n\
-         status=$?\n\
-         unset code\n\
-         if [[ $status -eq 0 ]]; then\n\
-           echo 'Authorization returned to Loopflow. This window can close.'\n\
-         else\n\
-           echo 'Loopflow stopped waiting; rerun lf auth connect.'\n\
-         fi\n\
-         exit $status\n"
-    )
-}
-
-#[cfg(all(target_os = "macos", not(test)))]
-async fn capture_claude_authorization_code_visibly() -> Result<SecretString> {
-    use std::io::{ErrorKind, Read};
-    use std::os::unix::fs::PermissionsExt;
-    use std::os::unix::net::UnixListener;
-
-    let handoff = tempfile::tempdir().context("create private Claude handoff")?;
-    let socket = handoff.path().join("authorization.sock");
-    let listener = UnixListener::bind(&socket).context("open private Claude handoff")?;
-    listener
-        .set_nonblocking(true)
-        .context("make Claude handoff nonblocking")?;
-    let script = handoff.path().join("Claude Authorization.command");
-    fs::write(&script, visible_claude_prompt_script(&socket))
-        .context("write visible Claude handoff")?;
-    fs::set_permissions(&script, fs::Permissions::from_mode(0o700))
-        .context("protect visible Claude handoff")?;
-
-    let status = Command::new("open")
-        .args(["-a", "Terminal"])
-        .arg(&script)
-        .status()
-        .context("open visible Claude authorization handoff")?;
-    if !status.success() {
-        return Err(anyhow!(
-            "could not open the visible Claude authorization handoff; rerun `lf auth connect claude <account>` in Terminal"
-        ));
-    }
-
-    let deadline = std::time::Instant::now() + AUTH_STATUS_POLL_TIMEOUT;
-    loop {
-        match listener.accept() {
-            Ok((stream, _)) => {
-                stream
-                    .set_read_timeout(Some(Duration::from_secs(2)))
-                    .context("bound Claude handoff read")?;
-                let mut code = String::new();
-                stream
-                    .take(4097)
-                    .read_to_string(&mut code)
-                    .context("read visible Claude handoff")?;
-                let code = code.trim();
-                if code.is_empty() || code.len() > 4096 {
-                    return Err(anyhow!("visible Claude handoff returned an invalid code"));
-                }
-                return Ok(SecretString::new(code.to_string()));
-            }
-            Err(error) if error.kind() == ErrorKind::WouldBlock => {
-                if std::time::Instant::now() >= deadline {
-                    return Err(anyhow!(
-                        "timed out waiting for the visible Claude authorization handoff"
-                    ));
-                }
-                tokio::time::sleep(Duration::from_millis(100)).await;
-            }
-            Err(error) => return Err(error).context("accept visible Claude handoff"),
-        }
-    }
-}
-
-#[cfg(all(not(target_os = "macos"), not(test)))]
-async fn capture_claude_authorization_code_visibly() -> Result<SecretString> {
+#[cfg(not(test))]
+async fn prompt_for_claude_authorization_code() -> Result<SecretString> {
     Ok(SecretString::new(rpassword::prompt_password(
-        "Browser handoff unavailable; paste the one-time code: ",
+        "Browser handoff unavailable; paste the one-time code in this terminal: ",
     )?))
 }
 
 #[cfg(test)]
-async fn capture_claude_authorization_code_visibly() -> Result<SecretString> {
+async fn prompt_for_claude_authorization_code() -> Result<SecretString> {
     Ok(SecretString::new("test-code".to_string()))
 }
 
@@ -1453,11 +1410,12 @@ fn format_relative_delta(seconds: i64) -> String {
 #[cfg(test)]
 mod tests {
     use std::fs;
+    use std::time::Duration;
 
     use time::OffsetDateTime;
 
     use crate::profile::EmailAddress;
-    use crate::provider_auth::{AuthStatus, Provider, ProviderAuthSnapshot};
+    use crate::provider_auth::{AuthError, AuthStatus, Provider, ProviderAuthSnapshot};
     use crate::store::{
         CredentialState, CredentialType, ProviderAccount, ProviderAccountId, RoutingState,
     };
@@ -1465,16 +1423,60 @@ mod tests {
     use super::{
         acquire_managed_login_lock, format_account, format_relative_delta, format_snapshot,
         import_account, install_claude_login, install_codex_login, parse_paid_through,
-        parse_routing_state,
+        parse_routing_state, wait_for_browser_confirmation,
     };
 
-    #[cfg(target_os = "macos")]
-    #[test]
-    fn visible_claude_handoff_neither_echoes_nor_embeds_the_code() {
-        let script = super::visible_claude_prompt_script(std::path::Path::new("/tmp/auth.sock"));
-        assert!(script.contains("read -r -s"));
-        assert!(script.contains("/usr/bin/nc -U '/tmp/auth.sock'"));
-        assert!(!script.contains("verification_uri"));
+    #[tokio::test(start_paused = true)]
+    async fn browser_confirmation_survives_old_timeout_boundary() {
+        let started_at = tokio::time::Instant::now();
+        let confirmation = async {
+            tokio::time::sleep(Duration::from_secs(181)).await;
+            Ok::<(), AuthError>(())
+        };
+
+        wait_for_browser_confirmation(confirmation, None, Provider::Codex, "operator@example.com")
+            .await
+            .expect("browser confirmation should outlive the old timeout");
+
+        assert_eq!(started_at.elapsed(), Duration::from_secs(181));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn browser_confirmation_uses_ten_minute_default() {
+        let started_at = tokio::time::Instant::now();
+
+        let error = wait_for_browser_confirmation(
+            std::future::pending::<std::result::Result<(), AuthError>>(),
+            None,
+            Provider::Codex,
+            "operator@example.com",
+        )
+        .await
+        .expect_err("browser confirmation should remain bounded");
+
+        assert_eq!(started_at.elapsed(), Duration::from_secs(600));
+        assert!(error
+            .to_string()
+            .contains("timed out waiting for Codex account 'operator@example.com'"));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn browser_confirmation_honors_provider_expiry() {
+        let started_at = tokio::time::Instant::now();
+
+        let error = wait_for_browser_confirmation(
+            std::future::pending::<std::result::Result<(), AuthError>>(),
+            Some(75),
+            Provider::Claude,
+            "operator@example.com",
+        )
+        .await
+        .expect_err("provider expiry should bound browser confirmation");
+
+        assert_eq!(started_at.elapsed(), Duration::from_secs(75));
+        assert!(error
+            .to_string()
+            .contains("timed out waiting for Claude account 'operator@example.com'"));
     }
 
     #[test]

--- a/rust/loopflow/src/provider_auth/mod.rs
+++ b/rust/loopflow/src/provider_auth/mod.rs
@@ -1815,11 +1815,12 @@ fn kill_auth_process_group(pid: u32) {
     crate::engine::platform::kill_process(pid);
 }
 
-/// Read Claude's one-time handoff from the visible Chrome page on macOS.
+/// Read Claude's one-time handoff from its Chrome page on macOS.
 ///
-/// The human still approves the provider page. Loopflow temporarily copies the
-/// rendered page, restores the clipboard inside the same AppleScript command,
-/// and keeps the handoff only in process memory.
+/// Polling only checks for the matching window. Once it appears, Loopflow
+/// copies the addressed tab without activating Chrome or synthesizing input,
+/// restores the clipboard inside the same AppleScript command, and keeps the
+/// handoff only in process memory.
 ///
 /// # Errors
 ///
@@ -1836,8 +1837,7 @@ pub async fn capture_claude_authorization_code_from_chrome(
         let deadline = Instant::now() + CLAUDE_BROWSER_AUTH_TIMEOUT;
         while Instant::now() < deadline {
             let output = ProcessCommand::new("osascript")
-                .args(["-e", CLAUDE_VISIBLE_PAGE_SCRIPT])
-                .env("LF_CHROME_PROFILE_LABEL", _browser_profile_label)
+                .args(["-e", CLAUDE_AUTH_WINDOW_SCRIPT, _browser_profile_label])
                 .output()
                 .map_err(|source| AuthError::CommandIo {
                     provider: Provider::Claude,
@@ -1846,9 +1846,19 @@ pub async fn capture_claude_authorization_code_from_chrome(
             if !output.status.success() {
                 return Ok(None);
             }
-            let page = String::from_utf8_lossy(&output.stdout);
-            if let Some(code) = claude_authorization_code_from_page(&page) {
-                return Ok(Some(code));
+            if String::from_utf8_lossy(&output.stdout).trim() == "ready" {
+                let output = ProcessCommand::new("osascript")
+                    .args(["-e", CLAUDE_PAGE_HARVEST_SCRIPT, _browser_profile_label])
+                    .output()
+                    .map_err(|source| AuthError::CommandIo {
+                        provider: Provider::Claude,
+                        source,
+                    })?;
+                if !output.status.success() {
+                    return Ok(None);
+                }
+                let page = String::from_utf8_lossy(&output.stdout);
+                return Ok(claude_authorization_code_from_page(&page));
             }
             tokio::time::sleep(Duration::from_secs(1)).await;
         }
@@ -1861,35 +1871,47 @@ pub async fn capture_claude_authorization_code_from_chrome(
 }
 
 #[cfg(target_os = "macos")]
-const CLAUDE_VISIBLE_PAGE_SCRIPT: &str = r#"
-set savedClipboard to the clipboard
-try
-    set profileLabel to system attribute "LF_CHROME_PROFILE_LABEL"
-    tell application "Google Chrome" to activate
+const CLAUDE_AUTH_WINDOW_SCRIPT: &str = r#"
+on run argv
+    set profileLabel to item 1 of argv
     tell application "System Events"
+        if not (exists process "Google Chrome") then return ""
         tell process "Google Chrome"
+            set authWindows to every window whose name contains "Authentication code | Claude Platform"
+            repeat with authWindow in authWindows
+                if name of authWindow contains "(" & profileLabel & ")" then return "ready"
+            end repeat
+        end tell
+    end tell
+    return ""
+end run
+"#;
+
+#[cfg(target_os = "macos")]
+const CLAUDE_PAGE_HARVEST_SCRIPT: &str = r#"
+on run argv
+    set savedClipboard to the clipboard
+    try
+        set profileLabel to item 1 of argv
+        tell application "Google Chrome"
             set authWindows to every window whose name contains "Authentication code | Claude Platform"
             set pageText to ""
             repeat with authWindow in authWindows
                 if name of authWindow contains "(" & profileLabel & ")" then
-                    perform action "AXRaise" of authWindow
-                    delay 0.2
-                    keystroke "a" using command down
-                    delay 0.1
-                    keystroke "c" using command down
-                    delay 0.2
+                    select all active tab of authWindow
+                    copy selection active tab of authWindow
                     set pageText to the clipboard as text
                     exit repeat
                 end if
             end repeat
         end tell
-    end tell
-    set the clipboard to savedClipboard
-    return pageText
-on error
-    set the clipboard to savedClipboard
-    error
-end try
+        set the clipboard to savedClipboard
+        return pageText
+    on error
+        set the clipboard to savedClipboard
+        error
+    end try
+end run
 "#;
 
 #[cfg(any(target_os = "macos", test))]
@@ -3987,6 +4009,42 @@ mod tests {
 
         assert_eq!(code.expose_secret(), expected);
         assert!(claude_authorization_code_from_page("short#code").is_none());
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn claude_browser_automation_compiles_without_focus_or_keyboard_control() {
+        for script in [CLAUDE_AUTH_WINDOW_SCRIPT, CLAUDE_PAGE_HARVEST_SCRIPT] {
+            assert!(!script.contains("activate"));
+            assert!(!script.contains("AXRaise"));
+            assert!(!script.contains("keystroke"));
+        }
+        assert!(!CLAUDE_AUTH_WINDOW_SCRIPT.contains("clipboard"));
+        assert!(CLAUDE_PAGE_HARVEST_SCRIPT.contains("select all active tab"));
+        assert!(CLAUDE_PAGE_HARVEST_SCRIPT.contains("copy selection active tab"));
+
+        let compiled = tempdir().expect("AppleScript compile output");
+        for (name, script) in [
+            ("window", CLAUDE_AUTH_WINDOW_SCRIPT),
+            ("harvest", CLAUDE_PAGE_HARVEST_SCRIPT),
+        ] {
+            // Resolve the installed app by path so this headless test can load
+            // Chrome's scripting dictionary without launching Chrome.
+            let script = script.replace(
+                "tell application \"Google Chrome\"",
+                "tell application \"/Applications/Google Chrome.app\"",
+            );
+            let output = ProcessCommand::new("/usr/bin/osacompile")
+                .args(["-e", &script, "-o"])
+                .arg(compiled.path().join(format!("{name}.scpt")))
+                .output()
+                .expect("compile Claude Chrome AppleScript");
+            assert!(
+                output.status.success(),
+                "{name} script did not compile: {}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+        }
     }
 
     #[test]

--- a/scratch/hotfix-lf-auth-connect-stop.md
+++ b/scratch/hotfix-lf-auth-connect-stop.md
@@ -1,0 +1,222 @@
+# Keep managed browser login alive without taking over the Mac
+
+## Problem
+
+`lf auth connect` is the recovery path for managed Claude and Codex accounts,
+but the recovery ceremony currently makes the machine difficult to use and can
+destroy its own OAuth callback listener before the human finishes.
+
+The Claude handoff runs one AppleScript every second for up to 120 seconds. That
+script activates Chrome, raises a window, sends global Cmd+A/Cmd+C keystrokes,
+and saves and restores the clipboard even while the expected authorization
+window does not exist. A user typing or copying in another app loses focus and
+can receive those synthetic keystrokes.
+
+The managed Codex path has the opposite problem: after opening the authorization
+page it owns the `codex login` process, private `.login-*` staging home, and
+localhost callback listener for only 180 seconds. Timing out drops the auth
+handle; `AuthProcessGroup` then kills the complete provider process group and
+the staging directory disappears. A later redirect to localhost:1455 therefore
+cannot complete. This blocks account recovery and, in turn, fleet task runners.
+
+This advances the Loopflow API Project's task-loop trust KR: account recovery
+must remain a usable, bounded foreground operation instead of turning ordinary
+human login latency into a fleet-wide manual rescue.
+
+## The demo
+
+Run `scripts/dev-lf auth connect claude <account>`, return to another app after
+the deliberate browser open, and keep typing while delaying approval. Polling
+and code harvest leave that app frontmost and never send it synthetic input.
+Then run `scripts/dev-lf auth connect codex manabot-eng@loopflow.studio`, wait
+more than three minutes before approving, observe periodic waiting messages,
+and see the command complete and `scripts/dev-lf usage` list the connected
+account.
+
+## Approach
+
+### Make Claude polling passive and harvesting one-shot
+
+Split `CLAUDE_VISIBLE_PAGE_SCRIPT` into two scripts with visibly different
+authority:
+
+1. A passive detection script asks System Events whether Google Chrome has a
+   window whose title contains both `Authentication code | Claude Platform` and
+   the selected Chrome profile label. It does not activate an app, raise a
+   window, read or write the clipboard, or synthesize input.
+2. `capture_claude_authorization_code_from_chrome` runs only that script during
+   its existing one-second/120-second poll. A missing window continues polling;
+   unavailable AppleScript control returns `Ok(None)` and leaves manual entry in
+   the invoking terminal.
+3. Once detection reports the exact window, run a separate harvest script once.
+   That script rechecks the title/profile pair and targets the matching Chrome
+   window's active tab with native `select all` and `copy selection` Apple
+   Events. It does not activate Chrome or raise any window. It restores the
+   clipboard and returns. Parse the handoff exactly as today. If the window
+   disappeared, Chrome rejects the targeted commands, or the page did not
+   contain a complete code, return `Ok(None)` and wait for a manual paste in the
+   invoking terminal; never open or activate another app as a fallback, repeat
+   the harvest, or use global keystrokes.
+
+Keep the harvest as one AppleScript command so its clipboard save/copy/restore
+window remains as short and internally paired as it is today. Use Chrome's
+tab-targeted `select all` and `copy selection` Apple Events instead of System
+Events' global keystrokes. The commands work against the addressed tab without
+making Chrome frontmost. They are present in both the installed Chrome
+scripting dictionary and [Chromium's current scripting
+definition](https://chromium.googlesource.com/chromium/src.git/+/refs/heads/main/chrome/browser/ui/cocoa/applescript/scripting.sdef),
+and they stay addressed to the Chrome tab even if another app remains
+frontmost. If macOS denies Chrome automation, the current `lf` process asks for
+the code instead of launching a second Terminal window or taking focus.
+
+Do not make `execute ... javascript` the primary path. Chrome exposes it, but
+[Chromium's handler](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/chrome/browser/ui/cocoa/applescript/tab_applescript.mm)
+rejects it unless the user has enabled JavaScript from Apple Events. Account
+recovery cannot acquire a new browser preference prerequisite.
+
+### Give the foreground login ceremony its real human window
+
+Replace the managed path's fixed
+`timeout(AUTH_STATUS_POLL_TIMEOUT, handle.wait())` with a private
+`wait_for_browser_confirmation` helper. The helper owns the `handle.wait()`
+future, a deadline, and a 30-second heartbeat interval:
+
+- use `flow.expires_in` when the provider actually emits a lifetime;
+- otherwise use the existing `AUTH_CODE_FLOW_TIMEOUT_SECS` (600 seconds);
+- print `Still waiting for browser approval (<N>s elapsed); the login listener is still running. Press Ctrl-C to cancel.` every 30 seconds;
+- return immediately when the provider command completes;
+- return the existing account-specific timeout error when the deadline expires.
+
+Use Tokio time for the deadline, elapsed duration, and heartbeat so the behavior
+is deterministic under a paused test clock. The helper should accept the auth
+wait future rather than own provider construction; this is the semantic
+boundary it supervises and lets the timeout behavior be proved without a live
+OAuth provider.
+
+Keep `AuthProcessGroup`, the `.login-*` tempdir, and the account login lock
+unchanged. Successful completion still verifies identity and atomically installs
+the staged credential. Timeout, command failure, or another ordinary early
+return still drops the handle and kills the provider group; the existing
+interrupt hook kills it on Ctrl-C before `lf` exits. The fix extends valid
+foreground ownership; it does not detach a callback server or leave credential
+state behind.
+
+### Prove the old boundary and the real recovery path
+
+Add paused-clock behavioral tests around `wait_for_browser_confirmation`:
+
+- a confirmation future completing at 181 seconds succeeds, proving the old
+  180-second failure boundary is gone;
+- a pending confirmation future times out at 600 seconds, proving the ceremony
+  remains bounded;
+- a provider-supplied expiry is honored instead of the default.
+
+Keep the existing process-group cancellation test as the proof that dropping or
+interrupting a wait still tears the provider child down. The focus guarantee
+needs a real macOS demo because its outcome is foreground application and
+keyboard behavior, not Rust state. During that demo, watch the frontmost app and
+clipboard while the auth window is absent, then approve once and confirm only
+one harvest occurs.
+
+## De-risking
+
+| Question | Finding | Impact on design |
+|----------|---------|------------------|
+| What kills the Codex callback listener at 180 seconds? | `connect_managed_account` wraps `handle.wait()` in the fixed 180-second timeout. On timeout the handle drops, and `AuthProcessGroup::drop` sends SIGKILL to the provider's process group. The private staging home then drops too. | Extend the owned foreground wait; do not detach or transfer the listener. |
+| Does the provider already give managed Codex a usable expiry? | `CodexAuthBroker` parses generic CLI output, but current `codex login` emits the loopback listener and authorization URL without an `expires_in`; `AuthFlowResponse.expires_in` is therefore normally `None`. | Default managed browser confirmation to the already-established 600-second authorization-code window. |
+| Will a longer wait make Ctrl-C leak the login server? | No. `lf` installs a SIGINT/SIGTERM/SIGHUP handler, and `AuthProcessGroup` registers an interrupt cleanup that kills the exact provider process group before process exit. | Preserve the existing owner and cleanup registration; no new signal path is needed. |
+| Can Chrome window presence be checked without focus? | The existing System Events query is read-only; `activate`, `AXRaise`, global keystrokes, and clipboard access are separate statements in the same script. Splitting them makes every unsuccessful poll passive. | Poll with a dedicated side-effect-free script. After an exact title/profile match, address the Chrome tab directly without crossing the focus or keyboard boundary. |
+| Can the page be read without the clipboard? | The installed Chrome scripting dictionary exposes JavaScript execution, but Chromium gates it behind the user's “Allow JavaScript from Apple Events” setting. Chrome also exposes tab-targeted selection/copy commands, which avoid global keystrokes but still use the clipboard. | Do not require JavaScript. Use targeted selection/copy once; if Chrome rejects it, ask in the invoking terminal rather than synthesizing input or activating another app. |
+| Can the 181-second regression be tested without waiting three minutes or logging into a provider? | Tokio's test dependency includes `test-util`; a private future-based wait helper can run under `#[tokio::test(start_paused = true)]`. Existing provider tests already prove callback URL parsing, authorization-code submission, and process-group teardown. | Add a focused paused-clock result test instead of provider mocks or a slow integration test. |
+| Does the fix need a config/env timeout override? | The provider flow already has an optional lifetime and the CLI already defines the 600-second human authorization window. A second knob would create policy drift without helping the reproduced case. | Use provider expiry or the single existing default; add no configuration surface. |
+
+## Alternatives considered
+
+| Approach | Tradeoff | Why not |
+|----------|----------|---------|
+| Read `document.body.innerText` through Chrome JavaScript | Eliminates focus, synthesized input, and clipboard mutation. | JavaScript from Apple Events is disabled unless the user changes a Chrome setting; recovery must work on an unprepared profile. |
+| Detach `codex login` after 180 seconds and let localhost:1455 outlive `lf` | The browser redirect could arrive indefinitely. | It abandons ownership of the staging home, lock, identity verification, credential installation, output, and cancellation. It replaces one timeout bug with an orphaned credential server. |
+| Wait forever for every managed provider | Removes arbitrary deadlines and leaves cancellation to Ctrl-C. | Provider authorization grants expire, headless callers can stall forever, and the product already has a 600-second interactive-flow policy. A bounded truthful wait is easier to operate. |
+| Keep one combined AppleScript but activate only conditionally inside it | Smallest textual diff. | The same script remains both observer and mutator, making repeated harvest on a partially loaded or changed window easy to reintroduce. Two scripts make the side-effect boundary structural. |
+| Retain global Cmd+A/Cmd+C for the one-shot harvest | Reuses the currently proven page-copy mechanism. | A foreground change between `AXRaise` and the keystrokes can still send input to another app. Chrome's tab-addressed commands fail closed into a prompt in the invoking terminal instead. |
+| Open a visible Terminal when native Chrome automation is unavailable | Preserves the current out-of-band manual handoff. | Launching another app violates the non-interference requirement. Keep the fallback in the terminal the user already chose to run. |
+
+## Key decisions
+
+- Human-confirmed intent: the deliberate browser open may take focus once. After
+  the user switches away, `lf auth connect` must still complete without any
+  poll, harvest, or fallback activating an app or sending synthetic input.
+- The passive poll has zero foreground, keyboard, or clipboard authority.
+- After the deliberate browser open, Loopflow never activates or raises Chrome
+  or another app. Detection and one-shot harvest both run in the background.
+- Synthetic keyboard input is removed from the browser handoff entirely;
+  one-shot selection/copy is addressed to the exact Chrome tab.
+- If native Chrome automation is unavailable, manual entry stays in the
+  invoking terminal and occurs only when the user returns to it deliberately.
+- The browser wait is 600 seconds by default, or the provider's stated expiry,
+  with a 30-second heartbeat and existing Ctrl-C cleanup.
+- The provider process remains a child of the foreground `lf auth connect`
+  command for its entire lifetime. No daemon, background callback owner, or
+  persistent staging state is introduced.
+- The live victim account is part of Done When, not an optional smoke test:
+  restoring the fleet's real recovery path is the user-visible point of this
+  hotfix.
+
+Wild success is boring in the best way: a password-manager/2FA/SSO login can
+take several minutes, `lf` periodically says why it is still present, the
+callback lands, and the user keeps using the machine without Loopflow changing
+the frontmost app or typing into it. Wild failure would be hiding the old
+behavior behind a longer timer: Chrome would still steal input, or a detached
+callback would write credentials after `lf` had stopped verifying the requested
+identity. The structural split and retained foreground ownership rule those
+outcomes out.
+
+## Scope
+
+- In scope: the managed Claude Chrome detection/harvest path in
+  `provider_auth/mod.rs`; the managed browser-confirmation wait in
+  `lf/commands/auth.rs`; focused Rust tests; real macOS Claude and Codex demos.
+- In scope: preserving current title/profile matching, providing a manual
+  fallback in the invoking terminal, staged credential verification/installation,
+  timeout cleanup, and Ctrl-C process-group cleanup.
+- Out of scope: changing provider CLI OAuth protocols, adding a Chrome
+  extension, enabling JavaScript from Apple Events, backgrounding login
+  servers, adding timeout configuration, or changing account/routing models.
+- Out of scope: broad auth-service refactoring or documentation that duplicates
+  the timeout constant; the command's heartbeat is the user-facing explanation.
+
+## Done when
+
+- `cargo test -p loopflow browser_confirmation` proves completion at 181
+  seconds, bounded failure at 600 seconds, and provider-expiry precedence under
+  paused time.
+- Existing focused provider tests still pass:
+  `cargo test -p loopflow generic_parser_waits_past_the_loopback_callback_listener`
+  and `cargo test -p loopflow cancelling_auth_wait_kills_the_provider_process_group`.
+- `cargo fmt --check` and `cargo clippy -p loopflow --all-targets -- -D warnings`
+  pass.
+- On macOS, `scripts/dev-lf auth connect claude <account>` can poll for the full
+  window while the user types and copies in another app: the deliberate browser
+  open may foreground Chrome once, and after the user leaves it neither an
+  unsuccessful poll nor the successful harvest changes focus or sends synthetic
+  input. Unsuccessful polls never touch the clipboard.
+- On this machine,
+  `scripts/dev-lf auth connect codex manabot-eng@loopflow.studio` remains alive
+  past 180 seconds, prints the heartbeat, accepts the localhost callback before
+  the 600-second deadline, reports the account connected, and
+  `scripts/dev-lf usage` shows it.
+- A Ctrl-C during either ceremony leaves no provider login process or localhost
+  listener behind. Staging-directory cleanup on signal-driven `process::exit`
+  is not added to this hotfix.
+
+## Measure
+
+Baseline: the Claude poll can activate Chrome and transact the clipboard once
+per second for 120 seconds; managed browser confirmation kills its provider
+process group at 180 seconds with no liveness output.
+
+After: the deliberate browser open is the last automatic focus transition;
+Claude detection and one-shot harvest cause zero foreground or keyboard events,
+and unsuccessful polls do not touch the clipboard. Managed login remains owned
+for up to 600 seconds (or the provider's stated lifetime) and emits one
+heartbeat every 30 seconds until completion.

--- a/scratch/questions.md
+++ b/scratch/questions.md
@@ -1,0 +1,13 @@
+# Open blockers
+
+- LOO-222 still needs two human-present proofs: the Claude focus/clipboard
+  observation and the delayed Codex login for
+  `manabot-eng@loopflow.studio` described in the review matrix.
+- Repeated `lf ask --user` attempts on 2026-08-19 were rejected because the
+  AgentInvocations had no active Turn authority. A parent or User Run with valid
+  control authority must open or perform the intervention.
+- The implementation is verified but not checkpointed. `lf commit` reached
+  the correct Loopflow path, then the sandbox denied writes to the shared Git
+  worktree index lock; the same call also reported the runtime ledger database
+  as read-only. The owning runner/final flow must commit once it has repository
+  metadata write authority. No raw Git workaround was attempted.

--- a/scratch/questions.md
+++ b/scratch/questions.md
@@ -3,11 +3,13 @@
 - LOO-222 still needs two human-present proofs: the Claude focus/clipboard
   observation and the delayed Codex login for
   `manabot-eng@loopflow.studio` described in the review matrix.
+- A headless `scripts/dev-lf auth connect codex manabot-eng@loopflow.studio`
+  attempt on 2026-08-19 failed before provider startup because the sandbox
+  could not resolve the provider account store (`Operation not permitted`).
+  The real-path proof requires host filesystem and browser authority.
 - Repeated `lf ask --user` attempts on 2026-08-19 were rejected because the
   AgentInvocations had no active Turn authority. A parent or User Run with valid
   control authority must open or perform the intervention.
-- The implementation is verified but not checkpointed. `lf commit` reached
-  the correct Loopflow path, then the sandbox denied writes to the shared Git
-  worktree index lock; the same call also reported the runtime ledger database
-  as read-only. The owning runner/final flow must commit once it has repository
-  metadata write authority. No raw Git workaround was attempted.
+- The auth implementation is checkpointed and pushed. This review-note cleanup
+  still needs the owning workflow to checkpoint it because the sandbox cannot
+  write the shared worktree index or runtime ledger.

--- a/scratch/review-hotfix-lf-auth-connect-stop.md
+++ b/scratch/review-hotfix-lf-auth-connect-stop.md
@@ -1,0 +1,47 @@
+# Review: managed browser login hotfix
+
+Reviewed and independently re-reviewed 2026-08-19 against the Task directive,
+design, and complete branch diff. No source defects were found in the
+implemented slice. The current worktree again passes the paused-clock browser
+confirmation tests and the macOS AppleScript compile/authority test. The two
+remaining proofs require a human-present macOS browser ceremony and are not
+simulated here.
+
+## Evidence matrix
+
+| Claim | Planned behavior | Implemented behavior | Proof | Result |
+|---|---|---|---|---|
+| Claude polling does not take focus or input | Window discovery has no activation, raising, clipboard, or synthesized keyboard authority | Polling runs only `CLAUDE_AUTH_WINDOW_SCRIPT`; harvesting runs once after an exact title/profile match | `cargo test -p loopflow claude_browser_automation_compiles_without_focus_or_keyboard_control`; source inspection | pass (source/compile), live focus gap |
+| Claude harvest is one-shot and background-addressed | Copy the exact Chrome tab without global keystrokes; fall back in the invoking terminal | Harvest uses Chrome `select all`/`copy selection`, contains no `activate`, `AXRaise`, or `keystroke`, then returns immediately; the former Terminal/socket handoff is deleted | Same AppleScript compile test; complete diff | pass (source/compile), live clipboard gap |
+| Managed confirmation survives the old boundary | Completion at 181 seconds succeeds and the callback owner remains alive | `wait_for_browser_confirmation` defaults to 600 seconds and owns `handle.wait()` until completion or deadline | `cargo test -p loopflow browser_confirmation -- --nocapture` completed at 181 seconds and printed the 30-second heartbeats | pass |
+| Browser confirmation remains bounded | Default timeout is 600 seconds; provider expiry wins | Tokio deadline uses `expires_in` or 600 seconds | Same paused-clock test completed both timeout cases at their exact boundaries | pass |
+| Full managed connection still installs verified credentials | Preserve staging-home, profile retry, identity verification, and installation | Existing `connect_account` path runs through the new wait and completes normally | `cargo test -p loopflow connect_tries_access_profiles_in_configured_order` | pass |
+| Cancellation tears down the provider listener | Dropping or interrupting the wait kills the exact provider process group | `AuthMonitor::drop` aborts its task; `AuthProcessGroup::drop` kills the group | `cargo test -p loopflow cancelling_auth_wait_kills_the_provider_process_group` | pass |
+| Loopback-listener output is not mistaken for completion | Continue waiting after the callback listener is announced | Generic parser/monitor keeps ownership until provider exit | `cargo test -p loopflow generic_parser_waits_past_the_loopback_callback_listener` | pass |
+| Slow real Codex approval completes | Delay approval past three minutes, accept localhost callback, connect the account, and show it in `lf usage` | Source and deterministic boundary proofs support the path | Human-present `scripts/dev-lf auth connect codex manabot-eng@loopflow.studio` | gap |
+| Real Claude ceremony leaves another app undisturbed | Type and copy elsewhere during polling and harvest without focus or clipboard interference | Source removes every focus/global-input operation and limits clipboard access to harvest | Human-present macOS observation | gap |
+
+## Source review
+
+- `connect_managed_account` remains the sole owner of the staging home, login
+  lock, provider handle, identity verification, and credential installation.
+- The two AppleScripts intentionally duplicate title/profile matching to keep
+  passive observation structurally separate from one-shot clipboard authority.
+- The 180-second `wait_for_active_status` policy remains only on the separate
+  service/store polling path; managed provider-process ownership now uses the
+  600-second browser-confirmation policy.
+- No background listener, timeout configuration, alternate auth model, or
+  compatibility path was introduced.
+
+## Disposition
+
+Do not publish yet. Complete the two human-present demos above, then refresh
+this matrix with the observed account and focus results. If both pass, the Task
+PR is ready for `lf pr publish`; review does not land it.
+
+Repeated review/implement attempts on 2026-08-19 tried to open that intervention
+with `lf ask --user`, but Loopflow rejected every Ask because the
+AgentInvocations had no active Turn authority. `lf ps --json` could not inspect
+the receipt in this sandbox (`Operation not permitted`). A local `lf commit`
+checkpoint was also sandbox-blocked from the shared Git worktree index, so no
+raw Git workaround or PR publication was attempted around the missing evidence.

--- a/scratch/review-hotfix-lf-auth-connect-stop.md
+++ b/scratch/review-hotfix-lf-auth-connect-stop.md
@@ -39,9 +39,16 @@ Do not publish yet. Complete the two human-present demos above, then refresh
 this matrix with the observed account and focus results. If both pass, the Task
 PR is ready for `lf pr publish`; review does not land it.
 
+A headless victim-path attempt on 2026-08-19 ran
+`scripts/dev-lf auth connect codex manabot-eng@loopflow.studio`, but the sandbox
+failed before provider startup while resolving the provider account store
+(`Operation not permitted`). It proves neither success nor failure at the
+browser boundary; the host-authorized ceremony remains required.
+
 Repeated review/implement attempts on 2026-08-19 tried to open that intervention
 with `lf ask --user`, but Loopflow rejected every Ask because the
 AgentInvocations had no active Turn authority. `lf ps --json` could not inspect
-the receipt in this sandbox (`Operation not permitted`). A local `lf commit`
-checkpoint was also sandbox-blocked from the shared Git worktree index, so no
-raw Git workaround or PR publication was attempted around the missing evidence.
+the receipt in this sandbox (`Operation not permitted`). The auth implementation
+is now checkpointed and pushed; review still does not publish it without the
+missing human-present evidence. This note cleanup remains uncommitted because
+the sandbox cannot write the shared worktree index or runtime ledger.


### PR DESCRIPTION
Superseded by LOO-223. This final checkpoint preserves the managed-auth implementation and design so LOO-223 can absorb the behavior and tests before this standalone Task is abandoned.