### PR TITLE
Make Task gate approval the sole human shipping decision — task: make the finally gate the sole shipping decision

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -147,10 +147,13 @@ contracts, evidence loops, Wave goals, and directions.
 ```bash
 lf pr publish   # push + create or update PR (no browser)
 lf pr open      # publish, then open the PR for review
-lf pr submit    # prepare the exact head; you click merge
+lf pr submit    # non-Task PR: prepare the exact head; you click merge
 lf pr arm       # arm exact-head auto-merge and return
 lf pr land      # watch, repair CI, and return after GitHub merges
 ```
+
+A managed Task ships only with `lf pr land` — its `finally` review is the single
+shipping decision, and `submit` (a human merge click) is refused inside a Task.
 
 ---
 

--- a/docs/lf.md
+++ b/docs/lf.md
@@ -790,15 +790,17 @@ fails — the PR is already published and its URL printed.
 ### lf pr submit
 
 Prepare the exact PR head, assign it to you, and stop for your merge click.
-Nothing merges automatically.
+Nothing merges automatically. `submit` is for ordinary non-Task PRs.
 
 ```bash
 lf pr submit
 ```
 
-On Task PRs, submit records one User merge request containing the exact head
-and Continue/Complete disposition. A later Task resume or head-changing
-Loopflow operation clears it.
+A managed Task worktree **rejects `submit`** before any push: a Task already has
+exactly one shipping decision — its `finally` review — so a GitHub merge click
+would be a competing second gate. Ship a Task with `lf pr land` (`-c` to
+complete, `--next <slug>` to rotate), which arms the merge mechanically once the
+gate approves.
 
 ### lf pr arm
 

--- a/rust/loopflow/src/engine/builtins/LOOPFLOW.md
+++ b/rust/loopflow/src/engine/builtins/LOOPFLOW.md
@@ -39,14 +39,20 @@ four publish the PR headlessly and open no browser:
   Stops there: no auto-merge. Your merge click on GitHub is the one required
   gate — the button unlocks once checks pass. (GitHub blocks approving your own
   PR, so the gate is the merge click, not a review approval.) Use this as the
-  default finish for anything a person should land by hand.
+  default finish for anything a person should land by hand. **A managed Task
+  rejects `submit`:** a Task already has exactly one shipping decision — its
+  `finally` review — so a GitHub merge click would be a competing second gate.
+  Ship a Task with `lf pr land` instead.
 - **`lf pr arm`** — prepare the exact head, request auto-merge, and return. Task
   disposition is recorded but is never applied before an authoritative merge.
 - **`lf pr land`** — run the same arm step, then join the one durable watcher for
   the PR. It observes GitHub, repairs failing required checks once per failed
   head, re-arms material repairs, and returns only after merge or an actionable
-  durable block. Inside a Task, bare `land` leaves the Task open; `-c` completes
-  it after merge and `--next <slug>` rotates it after merge.
+  durable block. Inside a managed Task, `lf pr land` is the one shipping
+  declaration: its `finally` review is the sole human shipping decision, and
+  Loopflow arms the exact reviewed head after approval instead of adding a human
+  merge click. Bare `land` leaves the Task open; `-c` completes it after merge,
+  and `--next <slug>` rotates it after merge.
 
 **`lf pr open`** is the one command that *presents* — it publishes, then opens
 the PR for review (the GitHub page in the browser). It is a human-initiated

--- a/rust/loopflow/src/engine/builtins/ops/skill/pr-submit.md
+++ b/rust/loopflow/src/engine/builtins/ops/skill/pr-submit.md
@@ -10,6 +10,12 @@ Use `pr-submit` (not `pr-land`) whenever a person should land the work by hand.
 approving your own PR, so the gate is the merge click, not a review approval —
 the button unlocks once checks pass.)
 
+**Managed Tasks reject `pr-submit`.** A Task already carries exactly one
+shipping decision — its `finally` review — so a human merge click would be a
+competing second gate. Ship a Task with `pr-land` (`-c` to complete, `--next
+<slug>` to rotate); `pr-submit` is only for ordinary non-Task PRs a person
+should land by hand.
+
 ## Orientation
 
 Before starting, orient yourself in this branch:
@@ -30,12 +36,12 @@ re-derive what these already record.
 `lf pr submit` handles the entire mechanical workflow: staging uncommitted changes, rebasing, creating or updating the PR, marking it ready, and assigning it to the human who will merge. It does **not** arm auto-merge.
 
 ```
-lf pr submit [--create-pr] [--complete|-c] [--next <slug>] [-m "commit message"] [--title "..."] [--body "..."]
+lf pr submit [--create-pr] [-m "commit message"] [--title "..."] [--body "..."]
 ```
 
-Inside a Task, bare submit leaves the Task open. Use `--next <slug>` when
-another serial PR follows, or `-c` when this merge completes the Task.
-Do not combine them; a retry before merge may change the disposition.
+`pr-submit` is for ordinary non-Task PRs. Inside a managed Task worktree it
+refuses before any push and points you at `lf pr land` — the Task's one
+shipping declaration (`-c` to complete, `--next <slug>` to rotate).
 
 **Do not run git commit, git push, gh pr create, or gh pr ready directly.** `lf pr submit` does all of this. Running those commands manually skips the assignment and leaves the PR in an inconsistent state.
 

--- a/rust/loopflow/src/ops/land.rs
+++ b/rust/loopflow/src/ops/land.rs
@@ -161,6 +161,15 @@ fn prepare_pr(
     // Refuse an already-empty Task before scratch cleanup can manufacture a
     // bookkeeping-only `.gitkeep` commit or any GitHub command observes it.
     crate::ops::task::require_task_pr_range_nonempty(&repo_root)?;
+    // A managed Task ships on one judgment: its `finally` review, declared with
+    // `lf pr land`. `submit` (assign for a human merge click) would be a second
+    // gate. Refuse it now — after the shared authority/range proofs, so a
+    // contaminated or empty range still reports that deeper problem first, but
+    // before the first push, any `gh pr` mutation, or PR-copy generation. Non-
+    // Task PRs are an explicit no-op and keep `submit` unchanged.
+    if matches!(finalize, Finalize::UserMerge) {
+        crate::ops::task::reject_managed_task_submit(&repo_root)?;
+    }
     let pr_exists = if options.local {
         false
     } else {

--- a/rust/loopflow/src/ops/task.rs
+++ b/rust/loopflow/src/ops/task.rs
@@ -1599,6 +1599,28 @@ pub(crate) fn guard_task_mutation_authority(repo: &Path) -> OpsResult<()> {
     })
 }
 
+/// Refuse `lf pr submit` inside a managed Task worktree, before any mutation.
+///
+/// `submit` marks a PR ready and assigns it for a human merge click. A managed
+/// Task already carries exactly one shipping judgment — its `finally`/`ship`
+/// gate, reviewed in the provider-backed conversation and declared with
+/// `lf pr land`. A second GitHub-side merge click would be a competing gate,
+/// so it is rejected rather than layered on top. Ordinary non-Task PRs are an
+/// explicit no-op and keep `submit` unchanged.
+pub(crate) fn reject_managed_task_submit(repo: &Path) -> OpsResult<()> {
+    block_on_task(async move {
+        let TaskAuthority::Authority { task, .. } = resolve_task_authority(repo).await? else {
+            return Ok(());
+        };
+        Err(task_error(format!(
+            "`lf pr submit` would add a second shipping gate, and managed Task {} already has one: its `finally` review. \
+             Declare the reviewed outcome with `lf pr land -c` (merge completes the Task) or `lf pr land --next <slug>` (another serial PR follows); \
+             Loopflow arms the merge mechanically once required checks pass.",
+            task.plan.identifier
+        )))
+    })
+}
+
 async fn validate_automated_task_authority(
     repo: &Path,
     store: &SharedStore,

--- a/rust/loopflow/tests/land_tests.rs
+++ b/rust/loopflow/tests/land_tests.rs
@@ -881,12 +881,16 @@ fn submit_assigns_reviewer_and_skips_auto_merge() {
     assert!(!log.contains("merge --auto"));
 }
 
+/// LOO-162 — `submit` (assign for a human merge click) is a competing second
+/// shipping gate, so a managed Task rejects it before any push, gh mutation, or
+/// durable merge request. The Task's one shipping decision is its `finally`
+/// review, declared with `lf pr land`.
 #[test]
-fn submit_surfaces_ready_failure_before_assignment() {
+fn submit_refuses_a_managed_task_before_any_mutation() {
     let home = tempfile::TempDir::new().expect("temp home");
     let repo = TestRepo::new();
     let base = repo.head_sha();
-    let branch = "jack/task-ready-failure";
+    let branch = "jack/task-managed-submit";
     repo.create_branch(branch);
     repo.create_file("feature.txt", "feature");
     repo.stage_all();
@@ -918,7 +922,15 @@ fn submit_surfaces_ready_failure_before_assignment() {
         &NullProgress,
     );
 
-    assert!(matches!(result, Err(OpsError::CommandFailed { .. })));
+    match result {
+        Err(OpsError::Message(message)) => {
+            assert!(
+                message.contains("second shipping gate") && message.contains("lf pr land"),
+                "refusal must explain the competing gate and name land: {message}"
+            );
+        }
+        other => panic!("managed Task submit must refuse with a message, got: {other:?}"),
+    }
     let runtime = tokio::runtime::Runtime::new().expect("task runtime");
     let pr = runtime
         .block_on(task.store.active_task_pr(&task.task.id))
@@ -926,10 +938,14 @@ fn submit_surfaces_ready_failure_before_assignment() {
         .expect("active PR");
     assert!(
         pr.merge_request().is_none(),
-        "failed remote finalization must not leave a false settlement owner"
+        "a refused submit must not leave a settlement owner"
     );
-    let log = fs::read_to_string(&log_path).expect("read gh log");
-    assert!(log.contains("pr ready"));
+    // Refused before any gh mutation: no ready, no assignment.
+    let log = fs::read_to_string(&log_path).unwrap_or_default();
+    assert!(
+        !log.contains("pr ready"),
+        "no gh mutation before refusal: {log}"
+    );
     assert!(!log.contains("pr edit --add-assignee @me"));
 }
 
@@ -1133,36 +1149,6 @@ fn latest_land_disposition_wins_before_merge() {
             "an unchanged head needs no replacement push:\n{log}"
         );
     }
-
-    submit(
-        repo.path(),
-        &LandOptions {
-            strict: true,
-            local: false,
-            create_pr: false,
-            complete: false,
-            next_slug: None,
-            worktree: None,
-            commit_message: None,
-            pr_title: Some("test title".to_string()),
-            pr_body: Some("test body".to_string()),
-            agent: None,
-        },
-        &NullProgress,
-    )
-    .expect("replace auto merge with user merge request");
-    let submitted_head = repo.head_sha();
-
-    let pr = runtime
-        .block_on(task.store.active_task_pr(&task.task.id))
-        .expect("read active PR")
-        .expect("active PR");
-    let request = pr.merge_request().expect("user merge request");
-    assert_eq!(request.mode, PrMergeMode::User);
-    assert_eq!(request.head_sha, submitted_head);
-    let log = fs::read_to_string(&log_path).expect("read gh log");
-    assert!(log.contains("pr merge 912 --disable-auto"));
-    assert!(log.contains("pr edit --add-assignee @me"));
 }
 
 #[test]

--- a/rust/loopflow/tests/task_pr_authority_tests.rs
+++ b/rust/loopflow/tests/task_pr_authority_tests.rs
@@ -512,3 +512,98 @@ fn ordinary_pr_publishes_when_no_registry_exists() {
         "an ordinary non-Task PR must still push and publish with no registry"
     );
 }
+
+/// LOO-162 — a managed Task has exactly one shipping decision: its `finally`
+/// review, declared with `lf pr land`. `lf pr submit` (assign for a human merge
+/// click) would be a competing second gate, so it must refuse **before any push
+/// or `gh pr` mutation**, and name the land declaration as the path forward.
+#[test]
+fn managed_task_submit_refuses_before_any_push() {
+    let home = tempfile::TempDir::new().expect("temp home");
+    let repo = TestRepo::new();
+    let base = repo.head_sha();
+
+    let log_path = home.path().join("gh.log");
+    let script = gh_record_script(log_path.to_string_lossy().as_ref());
+    let _env = EnvGuard::with_lf_home(
+        &[("gh", script.as_str()), ("open", noop_open_script())],
+        home.path(),
+    );
+
+    let branch = "jack/managed-submit";
+    repo.create_branch(branch);
+    repo.create_file("task.txt", "task work\n");
+    repo.stage_all();
+    repo.commit("task commit");
+    // Deliberately NOT pushed: the refusal must precede the first push.
+
+    let _task = register_task(home.path(), repo.path(), branch, &base);
+
+    let err = submit(
+        repo.path(),
+        &land_options(true, "managed submit"),
+        &NullProgress,
+    )
+    .expect_err("managed Task submit must refuse before any push");
+    let message = err.to_string();
+    assert!(
+        message.contains("second shipping gate"),
+        "refusal must explain the competing gate, got: {message}"
+    );
+    assert!(
+        message.contains("lf pr land"),
+        "refusal must name the land declaration, got: {message}"
+    );
+
+    assert!(
+        !remote_branch_exists(&repo, branch),
+        "the branch must never reach the remote when submit is refused"
+    );
+    assert_no_gh_pr_mutation(&log_path);
+}
+
+/// The refusal is scoped to managed Tasks: an ordinary non-Task worktree still
+/// `submit`s — pushing the branch and marking the PR ready — so the LOO-162 gate
+/// does not over-block the separation-of-duties workflow for plain PRs.
+#[test]
+fn ordinary_submit_still_assigns_for_review() {
+    let home = tempfile::TempDir::new().expect("temp home");
+    let repo = TestRepo::new();
+    let base = repo.head_sha();
+
+    let log_path = home.path().join("gh.log");
+    let script = gh_record_script(log_path.to_string_lossy().as_ref());
+    let _env = EnvGuard::with_lf_home(
+        &[("gh", script.as_str()), ("open", noop_open_script())],
+        home.path(),
+    );
+
+    // A healthy registry exists, but its one Task claims a different worktree —
+    // this checkout is provably not a Task worktree, so submit is unaffected.
+    let elsewhere = tempfile::TempDir::new().expect("unrelated worktree");
+    let _unrelated = register_task(home.path(), elsewhere.path(), "jack/elsewhere", &base);
+
+    let branch = "jack/ordinary-submit";
+    repo.create_branch(branch);
+    repo.create_file("task.txt", "ordinary work\n");
+    repo.stage_all();
+    repo.commit("ordinary commit");
+    repo.push_new_branch(branch);
+
+    submit(
+        repo.path(),
+        &land_options(true, "ordinary submit"),
+        &NullProgress,
+    )
+    .expect("ordinary non-Task submit still assigns for review");
+
+    let log = fs::read_to_string(&log_path).unwrap_or_default();
+    assert!(
+        log.contains("pr edit --add-assignee @me"),
+        "ordinary submit must assign the PR for a human merge, got log:\n{log}"
+    );
+    assert!(
+        !log.contains("merge --auto"),
+        "submit must never arm auto-merge, got log:\n{log}"
+    );
+}

--- a/tests/goldens/basic.md
+++ b/tests/goldens/basic.md
@@ -40,14 +40,20 @@ four publish the PR headlessly and open no browser:
   Stops there: no auto-merge. Your merge click on GitHub is the one required
   gate — the button unlocks once checks pass. (GitHub blocks approving your own
   PR, so the gate is the merge click, not a review approval.) Use this as the
-  default finish for anything a person should land by hand.
+  default finish for anything a person should land by hand. **A managed Task
+  rejects `submit`:** a Task already has exactly one shipping decision — its
+  `finally` review — so a GitHub merge click would be a competing second gate.
+  Ship a Task with `lf pr land` instead.
 - **`lf pr arm`** — prepare the exact head, request auto-merge, and return. Task
   disposition is recorded but is never applied before an authoritative merge.
 - **`lf pr land`** — run the same arm step, then join the one durable watcher for
   the PR. It observes GitHub, repairs failing required checks once per failed
   head, re-arms material repairs, and returns only after merge or an actionable
-  durable block. Inside a Task, bare `land` leaves the Task open; `-c` completes
-  it after merge and `--next <slug>` rotates it after merge.
+  durable block. Inside a managed Task, `lf pr land` is the one shipping
+  declaration: its `finally` review is the sole human shipping decision, and
+  Loopflow arms the exact reviewed head after approval instead of adding a human
+  merge click. Bare `land` leaves the Task open; `-c` completes it after merge,
+  and `--next <slug>` rotates it after merge.
 
 **`lf pr open`** is the one command that *presents* — it publishes, then opens
 the PR for review (the GitHub page in the browser). It is a human-initiated

--- a/tests/goldens/builtin_debug.md
+++ b/tests/goldens/builtin_debug.md
@@ -40,14 +40,20 @@ four publish the PR headlessly and open no browser:
   Stops there: no auto-merge. Your merge click on GitHub is the one required
   gate — the button unlocks once checks pass. (GitHub blocks approving your own
   PR, so the gate is the merge click, not a review approval.) Use this as the
-  default finish for anything a person should land by hand.
+  default finish for anything a person should land by hand. **A managed Task
+  rejects `submit`:** a Task already has exactly one shipping decision — its
+  `finally` review — so a GitHub merge click would be a competing second gate.
+  Ship a Task with `lf pr land` instead.
 - **`lf pr arm`** — prepare the exact head, request auto-merge, and return. Task
   disposition is recorded but is never applied before an authoritative merge.
 - **`lf pr land`** — run the same arm step, then join the one durable watcher for
   the PR. It observes GitHub, repairs failing required checks once per failed
   head, re-arms material repairs, and returns only after merge or an actionable
-  durable block. Inside a Task, bare `land` leaves the Task open; `-c` completes
-  it after merge and `--next <slug>` rotates it after merge.
+  durable block. Inside a managed Task, `lf pr land` is the one shipping
+  declaration: its `finally` review is the sole human shipping decision, and
+  Loopflow arms the exact reviewed head after approval instead of adding a human
+  merge click. Bare `land` leaves the Task open; `-c` completes it after merge,
+  and `--next <slug>` rotates it after merge.
 
 **`lf pr open`** is the one command that *presents* — it publishes, then opens
 the PR for review (the GitHub page in the browser). It is a human-initiated

--- a/tests/goldens/builtin_implement.md
+++ b/tests/goldens/builtin_implement.md
@@ -40,14 +40,20 @@ four publish the PR headlessly and open no browser:
   Stops there: no auto-merge. Your merge click on GitHub is the one required
   gate — the button unlocks once checks pass. (GitHub blocks approving your own
   PR, so the gate is the merge click, not a review approval.) Use this as the
-  default finish for anything a person should land by hand.
+  default finish for anything a person should land by hand. **A managed Task
+  rejects `submit`:** a Task already has exactly one shipping decision — its
+  `finally` review — so a GitHub merge click would be a competing second gate.
+  Ship a Task with `lf pr land` instead.
 - **`lf pr arm`** — prepare the exact head, request auto-merge, and return. Task
   disposition is recorded but is never applied before an authoritative merge.
 - **`lf pr land`** — run the same arm step, then join the one durable watcher for
   the PR. It observes GitHub, repairs failing required checks once per failed
   head, re-arms material repairs, and returns only after merge or an actionable
-  durable block. Inside a Task, bare `land` leaves the Task open; `-c` completes
-  it after merge and `--next <slug>` rotates it after merge.
+  durable block. Inside a managed Task, `lf pr land` is the one shipping
+  declaration: its `finally` review is the sole human shipping decision, and
+  Loopflow arms the exact reviewed head after approval instead of adding a human
+  merge click. Bare `land` leaves the Task open; `-c` completes it after merge,
+  and `--next <slug>` rotates it after merge.
 
 **`lf pr open`** is the one command that *presents* — it publishes, then opens
 the PR for review (the GitHub page in the browser). It is a human-initiated

--- a/tests/goldens/builtin_review_slice.md
+++ b/tests/goldens/builtin_review_slice.md
@@ -40,14 +40,20 @@ four publish the PR headlessly and open no browser:
   Stops there: no auto-merge. Your merge click on GitHub is the one required
   gate — the button unlocks once checks pass. (GitHub blocks approving your own
   PR, so the gate is the merge click, not a review approval.) Use this as the
-  default finish for anything a person should land by hand.
+  default finish for anything a person should land by hand. **A managed Task
+  rejects `submit`:** a Task already has exactly one shipping decision — its
+  `finally` review — so a GitHub merge click would be a competing second gate.
+  Ship a Task with `lf pr land` instead.
 - **`lf pr arm`** — prepare the exact head, request auto-merge, and return. Task
   disposition is recorded but is never applied before an authoritative merge.
 - **`lf pr land`** — run the same arm step, then join the one durable watcher for
   the PR. It observes GitHub, repairs failing required checks once per failed
   head, re-arms material repairs, and returns only after merge or an actionable
-  durable block. Inside a Task, bare `land` leaves the Task open; `-c` completes
-  it after merge and `--next <slug>` rotates it after merge.
+  durable block. Inside a managed Task, `lf pr land` is the one shipping
+  declaration: its `finally` review is the sole human shipping decision, and
+  Loopflow arms the exact reviewed head after approval instead of adding a human
+  merge click. Bare `land` leaves the Task open; `-c` completes it after merge,
+  and `--next <slug>` rotates it after merge.
 
 **`lf pr open`** is the one command that *presents* — it publishes, then opens
 the PR for review (the GitHub page in the browser). It is a human-initiated

--- a/tests/goldens/with_direction.md
+++ b/tests/goldens/with_direction.md
@@ -40,14 +40,20 @@ four publish the PR headlessly and open no browser:
   Stops there: no auto-merge. Your merge click on GitHub is the one required
   gate — the button unlocks once checks pass. (GitHub blocks approving your own
   PR, so the gate is the merge click, not a review approval.) Use this as the
-  default finish for anything a person should land by hand.
+  default finish for anything a person should land by hand. **A managed Task
+  rejects `submit`:** a Task already has exactly one shipping decision — its
+  `finally` review — so a GitHub merge click would be a competing second gate.
+  Ship a Task with `lf pr land` instead.
 - **`lf pr arm`** — prepare the exact head, request auto-merge, and return. Task
   disposition is recorded but is never applied before an authoritative merge.
 - **`lf pr land`** — run the same arm step, then join the one durable watcher for
   the PR. It observes GitHub, repairs failing required checks once per failed
   head, re-arms material repairs, and returns only after merge or an actionable
-  durable block. Inside a Task, bare `land` leaves the Task open; `-c` completes
-  it after merge and `--next <slug>` rotates it after merge.
+  durable block. Inside a managed Task, `lf pr land` is the one shipping
+  declaration: its `finally` review is the sole human shipping decision, and
+  Loopflow arms the exact reviewed head after approval instead of adding a human
+  merge click. Bare `land` leaves the Task open; `-c` completes it after merge,
+  and `--next <slug>` rotates it after merge.
 
 **`lf pr open`** is the one command that *presents* — it publishes, then opens
 the PR for review (the GitHub page in the browser). It is a human-initiated

--- a/tests/goldens/with_docs.md
+++ b/tests/goldens/with_docs.md
@@ -40,14 +40,20 @@ four publish the PR headlessly and open no browser:
   Stops there: no auto-merge. Your merge click on GitHub is the one required
   gate — the button unlocks once checks pass. (GitHub blocks approving your own
   PR, so the gate is the merge click, not a review approval.) Use this as the
-  default finish for anything a person should land by hand.
+  default finish for anything a person should land by hand. **A managed Task
+  rejects `submit`:** a Task already has exactly one shipping decision — its
+  `finally` review — so a GitHub merge click would be a competing second gate.
+  Ship a Task with `lf pr land` instead.
 - **`lf pr arm`** — prepare the exact head, request auto-merge, and return. Task
   disposition is recorded but is never applied before an authoritative merge.
 - **`lf pr land`** — run the same arm step, then join the one durable watcher for
   the PR. It observes GitHub, repairs failing required checks once per failed
   head, re-arms material repairs, and returns only after merge or an actionable
-  durable block. Inside a Task, bare `land` leaves the Task open; `-c` completes
-  it after merge and `--next <slug>` rotates it after merge.
+  durable block. Inside a managed Task, `lf pr land` is the one shipping
+  declaration: its `finally` review is the sole human shipping decision, and
+  Loopflow arms the exact reviewed head after approval instead of adding a human
+  merge click. Bare `land` leaves the Task open; `-c` completes it after merge,
+  and `--next <slug>` rotates it after merge.
 
 **`lf pr open`** is the one command that *presents* — it publishes, then opens
 the PR for review (the GitHub page in the browser). It is a human-initiated


### PR DESCRIPTION
Linear Task: [LOO-162](https://linear.app/loopflow/issue/LOO-162/make-llm-session-checkpoints-authoritative-for-task-landing)

## Try it!

Run the behavior proofs:

```bash
cargo test -p loopflow --test land_tests submit_refuses_a_managed_task_before_any_mutation
cargo test -p loopflow --test task_pr_authority_tests managed_task_submit_refuses_before_any_push
cargo test -p loopflow --test task_pr_authority_tests ordinary_submit_still_assigns_for_review
cargo test -p loopflow --test golden_prompt
```

Managed Task submission should refuse before any push or GitHub mutation and point to `lf pr land`. Ordinary non-Task submission should still mark the PR ready and assign it for a human merge. The prompt golden is verified locally: 1 passed, 0 failed. Registry-backed integration tests require the shared promotion lock unavailable in this sandbox and are left to hosted CI.

## Intent

Make the Task `finally` review the sole human shipping decision. Managed Tasks now reject `lf pr submit`, removing the redundant GitHub merge click while preserving `submit` for ordinary PRs.

## Assumptions

The existing `finally` gate, exact-head merge pin, and durable merge request remain the shipping authority. No explicit separation-of-duties policy exists for managed Tasks today; ordinary non-Task PRs retain that workflow.

## Key decisions

- Resolve Task authority and validate the PR range first, then reject managed `submit` before the first push, any `gh pr` mutation, or PR-copy generation.
- Keep the established `lf pr land -c` and `lf pr land --next <slug>` paths unchanged.
- Update user docs, builtin operational guidance, and prompt goldens to teach one Task shipping sequence.

## Not included

This does not add a future separation-of-duties configuration or enforce finally-phase ownership for ad hoc shell invocations outside the pinned flow.