### PR TITLE
Read historical CI-incident Runs during local promotion — runs: read historical CI incident triggers

### DIFF
--- a/rust/loopflow/src/durable.rs
+++ b/rust/loopflow/src/durable.rs
@@ -74,6 +74,8 @@ pub enum DurableDataError {
     InvalidSendState(String),
     #[error("invalid run state: {0}")]
     InvalidRunState(String),
+    #[error("invalid Run trigger: {0}")]
+    InvalidRunTrigger(String),
     #[error("invalid invocation state: {0}")]
     InvalidInvocationState(String),
     #[error("invalid boundary state: {0}")]
@@ -211,6 +213,12 @@ pub enum RunTrigger {
     Child {
         work: WorkRef,
     },
+    /// Opaque evidence from a retired controller. Only ended Runs may carry it.
+    #[serde(skip_deserializing)]
+    Historical {
+        trigger_kind: String,
+        raw_json: String,
+    },
     Recovery {
         prior_run_id: RunId,
     },
@@ -219,6 +227,65 @@ pub enum RunTrigger {
         prior_run_id: Option<RunId>,
     },
     User,
+}
+
+impl RunTrigger {
+    pub fn kind(&self) -> &str {
+        match self {
+            Self::Migration => "migration",
+            Self::Input { .. } => "input",
+            Self::Time { .. } => "time",
+            Self::Event { .. } => "event",
+            Self::Child { .. } => "child",
+            Self::Historical { trigger_kind, .. } => trigger_kind,
+            Self::Recovery { .. } => "recovery",
+            Self::HomeUpgrade { .. } => "home_upgrade",
+            Self::User => "user",
+        }
+    }
+
+    pub(crate) fn parse_persisted(
+        state: RunState,
+        raw_json: &str,
+    ) -> Result<Self, DurableDataError> {
+        let value: serde_json::Value = serde_json::from_str(raw_json)
+            .map_err(|error| DurableDataError::InvalidRunTrigger(error.to_string()))?;
+        let kind = value
+            .get("kind")
+            .and_then(serde_json::Value::as_str)
+            .ok_or_else(|| {
+                DurableDataError::InvalidRunTrigger(
+                    "expected an object with a string kind".to_string(),
+                )
+            })?;
+        if Self::_is_current_kind(kind) {
+            return serde_json::from_str(raw_json)
+                .map_err(|error| DurableDataError::InvalidRunTrigger(error.to_string()));
+        }
+        if state == RunState::Ended {
+            return Ok(Self::Historical {
+                trigger_kind: kind.to_string(),
+                raw_json: raw_json.to_string(),
+            });
+        }
+        Err(DurableDataError::InvalidRunTrigger(format!(
+            "unknown kind {kind:?} on {state:?} Run"
+        )))
+    }
+
+    fn _is_current_kind(kind: &str) -> bool {
+        matches!(
+            kind,
+            "migration"
+                | "input"
+                | "time"
+                | "event"
+                | "child"
+                | "recovery"
+                | "home_upgrade"
+                | "user"
+        )
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/rust/loopflow/src/store/migrations.rs
+++ b/rust/loopflow/src/store/migrations.rs
@@ -1067,12 +1067,7 @@ pub(crate) fn validate_persisted_json(conn: &rusqlite::Connection) -> StoreResul
         "identity",
         "failure_set_json",
     )?);
-    failures.extend(validate_json_column::<crate::durable::RunTrigger>(
-        conn,
-        "runs",
-        "id",
-        "trigger_json",
-    )?);
+    failures.extend(validate_run_triggers(conn)?);
     failures.extend(validate_json_column::<crate::durable::WaitOn>(
         conn, "waits", "id", "on_json",
     )?);
@@ -1104,6 +1099,34 @@ fn validate_json_column<T: DeserializeOwned>(
         let (row_key, json) = row?;
         if let Err(error) = serde_json::from_str::<T>(&json) {
             failures.push(format!("{table}.{column} row {row_key}: {error}"));
+        }
+    }
+    Ok(failures)
+}
+
+fn validate_run_triggers(conn: &rusqlite::Connection) -> StoreResult<Vec<String>> {
+    let mut statement = conn.prepare(
+        "SELECT CAST(id AS TEXT), state, trigger_json FROM runs WHERE trigger_json IS NOT NULL",
+    )?;
+    let rows = statement.query_map([], |row| {
+        Ok((
+            row.get::<_, String>(0)?,
+            row.get::<_, String>(1)?,
+            row.get::<_, String>(2)?,
+        ))
+    })?;
+    let mut failures = Vec::new();
+    for row in rows {
+        let (run_id, state, raw_json) = row?;
+        let state = match crate::durable::RunState::parse(&state) {
+            Ok(state) => state,
+            Err(error) => {
+                failures.push(format!("runs.trigger_json row {run_id}: {error}"));
+                continue;
+            }
+        };
+        if let Err(error) = crate::durable::RunTrigger::parse_persisted(state, &raw_json) {
+            failures.push(format!("runs.trigger_json row {run_id}: {error}"));
         }
     }
     Ok(failures)
@@ -2031,6 +2054,53 @@ mod tests {
         );
 
         apply_installed_development_sqlite(&conn, &[draft]).unwrap();
+    }
+
+    #[test]
+    fn installed_development_promotion_reads_arbitrary_historical_run_triggers() {
+        let conn = open();
+        apply_sqlite(&conn).unwrap();
+        conn.execute_batch(
+            "INSERT INTO waves (id, name, repo, created_at)
+             VALUES ('wave-ci-history', 'infrastructure', '/repo', 1);
+             INSERT INTO projects (id, wave_id, external_project_id, created_at)
+             VALUES ('project-ci-history', 'wave-ci-history', 'linear-project', 2);
+             INSERT INTO tasks (
+                 id, project_id, external_issue_id, issue_identifier, created_at
+             ) VALUES (
+                 'task-ci-history', 'project-ci-history', 'linear-task', 'LOO-262', 3
+             );
+             INSERT INTO epochs (
+                 id, number, task_id, state, current_rev, created_at, terminal_at
+             ) VALUES ('epoch-ci-history', 1, 'task-ci-history', 'done', 0, 4, 6);",
+        )
+        .unwrap();
+        let raw_json =
+            r#"{ "kind":"retired_controller", "opaque":[3,{"z":true}], "note":"keep spacing" }"#;
+        conn.execute(
+            "INSERT INTO runs (
+                id, epoch_id, home_id, state, trigger_json, source_kind,
+                source_id, created_at, ended_at
+             ) VALUES (
+                'run-ci-history', 'epoch-ci-history',
+                (SELECT id FROM homes WHERE route='local'), 'ended',
+                ?1, 'task', 'task-ci-history', 5, 6
+             )",
+            [raw_json],
+        )
+        .unwrap();
+
+        apply_installed_development_sqlite(&conn, &[]).unwrap();
+
+        assert_eq!(
+            conn.query_row(
+                "SELECT trigger_json FROM runs WHERE id='run-ci-history'",
+                [],
+                |row| row.get::<_, String>(0),
+            )
+            .unwrap(),
+            raw_json
+        );
     }
 
     fn baseline() -> Migration {

--- a/rust/loopflow/src/store/sqlite/durable.rs
+++ b/rust/loopflow/src/store/sqlite/durable.rs
@@ -2622,6 +2622,11 @@ pub(super) fn reserve_run_in(
     work: &WorkRef,
     trigger: &RunTrigger,
 ) -> StoreResult<(Run, RunContext)> {
+    if let RunTrigger::Historical { trigger_kind, .. } = trigger {
+        return Err(StoreError::InvalidData(format!(
+            "historical Run trigger {trigger_kind:?} cannot reserve a new Run"
+        )));
+    }
     let epoch = current_epoch_in(tx, work)?;
     let home_id = reserving_home_in(tx, work)?;
     if let Some(run) = run_for_epoch_in(tx, &epoch.id)? {
@@ -2848,6 +2853,8 @@ fn run_by_id_in(conn: &Connection, run_id: &RunId) -> StoreResult<Run> {
         ))
     })?;
     let work = work_from_parts((row.7, row.8, row.9))?;
+    let state = RunState::parse(&row.2).map_err(invalid_durable)?;
+    let trigger = RunTrigger::parse_persisted(state, &row.3).map_err(invalid_durable)?;
     Ok(Run {
         id: run_id.clone(),
         work,
@@ -2858,8 +2865,8 @@ fn run_by_id_in(conn: &Connection, run_id: &RunId) -> StoreResult<Run> {
             .map(u64::try_from)
             .transpose()
             .map_err(|_| StoreError::InvalidData("Run has a negative runtime generation".into()))?,
-        state: RunState::parse(&row.2).map_err(invalid_durable)?,
-        trigger: serde_json::from_str(&row.3)?,
+        state,
+        trigger,
         retry_of: row
             .4
             .map(|id| RunId::parse(&id).map_err(invalid_durable))
@@ -5172,7 +5179,7 @@ mod durable_store_tests {
     use crate::durable::{
         AdvanceReceipt, Ask, AskBody, AskId, AskOrigin, AskState, AskTarget, Author, BoundaryState,
         Containment, ContainmentObservation, EpochId, HomeId, InvocationRoute, RunAdvance,
-        RunControl, RunState, RunTrigger, StopCause, WorkRef, WorkStatus,
+        RunControl, RunId, RunState, RunTrigger, StopCause, WorkRef, WorkStatus,
     };
     use crate::id::WaveId;
     use crate::project::ProjectId;
@@ -5247,6 +5254,148 @@ mod durable_store_tests {
 
     fn store_with_wave() -> (tempfile::TempDir, SqliteStore, WorkRef) {
         _store_with_wave(true)
+    }
+
+    fn _insert_run_with_trigger(
+        path: &Path,
+        work: &WorkRef,
+        state: RunState,
+        raw_json: &str,
+    ) -> RunId {
+        let conn = rusqlite::Connection::open(path).unwrap();
+        let epoch_id = conn
+            .query_row(
+                "SELECT id FROM epochs WHERE wave_id=?1 ORDER BY number DESC LIMIT 1",
+                [work.id()],
+                |row| row.get::<_, String>(0),
+            )
+            .unwrap();
+        let run_id = RunId::new();
+        let (state, containment_kind, containment_id, cwd, started_at, ended_at) = match state {
+            RunState::Reserved => ("reserved", None, None, None, None, None),
+            RunState::Active => (
+                "active",
+                Some("process_group"),
+                Some("42"),
+                Some("/repo"),
+                Some(1_700_000_010),
+                None,
+            ),
+            RunState::Stopping => (
+                "stopping",
+                Some("process_group"),
+                Some("42"),
+                Some("/repo"),
+                Some(1_700_000_010),
+                None,
+            ),
+            RunState::Ended => ("ended", None, None, None, None, Some(1_700_000_020)),
+        };
+        conn.execute(
+            "INSERT INTO runs (
+                id, epoch_id, home_id, state, trigger_json, source_kind,
+                source_id, created_at, ended_at, containment_kind,
+                containment_id, cwd, started_at
+             ) VALUES (
+                ?1, ?2, (SELECT id FROM homes WHERE route='local'), ?3,
+                ?4, 'wave', ?5, 1700000010, ?6, ?7, ?8, ?9, ?10
+             )",
+            rusqlite::params![
+                run_id.as_str(),
+                epoch_id,
+                state,
+                raw_json,
+                work.id(),
+                ended_at,
+                containment_kind,
+                containment_id,
+                cwd,
+                started_at,
+            ],
+        )
+        .unwrap();
+        run_id
+    }
+
+    #[test]
+    fn ended_run_reads_unknown_trigger_as_byte_exact_historical_evidence() {
+        let (dir, store, work) = store_with_wave();
+        let path = dir.path().join("loopflow.db");
+        let raw_json =
+            r#"{ "kind":"retired_controller", "opaque":[3,{"z":true}], "note":"keep spacing" }"#;
+        let run_id = _insert_run_with_trigger(&path, &work, RunState::Ended, raw_json);
+
+        let run = store.latest_run(&work).unwrap().unwrap();
+
+        assert_eq!(run.id, run_id);
+        assert_eq!(run.trigger.kind(), "retired_controller");
+        assert_eq!(
+            run.trigger,
+            RunTrigger::Historical {
+                trigger_kind: "retired_controller".to_string(),
+                raw_json: raw_json.to_string(),
+            }
+        );
+        let conn = rusqlite::Connection::open(path).unwrap();
+        assert_eq!(
+            conn.query_row(
+                "SELECT trigger_json FROM runs WHERE id=?1",
+                [run_id.as_str()],
+                |row| row.get::<_, String>(0),
+            )
+            .unwrap(),
+            raw_json
+        );
+    }
+
+    #[test]
+    fn nonterminal_run_rejects_the_same_unknown_trigger() {
+        let raw_json =
+            r#"{ "kind":"retired_controller", "opaque":[3,{"z":true}], "note":"keep spacing" }"#;
+
+        for state in [RunState::Reserved, RunState::Active, RunState::Stopping] {
+            let (dir, store, work) = store_with_wave();
+            let run_id =
+                _insert_run_with_trigger(&dir.path().join("loopflow.db"), &work, state, raw_json);
+
+            let error = store.run_by_id(&run_id).unwrap_err();
+
+            assert!(error
+                .to_string()
+                .contains("unknown kind \"retired_controller\""));
+            assert!(error.to_string().contains(&format!("{state:?} Run")));
+        }
+    }
+
+    #[test]
+    fn ended_run_rejects_malformed_current_trigger() {
+        let (dir, store, work) = store_with_wave();
+        let run_id = _insert_run_with_trigger(
+            &dir.path().join("loopflow.db"),
+            &work,
+            RunState::Ended,
+            r#"{"kind":"input"}"#,
+        );
+
+        let error = store.run_by_id(&run_id).unwrap_err();
+
+        assert!(error.to_string().contains("missing field `basis`"));
+    }
+
+    #[test]
+    fn historical_trigger_cannot_reserve_a_new_run() {
+        let (_dir, store, work) = store_with_wave();
+        let trigger = RunTrigger::Historical {
+            trigger_kind: "retired_controller".to_string(),
+            raw_json: r#"{"kind":"retired_controller"}"#.to_string(),
+        };
+
+        let error = store.reserve_run(&work, &trigger).unwrap_err();
+
+        assert!(error
+            .to_string()
+            .contains("historical Run trigger \"retired_controller\" cannot reserve a new Run"));
+        assert!(store.latest_run(&work).unwrap().is_none());
     }
 
     fn activate_runtime_generation(path: &Path, store: &SqliteStore) {


### PR DESCRIPTION
Linear Task: [LOO-262](https://linear.app/loopflow/issue/LOO-262/read-historical-ci-incident-runs-during-local-promotion)

## Usage

```bash
cargo test -p loopflow ended_run_reads_unknown_trigger_as_byte_exact_historical_evidence
cargo test -p loopflow installed_development_promotion_reads_arbitrary_historical_run_triggers
```

## Summary

Allows ended Runs from retired CI controllers to remain readable when their persisted trigger kind is no longer recognized. Unknown triggers are retained as opaque historical evidence with their original JSON unchanged, so development promotion and incident review can consume old Run records without weakening validation for current data.

## Changes

- Parse unknown trigger kinds as historical evidence only for ended Runs
- Preserve historical trigger JSON byte-for-byte
- Keep malformed current triggers and unknown nonterminal triggers invalid
- Validate persisted Run triggers with their Run state during migrations
- Prevent historical evidence from being used to reserve new Runs