### PR TITLE
LOO-249: Make Task PR copy explain intent and lifecycle

### DIFF
--- a/docs/lf.md
+++ b/docs/lf.md
@@ -825,11 +825,11 @@ LOO-249: Make Task PR copy explain intent and lifecycle
 
 > [!NOTE]
 > **Task:** [LOO-249 — Make Task PR copy explain intent and lifecycle](https://linear.app/...)
-> **Task flow:** `incident` → `slice` → `ship-demo`
+> **Task cycle:** fix
 > **PR lifecycle:** Merging PR 1 completes the Task.
 ```
 
-The exact identifier, name, provider link, pinned flows, PR sequence, and merge
+The exact identifier, name, provider link, Task cycle, PR sequence, and merge
 disposition come from durable Task state. Generated or gate-authored prose adds
 the evaluation path, importance, and implementation-specific scope without
 repeating that context. Ordinary non-Task PR copy keeps its authored title and

--- a/docs/lf.md
+++ b/docs/lf.md
@@ -339,10 +339,10 @@ Every Task runs `first → loop N → finally`. Its Project supplies those three
 flows; Task launch pins their resolved names. `--first`, `--loop`, and
 `--finally` override them only while creating the Task. Task launch expands the
 three flows as one lifecycle: the loop must contain an autonomous skill step,
-and the final flow must end with `op: pr land -c`. The default and feature
-lifecycles ask a human to review the design before implementation, then review
-the configured-path demo before settlement. The fix lifecycle keeps only the
-demo review. Invalid persisted lifecycles remain visible in status with
+and the final flow must end with `op: pr land -c`. The default feature cycle
+asks a human to review the design before implementation, then review the
+configured-path demo before settlement. The fix cycle keeps only the demo
+review. Invalid persisted lifecycles remain visible in status with
 `no_action`; abandon and replace them with a valid selection.
 
 Every Task-owned PR keeps the Linear Task name at the start of its title and a

--- a/docs/lf.md
+++ b/docs/lf.md
@@ -818,6 +818,23 @@ does a PR whose auto-merge settlement is not armed. Only a current-head Auto
 merge request with Complete disposition records the terminal `lf pr land -c`
 intent.
 
+Task PR copy carries the Task contract before its reviewer-authored detail:
+
+```markdown
+LOO-249: Make Task PR copy explain intent and lifecycle
+
+> [!NOTE]
+> **Task:** [LOO-249 — Make Task PR copy explain intent and lifecycle](https://linear.app/...)
+> **Task flow:** `incident` → `slice` → `ship-demo`
+> **PR lifecycle:** Merging PR 1 completes the Task.
+```
+
+The exact identifier, name, provider link, pinned flows, PR sequence, and merge
+disposition come from durable Task state. Generated or gate-authored prose adds
+the evaluation path, importance, and implementation-specific scope without
+repeating that context. Ordinary non-Task PR copy keeps its authored title and
+body unchanged.
+
 If a Task reaches `finally` after its work already merged and rotation left a
 provably empty unpublished successor, `lf pr land -c` completes over the merged
 PR without creating another one. Earlier lifecycle phases still refuse the

--- a/rust/loopflow/src/engine/builtins/ops/skill/loopflow.md
+++ b/rust/loopflow/src/engine/builtins/ops/skill/loopflow.md
@@ -38,7 +38,7 @@ When the User asks to file or launch a Task, there are two kinds of work,
 distinguished by where the human gate sits:
 
 - **Fix** — behavior is wrong: a bug, a regression, live breakage. The Task
-  opens with the incident cycle (restore stops the bleeding, 5whys finds the
+  opens with the incident flow (restore stops the bleeding, 5whys finds the
   cause), fix work proceeds in the loop, and the human gates at a working
   demo — never a design doc:
 

--- a/rust/loopflow/src/engine/builtins/ops/skill/pr-message.md
+++ b/rust/loopflow/src/engine/builtins/ops/skill/pr-message.md
@@ -4,7 +4,7 @@ Review the diff against the PR base. Make the purpose, why it matters, meaningfu
 scope, and evaluation path obvious to a reviewer arriving cold.
 
 When Loopflow supplies Task context, it adds the canonical Task title, Linear
-link, Task flow, PR sequence, and merge disposition after generation. Do not
+link, Task cycle, PR sequence, and merge disposition after generation. Do not
 invent or repeat those facts from branch names or commit messages.
 
 Do not ask questions. If anything is unclear, make the best assumption and proceed.

--- a/rust/loopflow/src/engine/builtins/ops/skill/pr-message.md
+++ b/rust/loopflow/src/engine/builtins/ops/skill/pr-message.md
@@ -1,6 +1,11 @@
 Generate a PR title and body for the changes on this branch.
 
-Review the diff against the PR base and summarize what changed and why.
+Review the diff against the PR base. Make the purpose, why it matters, meaningful
+scope, and evaluation path obvious to a reviewer arriving cold.
+
+When Loopflow supplies Task context, it adds the canonical Task title, Linear
+link, Task flow, PR sequence, and merge disposition after generation. Do not
+invent or repeat those facts from branch names or commit messages.
 
 Do not ask questions. If anything is unclear, make the best assumption and proceed.
 
@@ -21,28 +26,36 @@ Examples:
 
 ## Body style
 
-Use markdown headers to organize the body. Open with a "Usage" or "Try it" section showing commands in code blocks. Then explain what changed.
+Use markdown headers to organize the body. Lead with concrete evaluation, then
+explain why the change matters and the meaningful implementation scope.
 
 Structure:
-1. **Usage section** (header + code block) - how to try it, run it, or see it in action
-2. **Summary** - one paragraph explaining what this PR does and why
-3. **Changes** (optional) - bullet list of notable changes if helpful
+1. **Evaluate** — commands or steps plus the observable result that proves the change
+2. **Why it matters** — one paragraph connecting the behavior to its user or operational consequence
+3. **What changed** — the important scope, decisions, or investment; do not enumerate files
+4. **Risks / Not included** (optional) — boundaries a reviewer should understand
 
-Keep it medium length. Stay high-level; don't enumerate every file.
+Keep it medium length. Prefer evidence over claims. Do not manufacture a demo
+when the diff only supports a test or inspection path.
 
 Example body:
 ```
-## Usage
+## Evaluate
 
 \`\`\`bash
 lf code
 lf ship
 \`\`\`
 
-Coding and shipping now have separate flows. `code` stops after implementation
-and compression; `ship` owns the gate and PR lifecycle.
+Observe that `lf code` stops after implementation and compression, while
+`lf ship` owns the gate and PR lifecycle.
 
-## Changes
+## Why it matters
+
+Separating implementation from settlement lets a reviewer inspect a stable
+change before any merge operation owns it.
+
+## What changed
 
 - Removed the standalone lint skill
 - Moved gate into shipping flows

--- a/rust/loopflow/src/engine/builtins/task/skill/gate.md
+++ b/rust/loopflow/src/engine/builtins/task/skill/gate.md
@@ -98,18 +98,15 @@ Make the change easy to review.
 
 3. **Write PR copy for ops handoff**
 
-   The PR body is written for an engineer picking this up cold. They're asking:
-   - What is the intention of this change?
-   - What assumptions does it make?
-   - What does it accomplish?
-   - How can I tinker with it and evaluate it myself?
+   The PR body is written for an engineer picking this up cold. Loopflow adds
+   the canonical Task title, Linear link, Task flow, PR sequence, and merge
+   disposition at publication; do not repeat or guess them in the handoff copy.
 
    Structure:
-   - **Try it!** — lead with this. Concrete commands to run, what the reviewer will see. Make it easy to tinker. If there are metrics, show them here: "Before: X, After: Y."
-   - **Intent** — one paragraph. Why this change exists and what it accomplishes. Not a file-by-file changelog.
-   - **Assumptions** — what this relies on being true. Environmental, architectural, or domain assumptions the reviewer should validate.
-   - **Key decisions** — choices that weren't obvious. What you picked and why.
-   - **Not included** — intentional omissions, if any.
+   - **Evaluate** — lead with concrete commands or steps and the observable result. If there are metrics, show "Before: X, After: Y."
+   - **Why it matters** — one paragraph connecting the behavior to its user or operational consequence.
+   - **What changed** — meaningful scope and decisions, not a file-by-file changelog.
+   - **Risks / Not included** — assumptions and intentional boundaries, when they help review.
 
    Write to:
    - `scratch/pr-title.txt` — one-line PR title

--- a/rust/loopflow/src/engine/builtins/task/skill/gate.md
+++ b/rust/loopflow/src/engine/builtins/task/skill/gate.md
@@ -99,7 +99,7 @@ Make the change easy to review.
 3. **Write PR copy for ops handoff**
 
    The PR body is written for an engineer picking this up cold. Loopflow adds
-   the canonical Task title, Linear link, Task flow, PR sequence, and merge
+   the canonical Task title, Linear link, Task cycle, PR sequence, and merge
    disposition at publication; do not repeat or guess them in the handoff copy.
 
    Structure:

--- a/rust/loopflow/src/ops/land.rs
+++ b/rust/loopflow/src/ops/land.rs
@@ -11,6 +11,7 @@ use crate::ops::commit::{commit_workflow, CommitOptions};
 use crate::ops::error::{OpsError, OpsResult};
 use crate::ops::pr::{
     generate_pr_copy, normalize_task_pr_copy, read_cached_pr_copy, PrCopy, PrInfo,
+    TaskPrCopyLifecycle,
 };
 
 use crate::ops::progress::Progress;
@@ -88,10 +89,17 @@ fn prepare_pr(
     if !options.local && !crate::ops::pr::gh_available() {
         return Err(OpsError::Message("gh CLI not found".to_string()));
     }
-    let task_identity = if options.local {
+    let task_context = if options.local {
         None
     } else {
-        crate::ops::task::task_pr_identity(&repo_root)?
+        crate::ops::task::task_pr_context(&repo_root)?
+    };
+    let copy_lifecycle = if options.complete {
+        TaskPrCopyLifecycle::Completes
+    } else {
+        TaskPrCopyLifecycle::Continues {
+            next_slug: options.next_slug.clone(),
+        }
     };
     let feature_branch = current_branch(&repo_root)?
         .ok_or_else(|| OpsError::Message("not on a branch".to_string()))?;
@@ -174,18 +182,20 @@ fn prepare_pr(
                     title,
                     body: body.unwrap_or_default(),
                 },
-                task_identity.as_ref(),
+                task_context.as_ref(),
+                &copy_lifecycle,
             )?;
             (Some(copy.title), Some(copy.body))
         }
-        (None, body) if task_identity.is_none() => (None, body),
+        (None, body) if task_context.is_none() => (None, body),
         (None, body) => {
             let copy = normalize_task_pr_copy(
                 PrCopy {
                     title: String::new(),
                     body: body.unwrap_or_default(),
                 },
-                task_identity.as_ref(),
+                task_context.as_ref(),
+                &copy_lifecycle,
             )?;
             (Some(copy.title), Some(copy.body))
         }

--- a/rust/loopflow/src/ops/pr.rs
+++ b/rust/loopflow/src/ops/pr.rs
@@ -220,13 +220,7 @@ pub(crate) fn normalize_task_pr_copy(
     }
 
     let task_link = context.task_link();
-    let lifecycle_plan = &context.lifecycle;
-    let task_flow = format!(
-        "{} → {} → {}",
-        _markdown_code(&lifecycle_plan.first.flow),
-        _markdown_code(&lifecycle_plan.loop_.flow),
-        _markdown_code(&lifecycle_plan.finally.flow),
-    );
+    let task_cycle = context.cycle().as_str();
     let pr_lifecycle = match lifecycle {
         TaskPrCopyLifecycle::Published => format!(
             "PR {} is published for review; no Task settlement is requested.",
@@ -248,7 +242,7 @@ pub(crate) fn normalize_task_pr_copy(
         }
     };
     let managed = format!(
-        "{TASK_PR_CONTEXT_START}\n> [!NOTE]\n> **Task:** {task_link}\n> **Task flow:** {task_flow}\n> **PR lifecycle:** {pr_lifecycle}\n{TASK_PR_CONTEXT_END}"
+        "{TASK_PR_CONTEXT_START}\n> [!NOTE]\n> **Task:** {task_link}\n> **Task cycle:** {task_cycle}\n> **PR lifecycle:** {pr_lifecycle}\n{TASK_PR_CONTEXT_END}"
     );
     let reviewer_context = _strip_managed_task_context(&copy.body);
     let body = if reviewer_context.is_empty() {
@@ -1656,11 +1650,9 @@ mod tests {
         assert_eq!(pr_number_from_url("https://example.com/not-a-pr"), None);
     }
 
-    fn task_pr_context() -> TaskPrContext {
+    fn task_pr_context(first_flow: &str) -> TaskPrContext {
         let mut lifecycle = TaskLifecyclePlan::defaults();
-        lifecycle.first.flow = "incident".to_string();
-        lifecycle.loop_.flow = "slice".to_string();
-        lifecycle.finally.flow = "ship-demo".to_string();
+        lifecycle.first.flow = first_flow.to_string();
         TaskPrContext {
             title: "Make Task PR copy explain intent and lifecycle".to_string(),
             identifier: "LOO-249".to_string(),
@@ -1671,13 +1663,13 @@ mod tests {
     }
 
     #[test]
-    fn task_pr_copy_uses_one_canonical_title_and_durable_context() {
+    fn fix_task_pr_copy_uses_one_canonical_title_and_durable_context() {
         let copy = normalize_task_pr_copy(
             PrCopy {
                 title: "pr copy: explain the review contract".to_string(),
                 body: "## Evaluate\n\n`cargo test -p loopflow task_pr_copy`".to_string(),
             },
-            Some(&task_pr_context()),
+            Some(&task_pr_context("incident")),
             &TaskPrCopyLifecycle::Completes,
         )
         .expect("normalize Task PR copy");
@@ -1691,7 +1683,7 @@ mod tests {
             "<!-- loopflow:task-pr-context:start -->\n\
 > [!NOTE]\n\
 > **Task:** [LOO-249 — Make Task PR copy explain intent and lifecycle](https://linear.app/loopflow/issue/LOO-249/task-pr-copy)\n\
-> **Task flow:** `incident` → `slice` → `ship-demo`\n\
+> **Task cycle:** fix\n\
 > **PR lifecycle:** Merging PR 1 completes the Task.\n\
 <!-- loopflow:task-pr-context:end -->\n\n\
 ## Evaluate\n\n`cargo test -p loopflow task_pr_copy`"
@@ -1699,20 +1691,20 @@ mod tests {
     }
 
     #[test]
-    fn task_pr_copy_refreshes_lifecycle_without_duplicating_context() {
+    fn feature_task_pr_copy_refreshes_lifecycle_without_duplicating_context() {
         let published = normalize_task_pr_copy(
             PrCopy {
                 title: "ignored".to_string(),
                 body: "Linear Task: [OLD-1](https://example.com/old)\n\nReviewer proof."
                     .to_string(),
             },
-            Some(&task_pr_context()),
+            Some(&task_pr_context("task-design")),
             &TaskPrCopyLifecycle::Published,
         )
         .expect("publish Task PR copy");
         let continued = normalize_task_pr_copy(
             published,
-            Some(&task_pr_context()),
+            Some(&task_pr_context("task-design")),
             &TaskPrCopyLifecycle::Continues {
                 next_slug: Some("follow-up-proof".to_string()),
             },
@@ -1729,6 +1721,7 @@ mod tests {
         assert!(continued.body.contains(
             "Merging PR 1 leaves the Task open and names `follow-up-proof` as the next serial PR."
         ));
+        assert!(continued.body.contains("> **Task cycle:** feature"));
         assert!(continued.body.ends_with("Reviewer proof."));
         assert!(!continued.body.contains("Linear Task: [OLD-1]"));
     }

--- a/rust/loopflow/src/ops/pr.rs
+++ b/rust/loopflow/src/ops/pr.rs
@@ -47,6 +47,15 @@ pub struct PrCopy {
 }
 
 const GITHUB_PR_TITLE_MAX_CHARS: usize = 256;
+const TASK_PR_CONTEXT_START: &str = "<!-- loopflow:task-pr-context:start -->";
+const TASK_PR_CONTEXT_END: &str = "<!-- loopflow:task-pr-context:end -->";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum TaskPrCopyLifecycle {
+    Published,
+    Continues { next_slug: Option<String> },
+    Completes,
+}
 
 #[derive(Debug, Deserialize)]
 struct GhPr {
@@ -75,7 +84,7 @@ pub fn create_or_update_pr(
     if !gh_available() {
         return Err(OpsError::Message("gh CLI not found".to_string()));
     }
-    let task_identity = crate::ops::task::task_pr_identity(repo)?;
+    let task_context = crate::ops::task::task_pr_context(repo)?;
 
     let main_repo = resolve_main_repo(repo);
     let default_branch = get_default_branch(&main_repo)?;
@@ -115,7 +124,8 @@ pub fn create_or_update_pr(
 
     let copy = normalize_task_pr_copy(
         resolve_pr_copy(repo, options, cached_copy, progress)?,
-        task_identity.as_ref(),
+        task_context.as_ref(),
+        &TaskPrCopyLifecycle::Published,
     )?;
     let current_branch_state = current_branch(repo)?;
     let current_head = rev_parse(repo, "HEAD")?;
@@ -183,63 +193,94 @@ pub fn create_or_update_pr(
 
 pub(crate) fn normalize_task_pr_copy(
     copy: PrCopy,
-    identity: Option<&crate::ops::task::TaskPrIdentity>,
+    context: Option<&crate::ops::task::TaskPrContext>,
+    lifecycle: &TaskPrCopyLifecycle,
 ) -> OpsResult<PrCopy> {
-    let Some(identity) = identity else {
+    let Some(context) = context else {
         return Ok(copy);
     };
-    let task_title = identity.title.trim();
-    if task_title.is_empty() || task_title.chars().any(|character| character.is_control()) {
+    let task_title = context.title.trim();
+    let task_identifier = context.identifier.trim();
+    if task_title.is_empty()
+        || task_identifier.is_empty()
+        || task_title.chars().any(char::is_control)
+        || task_identifier.chars().any(char::is_control)
+    {
         return Err(OpsError::Message(
-            "Task PR identity requires a non-empty, single-line Linear Task name".to_string(),
+            "Task PR context requires a non-empty, single-line Task identifier and name"
+                .to_string(),
         ));
     }
-    if task_title.chars().count() > GITHUB_PR_TITLE_MAX_CHARS {
+
+    let title = context.pr_title();
+    if title.chars().count() > GITHUB_PR_TITLE_MAX_CHARS {
         return Err(OpsError::Message(format!(
-            "Linear Task name exceeds GitHub's {GITHUB_PR_TITLE_MAX_CHARS}-character PR title limit"
+            "Task identifier and name exceed GitHub's {GITHUB_PR_TITLE_MAX_CHARS}-character PR title limit"
         )));
     }
 
-    let authored_title = copy.title.split_whitespace().collect::<Vec<_>>().join(" ");
-    let canonical_prefix = format!("{task_title} — ");
-    let title = if authored_title.starts_with(task_title) {
-        authored_title
-            .chars()
-            .take(GITHUB_PR_TITLE_MAX_CHARS)
-            .collect::<String>()
-            .trim_end()
-            .to_string()
-    } else {
-        let separator_chars = " — ".chars().count();
-        let suffix_chars =
-            GITHUB_PR_TITLE_MAX_CHARS.saturating_sub(task_title.chars().count() + separator_chars);
-        let suffix = authored_title
-            .chars()
-            .take(suffix_chars)
-            .collect::<String>()
-            .trim_end()
-            .to_string();
-        if suffix.is_empty() {
-            task_title.to_string()
-        } else {
-            format!("{canonical_prefix}{suffix}")
+    let task_link = context.task_link();
+    let lifecycle_plan = &context.lifecycle;
+    let task_flow = format!(
+        "{} → {} → {}",
+        _markdown_code(&lifecycle_plan.first.flow),
+        _markdown_code(&lifecycle_plan.loop_.flow),
+        _markdown_code(&lifecycle_plan.finally.flow),
+    );
+    let pr_lifecycle = match lifecycle {
+        TaskPrCopyLifecycle::Published => format!(
+            "PR {} is published for review; no Task settlement is requested.",
+            context.sequence
+        ),
+        TaskPrCopyLifecycle::Continues {
+            next_slug: Some(next_slug),
+        } => format!(
+            "Merging PR {} leaves the Task open and names {} as the next serial PR.",
+            context.sequence,
+            _markdown_code(next_slug)
+        ),
+        TaskPrCopyLifecycle::Continues { next_slug: None } => format!(
+            "Merging PR {} leaves the Task open for another serial PR.",
+            context.sequence
+        ),
+        TaskPrCopyLifecycle::Completes => {
+            format!("Merging PR {} completes the Task.", context.sequence)
         }
     };
+    let managed = format!(
+        "{TASK_PR_CONTEXT_START}\n> [!NOTE]\n> **Task:** {task_link}\n> **Task flow:** {task_flow}\n> **PR lifecycle:** {pr_lifecycle}\n{TASK_PR_CONTEXT_END}"
+    );
+    let reviewer_context = _strip_managed_task_context(&copy.body);
+    let body = if reviewer_context.is_empty() {
+        managed
+    } else {
+        format!("{managed}\n\n{reviewer_context}")
+    };
+    Ok(PrCopy { title, body })
+}
 
-    let anchor = format!("Linear Task: [{}]({})", identity.identifier, identity.url);
-    let reviewer_context = copy
-        .body
+fn _markdown_code(value: &str) -> String {
+    format!("`{}`", value.replace('`', "\\`"))
+}
+
+fn _strip_managed_task_context(body: &str) -> String {
+    let without_block = match (
+        body.find(TASK_PR_CONTEXT_START),
+        body.find(TASK_PR_CONTEXT_END),
+    ) {
+        (Some(start), Some(end)) if start < end => {
+            let after = end + TASK_PR_CONTEXT_END.len();
+            format!("{}\n{}", &body[..start], &body[after..])
+        }
+        _ => body.to_string(),
+    };
+    without_block
         .lines()
         .filter(|line| !line.trim_start().starts_with("Linear Task:"))
         .collect::<Vec<_>>()
-        .join("\n");
-    let reviewer_context = reviewer_context.trim();
-    let body = if reviewer_context.is_empty() {
-        anchor
-    } else {
-        format!("{anchor}\n\n{reviewer_context}")
-    };
-    Ok(PrCopy { title, body })
+        .join("\n")
+        .trim()
+        .to_string()
 }
 
 fn pr_info(branch: &str, pr: GhPr) -> PrInfo {
@@ -1429,9 +1470,10 @@ mod tests {
     use super::{
         classify_pr_read_failure, is_missing_pr, normalize_task_pr_copy, parse_generated_pr_copy,
         pr_number_from_url, GhCheck, GhRestHead, GhRestPr, MergeGateReading, PrCopy,
-        RequiredChecks,
+        RequiredChecks, TaskPrCopyLifecycle,
     };
-    use crate::ops::task::TaskPrIdentity;
+    use crate::ops::task::TaskPrContext;
+    use crate::task::TaskLifecyclePlan;
 
     fn check(name: &str, bucket: &str) -> GhCheck {
         GhCheck {
@@ -1614,90 +1656,94 @@ mod tests {
         assert_eq!(pr_number_from_url("https://example.com/not-a-pr"), None);
     }
 
-    #[test]
-    fn task_pr_copy_keeps_context_behind_canonical_identity() {
-        let identity = TaskPrIdentity {
-            title: "Remove semantic lifecycle validation".to_string(),
-            identifier: "LOO-230".to_string(),
-            url: "https://linear.app/loopflow/issue/LOO-230/remove-validation".to_string(),
-        };
+    fn task_pr_context() -> TaskPrContext {
+        let mut lifecycle = TaskLifecyclePlan::defaults();
+        lifecycle.first.flow = "incident".to_string();
+        lifecycle.loop_.flow = "slice".to_string();
+        lifecycle.finally.flow = "ship-demo".to_string();
+        TaskPrContext {
+            title: "Make Task PR copy explain intent and lifecycle".to_string(),
+            identifier: "LOO-249".to_string(),
+            url: "https://linear.app/loopflow/issue/LOO-249/task-pr-copy".to_string(),
+            lifecycle,
+            sequence: 1,
+        }
+    }
 
+    #[test]
+    fn task_pr_copy_uses_one_canonical_title_and_durable_context() {
         let copy = normalize_task_pr_copy(
             PrCopy {
-                title: "Explain the structural contract".to_string(),
-                body:
-                    "Linear Task: [OLD-1](https://example.com/old)\n\n## Summary\n\nUseful context."
-                        .to_string(),
+                title: "pr copy: explain the review contract".to_string(),
+                body: "## Evaluate\n\n`cargo test -p loopflow task_pr_copy`".to_string(),
             },
-            Some(&identity),
+            Some(&task_pr_context()),
+            &TaskPrCopyLifecycle::Completes,
         )
         .expect("normalize Task PR copy");
 
         assert_eq!(
             copy.title,
-            "Remove semantic lifecycle validation — Explain the structural contract"
+            "LOO-249: Make Task PR copy explain intent and lifecycle"
         );
         assert_eq!(
             copy.body,
-            "Linear Task: [LOO-230](https://linear.app/loopflow/issue/LOO-230/remove-validation)\n\n## Summary\n\nUseful context."
+            "<!-- loopflow:task-pr-context:start -->\n\
+> [!NOTE]\n\
+> **Task:** [LOO-249 — Make Task PR copy explain intent and lifecycle](https://linear.app/loopflow/issue/LOO-249/task-pr-copy)\n\
+> **Task flow:** `incident` → `slice` → `ship-demo`\n\
+> **PR lifecycle:** Merging PR 1 completes the Task.\n\
+<!-- loopflow:task-pr-context:end -->\n\n\
+## Evaluate\n\n`cargo test -p loopflow task_pr_copy`"
         );
+    }
+
+    #[test]
+    fn task_pr_copy_refreshes_lifecycle_without_duplicating_context() {
+        let published = normalize_task_pr_copy(
+            PrCopy {
+                title: "ignored".to_string(),
+                body: "Linear Task: [OLD-1](https://example.com/old)\n\nReviewer proof."
+                    .to_string(),
+            },
+            Some(&task_pr_context()),
+            &TaskPrCopyLifecycle::Published,
+        )
+        .expect("publish Task PR copy");
+        let continued = normalize_task_pr_copy(
+            published,
+            Some(&task_pr_context()),
+            &TaskPrCopyLifecycle::Continues {
+                next_slug: Some("follow-up-proof".to_string()),
+            },
+        )
+        .expect("refresh Task PR copy");
+
+        assert_eq!(
+            continued
+                .body
+                .matches("loopflow:task-pr-context:start")
+                .count(),
+            1
+        );
+        assert!(continued.body.contains(
+            "Merging PR 1 leaves the Task open and names `follow-up-proof` as the next serial PR."
+        ));
+        assert!(continued.body.ends_with("Reviewer proof."));
+        assert!(!continued.body.contains("Linear Task: [OLD-1]"));
     }
 
     #[test]
     fn non_task_pr_copy_is_unchanged() {
         let copy = PrCopy {
-            title: "Authored title".to_string(),
-            body: "Authored body".to_string(),
+            title: "auth: keep refresh ownership explicit".to_string(),
+            body: "## Evaluate\n\nRun the auth smoke test.".to_string(),
         };
 
         assert_eq!(
-            normalize_task_pr_copy(copy.clone(), None).expect("normalize ordinary PR"),
+            normalize_task_pr_copy(copy.clone(), None, &TaskPrCopyLifecycle::Published)
+                .expect("normalize ordinary PR"),
             copy
-        );
-    }
-
-    #[test]
-    fn task_title_anchor_is_never_partially_truncated() {
-        let task_title = "T".repeat(254);
-        let identity = TaskPrIdentity {
-            title: task_title.clone(),
-            identifier: "LOO-230".to_string(),
-            url: "https://linear.app/loopflow/issue/LOO-230/remove-validation".to_string(),
-        };
-
-        let copy = normalize_task_pr_copy(
-            PrCopy {
-                title: "context".to_string(),
-                body: "proof".to_string(),
-            },
-            Some(&identity),
-        )
-        .expect("normalize long Task title");
-
-        assert_eq!(copy.title, task_title);
-        assert_eq!(copy.title.chars().count(), 254);
-    }
-
-    #[test]
-    fn authored_task_title_prefix_is_not_duplicated() {
-        let identity = TaskPrIdentity {
-            title: "Remove semantic lifecycle validation".to_string(),
-            identifier: "LOO-230".to_string(),
-            url: "https://linear.app/loopflow/issue/LOO-230/remove-validation".to_string(),
-        };
-
-        let copy = normalize_task_pr_copy(
-            PrCopy {
-                title: "Remove semantic lifecycle validation: final cleanup".to_string(),
-                body: "proof".to_string(),
-            },
-            Some(&identity),
-        )
-        .expect("normalize already-anchored title");
-
-        assert_eq!(
-            copy.title,
-            "Remove semantic lifecycle validation: final cleanup"
         );
     }
 

--- a/rust/loopflow/src/ops/task.rs
+++ b/rust/loopflow/src/ops/task.rs
@@ -1795,7 +1795,7 @@ fn _validate_task_pr_copy(context: &TaskPrContext, title: &str, body: &str) -> O
         line.trim()
             .strip_prefix('>')
             .map(str::trim)
-             .is_some_and(|line| line == anchor)
+            .is_some_and(|line| line == anchor)
     }) {
         return Err(task_error(format!(
             "Task PR body must include the owning Linear Task link: {anchor}"

--- a/rust/loopflow/src/ops/task.rs
+++ b/rust/loopflow/src/ops/task.rs
@@ -56,10 +56,10 @@ pub struct TaskFlowOverrides {
     pub finally: Option<String>,
 }
 
-/// Named lifecycle presets: where the human gate sits, in one word.
+/// Named cycle presets: where the human gate sits, in one word.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TaskCycle {
-    /// Behavior is wrong. Opens with the incident cycle (restore → 5whys)
+    /// Behavior is wrong. Opens with the incident flow (restore → 5whys)
     /// and the human gates at the demo, not a design doc.
     Fix,
     /// Behavior should change; the human shapes the design before code.

--- a/rust/loopflow/src/ops/task.rs
+++ b/rust/loopflow/src/ops/task.rs
@@ -1572,11 +1572,12 @@ async fn validate_automated_task_authority(
     lease: &RunLease,
 ) -> OpsResult<()> {
     let main_repo = main_repo_root(repo)?;
-    let current = crate::ops::task_pm::resolve_task(
+    let current = Box::pin(crate::ops::task_pm::resolve_task_async(
         &main_repo,
         task.plan.id.as_str(),
         crate::ops::pm::PmRefresh::Never,
-    )
+    ))
+    .await
     .map_err(|error| {
         task_error(format!(
             "Task {} current PM authority refused: {error}",
@@ -1636,8 +1637,8 @@ pub(crate) fn request_task_pr_publication(repo: &Path, title: &str, body: &str) 
         else {
             return Ok(false);
         };
-        let identity = task_pr_identity_from_store(&store, &task).await?;
-        validate_task_pr_copy(&identity, title, body)?;
+        let context = _task_pr_context_from_store(&store, &task).await?;
+        _validate_task_pr_copy(&context, title, body)?;
         let mut pr = store
             .active_task_pr(&task.id)
             .await
@@ -1688,32 +1689,53 @@ pub(crate) fn request_task_pr_publication(repo: &Path, title: &str, body: &str) 
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct TaskPrIdentity {
+pub(crate) struct TaskPrContext {
     pub(crate) title: String,
     pub(crate) identifier: String,
     pub(crate) url: String,
+    pub(crate) lifecycle: crate::task::TaskLifecyclePlan,
+    pub(crate) sequence: u32,
 }
 
-pub(crate) fn task_pr_identity(repo: &Path) -> OpsResult<Option<TaskPrIdentity>> {
+impl TaskPrContext {
+    pub(crate) fn pr_title(&self) -> String {
+        format!("{}: {}", self.identifier.trim(), self.title.trim())
+    }
+
+    pub(crate) fn task_link(&self) -> String {
+        format!(
+            "[{} — {}]({})",
+            _markdown_link_text(self.identifier.trim()),
+            _markdown_link_text(self.title.trim()),
+            self.url
+        )
+    }
+}
+
+fn _markdown_link_text(value: &str) -> String {
+    value
+        .replace('\\', "\\\\")
+        .replace('[', "\\[")
+        .replace(']', "\\]")
+}
+
+pub(crate) fn task_pr_context(repo: &Path) -> OpsResult<Option<TaskPrContext>> {
     block_on_task(async move {
         let TaskAuthority::Authority { store, task, .. } = resolve_task_authority(repo).await?
         else {
             return Ok(None);
         };
-        task_pr_identity_from_store(&store, &task).await.map(Some)
+        _task_pr_context_from_store(&store, &task).await.map(Some)
     })
 }
 
-async fn task_pr_identity_from_store(
-    store: &SharedStore,
-    task: &Task,
-) -> OpsResult<TaskPrIdentity> {
+async fn _task_pr_context_from_store(store: &SharedStore, task: &Task) -> OpsResult<TaskPrContext> {
     let wave = owning_wave(store, task).await?;
     let snapshot = store
         .pm_snapshot(&task.wave_id)
         .await
         .map_err(|error| task_error(format!("failed to read cached PM snapshot: {error}")))?
-        .ok_or_else(|| missing_task_pr_url(task, wave.name()))?;
+        .ok_or_else(|| _missing_task_pr_url(task, wave.name()))?;
     let snapshot: PmSnapshot = serde_json::from_str(&snapshot.payload).map_err(|error| {
         task_error(format!(
             "cached PM snapshot for Wave {:?} is invalid: {error}. Run `lf pm sync --wave {}` before publishing this Task PR",
@@ -1725,20 +1747,27 @@ async fn task_pr_identity_from_store(
         .items
         .iter()
         .find(|item| item.id == task.plan.id.as_str())
-        .ok_or_else(|| missing_task_pr_url(task, wave.name()))?;
+        .ok_or_else(|| _missing_task_pr_url(task, wave.name()))?;
     let url = item
         .url
         .as_deref()
-        .filter(|url| valid_task_url(url))
-        .ok_or_else(|| missing_task_pr_url(task, wave.name()))?;
-    Ok(TaskPrIdentity {
+        .filter(|url| _valid_task_url(url))
+        .ok_or_else(|| _missing_task_pr_url(task, wave.name()))?;
+    let pr = store
+        .active_task_pr(&task.id)
+        .await
+        .map_err(|error| task_error(format!("failed to read active PR: {error}")))?
+        .ok_or_else(|| task_error(format!("Task {} has no active PR", task.plan.identifier)))?;
+    Ok(TaskPrContext {
         title: task.plan.title.clone(),
         identifier: task.plan.identifier.clone(),
         url: url.to_string(),
+        lifecycle: task.lifecycle.clone(),
+        sequence: pr.sequence,
     })
 }
 
-fn valid_task_url(value: &str) -> bool {
+fn _valid_task_url(value: &str) -> bool {
     let Ok(url) = reqwest::Url::parse(value) else {
         return false;
     };
@@ -1747,22 +1776,27 @@ fn valid_task_url(value: &str) -> bool {
         && !value.chars().any(char::is_control)
 }
 
-fn missing_task_pr_url(task: &Task, wave: &str) -> OpsError {
+fn _missing_task_pr_url(task: &Task, wave: &str) -> OpsError {
     task_error(format!(
         "Task {} has no valid provider URL in the cached PM snapshot. Run `lf pm sync --wave {wave}` before publishing this Task PR",
         task.plan.identifier,
     ))
 }
 
-fn validate_task_pr_copy(identity: &TaskPrIdentity, title: &str, body: &str) -> OpsResult<()> {
-    if !title.starts_with(identity.title.trim()) {
+fn _validate_task_pr_copy(context: &TaskPrContext, title: &str, body: &str) -> OpsResult<()> {
+    let expected_title = context.pr_title();
+    if title != expected_title {
         return Err(task_error(format!(
-            "Task PR title must start with the Linear Task name {:?}",
-            identity.title,
+            "Task PR title must be {expected_title:?}"
         )));
     }
-    let anchor = format!("Linear Task: [{}]({})", identity.identifier, identity.url);
-    if !body.lines().any(|line| line.trim() == anchor) {
+    let anchor = format!("**Task:** {}", context.task_link());
+    if !body.lines().any(|line| {
+        line.trim()
+            .strip_prefix('>')
+            .map(str::trim)
+             .is_some_and(|line| line == anchor)
+    }) {
         return Err(task_error(format!(
             "Task PR body must include the owning Linear Task link: {anchor}"
         )));

--- a/rust/loopflow/src/ops/task.rs
+++ b/rust/loopflow/src/ops/task.rs
@@ -82,6 +82,20 @@ impl TaskCycle {
             Self::Feature => ("task-design", "ship-demo"),
         }
     }
+
+    pub fn for_lifecycle(lifecycle: &crate::task::TaskLifecyclePlan) -> Self {
+        [Self::Fix, Self::Feature]
+            .into_iter()
+            .find(|cycle| lifecycle.first.flow == cycle.flows().0)
+            .unwrap_or(Self::Feature)
+    }
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Fix => "fix",
+            Self::Feature => "feature",
+        }
+    }
 }
 
 impl TaskFlowOverrides {
@@ -1709,6 +1723,10 @@ impl TaskPrContext {
             _markdown_link_text(self.title.trim()),
             self.url
         )
+    }
+
+    pub(crate) fn cycle(&self) -> TaskCycle {
+        TaskCycle::for_lifecycle(&self.lifecycle)
     }
 }
 

--- a/rust/loopflow/src/ops/task_pm.rs
+++ b/rust/loopflow/src/ops/task_pm.rs
@@ -43,9 +43,19 @@ async fn load_wave_async(repo: &Path, wave: &str, refresh: PmRefresh) -> OpsResu
 }
 
 pub fn resolve_task(repo: &Path, issue: &str, refresh: PmRefresh) -> OpsResult<ResolvedTask> {
+    let runtime = tokio::runtime::Runtime::new()
+        .map_err(|error| OpsError::Message(format!("failed to create async runtime: {error}")))?;
+    runtime.block_on(resolve_task_async(repo, issue, refresh))
+}
+
+pub(crate) async fn resolve_task_async(
+    repo: &Path,
+    issue: &str,
+    refresh: PmRefresh,
+) -> OpsResult<ResolvedTask> {
     let team_id = crate::ops::pm::repository_team_id(repo)?;
     let mut matches = Vec::new();
-    for snapshot in repository_snapshots(repo, &team_id)? {
+    for snapshot in repository_snapshots_async(repo, &team_id).await? {
         if let Some(item) = snapshot
             .items
             .iter()
@@ -67,7 +77,7 @@ pub fn resolve_task(repo: &Path, issue: &str, refresh: PmRefresh) -> OpsResult<R
             )))
         }
     };
-    let snapshot = load_wave(repo, &wave, refresh)?;
+    let snapshot = load_wave_async(repo, &wave, refresh).await?;
     let item = snapshot
         .items
         .iter()
@@ -158,6 +168,29 @@ fn repository_snapshots(repo: &Path, team_id: &str) -> OpsResult<Vec<PmShowResul
     let mut ownership = PmPortfolioValidator::default();
     for wave in crate::ops::pm::list_pm_waves(repo)? {
         let snapshot = match load_wave(repo, &wave, PmRefresh::Never) {
+            Ok(snapshot) => snapshot,
+            Err(error) if error.to_string().contains("has no local PM snapshot") => continue,
+            Err(error) => return Err(error),
+        };
+        ownership
+            .validate(
+                &snapshot.wave,
+                &snapshot.initiative,
+                Some(team_id),
+                &snapshot.projects,
+                &snapshot.items,
+            )
+            .map_err(|error| OpsError::Message(error.to_string()))?;
+        snapshots.push(snapshot);
+    }
+    Ok(snapshots)
+}
+
+async fn repository_snapshots_async(repo: &Path, team_id: &str) -> OpsResult<Vec<PmShowResult>> {
+    let mut snapshots = Vec::new();
+    let mut ownership = PmPortfolioValidator::default();
+    for wave in crate::ops::pm::list_pm_waves(repo)? {
+        let snapshot = match load_wave_async(repo, &wave, PmRefresh::Never).await {
             Ok(snapshot) => snapshot,
             Err(error) if error.to_string().contains("has no local PM snapshot") => continue,
             Err(error) => return Err(error),

--- a/rust/loopflow/tests/land_tests.rs
+++ b/rust/loopflow/tests/land_tests.rs
@@ -1028,6 +1028,7 @@ fn latest_land_disposition_wins_before_merge() {
     assert!(presentation.body.starts_with(
         "<!-- loopflow:task-pr-context:start -->\n> [!NOTE]\n> **Task:** [INF-123 — Prove Task PR transitions](https://linear.app/loopflow/issue/INF-123/prove-task-pr-transitions)"
     ));
+    assert!(presentation.body.contains("> **Task cycle:** feature"));
     assert!(presentation.body.contains(
         "> **PR lifecycle:** Merging PR 1 leaves the Task open and names `follow-up-proof` as the next serial PR."
     ));

--- a/rust/loopflow/tests/land_tests.rs
+++ b/rust/loopflow/tests/land_tests.rs
@@ -1024,9 +1024,12 @@ fn latest_land_disposition_wins_before_merge() {
         .presentation
         .as_ref()
         .expect("Task identity survives refresh and land");
-    assert_eq!(presentation.title, "Prove Task PR transitions — test title");
+    assert_eq!(presentation.title, "INF-123: Prove Task PR transitions");
     assert!(presentation.body.starts_with(
-        "Linear Task: [INF-123](https://linear.app/loopflow/issue/INF-123/prove-task-pr-transitions)\n\n"
+        "<!-- loopflow:task-pr-context:start -->\n> [!NOTE]\n> **Task:** [INF-123 — Prove Task PR transitions](https://linear.app/loopflow/issue/INF-123/prove-task-pr-transitions)"
+    ));
+    assert!(presentation.body.contains(
+        "> **PR lifecycle:** Merging PR 1 leaves the Task open and names `follow-up-proof` as the next serial PR."
     ));
     assert_eq!(publication.github.map(|pr| pr.number), Some(912));
     let merge = publication.merge.expect("explicit merge request");

--- a/rust/loopflow/tests/pr_tests.rs
+++ b/rust/loopflow/tests/pr_tests.rs
@@ -15,7 +15,7 @@ use loopflow::provider_auth::Provider;
 use loopflow::store::{CredentialState, ProviderAccount, ProviderAccountId, RoutingState};
 use loopflow::task::{
     AfterMerge, GithubPr, PrMergeMode, PrMergeRequest, PrPhase, PrPresentation, PrPublication,
-    TaskGateProposal,
+    TaskGateProposal, TaskLifecyclePlan,
 };
 use loopflow_test_support::TestRepo;
 use support::{
@@ -506,9 +506,7 @@ fn github_failure_leaves_publication_intent_observable() {
     assert!(presentation.body.contains(
         "> **Task:** [INF-123 — Prove Task PR transitions](https://linear.app/loopflow/issue/INF-123/prove-task-pr-transitions)"
     ));
-    assert!(presentation
-        .body
-        .contains("> **Task flow:** `task-design` → `slice` → `ship-demo`"));
+    assert!(presentation.body.contains("> **Task cycle:** feature"));
     assert!(presentation.body.contains(
         "> **PR lifecycle:** PR 1 is published for review; no Task settlement is requested."
     ));
@@ -518,7 +516,7 @@ fn github_failure_leaves_publication_intent_observable() {
 }
 
 #[test]
-fn configured_generation_adds_task_intent_and_lifecycle_to_pr_copy() {
+fn configured_feature_generation_adds_task_intent_and_lifecycle_to_pr_copy() {
     let home = tempfile::TempDir::new().expect("temp home");
     let gh = write_gh_script("[]", None);
     let agent = codex_script(
@@ -565,7 +563,7 @@ fn configured_generation_adds_task_intent_and_lifecycle_to_pr_copy() {
         "<!-- loopflow:task-pr-context:start -->\n\
 > [!NOTE]\n\
 > **Task:** [INF-123 — Prove Task PR transitions](https://linear.app/loopflow/issue/INF-123/prove-task-pr-transitions)\n\
-> **Task flow:** `task-design` → `slice` → `ship-demo`\n\
+> **Task cycle:** feature\n\
 > **PR lifecycle:** PR 1 is published for review; no Task settlement is requested.\n\
 <!-- loopflow:task-pr-context:end -->\n\n\
 ## Evaluate\n\n\
@@ -577,6 +575,60 @@ Reviewers can recover purpose and settlement behavior without reconstructing Tas
 Task publication now combines generated review guidance with durable Task context."
     );
     assert!(!presentation.title.contains("explain review contract"));
+}
+
+#[test]
+fn configured_fix_generation_names_the_task_cycle() {
+    let home = tempfile::TempDir::new().expect("temp home");
+    let gh = write_gh_script("[]", None);
+    let agent = codex_script(
+        r###"{"title":"generated title","body":"## Evaluate\n\nRun the configured fix proof."}"###,
+    );
+    let _env = EnvGuard::with_lf_home(
+        &[("gh", gh.as_str()), ("codex", agent.as_str())],
+        home.path(),
+    );
+    let repo = TestRepo::new();
+    let base = repo.head_sha();
+    let branch = "jack/task-fix-copy-proof";
+    repo.create_branch(branch);
+    repo.create_file("proof.txt", "configured fix generation\n");
+    repo.stage_all();
+    repo.commit("add configured fix generation proof");
+    repo.push_new_branch(branch);
+    let mut registered = register_task(home.path(), repo.path(), branch, &base);
+    registered.task.lifecycle = TaskLifecyclePlan::standard("incident", "slice", "ship-demo");
+    let runtime = tokio::runtime::Runtime::new().expect("update Task runtime");
+    runtime
+        .block_on(registered.store.update_task(&registered.task))
+        .expect("persist fix lifecycle");
+
+    create_or_update_pr(
+        repo.path(),
+        &PrOptions {
+            title: None,
+            body: None,
+            agent: Some("codex".to_string()),
+        },
+        &NullProgress,
+    )
+    .expect("generate and publish fix Task PR copy");
+
+    let pr = runtime
+        .block_on(registered.store.active_task_pr(&registered.task.id))
+        .expect("read active PR")
+        .expect("active PR");
+    let presentation = pr
+        .publication
+        .as_ref()
+        .and_then(|publication| publication.presentation.as_ref())
+        .expect("generated fix Task PR copy");
+    assert_eq!(presentation.title, "INF-123: Prove Task PR transitions");
+    assert!(presentation.body.contains("> **Task cycle:** fix"));
+    assert!(!presentation.body.contains("Task flow:"));
+    assert!(presentation.body.contains(
+        "> **PR lifecycle:** PR 1 is published for review; no Task settlement is requested."
+    ));
 }
 
 #[test]
@@ -776,6 +828,7 @@ fn serial_task_pr_publication_restores_task_context() {
     assert!(presentation.body.starts_with(
         "<!-- loopflow:task-pr-context:start -->\n> [!NOTE]\n> **Task:** [INF-123 — Prove Task PR transitions](https://linear.app/loopflow/issue/INF-123/prove-task-pr-transitions)"
     ));
+    assert!(presentation.body.contains("> **Task cycle:** feature"));
     assert!(presentation.body.contains(
         "> **PR lifecycle:** PR 2 is published for review; no Task settlement is requested."
     ));

--- a/rust/loopflow/tests/pr_tests.rs
+++ b/rust/loopflow/tests/pr_tests.rs
@@ -782,9 +782,7 @@ fn serial_task_pr_publication_restores_task_context() {
     assert!(presentation.body.ends_with("Serial reviewer context"));
     let gh_calls = fs::read_to_string(gh_log).expect("read GitHub calls");
     assert!(gh_calls.contains("--title INF-123: Prove Task PR transitions"));
-    assert!(gh_calls.contains(
-        "--body <!-- loopflow:task-pr-context:start -->"
-    ));
+    assert!(gh_calls.contains("--body <!-- loopflow:task-pr-context:start -->"));
 }
 
 #[test]

--- a/rust/loopflow/tests/pr_tests.rs
+++ b/rust/loopflow/tests/pr_tests.rs
@@ -501,17 +501,82 @@ fn github_failure_leaves_publication_intent_observable() {
     let presentation = publication
         .presentation
         .as_ref()
-        .expect("reviewer-facing Task identity");
-    assert_eq!(
-        presentation.title,
-        "Prove Task PR transitions — Persist publication first"
-    );
-    assert_eq!(
-        presentation.body,
-        "Linear Task: [INF-123](https://linear.app/loopflow/issue/INF-123/prove-task-pr-transitions)\n\nThe GitHub call will fail."
-    );
+        .expect("reviewer-facing Task copy");
+    assert_eq!(presentation.title, "INF-123: Prove Task PR transitions");
+    assert!(presentation.body.contains(
+        "> **Task:** [INF-123 — Prove Task PR transitions](https://linear.app/loopflow/issue/INF-123/prove-task-pr-transitions)"
+    ));
+    assert!(presentation
+        .body
+        .contains("> **Task flow:** `task-design` → `slice` → `ship-demo`"));
+    assert!(presentation.body.contains(
+        "> **PR lifecycle:** PR 1 is published for review; no Task settlement is requested."
+    ));
+    assert!(presentation.body.ends_with("The GitHub call will fail."));
     assert!(publication.github.is_none());
     assert!(publication.merge.is_none());
+}
+
+#[test]
+fn configured_generation_adds_task_intent_and_lifecycle_to_pr_copy() {
+    let home = tempfile::TempDir::new().expect("temp home");
+    let gh = write_gh_script("[]", None);
+    let agent = codex_script(
+        r###"{"title":"Prove Task PR transitions — explain review contract","body":"## Evaluate\n\n`cargo test -p loopflow task_pr_copy --lib`\n\nObserve one canonical Task title and an explicit merge disposition.\n\n## Why it matters\n\nReviewers can recover purpose and settlement behavior without reconstructing Task state.\n\n## What changed\n\nTask publication now combines generated review guidance with durable Task context."}"###,
+    );
+    let _env = EnvGuard::with_lf_home(
+        &[("gh", gh.as_str()), ("codex", agent.as_str())],
+        home.path(),
+    );
+    let repo = TestRepo::new();
+    let base = repo.head_sha();
+    let branch = "jack/task-copy-proof";
+    repo.create_branch(branch);
+    repo.create_file("proof.txt", "configured generation\n");
+    repo.stage_all();
+    repo.commit("add configured generation proof");
+    repo.push_new_branch(branch);
+    let task = register_task(home.path(), repo.path(), branch, &base);
+
+    create_or_update_pr(
+        repo.path(),
+        &PrOptions {
+            title: None,
+            body: None,
+            agent: Some("codex".to_string()),
+        },
+        &NullProgress,
+    )
+    .expect("generate and publish Task PR copy");
+
+    let runtime = tokio::runtime::Runtime::new().expect("read task runtime");
+    let pr = runtime
+        .block_on(task.store.active_task_pr(&task.task.id))
+        .expect("read active PR")
+        .expect("active PR");
+    let presentation = pr
+        .publication
+        .as_ref()
+        .and_then(|publication| publication.presentation.as_ref())
+        .expect("generated Task PR copy");
+    assert_eq!(presentation.title, "INF-123: Prove Task PR transitions");
+    assert_eq!(
+        presentation.body,
+        "<!-- loopflow:task-pr-context:start -->\n\
+> [!NOTE]\n\
+> **Task:** [INF-123 — Prove Task PR transitions](https://linear.app/loopflow/issue/INF-123/prove-task-pr-transitions)\n\
+> **Task flow:** `task-design` → `slice` → `ship-demo`\n\
+> **PR lifecycle:** PR 1 is published for review; no Task settlement is requested.\n\
+<!-- loopflow:task-pr-context:end -->\n\n\
+## Evaluate\n\n\
+`cargo test -p loopflow task_pr_copy --lib`\n\n\
+Observe one canonical Task title and an explicit merge disposition.\n\n\
+## Why it matters\n\n\
+Reviewers can recover purpose and settlement behavior without reconstructing Task state.\n\n\
+## What changed\n\n\
+Task publication now combines generated review guidance with durable Task context."
+    );
+    assert!(!presentation.title.contains("explain review contract"));
 }
 
 #[test]
@@ -573,7 +638,7 @@ fn task_pr_missing_cached_linear_url_refuses_before_remote_mutation() {
 }
 
 #[test]
-fn serial_task_pr_publication_restores_linear_identity_anchors() {
+fn serial_task_pr_publication_restores_task_context() {
     let home = tempfile::TempDir::new().expect("temp home");
     let gh_log = home.path().join("gh.log");
     let gh = gh_merged_pr_without_time_script(gh_log.to_string_lossy().as_ref());
@@ -707,17 +772,18 @@ fn serial_task_pr_publication_restores_linear_identity_anchors() {
         .as_ref()
         .and_then(|publication| publication.presentation.as_ref())
         .expect("serial reviewer copy");
-    assert_eq!(
-        presentation.title,
-        "Prove Task PR transitions — Second delivery slice"
-    );
+    assert_eq!(presentation.title, "INF-123: Prove Task PR transitions");
     assert!(presentation.body.starts_with(
-        "Linear Task: [INF-123](https://linear.app/loopflow/issue/INF-123/prove-task-pr-transitions)\n\n"
+        "<!-- loopflow:task-pr-context:start -->\n> [!NOTE]\n> **Task:** [INF-123 — Prove Task PR transitions](https://linear.app/loopflow/issue/INF-123/prove-task-pr-transitions)"
     ));
+    assert!(presentation.body.contains(
+        "> **PR lifecycle:** PR 2 is published for review; no Task settlement is requested."
+    ));
+    assert!(presentation.body.ends_with("Serial reviewer context"));
     let gh_calls = fs::read_to_string(gh_log).expect("read GitHub calls");
-    assert!(gh_calls.contains("--title Prove Task PR transitions — Second delivery slice"));
+    assert!(gh_calls.contains("--title INF-123: Prove Task PR transitions"));
     assert!(gh_calls.contains(
-        "--body Linear Task: [INF-123](https://linear.app/loopflow/issue/INF-123/prove-task-pr-transitions)"
+        "--body <!-- loopflow:task-pr-context:start -->"
     ));
 }
 

--- a/rust/loopflow/tests/support/mod.rs
+++ b/rust/loopflow/tests/support/mod.rs
@@ -404,7 +404,7 @@ fn register_task_with_process(
                 payload: pm_payload,
             })
             .await
-            .expect("cache Task PR identity");
+            .expect("cache Task PR context");
         store
             .create_project(&project)
             .await


### PR DESCRIPTION
<!-- loopflow:task-pr-context:start -->
> [!NOTE]
> **Task:** [LOO-249 — Make Task PR copy explain intent and lifecycle](https://linear.app/loopflow/issue/LOO-249/make-task-pr-copy-explain-intent-and-lifecycle)
> **Task cycle:** fix
> **PR lifecycle:** PR 1 is published for review; no Task settlement is requested.
<!-- loopflow:task-pr-context:end -->

## Try it!

```bash
cargo test -p loopflow --test pr_tests configured_feature_generation_adds_task_intent_and_lifecycle_to_pr_copy
cargo test -p loopflow --test pr_tests configured_fix_generation_names_the_task_cycle
cargo test -p loopflow --test land_tests latest_land_disposition_wins_before_merge
```

Observe one canonical Task title, a direct Linear link, `Task cycle: feature` or `Task cycle: fix`, and a PR lifecycle sentence that says exactly what merging this PR does.

## Intent

Give a reviewer arriving cold the durable purpose and lifecycle of a Task PR. The copy names the user-selected Task cycle instead of exposing its three constituent flow implementations, and keeps the merge disposition next to the owning Task.

## Assumptions

- The pinned first flow identifies the durable Task cycle: `incident` means fix; other valid Task lifecycles are feature cycles.
- Constituent flow names remain available in Task status for operational debugging, but they are not reviewer-facing intent.

## Key decisions

- Keep Task identity, cycle, PR sequence, and merge disposition machine-authored from durable state.
- Keep evaluation guidance and implementation scope agent-authored.
- Refresh the managed block idempotently across publish and land transitions.

## Not included

This does not change Task execution or ordinary non-Task PR copy.