### PR TITLE
Run the skill as a command in human-gate Ask sessions (not an inlined prompt) — ask: run human flow gates through the skill harness

### DIFF
--- a/rust/loopflow/src/ops/ask.rs
+++ b/rust/loopflow/src/ops/ask.rs
@@ -322,18 +322,21 @@ pub(crate) async fn serve(
     if ask.state.is_terminal() {
         return Ok(());
     }
-    let prompt = ask_prompt(&store, &ask).await?;
-    let config = crate::engine::load_config_or_default(Some(&ask.origin.cwd));
-    let agent = config.agent().to_string();
-    let result = run_provider(
-        &ask.origin.cwd,
-        &agent,
-        &prompt,
-        &invocation_id,
-        headless,
-        matches!(ask.request, crate::durable::AskBody::FlowStep { .. }),
-    )
-    .await;
+    // Two cases, two launches. A FlowStep gate runs the skill's REAL harness
+    // (the `lf <skill>` turn), so the session IS the skill — no generic agent to
+    // freelance an approval. An Intervention is a free-text thread with the User.
+    let result = match &ask.request {
+        crate::durable::AskBody::FlowStep { .. } => {
+            let turn = crate::task::runner::flow_step_harness_turn(&store, &ask).await?;
+            run_flow_step_harness(&ask.origin.cwd, turn, &invocation_id, headless).await
+        }
+        crate::durable::AskBody::Intervention { .. } => {
+            let prompt = ask_prompt(&store, &ask).await?;
+            let config = crate::engine::load_config_or_default(Some(&ask.origin.cwd));
+            let agent = config.agent().to_string();
+            run_provider(&ask.origin.cwd, &agent, &prompt, &invocation_id, headless).await
+        }
+    };
     let current = store.ask_by_id(&ask.id).await?;
     if current.state == AskState::Claimed
         && current.active_invocation_id.as_ref() == Some(&invocation_id)
@@ -405,13 +408,14 @@ async fn wait_until_presented(
     }
 }
 
+/// An Intervention thread: a detached free-text agent that must not adopt the
+/// originating Work. FlowStep gates never use this path.
 async fn run_provider(
     cwd: &Path,
     agent: &str,
     prompt: &str,
     invocation_id: &AgentInvocationId,
     headless: bool,
-    flow_step: bool,
 ) -> Result<ExitStatus> {
     let mut launch = crate::engine::AgentConfig {
         system_prompt: if headless {
@@ -426,11 +430,7 @@ async fn run_provider(
         task_prompt: prompt.to_string(),
         agent: Some(agent.to_string()),
         cwd: Some(cwd.to_path_buf()),
-        authority: if flow_step {
-            crate::engine::agent::AgentAuthority::Inherit
-        } else {
-            crate::engine::agent::AgentAuthority::Detached
-        },
+        authority: crate::engine::agent::AgentAuthority::Detached,
         ..Default::default()
     };
     launch.env.insert(
@@ -450,10 +450,39 @@ async fn run_provider(
     Ok(ExitStatus::from_raw(result.exit_code << 8))
 }
 
+/// Launch a human FlowStep gate as the skill's real harness turn — its own
+/// system prompt, context, and config (the `lf <skill>` launch), writing into
+/// the origin Task. No generic agent sits between the human and the skill.
+async fn run_flow_step_harness(
+    cwd: &Path,
+    turn: crate::lf::commands::run::PreparedHarnessTurn,
+    invocation_id: &AgentInvocationId,
+    headless: bool,
+) -> Result<ExitStatus> {
+    let mut launch = turn.config;
+    launch.task_prompt = turn.input;
+    launch.cwd = Some(cwd.to_path_buf());
+    launch.authority = crate::engine::agent::AgentAuthority::Inherit;
+    launch.env.insert(
+        crate::durable::AGENT_INVOCATION_ENV.to_string(),
+        invocation_id.as_str().to_string(),
+    );
+    let process = crate::engine::ProcessConfig {
+        auto: headless,
+        stream: false,
+        ..Default::default()
+    };
+    let capabilities = crate::engine::AgentCapabilities::default();
+    let result = tokio::task::spawn_blocking(move || {
+        crate::engine::launch_agent(&launch, &process, &capabilities)
+    })
+    .await??;
+    Ok(ExitStatus::from_raw(result.exit_code << 8))
+}
+
+/// The prompt for an Intervention (free-text thread with the User). FlowStep
+/// gates never reach here — they run the skill's harness via `flow_step_harness_turn`.
 async fn ask_prompt(store: &SharedStore, ask: &Ask) -> Result<String> {
-    if matches!(ask.request, crate::durable::AskBody::FlowStep { .. }) {
-        return crate::task::runner::flow_step_ask_prompt(store, ask).await;
-    }
     let invocations = store.ask_invocations(&ask.id).await?;
     let mut history = Vec::with_capacity(invocations.len());
     for invocation in invocations {

--- a/rust/loopflow/src/task/runner.rs
+++ b/rust/loopflow/src/task/runner.rs
@@ -2175,10 +2175,14 @@ fn task_seed(
     )
 }
 
-pub(crate) async fn flow_step_ask_prompt(
+/// Prepare the skill's REAL harness turn for a human flow gate — the same turn
+/// `lf <skill>` builds (its system prompt, context, config), with only the
+/// settlement contract appended to the input. The Ask session then IS the skill
+/// run, not a generic agent handed the skill's task text (which self-approved).
+pub(crate) async fn flow_step_harness_turn(
     store: &SharedStore,
     ask: &crate::durable::Ask,
-) -> Result<String> {
+) -> Result<crate::lf::commands::run::PreparedHarnessTurn> {
     let crate::durable::AskBody::FlowStep {
         flow,
         node_id,
@@ -2231,30 +2235,17 @@ pub(crate) async fn flow_step_ask_prompt(
     let project = owning_project(store, &task).await?;
     let wave = owning_wave(store, &task).await?;
     let seed = task_seed(&task, &project.plan, &pr, wave.name(), &boundary);
-    let prepared =
+    let mut prepared =
         crate::lf::commands::run::prepare_interactive_harness_turn(skill, &seed, wave.name())?;
-    Ok(human_flow_ask_prompt(
-        &prepared.input,
-        skill,
-        node_id,
-        &ask.id,
-        &ask.target,
-    ))
+    prepared.input = human_flow_settlement(&prepared.input, skill, node_id, &ask.id);
+    Ok(prepared)
 }
 
-fn human_flow_ask_prompt(
-    input: &str,
-    skill: &str,
-    node_id: &str,
-    ask_id: &AskId,
-    target: &crate::durable::AskTarget,
-) -> String {
-    let reviewer_mode = match target {
-        crate::durable::AskTarget::User => "Reviewer mode: Human reviewer. The authenticated User is present in this Ask session and owns the review decisions.\n\n",
-        crate::durable::AskTarget::Parent(_) => "",
-    };
+/// Append only the settlement contract to the skill's real input. The skill's
+/// own harness governs the review; the ask system owns just how the flow advances.
+fn human_flow_settlement(input: &str, skill: &str, node_id: &str, ask_id: &AskId) -> String {
     format!(
-        "{input}\n\n<lf:human-flow-node>\n{reviewer_mode}This is the actual writable `{skill}` Task step at human node `{node_id}`, not an advisory review. Work only in the origin Task and settle explicitly before leaving:\n- `lf ask resolve {ask_id} \"<concise verified summary>\"` accepts the step\n- `lf ask decline {ask_id} \"<reason>\"` returns to the preceding autonomous step\n- `lf ask release {ask_id} \"<reason>\"` leaves the node waiting\nA final response, clean exit, Ctrl-D, or window close never advances the flow.\n</lf:human-flow-node>"
+        "{input}\n\n<lf:human-flow-node>\nThis `{skill}` run is the actual writable Task step at human node `{node_id}`, not an advisory review. Settle explicitly before leaving:\n- `lf ask resolve {ask_id} \"<concise verified summary>\"` accepts the step\n- `lf ask decline {ask_id} \"<reason>\"` returns to the preceding autonomous step\n- `lf ask release {ask_id} \"<reason>\"` leaves the node waiting\nA final response, clean exit, Ctrl-D, or window close never advances the flow.\n</lf:human-flow-node>"
     )
 }
 
@@ -2304,7 +2295,7 @@ mod shipping_lifecycle_tests;
 #[cfg(test)]
 mod planning_tests {
     use super::{
-        completed_boundary_failure, execution_blocker_at_handoff, human_flow_ask_prompt,
+        completed_boundary_failure, execution_blocker_at_handoff, human_flow_settlement,
         preceding_autonomous_step, sync_task_state, task_seed, unhandled_failure_receipt,
     };
     use crate::chat::types::Lifecycle;
@@ -2514,18 +2505,17 @@ mod planning_tests {
     }
 
     #[test]
-    fn human_flow_settlement_contract_follows_the_authored_skill_handoff() {
-        let prompt = human_flow_ask_prompt(
-            "$review-design\n\n<lf:surface>human present</lf:surface>",
+    fn human_flow_settlement_wraps_the_skill_input() {
+        let prompt = human_flow_settlement(
+            "the real review-design harness input",
             "review-design",
             "review_kickoff",
             &AskId::parse("ask_00000000000000000000000000000001").unwrap(),
-            &AskTarget::User,
         );
 
-        assert!(prompt.starts_with("$review-design\n"));
+        // The skill's own input is preserved verbatim; only settlement is appended.
+        assert!(prompt.starts_with("the real review-design harness input"));
         assert!(prompt.contains("<lf:human-flow-node>"));
-        assert!(prompt.contains("Reviewer mode: Human reviewer"));
         assert!(prompt.contains("lf ask resolve ask_00000000000000000000000000000001"));
         assert!(prompt.contains("lf ask decline ask_00000000000000000000000000000001"));
         assert!(prompt.contains("lf ask release ask_00000000000000000000000000000001"));
@@ -3124,10 +3114,13 @@ mod planning_tests {
             AskBody::FlowStep { node_id, skill, .. }
                 if node_id == "review_kickoff" && skill == "review-design"
         ));
-        let prompt = super::flow_step_ask_prompt(&store, &queued[0])
+        let turn = super::flow_step_harness_turn(&store, &queued[0])
             .await
             .unwrap();
-        assert!(prompt.contains("Reviewer mode: Human reviewer"));
+        // The session runs the skill's real harness turn; only the settlement
+        // contract is appended — no generic-agent reviewer-mode injection.
+        assert!(turn.input.contains("<lf:human-flow-node>"));
+        assert!(turn.input.contains("lf ask resolve"));
         assert!(store
             .invocations_for_run(&lease.run_id)
             .await


### PR DESCRIPTION
Linear Task: [LOO-252](https://linear.app/loopflow/issue/LOO-252/run-the-skill-as-a-command-in-human-gate-ask-sessions-not-an-inlined)

## Usage

```bash
lf task run INF-123 --first task-design

# Inside the review-design gate:
lf ask resolve <ask-id> "design matches intent"
```

## Summary

Human flow gates now launch the gated skill through the same harness as `lf <skill>`, preserving its system prompt, context, configuration, and writable Task authority. This removes the generic-agent layer that could treat a human review as an ordinary prompt and self-approve it.

Intervention asks remain detached, free-text conversations. Both paths continue to use the durable Ask session and require explicit resolution, decline, or release.

## Changes

- Dispatch `FlowStep` and `Intervention` asks through separate launch paths
- Prepare flow gates from the skill’s real interactive harness turn
- Append only the flow settlement contract to the skill input
- Keep intervention providers detached from originating Work
- Update behavioral coverage for harness-backed flow gates