### PR TITLE
LOO-271: Record immutable execution contracts for replay

### DIFF
--- a/docs/lf.md
+++ b/docs/lf.md
@@ -195,10 +195,15 @@ level stays there. Put `--` before literal arguments that look like flags.
 
 ## Run Mode Flags
 
+```bash
+lf --batch --replay-safe -m codex:gpt-5.6 : "Return exactly: replay contract ready"
+```
+
 | Flag | Description |
 |------|-------------|
 | `-i, --interactive` | Run interactively (can interrupt, redirect) |
 | `-b, --batch` | Run in batch/headless mode |
+| `--replay-safe` | Record a strict detached native-Codex execution contract before launch; requires an explicit `codex:<model>` and clean worktree |
 | `--max-turns N` | Cap agent turns for this invocation |
 
 ## Model Flags
@@ -632,6 +637,12 @@ revision; missing revision identity does not match the current-only filter.
 `lf trace --content` is the explicit
 reader for the exact prompt and normalized conversation at one immutable
 run/invocation/turn address.
+
+`--replay-safe` freezes native Codex model, account, runtime, clean commit,
+permissions, prompts, and environment selectors before provider launch. It
+disables sandbox network, web search, Apps, and configured MCP servers, and
+disables notifications. Lifecycle hooks are refused. A complete capture
+publishes the final replay index; partial or interrupted capture does not.
 
 `lf replay check` accepts a full AgentInvocation id or one literal,
 unambiguous prefix from `lf runs`. It reads the whole selected Home ledger,

--- a/rust/loopflow/src/engine/agent.rs
+++ b/rust/loopflow/src/engine/agent.rs
@@ -19,8 +19,16 @@ use crate::engine::error::CoreError;
 use crate::engine::platform::kill_process;
 use crate::engine::stream::{format_event, ParseResult, StreamFormat, StreamParser};
 use crate::engine::structured_reply::{render_structured_reply_guidance, StructuredReply};
-use crate::provider_account::{resolve_provider_account_blocking, RateLimitSignal};
+use crate::provider_account::{
+    resolve_provider_account_blocking, resolve_provider_account_exact_blocking,
+    ProviderAccountRoute, RateLimitSignal,
+};
 use crate::provider_auth::Provider;
+use crate::replay::{
+    AgentConfigV1, ExecutionContractV1, LocalFileIdentityV1, ProcessConfigV1, ProviderExecutionV1,
+    RepositoryExecutionV1, StructuredReplyV1, EXECUTION_CONTRACT_SCHEMA_VERSION,
+};
+use crate::store::ProviderAccountId;
 
 /// PID of the current child agent process. The Ctrl+C handler sends SIGTERM
 /// to this process before exiting so the agent doesn't survive as an orphan.
@@ -153,6 +161,8 @@ pub struct AgentConfig {
     pub directive_relay: Option<std::path::PathBuf>,
     /// Environment scoped to this provider process and its descendants.
     pub env: BTreeMap<String, String>,
+    /// Require the strict detached V1 capture boundary before provider start.
+    pub replay_safe: bool,
 }
 
 impl AgentConfig {
@@ -187,7 +197,84 @@ impl std::fmt::Debug for AgentConfig {
             .field("structured_replies", &self.structured_replies)
             .field("directive_relay", &self.directive_relay)
             .field("env_keys", &self.env.keys().collect::<Vec<_>>())
+            .field("replay_safe", &self.replay_safe)
             .finish()
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum ExecutionContractError {
+    #[error("effective Codex model is unavailable")]
+    MissingEffectiveModel,
+    #[error("native managed Codex authority is unavailable: {0}")]
+    UnsupportedAuthority(String),
+    #[error("repository execution state is unavailable: {0}")]
+    RepositoryUnavailable(String),
+    #[error("Codex runtime identity is unavailable: {0}")]
+    RuntimeUnavailable(String),
+    #[error("execution contract persistence failed: {0}")]
+    Artifact(String),
+    #[error("replay-safe policy is not satisfied: {0}")]
+    UnsafeBoundary(String),
+}
+
+#[derive(Clone)]
+pub struct PreparedAgentInvocation {
+    launch: AgentConfig,
+    process: ProcessConfig,
+    executable: PathBuf,
+    argv: Vec<String>,
+    thread_method: String,
+    thread_params: serde_json::Map<String, serde_json::Value>,
+    environment_selectors: BTreeMap<String, String>,
+    account_route: ProviderAccountRoute,
+    execution_contract: crate::replay::ArtifactReferenceV1,
+}
+
+impl std::fmt::Debug for PreparedAgentInvocation {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PreparedAgentInvocation")
+            .field("provider", &"codex")
+            .field("agent", &self.launch.agent)
+            .field("account_id", self.account_route.account_id())
+            .field("executable", &self.executable)
+            .field("argv", &self.argv)
+            .field("thread_method", &self.thread_method)
+            .field("thread_params", &self.thread_params)
+            .field("environment_selectors", &self.environment_selectors)
+            .field("execution_contract", &self.execution_contract)
+            .finish()
+    }
+}
+
+impl PreparedAgentInvocation {
+    pub fn agent_config(&self) -> &AgentConfig {
+        &self.launch
+    }
+
+    pub fn process_config(&self) -> &ProcessConfig {
+        &self.process
+    }
+
+    pub(crate) fn executable(&self) -> &Path {
+        &self.executable
+    }
+
+    pub(crate) fn argv(&self) -> &[String] {
+        &self.argv
+    }
+
+    pub(crate) fn thread_request(&self) -> (&str, &serde_json::Map<String, serde_json::Value>) {
+        (&self.thread_method, &self.thread_params)
+    }
+
+    pub(crate) fn environment_selectors(&self) -> &BTreeMap<String, String> {
+        &self.environment_selectors
+    }
+
+    pub(crate) fn account_route(&self) -> &ProviderAccountRoute {
+        &self.account_route
     }
 }
 
@@ -693,6 +780,13 @@ pub enum AgentFailure {
 pub fn build_codex_thread_start_params(
     launch: &AgentConfig,
 ) -> serde_json::Map<String, serde_json::Value> {
+    _build_codex_thread_start_params(launch, read_codex_permission_config(launch.cwd.as_deref()))
+}
+
+fn _build_codex_thread_start_params(
+    launch: &AgentConfig,
+    permission_config: CodexPermissionConfig,
+) -> serde_json::Map<String, serde_json::Value> {
     let mut params = serde_json::Map::new();
 
     params.insert(
@@ -737,14 +831,13 @@ pub fn build_codex_thread_start_params(
             serde_json::Value::String("danger-full-access".to_string()),
         );
     } else {
-        let config = read_codex_permission_config(launch.cwd.as_deref());
-        if config.sandbox < Some(CodexSandboxMode::WorkspaceWrite) {
+        if permission_config.sandbox < Some(CodexSandboxMode::WorkspaceWrite) {
             params.insert(
                 "sandbox".to_string(),
                 serde_json::Value::String("workspace-write".to_string()),
             );
         }
-        if config.approval < Some(CodexApprovalPolicy::Never) {
+        if permission_config.approval < Some(CodexApprovalPolicy::Never) {
             params.insert(
                 "approvalPolicy".to_string(),
                 serde_json::Value::String("never".to_string()),
@@ -753,6 +846,611 @@ pub fn build_codex_thread_start_params(
     }
 
     params
+}
+
+#[derive(serde::Serialize)]
+struct EffectiveCodexConfigV1<'a> {
+    schema_version: u32,
+    argv: &'a [String],
+    thread_method: &'a str,
+    thread_params: &'a serde_json::Map<String, serde_json::Value>,
+    environment_selectors: &'a BTreeMap<String, String>,
+}
+
+#[derive(Debug)]
+struct CodexConfigSnapshot {
+    model: Option<String>,
+    permissions: CodexPermissionConfig,
+    files: Vec<LocalFileIdentityV1>,
+    network_tool_overrides: Vec<String>,
+    unsupported_automation: Vec<String>,
+}
+
+pub fn prepare_agent_invocation(
+    launch: &AgentConfig,
+    process: &ProcessConfig,
+    capture: &crate::trace::CaptureHandle,
+    requested_account: Option<ProviderAccountId>,
+) -> Result<Option<PreparedAgentInvocation>, ExecutionContractError> {
+    let (harness, explicit_model) = parse_agent(launch.agent());
+    if harness != "codex" || !process.auto || launch.resume_token.is_some() {
+        if launch.replay_safe {
+            return Err(ExecutionContractError::UnsafeBoundary(
+                "replay-safe capture requires a fresh headless Codex invocation".to_string(),
+            ));
+        }
+        return Ok(None);
+    }
+    if launch.replay_safe {
+        validate_replay_safe_launch(launch, explicit_model.as_deref())?;
+    }
+
+    let route = resolve_provider_account_exact_blocking(Provider::Codex, None, requested_account)
+        .map_err(|error| ExecutionContractError::UnsupportedAuthority(error.to_string()))?;
+    let Some(route) = route.filter(ProviderAccountRoute::uses_native_home) else {
+        if launch.replay_safe {
+            return Err(ExecutionContractError::UnsupportedAuthority(
+                "a connected native managed account is required".to_string(),
+            ));
+        }
+        return Ok(None);
+    };
+    let native_home = route
+        .native_home()
+        .expect("native route carries a credential home");
+    let cwd = launch.cwd.as_deref().ok_or_else(|| {
+        ExecutionContractError::RepositoryUnavailable("working directory is missing".to_string())
+    })?;
+    let config_snapshot = read_codex_config_snapshot(native_home, cwd)?;
+    if launch.replay_safe && !config_snapshot.unsupported_automation.is_empty() {
+        return Err(ExecutionContractError::UnsafeBoundary(format!(
+            "Codex config contains unsupported automation: {}",
+            config_snapshot.unsupported_automation.join(", ")
+        )));
+    }
+    let model = explicit_model
+        .filter(|model| !model.trim().is_empty())
+        .or(config_snapshot.model.clone())
+        .ok_or(ExecutionContractError::MissingEffectiveModel)?;
+
+    let mut pinned = launch.clone();
+    pinned.agent = Some(format!("codex:{model}"));
+    let repository = repository_execution(cwd)?;
+    if pinned.replay_safe && !repository.clean {
+        return Err(ExecutionContractError::UnsafeBoundary(
+            "the launch worktree is dirty".to_string(),
+        ));
+    }
+    let executable = resolve_program("codex", pinned.env.get("PATH"))?;
+    let binary = local_file_identity(&executable)?;
+    let runtime = resolve_codex_runtime(&executable)?;
+    let mut argv = vec![executable.display().to_string()];
+    argv.extend([
+        "-c".to_string(),
+        "cli_auth_credentials_store=\"file\"".to_string(),
+    ]);
+    if pinned.replay_safe {
+        for value in replay_safe_codex_overrides(&config_snapshot) {
+            argv.extend(["-c".to_string(), value]);
+        }
+    }
+    argv.push("app-server".to_string());
+    let thread_method = "thread/start".to_string();
+    let thread_params = _build_codex_thread_start_params(&pinned, config_snapshot.permissions);
+    let environment_selectors = effective_environment_selectors(&pinned, &route)?;
+    let effective_config = serde_json::to_vec(&EffectiveCodexConfigV1 {
+        schema_version: EXECUTION_CONTRACT_SCHEMA_VERSION,
+        argv: &argv,
+        thread_method: &thread_method,
+        thread_params: &thread_params,
+        environment_selectors: &environment_selectors,
+    })
+    .map_err(|error| ExecutionContractError::Artifact(error.to_string()))?;
+    let effective_reference = capture
+        .publish_effective_config(&effective_config)
+        .map_err(|error| ExecutionContractError::Artifact(error.to_string()))?;
+    let effective_path = crate::trace::resolve_artifact(&effective_reference.path)
+        .map_err(|error| ExecutionContractError::Artifact(error.to_string()))?;
+
+    let mut config_files = vec![runtime];
+    config_files.extend(config_snapshot.files);
+    config_files.push(LocalFileIdentityV1 {
+        path: effective_path.display().to_string(),
+        sha256: effective_reference.sha256,
+    });
+
+    let home_id = crate::journal::open_ledger()
+        .and_then(|store| store.local_home())
+        .map_err(|error| ExecutionContractError::Artifact(error.to_string()))?
+        .id
+        .to_string();
+    let initial_turn = capture
+        .initial_replay_turn()
+        .map_err(|error| ExecutionContractError::Artifact(error.to_string()))?;
+    let execution = ExecutionContractV1 {
+        schema_version: EXECUTION_CONTRACT_SCHEMA_VERSION,
+        invocation_id: capture.invocation_id().to_string(),
+        home_id,
+        repository,
+        provider: ProviderExecutionV1 {
+            provider: "codex".to_string(),
+            model,
+            account_id: route.account_id().to_string(),
+            binary,
+            config_files,
+        },
+        agent: project_agent_config(&pinned),
+        process: project_process_config(process),
+        sanitized_argv: argv.clone(),
+        environment_selectors: environment_selectors.clone(),
+        initial_turn,
+    };
+    let execution_contract = capture
+        .bind_execution_contract(&execution)
+        .map_err(|error| ExecutionContractError::Artifact(error.to_string()))?;
+    Ok(Some(PreparedAgentInvocation {
+        launch: pinned,
+        process: process.clone(),
+        executable,
+        argv,
+        thread_method,
+        thread_params,
+        environment_selectors,
+        account_route: route,
+        execution_contract,
+    }))
+}
+
+fn validate_replay_safe_launch(
+    launch: &AgentConfig,
+    explicit_model: Option<&str>,
+) -> Result<(), ExecutionContractError> {
+    if explicit_model.is_none_or(|model| model.trim().is_empty()) {
+        return Err(ExecutionContractError::MissingEffectiveModel);
+    }
+    let valid = launch.run_context == AgentRunContext::Detached
+        && launch.write_scope == AgentWriteScope::Worktree
+        && launch.execution_boundary.is_none()
+        && !launch.skip_permissions
+        && launch.directive_relay.is_none();
+    if valid {
+        return Ok(());
+    }
+    Err(ExecutionContractError::UnsafeBoundary(
+        "requires detached Run context, worktree-only writes, provider permissions, and no directive relay"
+            .to_string(),
+    ))
+}
+
+fn repository_execution(cwd: &Path) -> Result<RepositoryExecutionV1, ExecutionContractError> {
+    let root = crate::repository::CanonicalRepo::discover(cwd)
+        .map_err(|error| ExecutionContractError::RepositoryUnavailable(error.to_string()))?;
+    let commit = crate::engine::git::rev_parse(cwd, "HEAD")
+        .map_err(|error| ExecutionContractError::RepositoryUnavailable(error.to_string()))?;
+    let clean = crate::engine::git::is_clean(cwd)
+        .map_err(|error| ExecutionContractError::RepositoryUnavailable(error.to_string()))?;
+    Ok(RepositoryExecutionV1 {
+        root: root.to_string(),
+        commit,
+        clean,
+    })
+}
+
+fn read_codex_config_snapshot(
+    home: &Path,
+    cwd: &Path,
+) -> Result<CodexConfigSnapshot, ExecutionContractError> {
+    _read_codex_config_snapshot(home, cwd, Some(Path::new("/etc/codex/config.toml")))
+}
+
+fn _read_codex_config_snapshot(
+    home: &Path,
+    cwd: &Path,
+    system_config: Option<&Path>,
+) -> Result<CodexConfigSnapshot, ExecutionContractError> {
+    let mut loaded = Vec::new();
+    for path in system_config
+        .into_iter()
+        .map(Path::to_path_buf)
+        .chain(std::iter::once(home.join("config.toml")))
+    {
+        if let Some(config) = read_codex_config_file(&path, false)? {
+            loaded.push(config);
+        }
+    }
+    let profile = loaded
+        .iter()
+        .filter_map(|(_, bytes)| std::str::from_utf8(bytes).ok())
+        .filter_map(|contents| top_level_toml_string(contents, "profile"))
+        .next_back();
+    if let Some(profile) = profile {
+        if profile.is_empty() || profile.contains(['/', '\\']) || profile == "." || profile == ".."
+        {
+            return Err(ExecutionContractError::RuntimeUnavailable(format!(
+                "invalid selected Codex profile {profile:?}"
+            )));
+        }
+        let path = home.join(format!("{profile}.config.toml"));
+        let config = read_codex_config_file(&path, true)?.expect("required config was read");
+        loaded.push(config);
+    }
+    for path in codex_project_config_paths(cwd) {
+        if let Some(config) = read_codex_config_file(&path, false)? {
+            loaded.push(config);
+        }
+    }
+
+    let mut model = None;
+    let mut permissions = CodexPermissionConfig::default();
+    let mut files = Vec::new();
+    let mut network_tool_overrides = Vec::new();
+    let mut unsupported_automation = Vec::new();
+    for (path, bytes) in loaded {
+        let contents = std::str::from_utf8(&bytes).map_err(|error| {
+            ExecutionContractError::RuntimeUnavailable(format!(
+                "read {} as UTF-8: {error}",
+                path.display()
+            ))
+        })?;
+        permissions =
+            merge_codex_permission_config(permissions, parse_codex_permission_config(contents));
+        let mut in_top_level = true;
+        for line in contents.lines().map(str::trim) {
+            if let Some(section) = line
+                .strip_prefix('[')
+                .and_then(|line| line.strip_suffix(']'))
+            {
+                in_top_level = false;
+                let components = split_toml_path(section.trim());
+                match components.as_slice() {
+                    [root, server, ..] if root == "mcp_servers" => {
+                        network_tool_overrides.push(format!("mcp_servers.{server}.enabled=false"));
+                    }
+                    [root, plugin, servers, server, ..]
+                        if root == "plugins" && servers == "mcp_servers" =>
+                    {
+                        network_tool_overrides.push(format!(
+                            "plugins.{plugin}.mcp_servers.{server}.enabled=false"
+                        ));
+                    }
+                    [root, ..] if root == "hooks" => {
+                        unsupported_automation.push("hooks".to_string());
+                    }
+                    _ => {}
+                }
+                continue;
+            }
+            if !in_top_level {
+                continue;
+            }
+            let Some((key, _)) = line.split_once('=') else {
+                continue;
+            };
+            match key.trim() {
+                "hooks" => unsupported_automation.push("hooks".to_string()),
+                "mcp_servers" | "plugins" => {
+                    unsupported_automation.push(format!("inline {} table", key.trim()))
+                }
+                _ => {}
+            }
+        }
+        for line in contents
+            .lines()
+            .map(str::trim)
+            .take_while(|line| !line.starts_with('['))
+        {
+            if let Some(value) = parse_toml_string_assignment(line, "model") {
+                model = Some(value);
+            }
+        }
+        files.push(LocalFileIdentityV1 {
+            path: path.display().to_string(),
+            sha256: crate::replay::sha256_bytes(&bytes),
+        });
+    }
+    network_tool_overrides.sort();
+    network_tool_overrides.dedup();
+    unsupported_automation.sort();
+    unsupported_automation.dedup();
+    Ok(CodexConfigSnapshot {
+        model: model.filter(|model| !model.trim().is_empty()),
+        permissions,
+        files,
+        network_tool_overrides,
+        unsupported_automation,
+    })
+}
+
+fn read_codex_config_file(
+    path: &Path,
+    required: bool,
+) -> Result<Option<(PathBuf, Vec<u8>)>, ExecutionContractError> {
+    let path = match path.canonicalize() {
+        Ok(path) => path,
+        Err(error) if !required && error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => {
+            return Err(ExecutionContractError::RuntimeUnavailable(format!(
+                "canonicalize {}: {error}",
+                path.display()
+            )))
+        }
+    };
+    let bytes = fs::read(&path).map_err(|error| {
+        ExecutionContractError::RuntimeUnavailable(format!("read {}: {error}", path.display()))
+    })?;
+    Ok(Some((path, bytes)))
+}
+
+fn top_level_toml_string(contents: &str, key: &str) -> Option<String> {
+    contents
+        .lines()
+        .map(str::trim)
+        .take_while(|line| !line.starts_with('['))
+        .find_map(|line| parse_toml_string_assignment(line, key))
+}
+
+fn split_toml_path(value: &str) -> Vec<String> {
+    let mut components = Vec::new();
+    let mut start = 0;
+    let mut quote = None;
+    let mut escaped = false;
+    for (index, character) in value.char_indices() {
+        if escaped {
+            escaped = false;
+            continue;
+        }
+        if quote == Some('"') && character == '\\' {
+            escaped = true;
+            continue;
+        }
+        match (quote, character) {
+            (None, '"' | '\'') => quote = Some(character),
+            (Some(open), close) if open == close => quote = None,
+            (None, '.') => {
+                components.push(value[start..index].trim().to_string());
+                start = index + character.len_utf8();
+            }
+            _ => {}
+        }
+    }
+    components.push(value[start..].trim().to_string());
+    components
+}
+
+fn replay_safe_codex_overrides(snapshot: &CodexConfigSnapshot) -> Vec<String> {
+    let mut values = vec![
+        "sandbox_workspace_write.network_access=false".to_string(),
+        "web_search=\"disabled\"".to_string(),
+        "tools.web_search=false".to_string(),
+        "features.apps=false".to_string(),
+        "features.remote_plugin=false".to_string(),
+        "features.skill_mcp_dependency_install=false".to_string(),
+        "agents.enabled=false".to_string(),
+        "notify=[]".to_string(),
+        "check_for_update_on_startup=false".to_string(),
+    ];
+    values.extend(snapshot.network_tool_overrides.iter().cloned());
+    values
+}
+
+fn codex_project_config_paths(cwd: &Path) -> Vec<PathBuf> {
+    let mut ancestors = cwd.ancestors().map(Path::to_path_buf).collect::<Vec<_>>();
+    ancestors.reverse();
+    ancestors
+        .into_iter()
+        .map(|ancestor| ancestor.join(".codex").join("config.toml"))
+        .collect()
+}
+
+fn resolve_program(
+    program: &str,
+    path_override: Option<&String>,
+) -> Result<PathBuf, ExecutionContractError> {
+    let candidate = if Path::new(program).components().count() > 1 {
+        PathBuf::from(program)
+    } else {
+        let path = path_override
+            .map(std::ffi::OsString::from)
+            .or_else(|| env::var_os("PATH"))
+            .ok_or_else(|| {
+                ExecutionContractError::RuntimeUnavailable("PATH is unavailable".to_string())
+            })?;
+        env::split_paths(&path)
+            .map(|directory| directory.join(program))
+            .find(|path| path.is_file())
+            .ok_or_else(|| {
+                ExecutionContractError::RuntimeUnavailable(format!(
+                    "{program} is not present on the effective PATH"
+                ))
+            })?
+    };
+    candidate.canonicalize().map_err(|error| {
+        ExecutionContractError::RuntimeUnavailable(format!(
+            "canonicalize {}: {error}",
+            candidate.display()
+        ))
+    })
+}
+
+fn local_file_identity(path: &Path) -> Result<LocalFileIdentityV1, ExecutionContractError> {
+    let path = path.canonicalize().map_err(|error| {
+        ExecutionContractError::RuntimeUnavailable(format!(
+            "canonicalize {}: {error}",
+            path.display()
+        ))
+    })?;
+    let bytes = fs::read(&path).map_err(|error| {
+        ExecutionContractError::RuntimeUnavailable(format!("read {}: {error}", path.display()))
+    })?;
+    Ok(LocalFileIdentityV1 {
+        path: path.display().to_string(),
+        sha256: crate::replay::sha256_bytes(&bytes),
+    })
+}
+
+fn resolve_codex_runtime(entrypoint: &Path) -> Result<LocalFileIdentityV1, ExecutionContractError> {
+    if entrypoint.file_name().and_then(|name| name.to_str()) != Some("codex.js") {
+        return local_file_identity(entrypoint);
+    }
+    let package_root = entrypoint.parent().and_then(Path::parent).ok_or_else(|| {
+        ExecutionContractError::RuntimeUnavailable(format!(
+            "unrecognized Codex entrypoint layout: {}",
+            entrypoint.display()
+        ))
+    })?;
+    let (package, target) = match (env::consts::OS, env::consts::ARCH) {
+        ("macos", "aarch64") => ("codex-darwin-arm64", "aarch64-apple-darwin"),
+        ("macos", "x86_64") => ("codex-darwin-x64", "x86_64-apple-darwin"),
+        ("linux", "aarch64") => ("codex-linux-arm64", "aarch64-unknown-linux-musl"),
+        ("linux", "x86_64") => ("codex-linux-x64", "x86_64-unknown-linux-musl"),
+        (os, arch) => {
+            return Err(ExecutionContractError::RuntimeUnavailable(format!(
+                "unsupported Codex runtime platform {os}/{arch}"
+            )))
+        }
+    };
+    let candidates = [
+        package_root
+            .join("node_modules")
+            .join("@openai")
+            .join(package)
+            .join("vendor")
+            .join(target)
+            .join("bin")
+            .join("codex"),
+        package_root
+            .join("vendor")
+            .join(target)
+            .join("bin")
+            .join("codex"),
+    ];
+    let runtime = candidates
+        .into_iter()
+        .find(|path| path.is_file())
+        .ok_or_else(|| {
+            ExecutionContractError::RuntimeUnavailable(format!(
+                "native runtime for {} is unavailable",
+                entrypoint.display()
+            ))
+        })?;
+    local_file_identity(&runtime)
+}
+
+fn effective_environment_selectors(
+    launch: &AgentConfig,
+    route: &ProviderAccountRoute,
+) -> Result<BTreeMap<String, String>, ExecutionContractError> {
+    const ALLOWLIST: [&str; 11] = [
+        "PATH",
+        "SHELL",
+        "LANG",
+        "LC_ALL",
+        "LC_CTYPE",
+        "TERM",
+        "COLORTERM",
+        "NO_COLOR",
+        "TZ",
+        "CODEX_HOME",
+        "CLAUDE_CONFIG_DIR",
+    ];
+    let mut selectors = BTreeMap::new();
+    for name in ALLOWLIST {
+        let value = match launch.env.get(name) {
+            Some(value) => Some(value.clone()),
+            None => env::var_os(name)
+                .map(|value| value.into_string())
+                .transpose()
+                .map_err(|_| {
+                    ExecutionContractError::Artifact(format!(
+                        "environment selector {name} is not UTF-8"
+                    ))
+                })?,
+        };
+        if let Some(value) = value {
+            selectors.insert(name.to_string(), value);
+        }
+    }
+    selectors.insert(
+        "CODEX_HOME".to_string(),
+        route
+            .native_home()
+            .expect("native route carries a credential home")
+            .display()
+            .to_string(),
+    );
+    Ok(selectors)
+}
+
+fn project_agent_config(launch: &AgentConfig) -> AgentConfigV1 {
+    AgentConfigV1 {
+        agent: launch.agent().to_string(),
+        max_turns: launch.max_turns,
+        cwd: launch
+            .cwd
+            .as_deref()
+            .expect("prepared invocation has a cwd")
+            .display()
+            .to_string(),
+        run_context: match launch.run_context {
+            AgentRunContext::Inherit => "inherit",
+            AgentRunContext::Detached => "detached",
+        }
+        .to_string(),
+        permission_policy: if launch.skip_permissions {
+            "bypass"
+        } else {
+            "managed"
+        }
+        .to_string(),
+        write_scope: match launch.write_scope {
+            AgentWriteScope::Configured => "configured",
+            AgentWriteScope::Worktree => "worktree",
+        }
+        .to_string(),
+        writable_roots: launch
+            .execution_boundary
+            .as_ref()
+            .map(|boundary| {
+                boundary
+                    .writable_roots
+                    .iter()
+                    .map(|path| path.display().to_string())
+                    .collect()
+            })
+            .unwrap_or_default(),
+        network_access: launch.execution_boundary.is_some()
+            || launch.write_scope == AgentWriteScope::Configured,
+        skip_permissions: launch.skip_permissions,
+        structured_replies: launch
+            .structured_replies
+            .iter()
+            .map(|reply| StructuredReplyV1 {
+                name: reply.name.clone(),
+                description: reply.description.clone(),
+                guidance: reply.guidance.clone(),
+            })
+            .collect(),
+        directive_relay: launch
+            .directive_relay
+            .as_ref()
+            .map(|path| path.display().to_string()),
+    }
+}
+
+fn project_process_config(process: &ProcessConfig) -> ProcessConfigV1 {
+    ProcessConfigV1 {
+        surface: if process.auto { "headless" } else { "tui" }.to_string(),
+        unattended: process.auto,
+        stream: process.stream,
+        stream_format: match process.stream_format {
+            StreamFormat::Raw => "raw",
+            StreamFormat::Human(_) => "human",
+        }
+        .to_string(),
+        timeout_ms: process
+            .timeout
+            .map(|timeout| u64::try_from(timeout.as_millis()).unwrap_or(u64::MAX)),
+    }
 }
 
 /// Extra workspace roots agents need for Git worktree metadata.
@@ -1066,10 +1764,15 @@ pub fn launch_agent(
     process: &ProcessConfig,
     capabilities: &AgentCapabilities,
 ) -> Result<LaunchResult, CoreError> {
+    let retry_delays = if launch.replay_safe {
+        &[][..]
+    } else {
+        &TRANSIENT_RETRY_DELAYS
+    };
     _launch_with_transient_retries(
         launch,
         process,
-        &TRANSIENT_RETRY_DELAYS,
+        retry_delays,
         |attempt, retry| _launch_agent_once(attempt, process, capabilities, retry),
         thread::sleep,
     )
@@ -1433,17 +2136,6 @@ fn _launch_codex_harness_once(
 
     let implicit_capture = _begin_implicit_capture(launch, process, "codex", model.clone())?;
     let capture = process.capture.as_ref().or(implicit_capture.as_ref());
-    let account_route =
-        match resolve_provider_account_blocking(Provider::Codex, launch.resume_token.clone()) {
-            Ok(route) => route,
-            Err(error) => {
-                return Ok(AgentAttempt::AccountUnavailable(
-                    CoreError::ExecutionFailed(format!(
-                        "failed to select provider account: {error}"
-                    )),
-                ));
-            }
-        };
     if retry {
         if let Some(capture) = capture {
             capture
@@ -1467,6 +2159,31 @@ fn _launch_codex_harness_once(
             .entry(crate::ops::git_operation::LF_WORKTREE_WRITER_ID_ENV.to_string())
             .or_insert_with(|| guard.writer_id().to_string());
     }
+    let prepared = match capture {
+        Some(capture) if !retry => prepare_agent_invocation(&config, process, capture, None)
+            .map_err(|error| CoreError::ExecutionFailed(error.to_string()))?,
+        _ if launch.replay_safe => {
+            return Err(CoreError::ExecutionFailed(
+                "replay-safe launch has no durable capture authority".to_string(),
+            ));
+        }
+        _ => None,
+    };
+    let account_route = match &prepared {
+        Some(prepared) => Some(prepared.account_route().clone()),
+        None => {
+            match resolve_provider_account_blocking(Provider::Codex, launch.resume_token.clone()) {
+                Ok(route) => route,
+                Err(error) => {
+                    return Ok(AgentAttempt::AccountUnavailable(
+                        CoreError::ExecutionFailed(format!(
+                            "failed to select provider account: {error}"
+                        )),
+                    ));
+                }
+            }
+        }
+    };
 
     let runtime = tokio::runtime::Builder::new_current_thread()
         .enable_all()
@@ -1490,10 +2207,11 @@ fn _launch_codex_harness_once(
         if capture.is_some() {
             harness.set_raw_provider_sender(Some(raw_tx));
         }
-        harness
-            .start(&config)
-            .await
-            .map_err(|error| CoreError::ExecutionFailed(error.to_string()))?;
+        match &prepared {
+            Some(prepared) => harness.start_prepared(prepared).await,
+            None => harness.start(&config).await,
+        }
+        .map_err(|error| CoreError::ExecutionFailed(error.to_string()))?;
         let provider_session_id = harness.provider_session_id();
         if let Some(capture) = capture {
             capture.set_provider_session_id(provider_session_id.clone());
@@ -2204,6 +2922,74 @@ trust_level = "trusted"
     }
 
     #[test]
+    fn codex_config_snapshot_pins_selected_home_and_project_precedence() {
+        let temp = tempfile::tempdir().unwrap();
+        let home = temp.path().join("account");
+        let repo = temp.path().join("repo");
+        let system = temp.path().join("etc/config.toml");
+        std::fs::create_dir_all(&home).unwrap();
+        std::fs::create_dir_all(system.parent().unwrap()).unwrap();
+        std::fs::create_dir_all(repo.join(".codex")).unwrap();
+        std::fs::write(&system, "model = \"gpt-system\"\n").unwrap();
+        std::fs::write(
+            home.join("config.toml"),
+            "model = \"gpt-home\"\nprofile = \"proof\"\nsandbox_mode = \"read-only\"\n[mcp_servers.\"remote.one\"]\nurl = \"https://example.test\"\n",
+        )
+        .unwrap();
+        std::fs::write(home.join("proof.config.toml"), "model = \"gpt-profile\"\n").unwrap();
+        std::fs::write(
+            repo.join(".codex/config.toml"),
+            "model = \"gpt-project\"\nsandbox_mode = \"danger-full-access\"\napproval_policy = \"never\"\n",
+        )
+        .unwrap();
+
+        let snapshot = _read_codex_config_snapshot(&home, &repo, Some(&system)).unwrap();
+
+        assert_eq!(snapshot.model.as_deref(), Some("gpt-project"));
+        assert_eq!(
+            snapshot.permissions,
+            CodexPermissionConfig {
+                sandbox: Some(CodexSandboxMode::DangerFullAccess),
+                approval: Some(CodexApprovalPolicy::Never),
+            }
+        );
+        assert_eq!(snapshot.files.len(), 4);
+        assert_eq!(
+            snapshot.network_tool_overrides,
+            ["mcp_servers.\"remote.one\".enabled=false"]
+        );
+        assert!(snapshot.unsupported_automation.is_empty());
+        assert_eq!(
+            snapshot.files[0].path,
+            system.canonicalize().unwrap().display().to_string()
+        );
+        assert_eq!(
+            snapshot.files[1].path,
+            home.join("config.toml")
+                .canonicalize()
+                .unwrap()
+                .display()
+                .to_string()
+        );
+        assert_eq!(
+            snapshot.files[2].path,
+            home.join("proof.config.toml")
+                .canonicalize()
+                .unwrap()
+                .display()
+                .to_string()
+        );
+        assert_eq!(
+            snapshot.files[3].path,
+            repo.join(".codex/config.toml")
+                .canonicalize()
+                .unwrap()
+                .display()
+                .to_string()
+        );
+    }
+
+    #[test]
     fn codex_permission_args_supply_loopflow_floor_when_unset() {
         let args = codex_permission_args_for_config(CodexPermissionConfig::default(), true, false);
 
@@ -2851,6 +3637,7 @@ trust_level = "trusted"
             structured_replies: Vec::new(),
             directive_relay: None,
             env: BTreeMap::new(),
+            replay_safe: false,
         };
         let args = build_claude_session_turn_args("hello", &config, None);
         assert_eq!(args[0], "-p");
@@ -2880,6 +3667,7 @@ trust_level = "trusted"
             structured_replies: Vec::new(),
             directive_relay: None,
             env: BTreeMap::new(),
+            replay_safe: false,
         };
         let args = build_claude_session_turn_args("fix tests", &config, Some("sess_abc"));
         assert!(args.contains(&"--resume".to_string()));
@@ -2913,6 +3701,7 @@ trust_level = "trusted"
             }],
             directive_relay: None,
             env: BTreeMap::new(),
+            replay_safe: false,
         };
 
         let args = build_claude_session_turn_args("hello", &config, None);

--- a/rust/loopflow/src/engine/launch.rs
+++ b/rust/loopflow/src/engine/launch.rs
@@ -182,6 +182,7 @@ pub fn prepare_launch_prompt(
         structured_replies: structured_replies_for_context(&client_context, action_style),
         directive_relay: None,
         env: Default::default(),
+        replay_safe: false,
     };
 
     Ok(PreparedLaunchPrompt {

--- a/rust/loopflow/src/engine/mod.rs
+++ b/rust/loopflow/src/engine/mod.rs
@@ -28,8 +28,10 @@ pub mod worktrees;
 pub use agent::{
     build_agent_command, build_claude_command, build_codex_command, build_gemini_command,
     build_model_command, build_opencode_command, check_cli_available, codex_permission_args,
-    launch_agent, workspace_add_dirs, AgentCapabilities, AgentConfig, AgentExecutionBoundary,
-    AgentFailure, AgentWriteScope, ClaudeArgs, DefaultRunner, LaunchResult, ProcessConfig, Runner,
+    launch_agent, prepare_agent_invocation, workspace_add_dirs, AgentCapabilities, AgentConfig,
+    AgentExecutionBoundary, AgentFailure, AgentRunContext, AgentWriteScope, ClaudeArgs,
+    DefaultRunner, ExecutionContractError, LaunchResult, PreparedAgentInvocation, ProcessConfig,
+    Runner,
 };
 pub use command::{run_command, CommandError};
 pub use config::{

--- a/rust/loopflow/src/flowloop/wave.rs
+++ b/rust/loopflow/src/flowloop/wave.rs
@@ -1097,16 +1097,50 @@ impl WaveLoop {
                 return;
             }
         };
+        let resume_session_id =
+            provider_session_id_for_harness(self.provider_session.as_ref(), &prepared.harness);
+        let prepared_invocation = match capture.as_ref() {
+            Some(capture) if prepared.harness == "codex" && resume_session_id.is_none() => {
+                let process = crate::engine::ProcessConfig {
+                    auto: true,
+                    stream: true,
+                    capture: Some(capture.clone()),
+                    ..Default::default()
+                };
+                match crate::engine::agent::prepare_agent_invocation(
+                    &prepared.config,
+                    &process,
+                    capture,
+                    None,
+                ) {
+                    Ok(prepared) => prepared,
+                    Err(error) => {
+                        let _ = capture.finish("failed", true);
+                        let body_id = body.body_id.clone();
+                        self.open_body(body, answers).await;
+                        self.finish_failed_pass(
+                            &body_id,
+                            &format!("failed to prepare Codex execution contract: {error}"),
+                        )
+                        .await;
+                        return;
+                    }
+                }
+            }
+            _ => None,
+        };
         if capture.is_some() {
             harness.set_raw_provider_sender(Some(raw_tx));
         }
-        let resume_session_id =
-            provider_session_id_for_harness(self.provider_session.as_ref(), &prepared.harness);
         if resume_session_id.is_none() {
             self.provider_session = None;
         }
         harness.set_provider_session_id(resume_session_id);
-        if let Err(err) = harness.start(&prepared.config).await {
+        let start = match &prepared_invocation {
+            Some(prepared_invocation) => harness.start_prepared(prepared_invocation).await,
+            None => harness.start(&prepared.config).await,
+        };
+        if let Err(err) = start {
             finish_capture(capture.as_ref(), "failed");
             let body_id = body.body_id.clone();
             self.open_body(body, answers).await;

--- a/rust/loopflow/src/harness/claude.rs
+++ b/rust/loopflow/src/harness/claude.rs
@@ -394,6 +394,7 @@ mod tests {
             structured_replies: Vec::new(),
             directive_relay: None,
             env: Default::default(),
+            replay_safe: false,
         });
 
         let first = harness

--- a/rust/loopflow/src/harness/codex.rs
+++ b/rust/loopflow/src/harness/codex.rs
@@ -29,6 +29,7 @@ use tokio::task::JoinHandle;
 use crate::chat::types::{ConversationEvent, ConversationItem, TurnUsage};
 use crate::engine::agent::{
     build_codex_thread_start_params, system_prompt_with_structured_replies, AgentConfig,
+    PreparedAgentInvocation,
 };
 use crate::harness::codex_mapping::ItemPhase;
 use crate::harness::common::spawn_stderr_logger;
@@ -571,6 +572,7 @@ pub struct CodexHarness {
     /// matching response for the vendor thread id. 0 = none pending.
     thread_start_request_id: Arc<AtomicI64>,
     launch: Option<AgentConfig>,
+    prepared_launch: Option<PreparedAgentInvocation>,
     should_seed_prompt: bool,
     /// Pid of the live child's process group; 0 = none. Read by the interrupt
     /// hook so SIGINT/SIGTERM/SIGHUP kill the whole codex group before the
@@ -611,6 +613,7 @@ impl CodexHarness {
             initialize_request_id: Arc::new(AtomicI64::new(0)),
             thread_start_request_id: Arc::new(AtomicI64::new(0)),
             launch: None,
+            prepared_launch: None,
             should_seed_prompt: true,
             child_group: Arc::new(AtomicU32::new(0)),
             interrupt_hook_registered: false,
@@ -741,6 +744,7 @@ impl Harness for CodexHarness {
             return Ok(());
         }
         self.shutdown_requested.store(false, Ordering::Relaxed);
+        self.prepared_launch = None;
         self.launch = Some(config.clone());
         self.should_seed_prompt = true;
         let requested_session = self.resume_provider_session_id.clone();
@@ -769,6 +773,33 @@ impl Harness for CodexHarness {
         if let Err(err) = start_result {
             let _ = self.stop().await;
             return Err(err);
+        }
+        Ok(())
+    }
+
+    async fn start_prepared(&mut self, prepared: &PreparedAgentInvocation) -> Result<()> {
+        if self.child.is_some() {
+            return Ok(());
+        }
+        self.shutdown_requested.store(false, Ordering::Relaxed);
+        self.launch = Some(prepared.agent_config().clone());
+        self.prepared_launch = Some(prepared.clone());
+        self.should_seed_prompt = true;
+        self.resume_provider_session_id = None;
+        self.account_route = Some(prepared.account_route().clone());
+        *self
+            .provider_session_id
+            .lock()
+            .expect("codex provider session id lock poisoned") = None;
+        *self
+            .current_turn_id
+            .lock()
+            .expect("codex turn id lock poisoned") = None;
+
+        let start_result = self.start_inner(prepared.agent_config()).await;
+        if let Err(error) = start_result {
+            let _ = self.stop().await;
+            return Err(error);
         }
         Ok(())
     }
@@ -931,18 +962,28 @@ impl Harness for CodexHarness {
 
 impl CodexHarness {
     async fn start_inner(&mut self, launch: &AgentConfig) -> Result<()> {
-        let mut command = Command::new("codex");
-        if self
-            .account_route
-            .as_ref()
-            .is_some_and(ProviderAccountRoute::uses_native_home)
-        {
-            command.args(["-c", "cli_auth_credentials_store=\"file\""]);
-        }
+        let mut command = match &self.prepared_launch {
+            Some(prepared) => {
+                let mut command = Command::new(prepared.executable());
+                command.args(&prepared.argv()[1..]);
+                command
+            }
+            None => {
+                let mut command = Command::new("codex");
+                if self
+                    .account_route
+                    .as_ref()
+                    .is_some_and(ProviderAccountRoute::uses_native_home)
+                {
+                    command.args(["-c", "cli_auth_credentials_store=\"file\""]);
+                }
+                // Subcommand, not flag: codex-cli >= 0.142 renamed
+                // `--app-server` to `codex app-server` (verified against 0.142.5).
+                command.arg("app-server");
+                command
+            }
+        };
         command
-            // Subcommand, not flag: codex-cli >= 0.142 renamed `--app-server`
-            // to `codex app-server` (verified against 0.142.5).
-            .arg("app-server")
             .stdin(std::process::Stdio::piped())
             .stdout(std::process::Stdio::piped())
             .stderr(std::process::Stdio::piped())
@@ -950,6 +991,24 @@ impl CodexHarness {
             // must not leak a live app-server.
             .kill_on_drop(true);
         super::configure_agent_env(&mut command, launch);
+        if let Some(prepared) = &self.prepared_launch {
+            for name in [
+                "PATH",
+                "SHELL",
+                "LANG",
+                "LC_ALL",
+                "LC_CTYPE",
+                "TERM",
+                "COLORTERM",
+                "NO_COLOR",
+                "TZ",
+                "CODEX_HOME",
+                "CLAUDE_CONFIG_DIR",
+            ] {
+                command.env_remove(name);
+            }
+            command.envs(prepared.environment_selectors());
+        }
         if let Some(cwd) = &launch.cwd {
             command.current_dir(cwd);
         }
@@ -1239,8 +1298,17 @@ impl CodexHarness {
             .map_err(|_| anyhow!("codex initialize channel closed"))?;
         self.send_notification("initialized").await?;
 
-        let (thread_method, thread_params) =
-            build_thread_request(launch, self.resume_provider_session_id.as_deref());
+        let (thread_method, thread_params) = match &self.prepared_launch {
+            Some(prepared) => {
+                let (method, params) = prepared.thread_request();
+                (method.to_string(), params.clone())
+            }
+            None => {
+                let (method, params) =
+                    build_thread_request(launch, self.resume_provider_session_id.as_deref());
+                (method.to_string(), params)
+            }
+        };
         // The thread params include Loopflow's conservative defaults only when
         // Codex config is missing or less permissive. More permissive user or
         // repo config, such as danger-full-access, is left alone.
@@ -1249,7 +1317,7 @@ impl CodexHarness {
         let request_id = self.next_request_id;
         self.thread_start_request_id
             .store(request_id, Ordering::Relaxed);
-        self.send_request(thread_method, Value::Object(thread_params))
+        self.send_request(&thread_method, Value::Object(thread_params))
             .await?;
 
         // The vendor thread id arrives either in the thread/start response or

--- a/rust/loopflow/src/harness/mod.rs
+++ b/rust/loopflow/src/harness/mod.rs
@@ -49,8 +49,13 @@ pub(crate) fn configure_agent_run_context(
         return;
     }
     command
+        .env_remove(crate::durable::RUN_CONTEXT_ENV)
         .env_remove(crate::durable::RUN_ID_ENV)
-        .env_remove(crate::durable::AGENT_INVOCATION_ENV);
+        .env_remove(crate::durable::AGENT_INVOCATION_ENV)
+        .env_remove(crate::journal::LF_PROCESS_ID_ENV)
+        .env_remove(crate::journal::LF_TRACE_ID_ENV)
+        .env_remove(crate::engine::wave_context::WAVE_ID_ENV)
+        .env_remove("LF_PARENT_RUN_ID");
 }
 
 pub(crate) fn configure_agent_env(command: &mut tokio::process::Command, config: &AgentConfig) {
@@ -140,7 +145,11 @@ mod environment_tests {
         command
             .env(crate::durable::RUN_CONTEXT_ENV, "agent")
             .env(crate::durable::RUN_ID_ENV, "run_stale")
-            .env(crate::durable::AGENT_INVOCATION_ENV, "invocation_core");
+            .env(crate::durable::AGENT_INVOCATION_ENV, "invocation_core")
+            .env(crate::journal::LF_PROCESS_ID_ENV, "exec_stale")
+            .env(crate::journal::LF_TRACE_ID_ENV, "trace_stale")
+            .env(crate::engine::wave_context::WAVE_ID_ENV, "wave_stale")
+            .env("LF_PARENT_RUN_ID", "run_parent");
 
         configure_agent_run_context(&mut command, AgentRunContext::Detached);
 
@@ -149,12 +158,13 @@ mod environment_tests {
             .get_envs()
             .map(|(key, value)| (key.to_string_lossy().to_string(), value.map(OsString::from)))
             .collect::<std::collections::HashMap<_, _>>();
-        assert_eq!(
-            environment[crate::durable::RUN_CONTEXT_ENV],
-            Some(OsString::from("agent"))
-        );
+        assert_eq!(environment[crate::durable::RUN_CONTEXT_ENV], None);
         assert_eq!(environment[crate::durable::RUN_ID_ENV], None);
         assert_eq!(environment[crate::durable::AGENT_INVOCATION_ENV], None);
+        assert_eq!(environment[crate::journal::LF_PROCESS_ID_ENV], None);
+        assert_eq!(environment[crate::journal::LF_TRACE_ID_ENV], None);
+        assert_eq!(environment[crate::engine::wave_context::WAVE_ID_ENV], None);
+        assert_eq!(environment["LF_PARENT_RUN_ID"], None);
     }
 }
 
@@ -311,6 +321,12 @@ pub enum ApprovalPolicy {
 #[async_trait]
 pub trait Harness: Send + Sync {
     async fn start(&mut self, config: &AgentConfig) -> Result<()>;
+    async fn start_prepared(
+        &mut self,
+        _prepared: &crate::engine::agent::PreparedAgentInvocation,
+    ) -> Result<()> {
+        anyhow::bail!("harness does not support contract-bound launch")
+    }
     /// Start the next provider Turn from durable seed input.
     async fn send_input(&mut self, content: &str) -> Result<()>;
     /// Try to deliver input to the exact Turn currently active.

--- a/rust/loopflow/src/lf/commands/replay.rs
+++ b/rust/loopflow/src/lf/commands/replay.rs
@@ -1385,7 +1385,223 @@ fn _print_text(result: &ReplayCheckDto) {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeMap;
+    use std::ffi::OsString;
+    use std::fs;
+    #[cfg(unix)]
+    use std::os::unix::fs::PermissionsExt;
+    use std::path::{Path, PathBuf};
+    use std::process::Command;
+
     use super::*;
+    use crate::chat::types::{ConversationEvent, Lifecycle};
+    use crate::engine::agent::{
+        prepare_agent_invocation, AgentConfig, AgentRunContext, AgentWriteScope, ProcessConfig,
+    };
+    use crate::id::{ExecId, TraceId};
+    use crate::provider_account::new_account;
+    use crate::provider_auth::Provider;
+    use crate::store::{ProviderAccountId, StorageConfig};
+    use crate::trace::{CaptureHandle, CaptureStart, PreparedTurnContext, TraceCaptureContext};
+
+    struct AccountEnvironment {
+        lease: Option<OsString>,
+        selection: Option<OsString>,
+    }
+
+    impl AccountEnvironment {
+        fn clear() -> Self {
+            let lease = std::env::var_os(crate::provider_account::lease::ACCOUNT_LEASE_ENV);
+            let selection = std::env::var_os(crate::provider_account::lease::ACCOUNT_SELECTION_ENV);
+            std::env::remove_var(crate::provider_account::lease::ACCOUNT_LEASE_ENV);
+            std::env::remove_var(crate::provider_account::lease::ACCOUNT_SELECTION_ENV);
+            Self { lease, selection }
+        }
+    }
+
+    impl Drop for AccountEnvironment {
+        fn drop(&mut self) {
+            for (name, value) in [
+                (
+                    crate::provider_account::lease::ACCOUNT_LEASE_ENV,
+                    self.lease.as_ref(),
+                ),
+                (
+                    crate::provider_account::lease::ACCOUNT_SELECTION_ENV,
+                    self.selection.as_ref(),
+                ),
+            ] {
+                match value {
+                    Some(value) => std::env::set_var(name, value),
+                    None => std::env::remove_var(name),
+                }
+            }
+        }
+    }
+
+    struct ProducerFixture {
+        _account_environment: AccountEnvironment,
+        guard: crate::journal::TestLedgerGuard,
+        repo: PathBuf,
+        capture: CaptureHandle,
+        launch: AgentConfig,
+        process: ProcessConfig,
+        account_id: ProviderAccountId,
+        account_home: PathBuf,
+        sentinel: PathBuf,
+    }
+
+    fn _run_git(repo: &Path, args: &[&str]) {
+        let status = Command::new("git")
+            .arg("-C")
+            .arg(repo)
+            .args(args)
+            .status()
+            .unwrap();
+        assert!(status.success(), "git {args:?} failed");
+    }
+
+    fn _artifact_snapshot(root: &Path) -> Vec<(PathBuf, Vec<u8>)> {
+        fn collect(root: &Path, path: &Path, snapshot: &mut Vec<(PathBuf, Vec<u8>)>) {
+            let mut entries = fs::read_dir(path)
+                .unwrap()
+                .map(|entry| entry.unwrap().path())
+                .collect::<Vec<_>>();
+            entries.sort();
+            for entry in entries {
+                if entry.is_dir() {
+                    collect(root, &entry, snapshot);
+                } else {
+                    snapshot.push((
+                        entry.strip_prefix(root).unwrap().to_path_buf(),
+                        fs::read(&entry).unwrap(),
+                    ));
+                }
+            }
+        }
+
+        let mut snapshot = Vec::new();
+        collect(root, root, &mut snapshot);
+        snapshot
+    }
+
+    fn _producer_fixture() -> ProducerFixture {
+        let guard = crate::journal::TestLedgerGuard::new();
+        let account_environment = AccountEnvironment::clear();
+        let repo = guard.home().join("repo");
+        fs::create_dir_all(&repo).unwrap();
+        _run_git(&repo, &["init", "-b", "main"]);
+        fs::write(repo.join("README.md"), "replay producer proof\n").unwrap();
+        _run_git(&repo, &["add", "README.md"]);
+        _run_git(&repo, &["config", "user.name", "Loopflow Test"]);
+        _run_git(&repo, &["config", "user.email", "loopflow@example.com"]);
+        _run_git(&repo, &["commit", "-m", "proof"]);
+        let repo = repo.canonicalize().unwrap();
+
+        let bin = guard.home().join("bin");
+        fs::create_dir_all(&bin).unwrap();
+        let codex = bin.join("codex");
+        fs::write(&codex, "#!/bin/sh\n: > \"${0}.started\"\nexit 99\n").unwrap();
+        #[cfg(unix)]
+        {
+            let mut permissions = fs::metadata(&codex).unwrap().permissions();
+            permissions.set_mode(0o700);
+            fs::set_permissions(&codex, permissions).unwrap();
+        }
+        let sentinel = bin.join("codex.started");
+
+        let account_id = ProviderAccountId::parse("replay-test").unwrap();
+        let account_home = guard.home().join("accounts/codex/replay-test");
+        fs::create_dir_all(&account_home).unwrap();
+        fs::write(
+            account_home.join("config.toml"),
+            "web_search = \"live\"\nnotify = [\"echo\"]\n[sandbox_workspace_write]\nnetwork_access = true\n[mcp_servers.remote]\nurl = \"https://example.test\"\n",
+        )
+        .unwrap();
+        let account = new_account(
+            Provider::Codex,
+            account_id.clone(),
+            account_home.clone(),
+            None,
+        );
+        let runtime = tokio::runtime::Runtime::new().unwrap();
+        runtime.block_on(async {
+            let store =
+                crate::store::open_store(&StorageConfig::sqlite(guard.home().join("loopflow.db")))
+                    .await
+                    .unwrap();
+            store.upsert_provider_account(&account).await.unwrap();
+            store.apply_migration_for_test("replay_contracts").unwrap();
+        });
+
+        let capture = CaptureHandle::begin(
+            TraceCaptureContext {
+                run_id: TraceId::new(),
+                process_id: ExecId::new(),
+                repo: repo.clone(),
+                worktree: repo.clone(),
+                wave: None,
+                project: None,
+                task: None,
+                flow: None,
+                skill: Some("producer-proof".to_string()),
+            },
+            PreparedTurnContext::from_prompts("system", "task"),
+            CaptureStart {
+                provider: "codex".to_string(),
+                model: Some("gpt-5.6".to_string()),
+                surface: "headless".to_string(),
+                input_op: "initial".to_string(),
+                gather_ms: 1,
+                render_ms: 1,
+                raw_provider: true,
+                basis: None,
+                supervision: None,
+            },
+        )
+        .unwrap();
+        let launch = AgentConfig {
+            system_prompt: "system".to_string(),
+            task_prompt: "task".to_string(),
+            agent: Some("codex:gpt-5.6".to_string()),
+            cwd: Some(repo.clone()),
+            run_context: AgentRunContext::Detached,
+            write_scope: AgentWriteScope::Worktree,
+            env: BTreeMap::from([("PATH".to_string(), bin.display().to_string())]),
+            replay_safe: true,
+            ..Default::default()
+        };
+        let process = ProcessConfig {
+            auto: true,
+            stream: true,
+            capture: Some(capture.clone()),
+            ..Default::default()
+        };
+        ProducerFixture {
+            _account_environment: account_environment,
+            guard,
+            repo,
+            capture,
+            launch,
+            process,
+            account_id,
+            account_home,
+            sentinel,
+        }
+    }
+
+    fn _prepare(fixture: &ProducerFixture) -> crate::engine::agent::PreparedAgentInvocation {
+        let prepared = prepare_agent_invocation(
+            &fixture.launch,
+            &fixture.process,
+            &fixture.capture,
+            Some(fixture.account_id.clone()),
+        )
+        .unwrap()
+        .expect("native Codex capture should prepare");
+        assert!(!fixture.sentinel.exists());
+        prepared
+    }
 
     #[test]
     fn every_refusal_code_has_a_stable_snake_case_name() {
@@ -1418,5 +1634,210 @@ mod tests {
                 format!("\"{}\"", code.as_str())
             );
         }
+    }
+
+    #[test]
+    fn complete_native_codex_capture_is_bound_before_launch_and_replay_eligible() {
+        let fixture = _producer_fixture();
+        let prepared = _prepare(&fixture);
+        for expected in [
+            "sandbox_workspace_write.network_access=false",
+            "web_search=\"disabled\"",
+            "tools.web_search=false",
+            "features.apps=false",
+            "features.remote_plugin=false",
+            "mcp_servers.remote.enabled=false",
+            "notify=[]",
+        ] {
+            assert!(
+                prepared.argv().iter().any(|value| value == expected),
+                "missing replay-safe Codex override {expected}"
+            );
+        }
+        let invocation_id = fixture.capture.invocation_id().to_string();
+        let store = crate::journal::open_ledger().unwrap();
+        let capturing = store
+            .agent_invocations_matching_address(&invocation_id)
+            .unwrap()
+            .pop()
+            .unwrap();
+        assert_eq!(capturing.capture_status, "capturing");
+        assert_eq!(capturing.model.as_deref(), Some("gpt-5.6"));
+        assert!(store
+            .replay_contract_for_invocation(&invocation_id)
+            .unwrap()
+            .is_none());
+        assert!(fs::read_dir(fixture.capture.artifact_dir())
+            .unwrap()
+            .map(|entry| entry.unwrap().file_name().to_string_lossy().into_owned())
+            .any(|name| name.starts_with("execution-contract-v1-")));
+
+        fixture
+            .capture
+            .record_conversation(ConversationEvent::TurnStarted {
+                turn_id: "provider-turn".to_string(),
+            });
+        fixture
+            .capture
+            .record_conversation(ConversationEvent::TurnCompleted {
+                turn_id: "provider-turn".to_string(),
+                status: Lifecycle::Completed,
+            });
+        fixture.capture.finish("completed", false).unwrap();
+
+        let before = _artifact_snapshot(&fixture.capture.artifact_dir());
+        let first = check(&store, fixture.guard.home(), &invocation_id).unwrap();
+        let second = check(&store, fixture.guard.home(), &invocation_id).unwrap();
+        assert!(first.eligible, "replay refusal: {:?}", first.reasons);
+        assert_eq!(first, second);
+        assert_eq!(before, _artifact_snapshot(&fixture.capture.artifact_dir()));
+        assert!(!fixture.sentinel.exists());
+    }
+
+    #[test]
+    fn complete_managed_codex_capture_keeps_its_unsafe_delivery_authority() {
+        let mut fixture = _producer_fixture();
+        fixture.launch.replay_safe = false;
+        fixture.launch.run_context = AgentRunContext::Inherit;
+        fixture.launch.write_scope = AgentWriteScope::Configured;
+        fixture.launch.execution_boundary = Some(crate::engine::agent::AgentExecutionBoundary {
+            writable_roots: vec![fixture.guard.home().join("control")],
+        });
+        fixture.launch.skip_permissions = true;
+        _prepare(&fixture);
+        let invocation_id = fixture.capture.invocation_id().to_string();
+        fixture
+            .capture
+            .record_conversation(ConversationEvent::TurnStarted {
+                turn_id: "provider-turn".to_string(),
+            });
+        fixture
+            .capture
+            .record_conversation(ConversationEvent::TurnCompleted {
+                turn_id: "provider-turn".to_string(),
+                status: Lifecycle::Completed,
+            });
+        fixture.capture.finish("completed", false).unwrap();
+
+        let result = check(
+            &crate::journal::open_ledger().unwrap(),
+            fixture.guard.home(),
+            &invocation_id,
+        )
+        .unwrap();
+        assert!(!result.eligible);
+        assert!(result
+            .reasons
+            .iter()
+            .all(|reason| reason.code == ReplayRefusalCode::UnsafeExecutionBoundary));
+        assert_eq!(result.reasons.len(), 5);
+        assert!(!fixture.sentinel.exists());
+    }
+
+    #[test]
+    fn capture_without_provider_terminal_evidence_never_publishes_replay_index() {
+        let fixture = _producer_fixture();
+        _prepare(&fixture);
+        let invocation_id = fixture.capture.invocation_id().to_string();
+        fixture.capture.finish("completed", false).unwrap();
+
+        let store = crate::journal::open_ledger().unwrap();
+        assert!(store
+            .replay_contract_for_invocation(&invocation_id)
+            .unwrap()
+            .is_none());
+        let result = check(&store, fixture.guard.home(), &invocation_id).unwrap();
+        assert_eq!(
+            result
+                .reasons
+                .iter()
+                .map(|reason| reason.code)
+                .collect::<Vec<_>>(),
+            [
+                ReplayRefusalCode::CaptureIncomplete,
+                ReplayRefusalCode::MissingExecutionContract,
+                ReplayRefusalCode::MissingRepositoryRevision,
+            ]
+        );
+        assert!(!fixture.sentinel.exists());
+    }
+
+    #[test]
+    fn dirty_replay_safe_source_is_refused_before_provider_or_contract_write() {
+        let fixture = _producer_fixture();
+        fs::write(fixture.repo.join("dirty.txt"), "dirty\n").unwrap();
+        let error = prepare_agent_invocation(
+            &fixture.launch,
+            &fixture.process,
+            &fixture.capture,
+            Some(fixture.account_id.clone()),
+        )
+        .unwrap_err();
+        assert!(matches!(
+            error,
+            crate::engine::agent::ExecutionContractError::UnsafeBoundary(_)
+        ));
+        assert!(!fixture.sentinel.exists());
+        assert!(!fs::read_dir(fixture.capture.artifact_dir())
+            .unwrap()
+            .map(|entry| entry.unwrap().file_name().to_string_lossy().into_owned())
+            .any(|name| name.starts_with("execution-contract-v1-")));
+    }
+
+    #[test]
+    fn replay_safe_missing_model_is_a_typed_prelaunch_failure() {
+        let mut fixture = _producer_fixture();
+        fixture.launch.agent = Some("codex".to_string());
+        let error = prepare_agent_invocation(
+            &fixture.launch,
+            &fixture.process,
+            &fixture.capture,
+            Some(fixture.account_id.clone()),
+        )
+        .unwrap_err();
+        assert!(matches!(
+            error,
+            crate::engine::agent::ExecutionContractError::MissingEffectiveModel
+        ));
+        assert!(!fixture.sentinel.exists());
+    }
+
+    #[test]
+    fn replay_safe_unknown_account_is_a_typed_prelaunch_failure() {
+        let fixture = _producer_fixture();
+        let error = prepare_agent_invocation(
+            &fixture.launch,
+            &fixture.process,
+            &fixture.capture,
+            Some(ProviderAccountId::parse("unknown-account").unwrap()),
+        )
+        .unwrap_err();
+        assert!(matches!(
+            error,
+            crate::engine::agent::ExecutionContractError::UnsupportedAuthority(_)
+        ));
+        assert!(!fixture.sentinel.exists());
+    }
+
+    #[test]
+    fn replay_safe_codex_hooks_are_refused_before_provider_start() {
+        let fixture = _producer_fixture();
+        fs::write(
+            fixture.account_home.join("config.toml"),
+            "[hooks]\nSessionStart = []\n",
+        )
+        .unwrap();
+        let error = prepare_agent_invocation(
+            &fixture.launch,
+            &fixture.process,
+            &fixture.capture,
+            Some(fixture.account_id.clone()),
+        )
+        .unwrap_err();
+        assert!(matches!(
+            error,
+            crate::engine::agent::ExecutionContractError::UnsafeBoundary(_)
+        ));
+        assert!(!fixture.sentinel.exists());
     }
 }

--- a/rust/loopflow/src/lf/commands/run.rs
+++ b/rust/loopflow/src/lf/commands/run.rs
@@ -341,6 +341,11 @@ fn build_prompt_at(
         .clone()
         .expect("prepare_launch_prompt always sets agent");
     let (harness, model) = parse_agent(&agent);
+    if cli.replay_safe && (harness != "codex" || model.as_deref().is_none_or(str::is_empty)) {
+        return Err(anyhow!(
+            "--replay-safe requires an explicit codex:<model> selector"
+        ));
+    }
 
     let skill_name = discovered_skill
         .as_ref()
@@ -360,6 +365,14 @@ fn build_prompt_at(
     };
 
     let mut agent_config = prepared.config;
+    if cli.replay_safe {
+        agent_config.run_context = crate::engine::agent::AgentRunContext::Detached;
+        agent_config.write_scope = crate::engine::agent::AgentWriteScope::Worktree;
+        agent_config.execution_boundary = None;
+        agent_config.skip_permissions = false;
+        agent_config.directive_relay = None;
+        agent_config.replay_safe = true;
+    }
     let mut prompt = prepared.prompt;
     // Interactive handoffs use the vendor skill sigil because the vendor owns
     // the session from that point. Headless launches keep the fully assembled
@@ -441,7 +454,9 @@ fn is_interactive_run_with_tty(
     cli.tui
         || cli.ide
         || cli.interactive
-        || (!cli.batch && (attached_tty || (skill.is_none() && message.is_none())))
+        || (!cli.batch
+            && !cli.replay_safe
+            && (attached_tty || (skill.is_none() && message.is_none())))
 }
 
 fn should_launch_via_skill(skill_name: &str) -> bool {
@@ -571,17 +586,19 @@ fn launch_prompt(built: &PromptBuild, cli: &Cli, control: Option<CaptureControl>
         return result;
     }
 
-    let cli_check_start = Instant::now();
-    if !check_cli_available(&built.harness) {
-        return Err(anyhow!(
-            "'{}' CLI not found. Install it and rerun `lf init`.",
-            built.harness
-        ));
+    if built.harness != "codex" {
+        let cli_check_start = Instant::now();
+        if !check_cli_available(&built.harness) {
+            return Err(anyhow!(
+                "'{}' CLI not found. Install it and rerun `lf init`.",
+                built.harness
+            ));
+        }
+        debug!(
+            elapsed_ms = cli_check_start.elapsed().as_millis(),
+            "checked cli availability"
+        );
     }
-    debug!(
-        elapsed_ms = cli_check_start.elapsed().as_millis(),
-        "checked cli availability"
-    );
 
     let effective_system =
         crate::engine::agent::system_prompt_with_structured_replies(&built.agent_config);
@@ -616,11 +633,14 @@ fn launch_prompt(built: &PromptBuild, cli: &Cli, control: Option<CaptureControl>
     // (e.g. `cd` after `lf pr land` rotates worktrees).
     let directive_file = std::env::var("LOOPFLOW_DIRECTIVE_FILE").ok();
     let mut agent_config = built.agent_config.clone();
-    let relay_path = directive_file.as_ref().and_then(|_| {
-        tempfile::NamedTempFile::new()
-            .ok()
-            .map(|f| f.into_temp_path().to_path_buf())
-    });
+    let relay_path = (!cli.replay_safe)
+        .then_some(())
+        .and(directive_file.as_ref())
+        .and_then(|_| {
+            tempfile::NamedTempFile::new()
+                .ok()
+                .map(|f| f.into_temp_path().to_path_buf())
+        });
     if let Some(ref path) = relay_path {
         agent_config.directive_relay = Some(path.clone());
     }

--- a/rust/loopflow/src/lf/mod.rs
+++ b/rust/loopflow/src/lf/mod.rs
@@ -81,6 +81,14 @@ pub struct Cli {
     #[arg(short = 'b', long = "batch", short_alias = 'B')]
     pub batch: bool,
 
+    /// Record a strict detached Codex execution contract before launch
+    #[arg(
+        long = "replay-safe",
+        requires = "model",
+        conflicts_with_all = ["yolo", "interactive", "tui", "ide", "as_work"]
+    )]
+    pub replay_safe: bool,
+
     /// Hand off Claude, Codex, or OpenCode to the terminal (overrides session.launch)
     #[arg(long, conflicts_with = "ide")]
     pub tui: bool,
@@ -2740,6 +2748,28 @@ mod tests {
                 }
             }) if invocation == "invocation_742f7387"
         ));
+    }
+
+    #[test]
+    fn replay_safe_requires_an_explicit_model_and_conflicts_with_privileged_surfaces() {
+        let cli =
+            Cli::try_parse_from(["lf", "--batch", "--replay-safe", "--model", "codex:gpt-5.6"])
+                .expect("parse replay-safe launch");
+        assert!(cli.batch);
+        assert!(cli.replay_safe);
+        assert_eq!(cli.model.as_deref(), Some("codex:gpt-5.6"));
+
+        assert!(Cli::try_parse_from(["lf", "--batch", "--replay-safe"]).is_err());
+        for conflicting in ["--yolo", "--interactive", "--tui", "--ide"] {
+            assert!(Cli::try_parse_from([
+                "lf",
+                "--replay-safe",
+                "--model",
+                "codex:gpt-5.6",
+                conflicting,
+            ])
+            .is_err());
+        }
     }
 
     #[test]

--- a/rust/loopflow/src/project/runner.rs
+++ b/rust/loopflow/src/project/runner.rs
@@ -145,27 +145,8 @@ async fn run_project_inner(
         .map(crate::store::ProviderAccountId::parse)
         .transpose()
         .map_err(|reason| anyhow!("invalid Invocation account route: {reason}"))?;
-    harness.set_provider_account_id(requested_account);
+    harness.set_provider_account_id(requested_account.clone());
     store.validate_run_context(lease).await?;
-    harness.start(&prepared.turn.config).await?;
-    project.provider = harness_name;
-    project.provider_session_id = harness.provider_session_id();
-    let invocation = store
-        .observe_invocation_provider(
-            lease,
-            &invocation.id,
-            harness.provider_account_id(),
-            project.provider_session_id.clone(),
-        )
-        .await?;
-    let invocation_id = invocation.id.clone();
-    let invocation_route = invocation.route.clone();
-    supervision.account_id = invocation.route.account_id.clone();
-    supervision.resume_token = invocation.resume_token.clone();
-    if let Err(error) = store.update_project_for_run(&project, lease).await {
-        let _ = harness.stop().await;
-        return Err(error.into());
-    }
     let capture = flow.current().and_then(|step| {
         let context = match crate::journal::trace_capture_context(
             Path::new(wave.repo()),
@@ -200,6 +181,66 @@ async fn run_project_inner(
             }
         }
     });
+    if harness_name == "codex"
+        && project.provider_session_id.is_none()
+        && initial_input.is_none()
+        && capture.is_none()
+    {
+        return Err(anyhow!(
+            "Project trace capture must exist before a fresh Codex provider starts"
+        ));
+    }
+    let prepared_invocation = match capture.as_ref() {
+        Some(capture)
+            if harness_name == "codex"
+                && project.provider_session_id.is_none()
+                && initial_input.is_none() =>
+        {
+            let process = crate::engine::ProcessConfig {
+                auto: true,
+                stream: true,
+                capture: Some(capture.clone()),
+                ..Default::default()
+            };
+            match crate::engine::agent::prepare_agent_invocation(
+                &prepared.turn.config,
+                &process,
+                capture,
+                requested_account,
+            ) {
+                Ok(prepared) => prepared,
+                Err(error) => {
+                    let _ = capture.finish("failed", true);
+                    return Err(anyhow!(
+                        "Project execution contract could not be prepared: {error}"
+                    ));
+                }
+            }
+        }
+        _ => None,
+    };
+    match &prepared_invocation {
+        Some(prepared_invocation) => harness.start_prepared(prepared_invocation).await?,
+        None => harness.start(&prepared.turn.config).await?,
+    }
+    project.provider = harness_name;
+    project.provider_session_id = harness.provider_session_id();
+    let invocation = store
+        .observe_invocation_provider(
+            lease,
+            &invocation.id,
+            harness.provider_account_id(),
+            project.provider_session_id.clone(),
+        )
+        .await?;
+    let invocation_id = invocation.id.clone();
+    let invocation_route = invocation.route.clone();
+    supervision.account_id = invocation.route.account_id.clone();
+    supervision.resume_token = invocation.resume_token.clone();
+    if let Err(error) = store.update_project_for_run(&project, lease).await {
+        let _ = harness.stop().await;
+        return Err(error.into());
+    }
     if let Some(capture) = &capture {
         capture.set_provider_session_id(project.provider_session_id.clone());
     }
@@ -801,7 +842,11 @@ async fn start_project_flow_turn(
     let wave = owning_wave(store, project).await?;
     open_project_flow_body(flow, wave.repo())?;
     if let Some(capture) = capture {
-        capture.begin_turn_at("queued", &prepared.turn.input, Some(prepared.basis.clone()))?;
+        capture.begin_turn_at(
+            "message",
+            &prepared.turn.input,
+            Some(prepared.basis.clone()),
+        )?;
     }
     apply_input(
         store,

--- a/rust/loopflow/src/provider_account.rs
+++ b/rust/loopflow/src/provider_account.rs
@@ -215,6 +215,13 @@ impl ProviderAccountRoute {
         matches!(self.authority, AccountRouteAuthority::Local { .. })
     }
 
+    pub(crate) fn native_home(&self) -> Option<&Path> {
+        match &self.authority {
+            AccountRouteAuthority::Local { home, .. } => Some(home),
+            AccountRouteAuthority::Lease { .. } => None,
+        }
+    }
+
     /// Prove that this route can authenticate before durable Work is reserved.
     ///
     /// The token is deliberately consumed here and never returned: Task launch
@@ -1037,6 +1044,20 @@ pub(crate) fn resolve_provider_account_blocking(
         runtime.block_on(resolve_provider_account(
             provider,
             provider_session_id.as_deref(),
+        ))
+    })
+}
+
+pub(crate) fn resolve_provider_account_exact_blocking(
+    provider: Provider,
+    provider_session_id: Option<String>,
+    exact_account_id: Option<ProviderAccountId>,
+) -> Result<Option<ProviderAccountRoute>, ProviderAccountError> {
+    _run_blocking_account(provider, "exact-route", move |runtime| {
+        runtime.block_on(resolve_provider_account_exact(
+            provider,
+            provider_session_id.as_deref(),
+            exact_account_id.as_ref(),
         ))
     })
 }

--- a/rust/loopflow/src/store/sqlite.rs
+++ b/rust/loopflow/src/store/sqlite.rs
@@ -14,8 +14,8 @@ use crate::store::rows::{map_wave_row, now_unix};
 use crate::store::token_crypto;
 use crate::store::{
     AccountLimitRow, AttributedTurnUsage, CredentialState, PmSnapshotRow, ProviderAccount,
-    ProviderAccountId, ProviderAccountSelection, RoutingState, RunEventRow, StoreError,
-    StoreResult, TurnUsageSample, WaveLocatorUpdate,
+    ProviderAccountId, ProviderAccountSelection, ReplayContractRow, RoutingState, RunEventRow,
+    StoreError, StoreResult, TurnUsageSample, WaveLocatorUpdate,
 };
 #[cfg(test)]
 use crate::store::{
@@ -2209,6 +2209,7 @@ impl SqliteStore {
         &self,
         invocation: &AgentInvocationRow,
         turn: &AgentTurnRow,
+        replay_contract: Option<&ReplayContractRow>,
     ) -> StoreResult<()> {
         let mut conn = self.conn.lock().expect("store mutex poisoned");
         let tx = conn.transaction_with_behavior(TransactionBehavior::Immediate)?;
@@ -2238,6 +2239,68 @@ impl SqliteStore {
             ],
         )?;
         update_agent_turn(&tx, turn)?;
+        if let Some(contract) = replay_contract {
+            validate_replay_contract_insert(invocation, turn, contract)?;
+            tx.execute(
+                "INSERT INTO replay_contracts (
+                    invocation_id, schema_version, home_id, contract_path,
+                    contract_sha256, captured_at
+                 ) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+                params![
+                    contract.invocation_id,
+                    contract.schema_version,
+                    contract.home_id,
+                    contract.contract_path,
+                    contract.contract_sha256,
+                    contract.captured_at,
+                ],
+            )?;
+        }
+        tx.commit()?;
+        Ok(())
+    }
+
+    pub fn bind_trace_capture_runtime(
+        &self,
+        invocation_id: &str,
+        provider: &str,
+        model: &str,
+        account_id: &ProviderAccountId,
+    ) -> StoreResult<()> {
+        let mut conn = self.conn.lock().expect("store mutex poisoned");
+        let tx = conn.transaction_with_behavior(TransactionBehavior::Immediate)?;
+        let recorded_account = tx
+            .query_row(
+                "SELECT account_id FROM agent_invocations
+                 WHERE id=?1 AND capture_status='capturing'",
+                params![invocation_id],
+                |row| row.get::<_, Option<String>>(0),
+            )
+            .optional()?
+            .ok_or_else(|| {
+                StoreError::InvalidData(format!(
+                    "capture {invocation_id} is missing or no longer capturing"
+                ))
+            })?;
+        if recorded_account
+            .as_deref()
+            .is_some_and(|recorded| recorded != account_id.as_str())
+        {
+            return Err(StoreError::InvalidData(format!(
+                "capture {invocation_id} account {recorded_account:?} disagrees with prepared account {account_id}"
+            )));
+        }
+        let updated = tx.execute(
+            "UPDATE agent_invocations
+             SET provider=?2, model=?3, account_id=?4
+             WHERE id=?1 AND capture_status='capturing'",
+            params![invocation_id, provider, model, account_id.as_str()],
+        )?;
+        if updated != 1 {
+            return Err(StoreError::InvalidData(format!(
+                "capture {invocation_id} could not bind its prepared provider runtime"
+            )));
+        }
         tx.commit()?;
         Ok(())
     }
@@ -3176,6 +3239,32 @@ fn update_agent_turn(conn: &rusqlite::Connection, turn: &AgentTurnRow) -> StoreR
     Ok(())
 }
 
+fn validate_replay_contract_insert(
+    invocation: &AgentInvocationRow,
+    turn: &AgentTurnRow,
+    contract: &ReplayContractRow,
+) -> StoreResult<()> {
+    let valid = invocation.id == contract.invocation_id
+        && turn.invocation_id == invocation.id
+        && invocation.capture_status == "complete"
+        && matches!(invocation.outcome.as_str(), "completed" | "failed")
+        && matches!(turn.status.as_str(), "completed" | "failed")
+        && invocation.ended_at.is_some()
+        && turn.ended_at.is_some()
+        && contract.schema_version == crate::replay::REPLAY_CONTRACT_SCHEMA_VERSION
+        && crate::durable::HomeId::parse(&contract.home_id).is_ok()
+        && crate::trace::resolve_artifact_from(Path::new("."), &contract.contract_path).is_ok()
+        && crate::replay::is_lowercase_sha256(&contract.contract_sha256)
+        && contract.captured_at > 0;
+    if valid {
+        return Ok(());
+    }
+    Err(StoreError::InvalidData(format!(
+        "replay index for {} is not a complete terminal capture",
+        invocation.id
+    )))
+}
+
 fn map_agent_turn(row: &rusqlite::Row<'_>) -> rusqlite::Result<AgentTurnRow> {
     Ok(AgentTurnRow {
         id: row.get(0)?,
@@ -3415,7 +3504,7 @@ mod contention_tests {
         second_turn.ended_at = Some(4);
         second_turn.status = "completed".to_string();
         while_wal_writer_holds_lock(&store, &path, "capture finish", || {
-            store.finish_trace_capture(&invocation, &second_turn)
+            store.finish_trace_capture(&invocation, &second_turn, None)
         });
 
         let invocations = store

--- a/rust/loopflow/src/task/runner.rs
+++ b/rust/loopflow/src/task/runner.rs
@@ -157,35 +157,8 @@ async fn run_task_with(
         .map(crate::store::ProviderAccountId::parse)
         .transpose()
         .map_err(|reason| anyhow!("invalid Invocation account route: {reason}"))?;
-    harness.set_provider_account_id(requested_account);
+    harness.set_provider_account_id(requested_account.clone());
     store.validate_run_context(lease).await?;
-    harness.start(&prepared.turn.config).await?;
-    task.provider = harness_name;
-    task.provider_session_id = harness.provider_session_id();
-    let invocation = store
-        .observe_invocation_provider(
-            lease,
-            &invocation.id,
-            harness.provider_account_id(),
-            task.provider_session_id.clone(),
-        )
-        .await?;
-    let invocation_id = invocation.id.clone();
-    let invocation_route = invocation.route.clone();
-    supervision.account_id = invocation.route.account_id.clone();
-    supervision.resume_token = invocation.resume_token.clone();
-    if let Err(error) = store.update_task_for_run(&task, lease).await {
-        let _ = harness.stop().await;
-        return Err(error.into());
-    }
-    let mut state_fingerprint = task_state_fingerprint(&task)?;
-    let mut gate_fingerprint = if task.lifecycle_phase == TaskLifecyclePhase::Finally {
-        Some(task_gate_fingerprint(&task)?)
-    } else {
-        None
-    };
-
-    let mut pending = VecDeque::new();
     // Record this body's turns the way `flowloop/wave.rs` does. Without it a
     // Task's spend reaches no store at all: the provider runs in this
     // process, so no child `lf` records on its behalf.
@@ -242,6 +215,69 @@ async fn run_task_with(
         }
         None => None,
     };
+    let prepared_invocation = match capture.as_ref() {
+        Some(capture) if harness_name == "codex" && task.provider_session_id.is_none() => {
+            let process = crate::engine::ProcessConfig {
+                auto: true,
+                stream: true,
+                capture: Some(capture.clone()),
+                ..Default::default()
+            };
+            match crate::engine::agent::prepare_agent_invocation(
+                &prepared.turn.config,
+                &process,
+                capture,
+                requested_account,
+            ) {
+                Ok(prepared) => prepared,
+                Err(error) => {
+                    let _ = capture.finish("failed", true);
+                    return finish_execution_blocked(
+                        &store,
+                        &mut task,
+                        lease,
+                        harness.as_mut(),
+                        &[format!(
+                            "Task execution contract could not be prepared: {error}"
+                        )],
+                        None,
+                    )
+                    .await;
+                }
+            }
+        }
+        _ => None,
+    };
+    match &prepared_invocation {
+        Some(prepared_invocation) => harness.start_prepared(prepared_invocation).await?,
+        None => harness.start(&prepared.turn.config).await?,
+    }
+    task.provider = harness_name;
+    task.provider_session_id = harness.provider_session_id();
+    let invocation = store
+        .observe_invocation_provider(
+            lease,
+            &invocation.id,
+            harness.provider_account_id(),
+            task.provider_session_id.clone(),
+        )
+        .await?;
+    let invocation_id = invocation.id.clone();
+    let invocation_route = invocation.route.clone();
+    supervision.account_id = invocation.route.account_id.clone();
+    supervision.resume_token = invocation.resume_token.clone();
+    if let Err(error) = store.update_task_for_run(&task, lease).await {
+        let _ = harness.stop().await;
+        return Err(error.into());
+    }
+    let mut state_fingerprint = task_state_fingerprint(&task)?;
+    let mut gate_fingerprint = if task.lifecycle_phase == TaskLifecyclePhase::Finally {
+        Some(task_gate_fingerprint(&task)?)
+    } else {
+        None
+    };
+
+    let mut pending = VecDeque::new();
     if let Some(capture) = &capture {
         capture.set_provider_session_id(task.provider_session_id.clone());
     }
@@ -251,7 +287,7 @@ async fn run_task_with(
         lease,
         harness.as_mut(),
         &mut flow,
-        capture.as_ref(),
+        None,
         prepared,
     )
     .await?;
@@ -964,7 +1000,11 @@ async fn start_prepared_task_step(
         .await?;
     debug_assert!(!prepared.position.human);
     if let Some(capture) = capture {
-        capture.begin_turn_at("queued", &prepared.turn.input, Some(prepared.basis.clone()))?;
+        capture.begin_turn_at(
+            "message",
+            &prepared.turn.input,
+            Some(prepared.basis.clone()),
+        )?;
     }
     start_task_flow_turn(store, task, lease, harness, flow, prepared.turn).await?;
     Ok(prepared.basis)

--- a/rust/loopflow/src/trace.rs
+++ b/rust/loopflow/src/trace.rs
@@ -13,11 +13,16 @@ use serde_json::{json, Map, Value};
 use sha2::{Digest, Sha256};
 use time::OffsetDateTime;
 
-use crate::chat::types::{ConversationEvent, TurnUsage};
+use crate::chat::types::{ConversationEvent, Lifecycle, TurnUsage};
 use crate::engine::prompt::{account_prompt_tokens, count_tokens};
 use crate::engine::stream::{ResultSubtype, StreamEvent};
 use crate::id::{ExecId, TraceId};
-use crate::store::{StoreError, StoreResult};
+use crate::replay::{
+    context_manifest_sha256, sha256_bytes, ArtifactReferenceV1, ContextManifestIdentityV1,
+    ConversationReferenceV1, ExecutionContractV1, ReplayContractV1, ReplayTurnV1,
+    EXECUTION_CONTRACT_SCHEMA_VERSION, REPLAY_CONTRACT_SCHEMA_VERSION,
+};
+use crate::store::{ReplayContractRow, StoreError, StoreResult};
 
 pub use crate::durable::{AgentInvocationId, TurnId};
 
@@ -826,6 +831,24 @@ impl CaptureHandle {
         resolve_artifact(&relative).expect("capture stores a validated relative artifact path")
     }
 
+    pub fn initial_replay_turn(&self) -> StoreResult<ReplayTurnV1> {
+        let capture = self.0.lock().expect("trace capture mutex poisoned");
+        capture.replay_turn(&capture.turn)
+    }
+
+    pub fn publish_effective_config(&self, bytes: &[u8]) -> StoreResult<ArtifactReferenceV1> {
+        let capture = self.0.lock().expect("trace capture mutex poisoned");
+        capture.publish_content_addressed("effective-config-v1", bytes)
+    }
+
+    pub fn bind_execution_contract(
+        &self,
+        contract: &ExecutionContractV1,
+    ) -> StoreResult<ArtifactReferenceV1> {
+        let mut capture = self.0.lock().expect("trace capture mutex poisoned");
+        capture.bind_execution_contract(contract)
+    }
+
     pub fn begin(
         context: TraceCaptureContext,
         prepared: PreparedTurnContext,
@@ -972,6 +995,7 @@ struct TraceCapture {
     usage: TurnUsage,
     usage_observed: bool,
     usage_final: bool,
+    execution_contract: Option<ArtifactReferenceV1>,
     failed: Option<String>,
 }
 
@@ -1150,8 +1174,111 @@ impl TraceCapture {
             usage: TurnUsage::default(),
             usage_observed: false,
             usage_final: false,
+            execution_contract: None,
             failed: None,
         })
+    }
+
+    fn replay_turn(&self, turn: &AgentTurnRow) -> StoreResult<ReplayTurnV1> {
+        let ledger = crate::journal::open_ledger()?;
+        let assets = ledger
+            .context_assets_for_turns(std::slice::from_ref(&turn.id))?
+            .into_iter()
+            .map(|row| row.asset)
+            .collect::<Vec<_>>();
+        Ok(ReplayTurnV1 {
+            turn_id: turn.id.clone(),
+            ordinal: u32::try_from(turn.ordinal).map_err(|_| {
+                StoreError::InvalidData(format!("invalid Turn ordinal: {}", turn.ordinal))
+            })?,
+            input_op: turn.input_op.clone(),
+            timing: if turn.ordinal == 1 {
+                "initial".to_string()
+            } else {
+                "turn_boundary".to_string()
+            },
+            system_prompt: turn
+                .system_prompt_path
+                .as_deref()
+                .map(artifact_reference)
+                .transpose()?,
+            task_prompt: artifact_reference(&turn.task_prompt_path)?,
+            context_manifest: ContextManifestIdentityV1 {
+                sha256: context_manifest_sha256(&assets),
+                asset_count: u32::try_from(assets.len()).map_err(|_| {
+                    StoreError::InvalidData("context manifest is too large".to_string())
+                })?,
+            },
+        })
+    }
+
+    fn publish_content_addressed(
+        &self,
+        stem: &str,
+        bytes: &[u8],
+    ) -> StoreResult<ArtifactReferenceV1> {
+        let sha256 = sha256_bytes(bytes);
+        let artifact_dir = resolve_artifact(&self.invocation.artifact_dir)?;
+        let path = artifact_dir.join(format!("{stem}-{sha256}.json"));
+        publish_immutable(&path, bytes)?;
+        Ok(ArtifactReferenceV1 {
+            path: artifact_relative(&trace_root(), &path)?,
+            sha256,
+        })
+    }
+
+    fn bind_execution_contract(
+        &mut self,
+        contract: &ExecutionContractV1,
+    ) -> StoreResult<ArtifactReferenceV1> {
+        if self.failed.is_some() {
+            return Err(StoreError::InvalidData(
+                "a partial capture cannot bind an execution contract".to_string(),
+            ));
+        }
+        if self.execution_contract.is_some() {
+            return Err(StoreError::InvalidData(format!(
+                "capture {} already has an execution contract",
+                self.invocation.id
+            )));
+        }
+        let local_home = crate::journal::open_ledger()?.local_home()?.id;
+        let expected_turn = self.replay_turn(&self.turn)?;
+        if contract.schema_version != EXECUTION_CONTRACT_SCHEMA_VERSION
+            || contract.invocation_id != self.invocation.id
+            || contract.home_id != local_home.as_str()
+            || contract.repository.root != self.invocation.repo
+            || contract.agent.cwd != self.invocation.worktree
+            || contract.process.surface != self.invocation.surface
+            || contract.provider.provider.trim().is_empty()
+            || contract.provider.model.trim().is_empty()
+            || contract.initial_turn != expected_turn
+        {
+            return Err(StoreError::InvalidData(format!(
+                "execution contract identity disagrees with capture {}",
+                self.invocation.id
+            )));
+        }
+        let account_id = crate::store::ProviderAccountId::parse(&contract.provider.account_id)
+            .map_err(|error| StoreError::InvalidData(error.to_string()))?;
+        let bytes = serde_json::to_vec(contract)?;
+        let reference = self.publish_content_addressed(
+            &format!("execution-contract-v{}", contract.schema_version),
+            &bytes,
+        )?;
+        crate::journal::open_ledger()?.bind_trace_capture_runtime(
+            &self.invocation.id,
+            &contract.provider.provider,
+            &contract.provider.model,
+            &account_id,
+        )?;
+        self.invocation.provider = contract.provider.provider.clone();
+        self.invocation.model = Some(contract.provider.model.clone());
+        if let Some(supervision) = &mut self.invocation.supervision {
+            supervision.account_id = Some(account_id.to_string());
+        }
+        self.execution_contract = Some(reference.clone());
+        Ok(reference)
     }
 
     fn append_payload(&mut self, payload: RecordedConversationPayload) -> StoreResult<()> {
@@ -1466,6 +1593,109 @@ impl TraceCapture {
         crate::journal::open_ledger()?.finish_agent_turn_capture(&self.turn)
     }
 
+    fn finalize_replay_contract(&self, captured_at: i64) -> StoreResult<ReplayContractRow> {
+        let execution_contract = self.execution_contract.clone().ok_or_else(|| {
+            StoreError::InvalidData("complete replay capture has no execution contract".to_string())
+        })?;
+        let ledger = crate::journal::open_ledger()?;
+        let home_id = ledger.local_home()?.id.to_string();
+        let mut turns =
+            ledger.agent_turns_for_invocations(std::slice::from_ref(&self.invocation.id))?;
+        if let Some(current) = turns.iter_mut().find(|turn| turn.id == self.turn.id) {
+            *current = self.turn.clone();
+        }
+        turns.sort_by_key(|turn| turn.ordinal);
+        if turns.is_empty()
+            || turns
+                .iter()
+                .any(|turn| !matches!(turn.status.as_str(), "completed" | "failed"))
+        {
+            return Err(StoreError::InvalidData(
+                "replay contract requires complete terminal Turns".to_string(),
+            ));
+        }
+        let replay_turns = turns
+            .iter()
+            .map(|turn| self.replay_turn(turn))
+            .collect::<StoreResult<Vec<_>>>()?;
+        let conversation_bytes = fs::read(&self.conversation_path).map_err(|error| {
+            StoreError::InvalidData(format!(
+                "read {}: {error}",
+                self.conversation_path.display()
+            ))
+        })?;
+        let conversation = read_conversation_status(&self.conversation_path)?;
+        if conversation.incomplete_tail
+            || conversation.events.len() as i64 != self.invocation.conversation_event_count
+            || conversation_bytes.len() as i64 != self.invocation.conversation_bytes
+        {
+            return Err(StoreError::InvalidData(
+                "normalized conversation is not complete and self-consistent".to_string(),
+            ));
+        }
+        if turns.iter().any(|turn| {
+            let expected = match turn.status.as_str() {
+                "completed" => Lifecycle::Completed,
+                "failed" => Lifecycle::Failed,
+                _ => return true,
+            };
+            let terminal = conversation
+                .events
+                .iter()
+                .filter(|event| {
+                    event
+                        .turn_id
+                        .as_ref()
+                        .is_some_and(|id| id.as_str() == turn.id)
+                })
+                .filter_map(|event| match &event.payload {
+                    RecordedConversationPayload::Conversation { event } => match event.as_ref() {
+                        ConversationEvent::TurnCompleted { status, .. } => Some(*status),
+                        _ => None,
+                    },
+                    _ => None,
+                })
+                .collect::<Vec<_>>();
+            terminal.as_slice() != [expected]
+        }) {
+            return Err(StoreError::InvalidData(
+                "normalized conversation lacks exact terminal evidence for every Turn".to_string(),
+            ));
+        }
+        let replay = ReplayContractV1 {
+            schema_version: REPLAY_CONTRACT_SCHEMA_VERSION,
+            invocation_id: self.invocation.id.clone(),
+            home_id: home_id.clone(),
+            wave: self.invocation.wave.clone(),
+            project: self.invocation.project.clone(),
+            task: self.invocation.task.clone(),
+            flow: self.invocation.flow.clone(),
+            skill: self.invocation.skill.clone(),
+            execution_contract,
+            turns: replay_turns,
+            conversation: ConversationReferenceV1 {
+                path: self.invocation.conversation_path.clone(),
+                sha256: sha256_bytes(&conversation_bytes),
+                trace_schema_version: TRACE_SCHEMA_VERSION,
+                event_count: conversation.events.len() as u64,
+                bytes: conversation_bytes.len() as u64,
+            },
+        };
+        let bytes = serde_json::to_vec(&replay)?;
+        let reference = self.publish_content_addressed(
+            &format!("replay-contract-v{}", replay.schema_version),
+            &bytes,
+        )?;
+        Ok(ReplayContractRow {
+            invocation_id: self.invocation.id.clone(),
+            schema_version: replay.schema_version,
+            home_id,
+            contract_path: reference.path,
+            contract_sha256: reference.sha256,
+            captured_at,
+        })
+    }
+
     fn finish(&mut self, outcome: &str, prompt_only: bool) -> StoreResult<()> {
         if !matches!(outcome, "completed" | "failed" | "interrupted") {
             return Err(StoreError::InvalidData(format!(
@@ -1505,7 +1735,28 @@ impl TraceCapture {
             }
             .to_string()
         };
-        crate::journal::open_ledger()?.finish_trace_capture(&self.invocation, &self.turn)
+        let replay_contract = if self.invocation.capture_status == "complete"
+            && matches!(outcome, "completed" | "failed")
+            && self.execution_contract.is_some()
+        {
+            match self.finalize_replay_contract(now) {
+                Ok(contract) => Some(contract),
+                Err(error) => {
+                    self.failed = Some(error.to_string());
+                    self.invocation.capture_status = "partial".to_string();
+                    self.invocation.incomplete_reason = Some(error.to_string());
+                    self.turn.status = "partial".to_string();
+                    None
+                }
+            }
+        } else {
+            None
+        };
+        crate::journal::open_ledger()?.finish_trace_capture(
+            &self.invocation,
+            &self.turn,
+            replay_contract.as_ref(),
+        )
     }
 }
 
@@ -1627,6 +1878,68 @@ fn write_private(path: &Path, bytes: &[u8]) -> StoreResult<()> {
             StoreError::InvalidData(format!("set permissions on {}: {error}", path.display()))
         })?;
     Ok(())
+}
+
+fn publish_immutable(path: &Path, bytes: &[u8]) -> StoreResult<()> {
+    if path.exists() {
+        let recorded = fs::read(path).map_err(|error| {
+            StoreError::InvalidData(format!("read {}: {error}", path.display()))
+        })?;
+        if recorded == bytes {
+            return Ok(());
+        }
+        return Err(StoreError::InvalidData(format!(
+            "immutable trace artifact {} already exists with different bytes",
+            path.display()
+        )));
+    }
+    let file_name = path.file_name().ok_or_else(|| {
+        StoreError::InvalidData(format!("artifact has no file name: {}", path.display()))
+    })?;
+    let staging = path.with_file_name(format!(".{}.staging", file_name.to_string_lossy()));
+    let mut options = OpenOptions::new();
+    options.create_new(true).write(true);
+    #[cfg(unix)]
+    options.mode(0o600);
+    let mut file = options
+        .open(&staging)
+        .map_err(|error| StoreError::InvalidData(format!("open {}: {error}", staging.display())))?;
+    if let Err(error) = file.write_all(bytes).and_then(|_| file.sync_all()) {
+        let _ = fs::remove_file(&staging);
+        return Err(StoreError::InvalidData(format!(
+            "write {}: {error}",
+            staging.display()
+        )));
+    }
+    fs::rename(&staging, path).map_err(|error| {
+        let _ = fs::remove_file(&staging);
+        StoreError::InvalidData(format!(
+            "publish {} as {}: {error}",
+            staging.display(),
+            path.display()
+        ))
+    })?;
+    let parent = path.parent().ok_or_else(|| {
+        StoreError::InvalidData(format!("artifact has no parent: {}", path.display()))
+    })?;
+    let directory = OpenOptions::new()
+        .read(true)
+        .open(parent)
+        .map_err(|error| StoreError::InvalidData(format!("open {}: {error}", parent.display())))?;
+    directory
+        .sync_all()
+        .map_err(|error| StoreError::InvalidData(format!("sync {}: {error}", parent.display())))?;
+    Ok(())
+}
+
+fn artifact_reference(relative: &str) -> StoreResult<ArtifactReferenceV1> {
+    let path = resolve_artifact(relative)?;
+    let bytes = fs::read(&path)
+        .map_err(|error| StoreError::InvalidData(format!("read {}: {error}", path.display())))?;
+    Ok(ArtifactReferenceV1 {
+        path: relative.to_string(),
+        sha256: sha256_bytes(&bytes),
+    })
 }
 
 fn append_json_line<T: Serialize>(path: &Path, value: &T) -> StoreResult<usize> {


### PR DESCRIPTION
<!-- loopflow:task-pr-context:start -->
> [!NOTE]
> **Task:** [LOO-271 — Record immutable execution contracts for replay](https://linear.app/loopflow/issue/LOO-271/record-immutable-execution-contracts-for-replay)
> **Task cycle:** feature
> **PR lifecycle:** Merging PR 1 completes the Task.
<!-- loopflow:task-pr-context:end -->

## Evaluate

```bash
cargo test -p loopflow --lib complete_native_codex_capture_is_bound_before_launch_and_replay_eligible
cargo test -p loopflow --lib replay_safe_
```

Observe that preparation records the exact launch without starting the provider, the replay index remains absent until terminal provider evidence arrives, and the completed capture is deterministically replay-eligible. Refusal cases stop dirty worktrees, missing models or accounts, and lifecycle hooks before provider launch.

## Why it matters

`lf replay check` can only make a trustworthy decision when the source run records what actually launched before configuration, routing, or repository state can change. Immutable producer contracts prevent eligibility from being reconstructed from the current machine or granted to partial captures.

## What changed

- Prepared fresh headless native Codex invocations by pinning the model, managed account, executable and runtime hashes, layered configuration, repository commit, prompts, process settings, sanitized arguments, and selected environment
- Added `--replay-safe` for a clean, detached, worktree-only boundary with an explicit model; it disables networked tools, Apps, MCP servers, notifications, retries, and directive relays, and refuses lifecycle hooks
- Started Codex through the prepared invocation across direct, Task, Project, and Wave execution paths so the launched process matches the recorded contract
- Published content-addressed execution artifacts before launch, then atomically indexed the final replay contract only after complete terminal Turn and conversation evidence
- Preserved unsafe authority in ordinary managed captures so `lf replay check` reports the real boundary instead of treating it as eligible

## Risks / Not included

- Strict replay-safe capture is limited to fresh headless native managed Codex invocations; interactive or resumed sessions, leased-token authority, other providers, and dirty worktrees remain unsupported or ineligible
- This change records and validates replay inputs; it does not launch the recorded replay