### PR TITLE
Restore Task launch from User control turns — restore runtime context for Work bodies

### DIFF
--- a/rust/loopflow/src/bin/lf.rs
+++ b/rust/loopflow/src/bin/lf.rs
@@ -478,6 +478,22 @@ fn in_repo_runtime<T>(
     with_runtime(&repo_root, command, || run(&repo_root))
 }
 
+fn run_work_runner_entrypoint<T>(
+    command: &[String],
+    kind: &str,
+    work_id: &str,
+    run: impl FnOnce(loopflow::durable::WorkRef) -> anyhow::Result<T>,
+) -> anyhow::Result<T> {
+    in_repo_runtime(command, |_| {
+        let work = match kind {
+            "project" => loopflow::durable::WorkRef::Project(work_id.parse()?),
+            "task" => loopflow::durable::WorkRef::Task(work_id.parse()?),
+            _ => anyhow::bail!("unsupported hidden Work kind: {kind}"),
+        };
+        run(work)
+    })
+}
+
 fn with_skill_runtime<T>(
     repo_root: &std::path::Path,
     skill_name: &str,
@@ -688,6 +704,13 @@ impl EnvGuard {
     fn set(key: &'static str, value: impl Into<String>) -> Self {
         let previous = std::env::var_os(key);
         std::env::set_var(key, value.into());
+        Self { key, previous }
+    }
+
+    #[cfg(test)]
+    fn clear(key: &'static str) -> Self {
+        let previous = std::env::var_os(key);
+        std::env::remove_var(key);
         Self { key, previous }
     }
 }
@@ -1532,12 +1555,9 @@ fn main() -> anyhow::Result<()> {
                 in_repo_runtime(&args, |repo| loopflow::lf::commands::work::run(cmd, repo))
             }
             Some(Commands::WorkRunner { kind, work_id }) => {
-                let work = match kind.as_str() {
-                    "project" => loopflow::durable::WorkRef::Project(work_id.parse()?),
-                    "task" => loopflow::durable::WorkRef::Task(work_id.parse()?),
-                    _ => unreachable!("clap validates Work kind"),
-                };
-                tokio::runtime::Runtime::new()?.block_on(loopflow::work_runner::run_work(work))
+                run_work_runner_entrypoint(&args, kind, work_id, |work| {
+                    tokio::runtime::Runtime::new()?.block_on(loopflow::work_runner::run_work(work))
+                })
             }
             Some(Commands::Tokens { json, days }) => {
                 loopflow::lf::commands::tokens::run(*json, *days)
@@ -1784,11 +1804,16 @@ fn main() -> anyhow::Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use super::{arg_tables, format_task_pr_line, normalize_ssh_args, reorder_args, CwdGuard};
+    use super::{
+        arg_tables, format_task_pr_line, normalize_ssh_args, reorder_args,
+        run_work_runner_entrypoint, CwdGuard, EnvGuard,
+    };
 
     use clap::Parser;
     use loopflow::lf::{Cli, Commands, PmCommand, PmTaskCommand, PrCommand};
     use loopflow::task::{GithubPr, PrPublication, TaskId, TaskPr, TaskPrId};
+
+    static PROCESS_STATE_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
     fn published_pr() -> TaskPr {
         let now = time::OffsetDateTime::now_utc();
@@ -1952,8 +1977,7 @@ mod tests {
 
     #[test]
     fn bound_cwd_is_entered_for_the_invocation_and_restored_afterward() {
-        static CWD_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-        let _lock = CWD_LOCK.lock().unwrap();
+        let _lock = PROCESS_STATE_LOCK.lock().unwrap();
         let previous = std::env::current_dir().unwrap();
         let directory = tempfile::tempdir().unwrap();
 
@@ -1965,6 +1989,52 @@ mod tests {
         drop(guard);
 
         assert_eq!(std::env::current_dir().unwrap(), previous);
+    }
+
+    #[test]
+    fn work_runner_entrypoint_initializes_trace_context_before_body() {
+        let _lock = PROCESS_STATE_LOCK.lock().unwrap();
+        let _env = [
+            loopflow::journal::LF_TRACE_ID_ENV,
+            loopflow::journal::LF_PROCESS_ID_ENV,
+            loopflow::durable::RUN_CONTEXT_ENV,
+            loopflow::durable::RUN_LEASE_ENV,
+            loopflow::durable::AGENT_INVOCATION_ENV,
+            loopflow::engine::wave_context::WAVE_ID_ENV,
+        ]
+        .into_iter()
+        .map(EnvGuard::clear)
+        .collect::<Vec<_>>();
+        let directory = tempfile::tempdir().unwrap();
+        let _cwd = CwdGuard::enter(directory.path()).unwrap();
+        let command = vec![
+            "lf".to_string(),
+            "__work".to_string(),
+            "task".to_string(),
+            "task_00000000000000000000000000000000".to_string(),
+        ];
+
+        let mut capture_context = None;
+        let result = run_work_runner_entrypoint(
+            &command,
+            "task",
+            "task_00000000000000000000000000000000",
+            |work| {
+                assert!(matches!(work, loopflow::durable::WorkRef::Task(_)));
+                capture_context = Some(loopflow::journal::trace_capture_context(
+                    directory.path(),
+                    Some("first".to_string()),
+                    Some("review-design".to_string()),
+                )?);
+                Ok(())
+            },
+        );
+
+        result.unwrap();
+        let context = capture_context.expect("WorkRunner body should have trace context");
+        assert_eq!(context.worktree, directory.path());
+        assert_eq!(context.flow.as_deref(), Some("first"));
+        assert_eq!(context.skill.as_deref(), Some("review-design"));
     }
 
     #[test]

--- a/rust/loopflow/src/engine/agent.rs
+++ b/rust/loopflow/src/engine/agent.rs
@@ -1374,31 +1374,33 @@ fn _begin_implicit_capture(
         .cwd
         .as_deref()
         .and_then(|cwd| {
-            crate::journal::trace_capture_context(cwd, None, None).map(|context| {
-                let system_prompt = process
-                    .context_file
-                    .as_deref()
-                    .and_then(|path| fs::read_to_string(path).ok())
-                    .unwrap_or_else(|| system_prompt_with_structured_replies(launch));
-                crate::trace::CaptureHandle::begin(
-                    context,
-                    crate::trace::PreparedTurnContext::from_prompts(
-                        &system_prompt,
-                        &launch.task_prompt,
-                    ),
-                    crate::trace::CaptureStart {
-                        provider: harness.to_string(),
-                        model,
-                        surface: if process.auto { "headless" } else { "tui" }.to_string(),
-                        input_op: "initial".to_string(),
-                        gather_ms: 0,
-                        render_ms: 0,
-                        raw_provider: process.auto,
-                        basis: None,
-                        supervision: None,
-                    },
-                )
-            })
+            crate::journal::trace_capture_context(cwd, None, None)
+                .ok()
+                .map(|context| {
+                    let system_prompt = process
+                        .context_file
+                        .as_deref()
+                        .and_then(|path| fs::read_to_string(path).ok())
+                        .unwrap_or_else(|| system_prompt_with_structured_replies(launch));
+                    crate::trace::CaptureHandle::begin(
+                        context,
+                        crate::trace::PreparedTurnContext::from_prompts(
+                            &system_prompt,
+                            &launch.task_prompt,
+                        ),
+                        crate::trace::CaptureStart {
+                            provider: harness.to_string(),
+                            model,
+                            surface: if process.auto { "headless" } else { "tui" }.to_string(),
+                            input_op: "initial".to_string(),
+                            gather_ms: 0,
+                            render_ms: 0,
+                            raw_provider: process.auto,
+                            basis: None,
+                            supervision: None,
+                        },
+                    )
+                })
         })
         .transpose()
         .map_err(|error| {

--- a/rust/loopflow/src/flowloop/wave.rs
+++ b/rust/loopflow/src/flowloop/wave.rs
@@ -879,7 +879,7 @@ impl WaveLoop {
             Some(step.flow.clone()),
             Some(step.step.clone()),
         ) {
-            Some(context) => match crate::trace::CaptureHandle::begin(
+            Ok(context) => match crate::trace::CaptureHandle::begin(
                 context,
                 prepared.context.clone(),
                 crate::trace::CaptureStart {
@@ -906,8 +906,8 @@ impl WaveLoop {
                     return;
                 }
             },
-            None if cfg!(test) => None,
-            None => {
+            Err(_) if cfg!(test) => None,
+            Err(_) => {
                 let body_id = body.body_id.clone();
                 self.open_body(body, answers).await;
                 self.finish_failed_pass(&body_id, "trace capture identity is unavailable")

--- a/rust/loopflow/src/journal/mod.rs
+++ b/rust/loopflow/src/journal/mod.rs
@@ -360,10 +360,10 @@ pub fn trace_capture_context(
     worktree: &Path,
     flow: Option<String>,
     skill: Option<String>,
-) -> Option<crate::trace::TraceCaptureContext> {
-    let context = current_context()?;
+) -> Result<crate::trace::TraceCaptureContext, TraceCaptureContextError> {
+    let context = current_context().ok_or(TraceCaptureContextError::MissingJournalRunContext)?;
     let (project, task) = child_work_attribution();
-    Some(crate::trace::TraceCaptureContext {
+    Ok(crate::trace::TraceCaptureContext {
         run_id: context.run_id,
         process_id: context.process_id,
         repo: context
@@ -377,6 +377,15 @@ pub fn trace_capture_context(
         flow,
         skill,
     })
+}
+
+#[derive(Debug, PartialEq, Eq, thiserror::Error)]
+#[non_exhaustive]
+pub enum TraceCaptureContextError {
+    #[error(
+        "journal Run context is missing; Work-owned provider entrypoints must enter repo runtime before trace capture starts"
+    )]
+    MissingJournalRunContext,
 }
 
 fn child_work_attribution() -> (Option<String>, Option<String>) {
@@ -921,6 +930,25 @@ mod tests {
         assert_ne!(resolved, ambient_home.path().join("loopflow.db"));
         assert!(!ambient_db.exists());
         assert!(!ambient_home.path().join("loopflow.db").exists());
+    }
+
+    #[test]
+    fn trace_capture_context_names_missing_journal_run_context() {
+        let _guard = journal_test_guard();
+        let repo = TestRepo::new();
+
+        let error = super::trace_capture_context(
+            repo.path(),
+            Some("task-design".to_string()),
+            Some("review-design".to_string()),
+        )
+        .expect_err("trace capture requires an active journal Run context");
+
+        assert_eq!(
+            error,
+            super::TraceCaptureContextError::MissingJournalRunContext
+        );
+        assert!(error.to_string().contains("journal Run context is missing"));
     }
 
     fn started_fields(

--- a/rust/loopflow/src/lf/commands/ops/mod.rs
+++ b/rust/loopflow/src/lf/commands/ops/mod.rs
@@ -2371,7 +2371,7 @@ fn launch_skill_agent(
     let (provider, model) = crate::engine::parse_agent(agent);
     let capture_context =
         crate::journal::trace_capture_context(repo_root, None, Some(skill_name.to_string()))
-            .ok_or_else(|| anyhow!("trace capture identity is unavailable before agent launch"))?;
+            .map_err(|_| anyhow!("trace capture identity is unavailable before agent launch"))?;
     let capture = crate::trace::CaptureHandle::begin(
         capture_context,
         context,

--- a/rust/loopflow/src/lf/commands/run.rs
+++ b/rust/loopflow/src/lf/commands/run.rs
@@ -633,7 +633,7 @@ fn begin_capture(
 ) -> Result<crate::trace::CaptureHandle> {
     let context =
         crate::journal::trace_capture_context(&built.repo_root, None, built.skill_name.clone())
-            .ok_or_else(|| anyhow!("trace capture identity is unavailable before agent launch"))?;
+            .map_err(|_| anyhow!("trace capture identity is unavailable before agent launch"))?;
     crate::trace::CaptureHandle::begin(
         context,
         built.context.clone(),

--- a/rust/loopflow/src/project/runner.rs
+++ b/rust/loopflow/src/project/runner.rs
@@ -160,11 +160,17 @@ async fn run_project_inner(
         return Err(error.into());
     }
     let capture = flow.current().and_then(|step| {
-        let context = crate::journal::trace_capture_context(
+        let context = match crate::journal::trace_capture_context(
             Path::new(wave.repo()),
             Some(step.flow.clone()),
             Some(step.step.clone()),
-        )?;
+        ) {
+            Ok(context) => context,
+            Err(error) => {
+                tracing::warn!(%error, "failed to establish Project trace capture");
+                return None;
+            }
+        };
         match crate::trace::CaptureHandle::begin(
             context,
             prepared.turn.context.clone(),

--- a/rust/loopflow/src/task/runner.rs
+++ b/rust/loopflow/src/task/runner.rs
@@ -209,20 +209,23 @@ async fn run_task_with(
     // process, so no child `lf` records on its behalf.
     let capture = match flow.current() {
         Some(step) => {
-            let Some(context) = crate::journal::trace_capture_context(
+            let context = match crate::journal::trace_capture_context(
                 Path::new(&task.worktree),
                 Some(step.flow.clone()),
                 Some(step.step.clone()),
-            ) else {
-                return finish_execution_blocked(
-                    &store,
-                    &mut task,
-                    lease,
-                    harness.as_mut(),
-                    &["Loopflow active Turn authority has no Run execution context".to_string()],
-                    None,
-                )
-                .await;
+            ) {
+                Ok(context) => context,
+                Err(error) => {
+                    return finish_execution_blocked(
+                        &store,
+                        &mut task,
+                        lease,
+                        harness.as_mut(),
+                        &[format!("Task trace capture prerequisite missing: {error}")],
+                        None,
+                    )
+                    .await;
+                }
             };
             match crate::trace::CaptureHandle::begin(
                 context,


### PR DESCRIPTION
Linear Task: [LOO-237](https://linear.app/loopflow/issue/LOO-237/carry-run-execution-context-across-user-wave-and-project-runners)

## Usage

```console
lf --wave product task run <issue-id>
```

## Summary

User-control Task and Project launches now enter repository runtime before the hidden Work runner begins. This installs journal trace context for provider capture while preserving durable Run authority and each runner’s existing failure policy.

## Changes

- wrap hidden Project and Task Work entrypoints in repository runtime
- name missing journal trace context with a typed prerequisite error
- prove trace context exists before the injected Work body runs
- preserve Task-fatal and Project-best-effort capture behavior

## Proof

- `cargo test -p loopflow work_runner_entrypoint_initializes_trace_context_before_body`
- `cargo test -p loopflow trace_capture_context_names_missing_journal_run_context`
- `cargo clippy --all-targets -- -D warnings`
- a fresh User-control replay resumed LOO-234, completed kickoff, and created review-design Ask `ask_d04c0a6fe1664391a278fd4cb2b1ffb3` without the former missing-context failure