### PR TITLE
Main agents move off canonical main into a worktree — agents: isolate default and wave sessions in worktrees

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,10 @@ cargo install --git https://github.com/loopflowstudio/loopflow --bin lf
 
 The Mac app — wave chat, the machine-wide roadmap, every task's worktree — is
 [`Loopflow-latest.dmg`](https://downloads.loopflow.studio/Loopflow-latest.dmg).
-It bundles `lf`; open it explicitly with `lf desktop`. Bare `lf` starts the terminal control conversation.
+It bundles `lf`; open it explicitly with `lf desktop`. Bare `lf` starts the
+terminal control conversation. On canonical main, it first carries local
+commits and uncommitted files into an author-scoped sibling worktree so the
+conversation cannot dirty main.
 
 Give an external agent harness the Loopflow operating skill:
 

--- a/STYLE.md
+++ b/STYLE.md
@@ -168,6 +168,14 @@ Every line of code must earn its place. Readable code is not terse code; don't s
 
 Start with minimal data structures and APIs. If the core is right, trimming excess at the edges is straightforward.
 
+## Flexibility
+
+Meet the caller where they are. When code breaks because it assumed a fixed context—running on `main`, an un-owned worktree, an ambient home—accept the context and adapt to it. Resolve the right thing automatically; don't add a guard, a verification, an allowlist, or a precondition that refuses.
+
+Rigidity is usually what caused the failure: refuse the context, and someone works around the refusal and corrupts state. Flexibility deletes the whole failure class. Every guard is one more thing to remember and one more thing that can drift across hand-mirrored layers.
+
+The instinct on a bug is often a new check. Invert it: can the system adapt instead? Prefer dropping a precondition to adding one. If a fix reads as "extend the allowlist," "verify identity," or "add scaffolding," reframe it as a reduction before shipping. The best fix makes the system smaller and gets in our own way less.
+
 ## Wave Planning
 
 Use three planning nouns, and keep them distinct by kind rather than size:

--- a/rust/loopflow/src/bin/lf.rs
+++ b/rust/loopflow/src/bin/lf.rs
@@ -478,6 +478,23 @@ fn in_repo_runtime<T>(
     with_runtime(&repo_root, command, || run(&repo_root))
 }
 
+fn run_default_agent(cli: &Cli, command: &[String]) -> anyhow::Result<()> {
+    let repo_root = loopflow::lf::commands::util::find_repo_root()?;
+    let moved = loopflow::engine::worktrees::move_default_agent_to_worktree(&repo_root)?;
+    match moved {
+        Some(worktree) => {
+            eprintln!("moved to `{}`", worktree.path.display());
+            let _cwd = CwdGuard::enter(&worktree.path)?;
+            with_runtime(&worktree.path, command, || {
+                loopflow::lf::commands::run::run(Some("loopflow"), None, cli)
+            })
+        }
+        None => with_runtime(&repo_root, command, || {
+            loopflow::lf::commands::run::run(Some("loopflow"), None, cli)
+        }),
+    }
+}
+
 fn run_work_runner_entrypoint<T>(
     command: &[String],
     kind: &str,
@@ -1789,9 +1806,7 @@ fn main() -> anyhow::Result<()> {
                     Err(err) => Err(err),
                 }
             }
-            None => in_repo_runtime(&args, |_| {
-                loopflow::lf::commands::run::run(Some("loopflow"), None, &cli)
-            }),
+            None => run_default_agent(&cli, &args),
         }
     };
 
@@ -1841,6 +1856,18 @@ mod tests {
             created_at: now,
             updated_at: now,
         }
+    }
+
+    #[test]
+    fn only_bare_lf_selects_the_default_agent_surface() {
+        let bare = Cli::try_parse_from(["lf"]).unwrap();
+        assert!(bare.command.is_none());
+
+        let code = Cli::try_parse_from(["lf", "code"]).unwrap();
+        assert!(matches!(
+            code.command,
+            Some(Commands::External(parts)) if parts == ["code"]
+        ));
     }
 
     /// A healthy linkage says nothing: silence on the happy path keeps the status

--- a/rust/loopflow/src/engine/git.rs
+++ b/rust/loopflow/src/engine/git.rs
@@ -131,6 +131,11 @@ pub fn fetch(repo: &Path, remote: &str, refspec: &str) -> Result<(), GitError> {
     Ok(())
 }
 
+pub(crate) fn has_origin(repo: &Path) -> Result<bool, GitError> {
+    let output = run_git(repo, &["config", "--get", "remote.origin.url"])?;
+    Ok(output.status.success() && !String::from_utf8_lossy(&output.stdout).trim().is_empty())
+}
+
 /// Check if `commit` is an ancestor of `descendant`.
 /// Returns true if commit is fully merged into descendant.
 pub fn is_ancestor(repo: &Path, commit: &str, descendant: &str) -> Result<bool, GitError> {

--- a/rust/loopflow/src/engine/wave_context.rs
+++ b/rust/loopflow/src/engine/wave_context.rs
@@ -350,8 +350,18 @@ pub fn wave_origin(repo_root: &Path) -> PathBuf {
 /// The Wave's prompt memory, read directly from applicable `MEMORY.md` files.
 pub fn gather_wave_memory(repo_root: &Path, wave: &str) -> Option<String> {
     let origin = wave_origin(repo_root);
-    let chain = memory_wave_chain(&origin, wave).unwrap_or_else(|| vec![wave.to_string()]);
-    gather_memory_chain(&origin, &chain)
+    gather_wave_memory_from(&origin, &origin, wave)
+}
+
+/// Resolve inherited Wave scope from the canonical registry while reading the
+/// mutable memory files from the resident's execution checkout.
+pub(crate) fn gather_wave_memory_from(
+    origin: &Path,
+    content_repo: &Path,
+    wave: &str,
+) -> Option<String> {
+    let chain = memory_wave_chain(origin, wave).unwrap_or_else(|| vec![wave.to_string()]);
+    gather_memory_chain(content_repo, &chain)
 }
 
 /// Resolve lexical memory scope through the registry.

--- a/rust/loopflow/src/engine/worktrees.rs
+++ b/rust/loopflow/src/engine/worktrees.rs
@@ -1,7 +1,8 @@
 use crate::engine::error::GitError;
 use crate::engine::git::{
-    delete_local_branch, get_default_branch, has_commits_beyond, is_ancestor, is_clean,
-    is_squash_merged, rev_parse, sync_main, worktree_add, worktree_remove, WorktreeBranch,
+    current_branch, delete_local_branch, fetch, get_default_branch, has_commits_beyond, has_origin,
+    is_ancestor, is_clean, is_squash_merged, rev_parse, stash_including_untracked, stash_pop,
+    sync_main, worktree_add, worktree_remove, WorktreeBranch,
 };
 use crate::engine::identity::WorktreeName;
 use crate::engine::naming::git_user;
@@ -161,6 +162,13 @@ pub struct CreateWorktreeResult {
     pub base_commit: Option<String>,
 }
 
+/// One main agent's isolated execution checkout.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AgentWorktree {
+    pub path: PathBuf,
+    pub branch: String,
+}
+
 pub fn git_common_dir(repo: &Path) -> Result<PathBuf, GitError> {
     let output = Command::new("git")
         .arg("-C")
@@ -244,6 +252,19 @@ fn short_hash(value: &str, chars: usize) -> String {
     let mut hash = hex::encode(digest);
     hash.truncate(chars);
     hash
+}
+
+/// Stable flat placement name for a Wave resident. Nested locators keep a
+/// readable prefix and a hash of the complete slug so sanitization cannot
+/// collapse distinct Waves onto one checkout.
+pub fn wave_agent_segment(wave: &str) -> Result<WorktreeSegment, PlacementError> {
+    let readable = crate::engine::naming::sanitize_for_branch(wave).replace('.', "-");
+    let name = if wave.contains('/') {
+        format!("wave-{readable}-{}", short_hash(wave, 8))
+    } else {
+        format!("wave-{readable}")
+    };
+    WorktreeSegment::parse(&name)
 }
 
 /// Extract the suffix from a named sibling worktree directory.
@@ -1152,6 +1173,230 @@ pub fn create_from_placement_plan(
     }
 }
 
+/// Resolve or create an author-scoped sibling worktree for a main agent.
+///
+/// New worktrees start from the fetched default branch when `origin` exists,
+/// and from the local default branch otherwise. Existing placements are
+/// reused only at their deterministic sibling path.
+pub fn ensure_agent_worktree(
+    main_repo: &Path,
+    segment: WorktreeSegment,
+) -> Result<AgentWorktree, GitError> {
+    let main_repo = canonical_default_checkout(main_repo)?;
+    let mut plan = deterministic_agent_plan(&main_repo, segment)?;
+    if plan.strategy == PlacementStrategy::Create {
+        plan.base_ref = agent_base_ref(&main_repo, true)?;
+    }
+    create_agent_worktree(&main_repo, &plan)
+}
+
+pub(crate) fn existing_agent_worktree(
+    main_repo: &Path,
+    segment: WorktreeSegment,
+) -> Result<Option<AgentWorktree>, GitError> {
+    let plan = deterministic_agent_plan(main_repo, segment)?;
+    match plan.strategy {
+        PlacementStrategy::UseExistingWorktree => Ok(Some(AgentWorktree {
+            path: plan.worktree_path,
+            branch: plan.branch,
+        })),
+        PlacementStrategy::Create | PlacementStrategy::CheckoutExisting => Ok(None),
+    }
+}
+
+/// Move a bare/default `lf` session off canonical main while preserving both
+/// local commits and uncommitted files. A deliberate non-default checkout and
+/// an existing linked worktree are left alone.
+pub fn move_default_agent_to_worktree(repo: &Path) -> Result<Option<AgentWorktree>, GitError> {
+    let main_repo = main_repo_root(repo)?;
+    let checkout = std::fs::canonicalize(repo).unwrap_or_else(|_| repo.to_path_buf());
+    let canonical = std::fs::canonicalize(&main_repo).unwrap_or_else(|_| main_repo.clone());
+    if checkout != canonical {
+        return Ok(None);
+    }
+
+    let default_branch = get_default_branch(&main_repo)?;
+    if current_branch(&main_repo)?.as_deref() != Some(default_branch.as_str()) {
+        return Ok(None);
+    }
+
+    let base_ref = agent_base_ref(&main_repo, false)?;
+    let head = rev_parse(&main_repo, "HEAD")?;
+    let dirty = !is_clean(&main_repo)?;
+    let carries_state = dirty || has_commits_beyond(&main_repo, &default_branch, &base_ref)?;
+    let stable = WorktreeSegment::parse("agent").map_err(placement_git_error)?;
+    let expected_stable = worktree_path(&main_repo, stable.as_str());
+    let stable_plan = plan_placement(&main_repo, stable)?;
+    let stable_collision = match stable_plan.strategy {
+        PlacementStrategy::UseExistingWorktree => {
+            normalized_path(&stable_plan.worktree_path) != normalized_path(&expected_stable)
+        }
+        PlacementStrategy::Create | PlacementStrategy::CheckoutExisting => expected_stable.exists(),
+    };
+    let mut plan = if stable_collision
+        || (carries_state && stable_plan.strategy != PlacementStrategy::Create)
+    {
+        unique_agent_plan(&main_repo, &head)?
+    } else {
+        stable_plan
+    };
+    if plan.strategy == PlacementStrategy::Create {
+        plan.base_ref = if carries_state { "HEAD" } else { &base_ref }.to_string();
+    }
+
+    let stashed = stash_including_untracked(&main_repo)?;
+    let worktree = match create_agent_worktree(&main_repo, &plan) {
+        Ok(worktree) => worktree,
+        Err(error) => {
+            if stashed {
+                let _ = stash_pop(&main_repo);
+            }
+            return Err(error);
+        }
+    };
+
+    if let Err(error) = reset_checkout_to(&main_repo, &base_ref) {
+        if stashed {
+            let _ = stash_pop(&main_repo);
+        }
+        return Err(error);
+    }
+    if stashed {
+        stash_pop(&worktree.path).map_err(|error| GitError::CommandFailed {
+            command: "move default lf state".to_string(),
+            stderr: format!(
+                "canonical main is clean and the moved state remains recoverable in the latest stash, but applying it in {} failed: {error}",
+                worktree.path.display()
+            ),
+        })?;
+    }
+
+    Ok(Some(worktree))
+}
+
+fn deterministic_agent_plan(
+    main_repo: &Path,
+    segment: WorktreeSegment,
+) -> Result<PlacementPlan, GitError> {
+    let expected_path = worktree_path(main_repo, segment.as_str());
+    let plan = plan_placement(main_repo, segment)?;
+    if plan.strategy == PlacementStrategy::UseExistingWorktree
+        && normalized_path(&plan.worktree_path) != normalized_path(&expected_path)
+    {
+        return Err(GitError::CommandFailed {
+            command: "resolve agent worktree".to_string(),
+            stderr: format!(
+                "branch {} is checked out at {}, expected {}",
+                plan.branch,
+                plan.worktree_path.display(),
+                expected_path.display()
+            ),
+        });
+    }
+    if plan.strategy != PlacementStrategy::UseExistingWorktree && expected_path.exists() {
+        return Err(GitError::CommandFailed {
+            command: "resolve agent worktree".to_string(),
+            stderr: format!(
+                "expected agent worktree path is occupied: {}",
+                expected_path.display()
+            ),
+        });
+    }
+    Ok(plan)
+}
+
+fn create_agent_worktree(
+    main_repo: &Path,
+    plan: &PlacementPlan,
+) -> Result<AgentWorktree, GitError> {
+    let created = create_from_placement_plan(main_repo, plan)?;
+    Ok(AgentWorktree {
+        path: created.path,
+        branch: created.branch,
+    })
+}
+
+fn canonical_default_checkout(main_repo: &Path) -> Result<PathBuf, GitError> {
+    let main = main_repo_root(main_repo)?;
+    let main = std::fs::canonicalize(&main).unwrap_or(main);
+    let default_branch = get_default_branch(&main)?;
+    let branch = current_branch(&main)?;
+    if branch.as_deref() != Some(default_branch.as_str()) {
+        return Err(GitError::CommandFailed {
+            command: "resolve agent worktree".to_string(),
+            stderr: format!(
+                "canonical checkout is on {}, expected {default_branch}",
+                branch.as_deref().unwrap_or("detached HEAD")
+            ),
+        });
+    }
+    Ok(main)
+}
+
+fn agent_base_ref(main_repo: &Path, require_fetch: bool) -> Result<String, GitError> {
+    let default_branch = get_default_branch(main_repo)?;
+    if !has_origin(main_repo)? {
+        return Ok(default_branch);
+    }
+    match fetch(main_repo, "origin", &default_branch) {
+        Ok(()) => Ok(format!("origin/{default_branch}")),
+        Err(error) if require_fetch => Err(error),
+        Err(_) if rev_parse(main_repo, &format!("origin/{default_branch}")).is_ok() => {
+            Ok(format!("origin/{default_branch}"))
+        }
+        Err(_) => Ok(default_branch),
+    }
+}
+
+fn unique_agent_plan(repo: &Path, head: &str) -> Result<PlacementPlan, GitError> {
+    for attempt in 0_u32..100 {
+        let nonce = format!(
+            "{head}-{}-{}-{attempt}",
+            std::process::id(),
+            SystemTime::now()
+                .duration_since(SystemTime::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_nanos()
+        );
+        let name = format!("agent-{}", short_hash(&nonce, 8));
+        let segment = WorktreeSegment::parse(&name).map_err(placement_git_error)?;
+        let plan = plan_placement(repo, segment)?;
+        if plan.strategy == PlacementStrategy::Create && !plan.worktree_path.exists() {
+            return Ok(plan);
+        }
+    }
+    Err(GitError::CommandFailed {
+        command: "resolve agent worktree".to_string(),
+        stderr: "could not allocate a unique default-agent worktree".to_string(),
+    })
+}
+
+fn reset_checkout_to(repo: &Path, target: &str) -> Result<(), GitError> {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(repo)
+        .args(["reset", "--hard", target])
+        .output()?;
+    if output.status.success() {
+        return Ok(());
+    }
+    Err(GitError::CommandFailed {
+        command: format!("git reset --hard {target}"),
+        stderr: String::from_utf8_lossy(&output.stderr).to_string(),
+    })
+}
+
+fn normalized_path(path: &Path) -> PathBuf {
+    path.canonicalize().unwrap_or_else(|_| path.to_path_buf())
+}
+
+fn placement_git_error(error: PlacementError) -> GitError {
+    GitError::CommandFailed {
+        command: "resolve agent worktree".to_string(),
+        stderr: error.to_string(),
+    }
+}
+
 pub fn schedule_upstream_sync(worktree: PathBuf, branch: String) {
     thread::spawn(move || {
         // Don't block the caller on network/auth issues. Retry in the background.
@@ -1189,8 +1434,9 @@ pub fn push_branch_with_upstream(worktree: &Path, branch: &str) -> Result<(), Gi
 #[cfg(test)]
 mod tests {
     use super::{
-        abandoned_prune_reason, apply_network_enrichment, parse_pull_request_states,
-        plan_placement, prune_abandoned_prompt_logs, prune_branch_worktree, worktree_path,
+        abandoned_prune_reason, apply_network_enrichment, ensure_agent_worktree,
+        move_default_agent_to_worktree, parse_pull_request_states, plan_placement,
+        prune_abandoned_prompt_logs, prune_branch_worktree, wave_agent_segment, worktree_path,
         worktree_prune_reason, PlacementError, PlacementStrategy, PullRequestState,
         TargetedPruneOutcome, WorktreePruneReason, WorktreeSegment, WorktreeState,
     };
@@ -1219,6 +1465,43 @@ mod tests {
                 .expect("git config");
         }
         dir
+    }
+
+    fn git(repo: &Path, args: &[&str]) {
+        let output = Command::new("git")
+            .arg("-C")
+            .arg(repo)
+            .args(args)
+            .output()
+            .expect("run git");
+        assert!(
+            output.status.success(),
+            "git {}: {}",
+            args.join(" "),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    fn repo_with_origin() -> (tempfile::TempDir, std::path::PathBuf) {
+        let root = tempfile::tempdir().expect("temp root");
+        let repo = root.path().join("repo");
+        let origin = root.path().join("origin.git");
+        std::fs::create_dir_all(&repo).unwrap();
+        std::fs::create_dir_all(&origin).unwrap();
+        git(&repo, &["init", "-b", "main"]);
+        git(&repo, &["config", "user.name", "tester"]);
+        git(&repo, &["config", "user.email", "t@example.com"]);
+        std::fs::write(repo.join("tracked.txt"), "base\n").unwrap();
+        git(&repo, &["add", "."]);
+        git(&repo, &["commit", "-m", "base"]);
+        git(&origin, &["init", "--bare"]);
+        git(
+            &repo,
+            &["remote", "add", "origin", origin.to_str().unwrap()],
+        );
+        git(&repo, &["push", "-u", "origin", "main"]);
+        git(&origin, &["symbolic-ref", "HEAD", "refs/heads/main"]);
+        (root, repo)
     }
 
     #[test]
@@ -1498,5 +1781,112 @@ mod tests {
         assert_eq!(plan.branch, "tester/child");
         assert_eq!(plan.base_ref, "main");
         assert_eq!(plan.strategy, PlacementStrategy::Create);
+    }
+
+    #[test]
+    fn wave_agent_worktree_is_fetched_isolated_and_reused() {
+        let (_root, repo) = repo_with_origin();
+        std::fs::write(repo.join("upstream.txt"), "new upstream\n").unwrap();
+        git(&repo, &["add", "."]);
+        git(&repo, &["commit", "-m", "upstream"]);
+        git(&repo, &["push", "origin", "main"]);
+        git(&repo, &["reset", "--hard", "HEAD^"]);
+
+        let segment = wave_agent_segment("ship").unwrap();
+        let first = ensure_agent_worktree(&repo, segment.clone()).unwrap();
+        let second = ensure_agent_worktree(&repo, segment).unwrap();
+
+        assert_eq!(first, second);
+        assert_eq!(first.branch, "tester/wave-ship");
+        assert_eq!(
+            super::rev_parse(&first.path, "HEAD").unwrap(),
+            super::rev_parse(&repo, "origin/main").unwrap()
+        );
+        assert!(super::is_clean(&repo).unwrap());
+        assert!(!super::has_commits_beyond(&repo, "main", "origin/main").unwrap());
+    }
+
+    #[test]
+    fn wave_agent_worktree_refuses_a_branch_checked_out_elsewhere() {
+        let (root, repo) = repo_with_origin();
+        let segment = wave_agent_segment("ship").unwrap();
+        let resident = ensure_agent_worktree(&repo, segment.clone()).unwrap();
+        let displaced = root.path().join("displaced");
+        git(
+            &repo,
+            &[
+                "worktree",
+                "move",
+                resident.path.to_str().unwrap(),
+                displaced.to_str().unwrap(),
+            ],
+        );
+
+        let error =
+            ensure_agent_worktree(&repo, segment).expect_err("resident placement is deterministic");
+
+        assert!(error.to_string().contains(displaced.to_str().unwrap()));
+        assert!(error.to_string().contains("expected"));
+        assert!(super::is_clean(&repo).unwrap());
+    }
+
+    #[test]
+    fn nested_wave_segments_cannot_collapse_into_flat_slugs() {
+        let nested = wave_agent_segment("platform/security").unwrap();
+        let flat = wave_agent_segment("platform-security").unwrap();
+
+        assert_ne!(nested, flat);
+        assert!(nested.as_str().starts_with("wave-platform-security-"));
+    }
+
+    #[test]
+    fn default_agent_carries_commits_and_uncommitted_files_off_main() {
+        let (_root, repo) = repo_with_origin();
+        std::fs::write(repo.join("ahead.txt"), "committed ahead\n").unwrap();
+        git(&repo, &["add", "."]);
+        git(&repo, &["commit", "-m", "ahead"]);
+        std::fs::write(repo.join("tracked.txt"), "edited\n").unwrap();
+        std::fs::write(repo.join("untracked.txt"), "untracked\n").unwrap();
+
+        let moved = move_default_agent_to_worktree(&repo)
+            .unwrap()
+            .expect("canonical main moves");
+
+        assert!(super::is_clean(&repo).unwrap());
+        assert_eq!(
+            super::rev_parse(&repo, "HEAD").unwrap(),
+            super::rev_parse(&repo, "origin/main").unwrap()
+        );
+        assert_eq!(
+            std::fs::read_to_string(moved.path.join("tracked.txt")).unwrap(),
+            "edited\n"
+        );
+        assert_eq!(
+            std::fs::read_to_string(moved.path.join("untracked.txt")).unwrap(),
+            "untracked\n"
+        );
+        assert!(moved.path.join("ahead.txt").is_file());
+        assert!(move_default_agent_to_worktree(&moved.path)
+            .unwrap()
+            .is_none());
+    }
+
+    #[test]
+    fn default_agent_starts_from_origin_when_clean_main_is_behind() {
+        let (_root, repo) = repo_with_origin();
+        std::fs::write(repo.join("upstream.txt"), "new upstream\n").unwrap();
+        git(&repo, &["add", "."]);
+        git(&repo, &["commit", "-m", "upstream"]);
+        git(&repo, &["push", "origin", "main"]);
+        git(&repo, &["reset", "--hard", "HEAD^"]);
+
+        let moved = move_default_agent_to_worktree(&repo)
+            .unwrap()
+            .expect("canonical main moves");
+
+        let upstream = super::rev_parse(&repo, "origin/main").unwrap();
+        assert_eq!(super::rev_parse(&repo, "HEAD").unwrap(), upstream);
+        assert_eq!(super::rev_parse(&moved.path, "HEAD").unwrap(), upstream);
+        assert!(moved.path.join("upstream.txt").is_file());
     }
 }

--- a/rust/loopflow/src/flowloop/wave.rs
+++ b/rust/loopflow/src/flowloop/wave.rs
@@ -45,9 +45,10 @@
 //! there is no in-process limbo. The listener disappearing (send failure,
 //! inbox closed) ends the residency cleanly instead: `Ok(())`.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeSet, HashMap, HashSet};
 use std::ffi::OsString;
 use std::path::{Path, PathBuf};
+use std::process::Command;
 use std::str::FromStr;
 use std::sync::Arc;
 use std::time::Duration;
@@ -99,12 +100,97 @@ fn finish_capture(capture: Option<&crate::trace::CaptureHandle>, outcome: &str) 
     }
 }
 
+async fn finish_resident_skill_work(resident_repo: &Path, wave: &str, skill: &str) -> Result<()> {
+    validate_resident_changes(resident_repo, wave)?;
+    if !crate::lf::commands::flow::commit_skill_work(resident_repo, skill)? {
+        return Ok(());
+    }
+
+    let branch = crate::engine::git::current_branch(resident_repo)?
+        .unwrap_or_else(|| "detached HEAD".to_string());
+    let head = crate::engine::git::rev_parse(resident_repo, "HEAD")?;
+    let resident_repo = resident_repo.to_path_buf();
+    let retained_path = resident_repo.display().to_string();
+    let title = format!("wave/{wave}: curate resident state");
+    let body = format!("Curates the inline GOAL.md and MEMORY.md state owned by Wave `{wave}`.");
+    let options = crate::ops::LandOptions {
+        strict: true,
+        local: false,
+        create_pr: true,
+        complete: false,
+        next_slug: None,
+        worktree: None,
+        commit_message: None,
+        pr_title: Some(title),
+        pr_body: Some(body),
+        agent: None,
+    };
+    tokio::task::spawn_blocking(move || {
+        crate::lf::commands::ops::land_repo(&resident_repo, &options, &crate::ops::NullProgress)
+    })
+    .await
+    .map_err(|error| anyhow!("resident delivery task failed: {error}"))?
+    .map_err(|error| {
+        anyhow!(
+            "resident delivery failed; retained {branch} at {head} in {}: {error:#}",
+            retained_path
+        )
+    })?;
+    Ok(())
+}
+
+fn validate_resident_changes(resident_repo: &Path, wave: &str) -> Result<()> {
+    let changed = resident_changed_paths(resident_repo)?;
+    let wave_root = Path::new("wave").join(wave);
+    let allowed = BTreeSet::from([wave_root.join("GOAL.md"), wave_root.join("MEMORY.md")]);
+    let unexpected = changed
+        .difference(&allowed)
+        .map(|path| path.display().to_string())
+        .collect::<Vec<_>>();
+    if unexpected.is_empty() {
+        return Ok(());
+    }
+    anyhow::bail!(
+        "Wave resident may only curate wave/{wave}/GOAL.md and wave/{wave}/MEMORY.md; unexpected changes: {}",
+        unexpected.join(", ")
+    )
+}
+
+fn resident_changed_paths(repo: &Path) -> Result<BTreeSet<PathBuf>> {
+    let mut changed = BTreeSet::new();
+    for args in [
+        vec!["diff", "--name-only", "-z", "HEAD", "--"],
+        vec!["ls-files", "--others", "--exclude-standard", "-z"],
+    ] {
+        let output = Command::new("git")
+            .arg("-C")
+            .arg(repo)
+            .args(&args)
+            .output()?;
+        if !output.status.success() {
+            anyhow::bail!(
+                "git {} failed while validating resident changes: {}",
+                args.join(" "),
+                String::from_utf8_lossy(&output.stderr).trim()
+            );
+        }
+        changed.extend(
+            output
+                .stdout
+                .split(|byte| *byte == 0)
+                .filter(|path| !path.is_empty())
+                .map(|path| PathBuf::from(String::from_utf8_lossy(path).into_owned())),
+        );
+    }
+    Ok(changed)
+}
+
 // -- Cron: the third deadline ------------------------------------------------
 
 /// The wave's cron lines, re-read from GOAL.md frontmatter on every deadline
 /// computation — editing the file reschedules a live loop, no restart.
-fn read_crons(origin_repo: &Path, wave: &str) -> Vec<WaveCronDef> {
-    read_wave_config(origin_repo, wave)
+fn read_crons(resident_repo: &Path, wave: &str) -> Vec<WaveCronDef> {
+    read_wave_config(resident_repo, wave)
         .and_then(|config| config.crons)
         .unwrap_or_default()
 }
@@ -177,14 +263,20 @@ pub fn path_for_children() -> OsString {
 /// One pass's seed: the shared loopflow operating document (pass seeds
 /// bypass context assembly, so the `<lf:loopflow>` section is emitted here),
 /// the orchestration discipline, the rendered goal seed, and the wake that
-/// opened the pass. Reads GOAL.md and MEMORY.md from the ORIGIN repo (reads
-/// are free; writes go through the listener's doors).
+/// opened the pass. Mutable GOAL.md and MEMORY.md follow the resident writer;
+/// installed flow definitions remain canonical control-plane inputs.
 ///
 /// Order is stable → volatile so providers can prefix-cache fresh sessions:
 /// the doctrine and discipline are byte-identical every pass, the goal seed
 /// ends with rewritten-every-pass memory, and the wake is unique per pass.
-fn wave_pass_seed(origin_repo: &Path, wave: &str, wake: &str, metric_context: &str) -> String {
-    let seed = build_goal_seed(origin_repo, wave);
+fn wave_pass_seed(
+    resident_repo: &Path,
+    origin_repo: &Path,
+    wave: &str,
+    wake: &str,
+    metric_context: &str,
+) -> String {
+    let seed = build_goal_seed(resident_repo, origin_repo, wave);
     format!(
         "{}\n\n{}\n\n{seed}\n\n{metric_context}\n\n<lf:wave-executive-loop>\n1. What is most important?\n2. What signals are arriving?\n3. What works?\n4. What does not?\n5. What is the current strategy?\n6. How should strategy adjust?\n\nTreat metrics as evidence, never as automatic KR completion or a composite Wave score.\n</lf:wave-executive-loop>\n\n<wake>\n{wake}\n</wake>",
         crate::engine::prompt::loopflow_section(),
@@ -237,12 +329,14 @@ async fn wave_metric_context(
 
 /// The wave's rendered `GOAL.md` plus current memory, or a minimal-but-real
 /// fallback when there's no `GOAL.md` so the loop still has an identity.
-fn build_goal_seed(repo: &Path, wave: &str) -> String {
-    let memory = crate::engine::wave_context::gather_wave_memory(repo, wave).unwrap_or_default();
-    match load_goal(wave, repo) {
+fn build_goal_seed(resident_repo: &Path, origin_repo: &Path, wave: &str) -> String {
+    let memory =
+        crate::engine::wave_context::gather_wave_memory_from(origin_repo, resident_repo, wave)
+            .unwrap_or_default();
+    match load_goal(wave, resident_repo) {
         Ok(goal) => {
             let ctx = GoalRenderContext {
-                flows: available_flow_names(repo),
+                flows: available_flow_names(origin_repo),
                 memory,
             };
             render_goal(&goal, &ctx)
@@ -383,20 +477,31 @@ enum BodyBackend {
 pub async fn run_loop(
     client: ListenerClient,
     inbox_rx: mpsc::UnboundedReceiver<InboxItem>,
-    cwd: PathBuf,
+    resident_repo: PathBuf,
     origin_repo: PathBuf,
     wave: String,
     config: LoopConfig,
 ) -> Result<()> {
     let control = wave_control(&wave).await?;
+    let prepare_origin = origin_repo.clone();
+    let prepare_resident = resident_repo.clone();
     let backend = BodyBackend::Harness {
-        prepare: Box::new(crate::lf::commands::run::prepare_harness_turn),
+        prepare: Box::new(move |skill, message, wave, max_turns| {
+            crate::lf::commands::run::prepare_wave_harness_turn(
+                skill,
+                message,
+                wave,
+                max_turns,
+                &prepare_origin,
+                &prepare_resident,
+            )
+        }),
         create: Box::new(default_create_harness),
     };
     run_loop_with(
         client,
         inbox_rx,
-        cwd,
+        resident_repo,
         origin_repo,
         wave,
         config,
@@ -443,7 +548,7 @@ async fn wave_control(wave: &str) -> Result<Option<WaveControl>> {
 async fn run_loop_with(
     client: ListenerClient,
     mut inbox_rx: mpsc::UnboundedReceiver<InboxItem>,
-    cwd: PathBuf,
+    resident_repo: PathBuf,
     origin_repo: PathBuf,
     wave: String,
     config: LoopConfig,
@@ -455,7 +560,7 @@ async fn run_loop_with(
     });
     let mut wave_loop = WaveLoop {
         client,
-        cwd,
+        resident_repo,
         origin_repo,
         wave,
         config,
@@ -512,7 +617,7 @@ async fn run_loop_with(
 
 struct WaveLoop {
     client: ListenerClient,
-    cwd: PathBuf,
+    resident_repo: PathBuf,
     origin_repo: PathBuf,
     wave: String,
     config: LoopConfig,
@@ -545,7 +650,7 @@ impl WaveLoop {
 
     fn cron_deadline(&self) -> Option<Instant> {
         let now = Utc::now();
-        let next = read_crons(&self.origin_repo, &self.wave)
+        let next = read_crons(&self.resident_repo, &self.wave)
             .iter()
             .filter_map(|cron| {
                 next_cron_fire(
@@ -609,7 +714,7 @@ impl WaveLoop {
 
     async fn on_cron(&mut self, inbox_rx: &mut mpsc::UnboundedReceiver<InboxItem>) {
         let now = Utc::now();
-        let due: Vec<WaveCronDef> = read_crons(&self.origin_repo, &self.wave)
+        let due: Vec<WaveCronDef> = read_crons(&self.resident_repo, &self.wave)
             .into_iter()
             .filter(|cron| {
                 next_cron_fire(
@@ -694,7 +799,7 @@ impl WaveLoop {
                         containment: crate::durable::Containment::ProcessGroup {
                             id: i64::from(process_group),
                         },
-                        cwd: self.cwd.clone(),
+                        cwd: self.resident_repo.clone(),
                     },
                 )
                 .await?;
@@ -759,7 +864,13 @@ impl WaveLoop {
             let completed_index = step.index;
             let metric_context =
                 wave_metric_context(self.control.as_ref(), &self.origin_repo, &self.wave).await;
-            let seed = wave_pass_seed(&self.origin_repo, &self.wave, &wake, &metric_context);
+            let seed = wave_pass_seed(
+                &self.resident_repo,
+                &self.origin_repo,
+                &self.wave,
+                &wake,
+                &metric_context,
+            );
             let live_skill = step.kind == StepKind::Skill
                 && matches!(&self.backend, BodyBackend::Harness { .. });
             if live_skill {
@@ -793,7 +904,7 @@ impl WaveLoop {
         answers: Vec<String>,
         inbox_rx: &mut mpsc::UnboundedReceiver<InboxItem>,
     ) {
-        let body = body_provenance(&step, &self.cwd);
+        let body = body_provenance(&step, &self.resident_repo);
         let body_id = body.body_id.clone();
         self.open_body(body, answers).await;
         if self.end.is_some() {
@@ -802,10 +913,12 @@ impl WaveLoop {
 
         let child = match &self.backend {
             BodyBackend::Harness { .. } => {
-                spawn_wave_step(&self.cwd, &step, &seed, self.config.max_turns)
+                spawn_wave_step(&self.resident_repo, &step, &seed, self.config.max_turns)
             }
             #[cfg(test)]
-            BodyBackend::Process(spawn) => spawn(&self.cwd, &step, &seed, self.config.max_turns),
+            BodyBackend::Process(spawn) => {
+                spawn(&self.resident_repo, &step, &seed, self.config.max_turns)
+            }
         };
         let child = match child {
             Ok(child) => child,
@@ -879,7 +992,7 @@ impl WaveLoop {
         destination: &MessageDestination,
         inbox_rx: &mut mpsc::UnboundedReceiver<InboxItem>,
     ) {
-        let mut body = body_provenance(&step, &self.cwd);
+        let mut body = body_provenance(&step, &self.resident_repo);
         let prepared = match &self.backend {
             BodyBackend::Harness { prepare, .. } => {
                 prepare(&step.step, &seed, &self.wave, self.config.max_turns)
@@ -920,7 +1033,7 @@ impl WaveLoop {
         };
 
         let capture = match crate::journal::trace_capture_context(
-            &self.cwd,
+            &self.resident_repo,
             Some(step.flow.clone()),
             Some(step.step.clone()),
         ) {
@@ -1294,11 +1407,11 @@ impl WaveLoop {
         match status {
             Lifecycle::Completed => {
                 if let Err(err) =
-                    crate::lf::commands::flow::commit_skill_work(&self.cwd, &step.step)
+                    finish_resident_skill_work(&self.resident_repo, &self.wave, &step.step).await
                 {
                     self.finish_failed_pass(
                         body_id,
-                        &format!("failed to commit {}: {err:#}", step.step),
+                        &format!("failed to deliver {}: {err:#}", step.step),
                     )
                     .await;
                     return;
@@ -1543,6 +1656,42 @@ mod tests {
     }
 
     #[test]
+    fn resident_completion_accepts_only_its_wave_state_files() {
+        let repo = loopflow_test_support::TestRepo::new();
+        repo.create_file("wave/ship/GOAL.md", "Ship.\n");
+        repo.create_file("wave/ship/MEMORY.md", "Empty.\n");
+        repo.create_file("src/lib.rs", "// source\n");
+        repo.stage_all();
+        repo.commit("base");
+
+        repo.create_file("wave/ship/MEMORY.md", "Curated.\n");
+        validate_resident_changes(repo.path(), "ship").expect("owned memory is allowed");
+
+        repo.create_file("src/lib.rs", "// changed\n");
+        let error = validate_resident_changes(repo.path(), "ship")
+            .expect_err("source edits cannot auto-land");
+        assert!(error.to_string().contains("src/lib.rs"));
+    }
+
+    #[tokio::test]
+    async fn resident_completion_does_not_publish_an_unchanged_tree() {
+        let repo = loopflow_test_support::TestRepo::new();
+        repo.create_file("wave/ship/GOAL.md", "Ship.\n");
+        repo.stage_all();
+        repo.commit("base");
+
+        let head = crate::engine::git::rev_parse(repo.path(), "HEAD").unwrap();
+        finish_resident_skill_work(repo.path(), "ship", "assess")
+            .await
+            .unwrap();
+
+        assert_eq!(
+            crate::engine::git::rev_parse(repo.path(), "HEAD").unwrap(),
+            head
+        );
+    }
+
+    #[test]
     fn discord_chat_batches_only_the_fifo_prefix_for_one_destination() {
         let mut queue = vec![
             queued_message("discord-1", Some(discord_source("1"))),
@@ -1761,6 +1910,47 @@ mod tests {
         panic!("condition not met in time: {what}");
     }
 
+    fn init_test_git_repo(path: &Path) {
+        let status = std::process::Command::new("git")
+            .args([
+                "-c",
+                "user.name=Loopflow Test",
+                "-c",
+                "user.email=test@loopflow.dev",
+                "init",
+                "--quiet",
+            ])
+            .current_dir(path)
+            .status()
+            .expect("git init");
+        assert!(status.success());
+
+        std::fs::write(path.join(".gitignore"), ".lf/\n").expect("write gitignore");
+        let status = std::process::Command::new("git")
+            .args(["add", ".gitignore"])
+            .current_dir(path)
+            .status()
+            .expect("git add");
+        assert!(status.success());
+
+        let status = std::process::Command::new("git")
+            .args([
+                "-c",
+                "user.name=Loopflow Test",
+                "-c",
+                "user.email=test@loopflow.dev",
+                "commit",
+                "--quiet",
+                "--allow-empty",
+                "-m",
+                "initial",
+            ])
+            .current_dir(path)
+            .status()
+            .expect("git commit");
+        assert!(status.success());
+    }
+
     fn started_answers(events: &[EventKind]) -> Vec<Vec<MessageId>> {
         events
             .iter()
@@ -1908,12 +2098,7 @@ mod tests {
     #[tokio::test]
     async fn stale_wave_definition_resets_before_running_the_fresh_flow() {
         let tmp = tempfile::tempdir().expect("tempdir");
-        let status = std::process::Command::new("git")
-            .args(["init", "--quiet"])
-            .current_dir(tmp.path())
-            .status()
-            .expect("git init");
-        assert!(status.success());
+        init_test_git_repo(tmp.path());
 
         let (mut journal, _) =
             Journal::open(&journal_path(tmp.path(), "ship")).expect("open journal");
@@ -2059,12 +2244,7 @@ mod tests {
     #[tokio::test]
     async fn steer_reaches_the_live_body_and_streams_into_one_turn() {
         let tmp = tempfile::tempdir().expect("tempdir");
-        let status = std::process::Command::new("git")
-            .args(["init", "--quiet"])
-            .current_dir(tmp.path())
-            .status()
-            .expect("git init");
-        assert!(status.success());
+        init_test_git_repo(tmp.path());
 
         let inputs = Arc::new(Mutex::new(Vec::new()));
         let harness_inputs = inputs.clone();
@@ -2145,12 +2325,7 @@ mod tests {
     #[tokio::test]
     async fn unsupported_steer_waits_for_the_next_wave_boundary() {
         let tmp = tempfile::tempdir().expect("tempdir");
-        let status = std::process::Command::new("git")
-            .args(["init", "--quiet"])
-            .current_dir(tmp.path())
-            .status()
-            .expect("git init");
-        assert!(status.success());
+        init_test_git_repo(tmp.path());
 
         let inputs = Arc::new(Mutex::new(Vec::new()));
         let harness_inputs = inputs.clone();
@@ -2263,6 +2438,7 @@ mod tests {
 
         let seed = wave_pass_seed(
             tmp.path(),
+            tmp.path(),
             "ship",
             "hello from chat",
             "<lf:metric-portfolio>\n{\"metrics\":[],\"contract_issues\":[]}\n</lf:metric-portfolio>",
@@ -2285,6 +2461,41 @@ mod tests {
             LoopConfig::default().heartbeat_idle,
             Duration::from_secs(4 * 60 * 60)
         );
+    }
+
+    #[test]
+    fn wave_pass_reads_mutable_state_from_resident_and_catalog_from_origin() {
+        let origin = tempfile::tempdir().unwrap();
+        let resident = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(origin.path().join("wave/ship")).unwrap();
+        std::fs::create_dir_all(origin.path().join(".lf/flows")).unwrap();
+        std::fs::create_dir_all(resident.path().join("wave/ship")).unwrap();
+        std::fs::write(
+            origin.path().join("wave/ship/MEMORY.md"),
+            "stale canonical memory\n",
+        )
+        .unwrap();
+        std::fs::write(
+            origin.path().join(".lf/flows/canonical.yaml"),
+            "- implement\n",
+        )
+        .unwrap();
+        std::fs::write(
+            resident.path().join("wave/ship/GOAL.md"),
+            "Use the current state.\n",
+        )
+        .unwrap();
+        std::fs::write(
+            resident.path().join("wave/ship/MEMORY.md"),
+            "curated resident memory\n",
+        )
+        .unwrap();
+
+        let seed = wave_pass_seed(resident.path(), origin.path(), "ship", "continue", "");
+
+        assert!(seed.contains("curated resident memory"));
+        assert!(!seed.contains("stale canonical memory"));
+        assert!(seed.contains("canonical"));
     }
 
     #[tokio::test]

--- a/rust/loopflow/src/lf/commands/flow.rs
+++ b/rust/loopflow/src/lf/commands/flow.rs
@@ -438,14 +438,13 @@ fn run_skill_with_journal(
 }
 
 /// Commit any uncommitted changes left by the previous skill.
-pub(crate) fn commit_skill_work(repo: &Path, skill_name: &str) -> Result<()> {
+pub(crate) fn commit_skill_work(repo: &Path, skill_name: &str) -> Result<bool> {
     let options = CommitOptions {
         add: true,
         message: Some(format!("lf commit: {skill_name}")),
         ..CommitOptions::for_task(skill_name)
     };
-    commit_workflow(repo, &options, &NullProgress)?;
-    Ok(())
+    commit_workflow(repo, &options, &NullProgress).map_err(Into::into)
 }
 fn write_temp_skill(repo: &Path, name: &str, prompt: &str) -> Result<TempSkillGuard> {
     let tmp_skill_dir = repo.join(".lf/skills");

--- a/rust/loopflow/src/lf/commands/ops/mod.rs
+++ b/rust/loopflow/src/lf/commands/ops/mod.rs
@@ -420,8 +420,16 @@ fn with_rebase_retry<T>(
 
 fn land_current(options: &LandOptions, progress: &impl Progress) -> Result<()> {
     let repo_root = find_repo_root()?;
+    land_repo(&repo_root, options, progress)
+}
+
+pub(crate) fn land_repo(
+    repo_root: &Path,
+    options: &LandOptions,
+    progress: &impl Progress,
+) -> Result<()> {
     // The wave home stays put on land — no rotation, no cd.
-    with_rebase_retry(&repo_root, "land", progress, |repo, integrated| {
+    with_rebase_retry(repo_root, "land", progress, |repo, integrated| {
         if integrated {
             finish_land_after_rebase(repo, options, progress)
         } else {

--- a/rust/loopflow/src/lf/commands/run.rs
+++ b/rust/loopflow/src/lf/commands/run.rs
@@ -185,6 +185,25 @@ pub(crate) fn prepare_harness_turn(
     prepare_runner_turn(skill, message, &cli)
 }
 
+pub(crate) fn prepare_wave_harness_turn(
+    skill: &str,
+    message: &str,
+    wave: &str,
+    max_turns: Option<u32>,
+    origin_repo: &std::path::Path,
+    resident_repo: &std::path::Path,
+) -> Result<PreparedHarnessTurn> {
+    let cli = Cli {
+        batch: true,
+        wave: Some(wave.to_string()),
+        max_turns,
+        ..Cli::default()
+    };
+    let mut prepared = prepare_runner_turn_at(skill, message, &cli, origin_repo.to_path_buf())?;
+    prepared.config.cwd = Some(resident_repo.to_path_buf());
+    Ok(prepared)
+}
+
 pub(crate) fn prepare_interactive_harness_turn(
     skill: &str,
     message: &str,
@@ -199,7 +218,17 @@ pub(crate) fn prepare_interactive_harness_turn(
 }
 
 fn prepare_runner_turn(skill: &str, message: &str, cli: &Cli) -> Result<PreparedHarnessTurn> {
-    let mut built = build_prompt(Some(skill), Some(message), cli)?;
+    let repo_root = find_repo_root()?;
+    prepare_runner_turn_at(skill, message, cli, repo_root)
+}
+
+fn prepare_runner_turn_at(
+    skill: &str,
+    message: &str,
+    cli: &Cli,
+    repo_root: PathBuf,
+) -> Result<PreparedHarnessTurn> {
+    let mut built = build_prompt_at(Some(skill), Some(message), cli, repo_root)?;
     built.components.message_context = Some((
         crate::trace::ContextAssetKind::Goal,
         crate::trace::ContextScope::Step,
@@ -228,7 +257,15 @@ fn build_prompt(skill: Option<&str>, message: Option<&str>, cli: &Cli) -> Result
     let start = Instant::now();
     let repo_root = find_repo_root()?;
     debug!(elapsed_ms = start.elapsed().as_millis(), "found repo root");
+    build_prompt_at(skill, message, cli, repo_root)
+}
 
+fn build_prompt_at(
+    skill: Option<&str>,
+    message: Option<&str>,
+    cli: &Cli,
+    repo_root: PathBuf,
+) -> Result<PromptBuild> {
     let config_start = Instant::now();
     let config = load_config_or_default(Some(&repo_root));
     debug!(
@@ -962,7 +999,8 @@ pub fn split_skill_args(args: &[String]) -> Result<(String, Vec<String>)> {
 mod tests {
     use super::{
         attributed_context, is_interactive_run, is_interactive_run_with_tty,
-        should_launch_via_skill, skill_launch_seed, split_skill_args, BoundEnvironment,
+        prepare_wave_harness_turn, should_launch_via_skill, skill_launch_seed, split_skill_args,
+        BoundEnvironment,
     };
     use crate::durable::{BoundaryState, InvocationRoute, WorkRef};
     use crate::engine::prompt::{Document, DocumentSource, PromptComponents};
@@ -975,6 +1013,32 @@ mod tests {
     use crate::wave::Wave;
     use clap::Parser;
     use std::sync::Arc;
+
+    #[test]
+    fn wave_harness_loads_canonical_skill_and_executes_in_resident_worktree() {
+        let origin = loopflow_test_support::TestRepo::new();
+        origin.create_file(".lf/skills/proof.md", "canonical skill instructions");
+        origin.stage_all();
+        origin.commit("canonical skill");
+        let resident = loopflow_test_support::TestRepo::new();
+        resident.create_file(".lf/skills/proof.md", "stale resident skill instructions");
+        resident.stage_all();
+        resident.commit("stale resident skill");
+
+        let prepared = prepare_wave_harness_turn(
+            "proof",
+            "continue",
+            "ship",
+            Some(4),
+            origin.path(),
+            resident.path(),
+        )
+        .unwrap();
+
+        assert_eq!(prepared.config.cwd.as_deref(), Some(resident.path()));
+        assert!(prepared.input.contains("canonical skill instructions"));
+        assert!(!prepared.input.contains("stale resident skill instructions"));
+    }
 
     #[tokio::test]
     async fn bound_environment_exports_exact_run_identity_and_restores_ambient_values() {

--- a/rust/loopflow/src/ops/git_operation.rs
+++ b/rust/loopflow/src/ops/git_operation.rs
@@ -735,6 +735,7 @@ mod tests {
         std::env::set_var("LF_AGENT_INVOCATION_ID", "invocation_stale");
         std::env::set_var("LF_TRACE_ID", "trace_stale");
         std::env::set_var("LF_PROCESS_ID", "process_stale");
+        std::env::remove_var("LF_WORKTREE_WRITER_ID");
         let guard = prepare_agent_writer(&repo, &BTreeMap::new())
             .unwrap()
             .expect("Git repo gets a writer");

--- a/rust/loopflow/src/provider_account/lease.rs
+++ b/rust/loopflow/src/provider_account/lease.rs
@@ -1682,7 +1682,18 @@ mod tests {
     #[allow(clippy::await_holding_lock)]
     #[tokio::test]
     async fn broker_serves_a_fixed_grant_and_fails_closed_on_drop() {
+        let _lock = crate::journal::test_env_lock();
         let temp = tempdir().unwrap();
+        let _home = RestoreEnv::capture("LF_HOME");
+        let _database = RestoreEnv::capture("LF_DB_PATH");
+        let _control_home = RestoreEnv::capture("LF_CONTROL_HOME");
+        let _control_database = RestoreEnv::capture("LF_CONTROL_DB_PATH");
+        let _lease = RestoreEnv::capture(ACCOUNT_LEASE_ENV);
+        std::env::set_var("LF_HOME", temp.path());
+        std::env::remove_var("LF_DB_PATH");
+        std::env::set_var("LF_CONTROL_HOME", temp.path());
+        std::env::remove_var("LF_CONTROL_DB_PATH");
+        std::env::remove_var(ACCOUNT_LEASE_ENV);
         let store = Arc::new(
             open_store(&StorageConfig::sqlite(temp.path().join("lease.db")))
                 .await
@@ -1898,8 +1909,6 @@ mod tests {
             client.resolve(Provider::Codex, None).unwrap().account_id,
             id("primary")
         );
-        let _lock = crate::journal::test_env_lock();
-        let _restore = RestoreEnv::capture(ACCOUNT_LEASE_ENV);
         std::env::set_var(ACCOUNT_LEASE_ENV, broker.local_handle().encode().unwrap());
         let route = crate::provider_account::resolve_provider_account(Provider::Claude, None)
             .await

--- a/rust/loopflow/src/wave/README.md
+++ b/rust/loopflow/src/wave/README.md
@@ -22,11 +22,13 @@ Project and Task observations. The resident owns the pass
 scheduler and provider process. It reads the listener's inbox and returns
 ordered deltas; it never writes the journal directly.
 
-Repository mutations belong to Tasks in their own sibling worktrees.
-The Wave coordinates Projects and Tasks from the canonical checkout. Its UUID
-is stable identity; canonical checkout plus normalized name is its mutable
-locator. Two repositories may each own a Wave named `product` without sharing
-state.
+The listener keeps the canonical checkout as its journal and control plane.
+The resident runs from the long-lived sibling `<repo>.wave-<name>` worktree.
+Inline `GOAL.md` and `MEMORY.md` curation commits there and arms a normal
+CI-gated pull request; every other repository mutation still belongs to a Task
+in its own sibling worktree. The Wave UUID is stable identity; canonical
+checkout plus normalized name is its mutable locator. Two repositories may
+each own a Wave named `product` without sharing state.
 
 ## Persistence and discovery
 
@@ -86,7 +88,9 @@ Relocation preserves the UUID, PM projection, Work and Run history, Home
 placement, authored files, and journal. It moves a complete Wave chord when the
 repository changes, carries nested descendants through a rename, requires
 compatible configured PM Teams, and refuses live Work or divergent target
-files. Retry completes verified source cleanup after a crash at the commit
+files. A dirty, unpublished, or open-PR resident worktree also blocks the move;
+after merge, relocation fast-forwards canonical main before copying the authored
+Wave state. Retry completes verified source cleanup after a crash at the commit
 boundary.
 
 ## Thread

--- a/rust/loopflow/src/wave/mod.rs
+++ b/rust/loopflow/src/wave/mod.rs
@@ -12,16 +12,15 @@
 //! - supervises the resident ([`supervisor`]): process liveness, the respawn
 //!   ladder, the interrupt janitor.
 //!
-//! The resident ([`resident`]) owns the pass scheduler, runs from the clean
-//! canonical main checkout as a read-and-coordinate control plane, consumes
-//! its own wave's `/events?inbox=true` subscription, and publishes ordered
-//! turn deltas back through the resident door. The wire between them is
-//! [`wire`].
+//! The resident ([`resident`]) owns the pass scheduler, runs from a dedicated
+//! sibling worktree, consumes its own wave's `/events?inbox=true`
+//! subscription, and publishes ordered turn deltas back through the resident
+//! door. The wire between them is [`wire`].
 //!
 //! ```text
 //!   lf wave <name>                      lf __resident <name>
 //!   ┌───────────────────────┐  spawns   ┌──────────────────────────┐
-//!   │ LISTENER (origin repo)│──────────▶│ RESIDENT (clean main)    │
+//!   │ LISTENER (origin repo)│──────────▶│ RESIDENT (worktree)      │
 //!   │ pens · folds · doors  │           │ pass scheduler           │
 //!   │ observer · supervisor │◀──deltas──│ seed · queue             │
 //!   └──────────┬────────────┘           └────────────▲─────────────┘
@@ -33,8 +32,8 @@
 //! not a second product surface.
 //!
 //! Truth is the per-wave append-only [`journal`] (JSONL under `.lf/journal/
-//! waves/<name>/` in the ORIGIN repo — the listener serves from the origin
-//! and no longer creates worktrees); the in-process state
+//! waves/<name>/` in the ORIGIN repo — the listener serves from the origin,
+//! while its resident writes only in the sibling worktree); the in-process state
 //! ([`runtime::WaveRuntime`]) is a fold of it, rebuilt on boot so a restart
 //! keeps the whole conversation. The journal is listener-owned persistence;
 //! the resident never touches journal files. The only coordination files are
@@ -77,7 +76,9 @@ use secrecy::SecretString;
 
 use crate::engine::repo::find_repo_root;
 use crate::engine::wave_config::{try_read_wave_chat_config, WaveChatConfig};
-use crate::engine::worktrees::main_repo_root;
+use crate::engine::worktrees::{
+    ensure_agent_worktree, main_repo_root, wave_agent_segment, AgentWorktree,
+};
 use crate::ops::util::normalize_wave_name;
 use crate::store::{open_existing_store, SharedStore};
 use crate::wave::chat::ChatBacking;
@@ -87,6 +88,11 @@ use crate::wave::runtime::WaveRuntime;
 /// here so the spawner and the CLI cannot drift apart silently.
 pub(crate) const RESIDENT_SUBCOMMAND: &str = "__resident";
 pub(crate) const WAVE_SERVER_ENDPOINT_ENV: &str = "LF_WAVE_SERVER_ENDPOINT";
+
+pub(crate) fn resolve_resident_worktree(main_repo: &Path, wave: &str) -> Result<AgentWorktree> {
+    let segment = wave_agent_segment(wave)?;
+    ensure_agent_worktree(main_repo, segment).map_err(Into::into)
+}
 
 #[derive(Debug)]
 pub(crate) struct ListenerSignals<F> {
@@ -252,14 +258,20 @@ impl Drop for WaveRunGuard {
 fn resident_spawner(
     lf_bin: PathBuf,
     wave: String,
-    repo_root: PathBuf,
+    resident_repo: PathBuf,
     endpoint: String,
     token: String,
     resident_env: Vec<(String, String)>,
 ) -> supervisor::SpawnResident {
     Box::new(move || {
-        let mut command =
-            resident_command(&lf_bin, &wave, &repo_root, &endpoint, &token, &resident_env);
+        let mut command = resident_command(
+            &lf_bin,
+            &wave,
+            &resident_repo,
+            &endpoint,
+            &token,
+            &resident_env,
+        );
         // No kill_on_drop: shutdown stops the supervisor FIRST (so a TERM'd
         // resident's exit isn't journaled as a failure), then SIGTERMs the
         // resident by pid — its hooks stop the vendor process group. A
@@ -273,7 +285,7 @@ fn resident_spawner(
 fn resident_command(
     lf_bin: &Path,
     wave: &str,
-    repo_root: &Path,
+    resident_repo: &Path,
     endpoint: &str,
     token: &str,
     resident_env: &[(String, String)],
@@ -282,7 +294,7 @@ fn resident_command(
     command
         .arg(RESIDENT_SUBCOMMAND)
         .arg(wave)
-        .current_dir(repo_root)
+        .current_dir(resident_repo)
         .env(WAVE_SERVER_ENDPOINT_ENV, endpoint)
         .env(wire::RESIDENT_TOKEN_ENV, token)
         // The resident's children must resolve `lf` to this binary.
@@ -403,6 +415,10 @@ where
         );
     }
 
+    let resident_worktree = spawn_resident
+        .then(|| resolve_resident_worktree(&repo_root, &wave))
+        .transpose()?;
+
     // Bind before opening the journal for writing: the registry pre-flight
     // needs this boot's endpoint, and a refused start must scribble NOTHING —
     // no journal opened, no ServerStarted appended. Binding a loopback port
@@ -520,7 +536,11 @@ where
         resident_spawner(
             lf_bin,
             wave.clone(),
-            repo_root.clone(),
+            resident_worktree
+                .as_ref()
+                .expect("a spawned resident has an isolated worktree")
+                .path
+                .clone(),
             addr.to_string(),
             token.clone(),
             resident_env,
@@ -598,7 +618,11 @@ where
             .map(|(store, lease)| server::WaveRunAttach {
                 store: Arc::clone(store),
                 lease: lease.clone(),
-                cwd: repo_root.clone(),
+                cwd: resident_worktree
+                    .as_ref()
+                    .expect("a Wave Run has a spawned resident worktree")
+                    .path
+                    .clone(),
             }),
     );
     let result = axum::serve(listener, app)
@@ -692,6 +716,7 @@ mod tests {
             &[(discord::TOKEN_ENV.to_string(), "must-not-pass".to_string())],
         );
         assert_eq!(command.as_std().get_program(), "/paired/bin/lf");
+        assert_eq!(command.as_std().get_current_dir(), Some(Path::new("/tmp")));
         assert!(command
             .as_std()
             .get_envs()

--- a/rust/loopflow/src/wave/relocate.rs
+++ b/rust/loopflow/src/wave/relocate.rs
@@ -7,6 +7,11 @@ use fs2::FileExt;
 use serde::{Deserialize, Serialize};
 
 use crate::durable::WorkRef;
+use crate::engine::git::{
+    current_branch, fetch, get_default_branch, has_origin, is_ancestor, is_clean, is_squash_merged,
+    sync_main,
+};
+use crate::engine::worktrees::{existing_agent_worktree, github_repo_nwo, wave_agent_segment};
 use crate::id::WaveId;
 use crate::repository::CanonicalRepo;
 use crate::store::{Store, WaveLocatorUpdate};
@@ -370,6 +375,77 @@ async fn preflight(store: &Store, moves: &mut [PlannedWaveMove]) -> Result<()> {
             }
         }
         ensure_wave_stopped(store, planned.wave.id()).await?;
+        prepare_source_for_relocation(planned)?;
+    }
+    Ok(())
+}
+
+fn prepare_source_for_relocation(planned: &PlannedWaveMove) -> Result<()> {
+    let Ok(source_repo) = CanonicalRepo::discover(Path::new(planned.wave.repo())) else {
+        return Ok(());
+    };
+    let source_repo = source_repo.as_path();
+    let default_branch = get_default_branch(source_repo)?;
+    let branch = current_branch(source_repo)?;
+    if branch.as_deref() != Some(default_branch.as_str()) {
+        return Err(anyhow!(
+            "cannot relocate Wave {} while canonical checkout {} is on {}, expected {default_branch}",
+            planned.wave.id(),
+            source_repo.display(),
+            branch.as_deref().unwrap_or("detached HEAD")
+        ));
+    }
+    if !is_clean(source_repo)? {
+        return Err(anyhow!(
+            "cannot relocate Wave {} while canonical checkout {} is dirty",
+            planned.wave.id(),
+            source_repo.display()
+        ));
+    }
+
+    let origin_exists = has_origin(source_repo)?;
+    let merge_target = if origin_exists {
+        fetch(source_repo, "origin", &default_branch)?;
+        format!("origin/{default_branch}")
+    } else {
+        default_branch.clone()
+    };
+
+    let segment = wave_agent_segment(planned.wave.name())?;
+    if let Some(resident) = existing_agent_worktree(source_repo, segment)? {
+        if !is_clean(&resident.path)? {
+            return Err(anyhow!(
+                "cannot relocate Wave {} while resident worktree {} is dirty",
+                planned.wave.id(),
+                resident.path.display()
+            ));
+        }
+        if github_repo_nwo(source_repo).is_some()
+            && crate::ops::current_pr(&resident.path)?.is_some()
+        {
+            return Err(anyhow!(
+                "cannot relocate Wave {} while resident branch {} has an open pull request",
+                planned.wave.id(),
+                resident.branch
+            ));
+        }
+        let integrated = is_ancestor(&resident.path, &resident.branch, &merge_target)?
+            || is_squash_merged(&resident.path, &resident.branch, &merge_target)?;
+        if !integrated {
+            return Err(anyhow!(
+                "cannot relocate Wave {} while resident branch {} has changes absent from {merge_target}",
+                planned.wave.id(),
+                resident.branch
+            ));
+        }
+    }
+
+    if origin_exists && !sync_main(source_repo, &default_branch)? {
+        return Err(anyhow!(
+            "cannot fast-forward canonical checkout {} to origin/{default_branch} before relocating Wave {}",
+            source_repo.display(),
+            planned.wave.id()
+        ));
     }
     Ok(())
 }
@@ -839,12 +915,68 @@ async fn recover_committed_relocation(
 #[cfg(test)]
 mod tests {
     use super::{
-        recovery_path, relocate_wave, relocation_recovery, remove_old_paths, stage_tree,
-        write_recovery, PlannedWaveMove, RelocationPath,
+        prepare_source_for_relocation, recovery_path, relocate_wave, relocation_recovery,
+        remove_old_paths, stage_tree, write_recovery, PlannedWaveMove, RelocationPath,
     };
     use crate::id::WaveId;
     use crate::store::{open_store, StorageConfig, WaveLocatorUpdate};
     use crate::wave::{Wave, WaveLocator};
+    use std::path::{Path, PathBuf};
+    use std::process::Command;
+
+    fn git(repo: &Path, args: &[&str]) {
+        let output = Command::new("git")
+            .arg("-C")
+            .arg(repo)
+            .args(args)
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "git {}: {}",
+            args.join(" "),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    fn relocation_repo() -> (tempfile::TempDir, PathBuf, PlannedWaveMove) {
+        let root = tempfile::tempdir().unwrap();
+        let repo = root.path().join("repo");
+        let origin = root.path().join("origin.git");
+        std::fs::create_dir_all(repo.join("wave/infrastructure")).unwrap();
+        std::fs::create_dir_all(&origin).unwrap();
+        git(&repo, &["init", "-b", "main"]);
+        git(&repo, &["config", "user.name", "tester"]);
+        git(&repo, &["config", "user.email", "t@example.com"]);
+        std::fs::write(
+            repo.join("wave/infrastructure/GOAL.md"),
+            "# Infrastructure\n",
+        )
+        .unwrap();
+        std::fs::write(repo.join("wave/infrastructure/MEMORY.md"), "Initial.\n").unwrap();
+        git(&repo, &["add", "."]);
+        git(&repo, &["commit", "-m", "base"]);
+        git(&origin, &["init", "--bare"]);
+        git(
+            &repo,
+            &["remote", "add", "origin", origin.to_str().unwrap()],
+        );
+        git(&repo, &["push", "-u", "origin", "main"]);
+        git(&origin, &["symbolic-ref", "HEAD", "refs/heads/main"]);
+        let canonical = std::fs::canonicalize(&repo).unwrap();
+        let wave = Wave::new(
+            WaveId::new(),
+            "infrastructure".to_string(),
+            canonical.display().to_string(),
+        );
+        let target = WaveLocator::discover(&repo, "platform").unwrap();
+        let planned = PlannedWaveMove {
+            wave,
+            target,
+            retire_collision: None,
+        };
+        (root, repo, planned)
+    }
 
     #[test]
     fn committed_cleanup_preserves_a_source_that_changed_after_staging() {
@@ -893,6 +1025,52 @@ mod tests {
         assert_eq!(
             std::fs::read_to_string(target.join("events.jsonl")).unwrap(),
             "unrelated\n"
+        );
+    }
+
+    #[test]
+    fn relocation_waits_for_resident_state_then_syncs_the_merged_bytes() {
+        let (root, repo, planned) = relocation_repo();
+        let resident = crate::wave::resolve_resident_worktree(&repo, "infrastructure").unwrap();
+        std::fs::write(
+            resident.path.join("wave/infrastructure/MEMORY.md"),
+            "Curated.\n",
+        )
+        .unwrap();
+        git(&resident.path, &["add", "."]);
+        git(&resident.path, &["commit", "-m", "curate memory"]);
+
+        let pending = prepare_source_for_relocation(&planned)
+            .expect_err("unmerged resident state blocks relocation");
+        assert!(pending.to_string().contains("absent from origin/main"));
+
+        let integration = root.path().join("integration");
+        git(
+            root.path(),
+            &[
+                "clone",
+                repo.join("../origin.git").to_str().unwrap(),
+                integration.to_str().unwrap(),
+            ],
+        );
+        git(&integration, &["config", "user.name", "integrator"]);
+        git(&integration, &["config", "user.email", "i@example.com"]);
+        let resident_head = crate::engine::git::rev_parse(&resident.path, "HEAD").unwrap();
+        git(
+            &integration,
+            &[
+                "fetch",
+                &resident.path.display().to_string(),
+                &resident_head,
+            ],
+        );
+        git(&integration, &["cherry-pick", &resident_head]);
+        git(&integration, &["push", "origin", "main"]);
+
+        prepare_source_for_relocation(&planned).expect("merged resident state may relocate");
+        assert_eq!(
+            std::fs::read_to_string(repo.join("wave/infrastructure/MEMORY.md")).unwrap(),
+            "Curated.\n"
         );
     }
 

--- a/rust/loopflow/src/wave/resident.rs
+++ b/rust/loopflow/src/wave/resident.rs
@@ -11,9 +11,9 @@
 //!   on connect;
 //! - **output**: ordered wire deltas through the token-gated resident door.
 //!
-//! The resident runs from a clean canonical main checkout. Wave turns read and
-//! coordinate there; file-writing work must first become a Task with
-//! its own worktree.
+//! The resident runs from a dedicated sibling worktree. The canonical checkout
+//! remains the listener-owned control plane; inline Wave state curation is
+//! delivered from the resident branch through a pull request.
 //!
 //! # Lifecycle
 //! Spawned by the listener with the endpoint and
@@ -72,7 +72,7 @@ pub fn run(name: &str) -> Result<()> {
         &wave,
     )?;
 
-    let loop_cwd = wave_main_checkout(&main_repo)?;
+    let loop_cwd = crate::wave::resolve_resident_worktree(&main_repo, &wave)?.path;
     if std::env::current_dir().ok().as_deref() != Some(loop_cwd.as_path()) {
         std::env::set_current_dir(&loop_cwd)?;
     }
@@ -83,7 +83,7 @@ pub fn run(name: &str) -> Result<()> {
 
     println!(
         "lf wave · {wave} · resident · listener http://{endpoint} \
-         · control plane {}",
+         · worktree {}",
         loop_cwd.display()
     );
 
@@ -103,7 +103,7 @@ pub fn run(name: &str) -> Result<()> {
 /// listener's supervisor takes it from there).
 pub async fn drive(
     client: ListenerClient,
-    cwd: PathBuf,
+    resident_repo: PathBuf,
     origin_repo: PathBuf,
     wave: String,
     config: LoopConfig,
@@ -121,22 +121,9 @@ pub async fn drive(
     }
     let (inbox_tx, inbox_rx) = mpsc::unbounded_channel();
     let subscription = tokio::spawn(follow_inbox(client.endpoint().to_string(), inbox_tx));
-    let result = run_loop(client, inbox_rx, cwd, origin_repo, wave, config).await;
+    let result = run_loop(client, inbox_rx, resident_repo, origin_repo, wave, config).await;
     subscription.abort();
     result
-}
-
-fn wave_main_checkout(main_repo: &Path) -> Result<PathBuf> {
-    let main = std::fs::canonicalize(main_repo).unwrap_or_else(|_| main_repo.to_path_buf());
-    let default_branch = crate::engine::git::get_default_branch(&main)?;
-    let branch = crate::engine::git::current_branch(&main)?;
-    if branch.as_deref() != Some(default_branch.as_str()) {
-        bail!(
-            "cannot start Wave resident: canonical checkout is on {}, expected {default_branch}",
-            branch.as_deref().unwrap_or("detached HEAD")
-        );
-    }
-    Ok(main)
 }
 
 /// Where the listener is and how to prove we belong at its resident door:
@@ -523,21 +510,24 @@ mod tests {
     }
 
     #[test]
-    fn wave_resident_uses_main_without_claiming_its_dirty_state() {
+    fn wave_resident_reuses_its_worktree_without_claiming_dirty_main_state() {
         let repo = loopflow_test_support::TestRepo::new();
         repo.create_file(".gitignore", "**/.wave-endpoint\n**/.wave-resident-token\n");
         repo.stage_all();
         repo.commit("ignore wave discovery files");
         repo.create_file("wave/infrastructure/.wave-endpoint", "127.0.0.1:50123");
         repo.create_file("wave/infrastructure/.wave-resident-token", "test-token");
-        assert_eq!(
-            wave_main_checkout(repo.path()).expect("clean main"),
+        let first = crate::wave::resolve_resident_worktree(repo.path(), "infrastructure")
+            .expect("clean main");
+        assert_ne!(
+            first.path.canonicalize().unwrap(),
             std::fs::canonicalize(repo.path()).expect("canonical repo")
         );
         std::fs::write(repo.path().join("dirty.txt"), "dirty\n").expect("dirty main");
-        assert_eq!(
-            wave_main_checkout(repo.path()).expect("dirty main remains readable"),
-            std::fs::canonicalize(repo.path()).expect("canonical repo")
-        );
+        let second = crate::wave::resolve_resident_worktree(repo.path(), "infrastructure")
+            .expect("dirty main does not enter the resident worktree");
+        assert_eq!(first, second);
+        assert!(!second.path.join("dirty.txt").exists());
+        assert!(repo.path().join("dirty.txt").exists());
     }
 }

--- a/rust/loopflow/src/wave_host.rs
+++ b/rust/loopflow/src/wave_host.rs
@@ -487,6 +487,8 @@ pub(crate) async fn waves_for_home(
 #[cfg(test)]
 mod tests {
     use std::ffi::OsString;
+    use std::path::Path;
+    use std::process::Command;
     use std::sync::Arc;
 
     use crate::durable::{Containment, HomeId, RunAdvance, RunState, RunTrigger, WorkRef};
@@ -517,6 +519,29 @@ mod tests {
                     None => std::env::remove_var(name),
                 }
             }
+        }
+    }
+
+    fn init_test_git_repo(repo: &Path) {
+        for args in [
+            vec!["init", "-b", "main"],
+            vec!["config", "user.email", "test@example.com"],
+            vec!["config", "user.name", "Test User"],
+            vec!["add", "."],
+            vec!["commit", "-m", "initial"],
+        ] {
+            let output = Command::new("git")
+                .arg("-C")
+                .arg(repo)
+                .args(&args)
+                .output()
+                .expect("run git");
+            assert!(
+                output.status.success(),
+                "git {} failed: {}",
+                args.join(" "),
+                String::from_utf8_lossy(&output.stderr)
+            );
         }
     }
 
@@ -822,6 +847,7 @@ mod tests {
             ),
         )
         .expect("write Wave goal");
+        init_test_git_repo(&repo);
         let locator = WaveLocator::discover(&repo, "product").expect("discover Wave locator");
         let wave = Wave::new(
             WaveId::new(),

--- a/rust/loopflow/tests/wave_repository_ownership.rs
+++ b/rust/loopflow/tests/wave_repository_ownership.rs
@@ -23,12 +23,30 @@ use time::OffsetDateTime;
 
 fn repository(path: &Path) {
     std::fs::create_dir_all(path).unwrap();
+    git(path, &["init", "-b", "main"]);
+    git(path, &["config", "user.email", "test@example.com"]);
+    git(path, &["config", "user.name", "Test User"]);
+    std::fs::write(path.join(".gitignore"), ".lf/\n").unwrap();
+    commit(path, "initial");
+}
+
+fn git(path: &Path, args: &[&str]) {
     let output = Command::new("git")
-        .args(["init", "-b", "main"])
+        .args(args)
         .current_dir(path)
         .output()
         .unwrap();
-    assert!(output.status.success());
+    assert!(
+        output.status.success(),
+        "git {} failed: {}",
+        args.join(" "),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn commit(repo: &Path, message: &str) {
+    git(repo, &["add", "."]);
+    git(repo, &["commit", "-m", message]);
 }
 
 fn author_wave(repo: &Path, slug: &str, marker: &str) {
@@ -38,6 +56,7 @@ fn author_wave(repo: &Path, slug: &str, marker: &str) {
     let journal = journal::journal_path(repo, slug);
     std::fs::create_dir_all(journal.parent().unwrap()).unwrap();
     std::fs::write(journal, format!("{{\"repository\":\"{marker}\"}}\n")).unwrap();
+    commit(repo, &format!("author {slug}"));
 }
 
 fn registered_wave(repo: &Path, slug: &str) -> Wave {
@@ -555,6 +574,7 @@ async fn repositories_own_same_named_waves_and_relocation_preserves_identity() {
     assert!(repo_a.join("wave/infrastructure").is_dir());
     std::fs::remove_dir_all(repo_a.join("wave/platform")).unwrap();
     std::fs::remove_dir_all(repo_a.join(".lf/journal/waves/platform")).unwrap();
+    commit(&repo_a, "remove divergent target");
 
     rusqlite::Connection::open(&database)
         .unwrap()
@@ -574,6 +594,7 @@ async fn repositories_own_same_named_waves_and_relocation_preserves_identity() {
     );
     assert!(repo_a.join("wave/infrastructure").is_dir());
     assert!(repo_a.join("wave/platform").is_dir());
+    commit(&repo_a, "record staged relocation");
     rusqlite::Connection::open(&database)
         .unwrap()
         .execute_batch("DROP TRIGGER fail_wave_relocation")
@@ -614,6 +635,7 @@ async fn repositories_own_same_named_waves_and_relocation_preserves_identity() {
             .id(),
         beta.id()
     );
+    commit(&repo_a, "record Wave rename");
 
     relocate_wave(&store, alpha.id(), &repo_a, Some(&repo_c), None)
         .await
@@ -798,6 +820,7 @@ async fn relocation_retires_an_empty_destination_shadow_without_losing_identity(
             .await
             .unwrap();
         assert_eq!(receipt.wave_id, established.id().as_str());
+        commit(&source, &format!("relocate {}", established.name()));
 
         let active = store
             .get_wave_at(&WaveLocator::discover(&target, established.name()).unwrap())


### PR DESCRIPTION
Linear Task: [LOO-253](https://linear.app/loopflow/issue/LOO-253/main-agents-move-off-canonical-main-into-a-worktree)

## Usage

```bash
# From the canonical default branch
lf
lf wave product
git worktree list
```

Bare `lf` reports the sibling worktree it moved into. Wave residents run from a stable `<repo>.wave-product` worktree, while canonical main remains clean.

## Summary

Moves default terminal agents and long-running Wave residents out of the canonical checkout. This prevents agent activity from dirtying the shared control plane while preserving existing local commits, tracked edits, and untracked files instead of refusing the session or discarding work.

## Changes

- Carries canonical-main state into an author-scoped agent worktree and resets main to the fetched default branch; deliberate non-default checkouts and existing linked worktrees remain unchanged
- Gives each Wave resident a deterministic sibling worktree, with collision-safe names for nested Waves
- Loads canonical skills and flow definitions while reading mutable `GOAL.md`, `MEMORY.md`, and cron state from the resident checkout
- Restricts inline resident writes to the Wave's own goal and memory, then commits them and opens a strict CI-gated pull request
- Blocks Wave relocation while resident changes are dirty, unpublished, or under an open PR, and syncs merged state back to canonical main before moving files
- Adds behavioral coverage and updates the repository and Wave ownership documentation