### PR TITLE
LOO-274: Restore Wave fleet and roadmap loading in the Mac app

### DIFF
--- a/python/tests/test_loopflow_dev.py
+++ b/python/tests/test_loopflow_dev.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "scripts/loopflow-dev.py"
+MODULE_NAME = "_loopflow_dev_script"
+SPEC = importlib.util.spec_from_file_location(MODULE_NAME, SCRIPT)
+if SPEC is None or SPEC.loader is None:
+    raise RuntimeError(f"failed to load module spec from {SCRIPT}")
+loopflow_dev = importlib.util.module_from_spec(SPEC)
+sys.modules[MODULE_NAME] = loopflow_dev
+SPEC.loader.exec_module(loopflow_dev)
+
+
+def test_app_environment_preserves_selected_control_home(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("LF_CONTROL_HOME", "/tmp/selected-home")
+    monkeypatch.setenv("LF_CONTROL_DB_PATH", "/tmp/selected-home/loopflow.db")
+    monkeypatch.delenv("LF_HOME", raising=False)
+    monkeypatch.delenv("LF_DB_PATH", raising=False)
+
+    environment = loopflow_dev._app_environment(Path("/tmp/repo"))
+
+    assert environment == {
+        "LOOPFLOW_DEV_WAVE_REPO": "/tmp/repo",
+        "LF_CONTROL_HOME": "/tmp/selected-home",
+        "LF_CONTROL_DB_PATH": "/tmp/selected-home/loopflow.db",
+    }

--- a/python/tests/test_loopflow_dev.py
+++ b/python/tests/test_loopflow_dev.py
@@ -17,18 +17,14 @@ sys.modules[MODULE_NAME] = loopflow_dev
 SPEC.loader.exec_module(loopflow_dev)
 
 
-def test_app_environment_preserves_selected_control_home(
+def test_app_environment_does_not_override_machine_install_authority(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setenv("LF_CONTROL_HOME", "/tmp/selected-home")
     monkeypatch.setenv("LF_CONTROL_DB_PATH", "/tmp/selected-home/loopflow.db")
-    monkeypatch.delenv("LF_HOME", raising=False)
-    monkeypatch.delenv("LF_DB_PATH", raising=False)
+    monkeypatch.setenv("LF_HOME", "/tmp/ambient-home")
+    monkeypatch.setenv("LF_DB_PATH", "/tmp/ambient-home/loopflow.db")
 
     environment = loopflow_dev._app_environment(Path("/tmp/repo"))
 
-    assert environment == {
-        "LOOPFLOW_DEV_WAVE_REPO": "/tmp/repo",
-        "LF_CONTROL_HOME": "/tmp/selected-home",
-        "LF_CONTROL_DB_PATH": "/tmp/selected-home/loopflow.db",
-    }
+    assert environment == {"LOOPFLOW_DEV_WAVE_REPO": "/tmp/repo"}

--- a/scratch/restore-wave-fleet-and-roadmap.md
+++ b/scratch/restore-wave-fleet-and-roadmap.md
@@ -1,0 +1,108 @@
+# Restore Wave fleet and roadmap loading
+
+## Finish line
+
+The configured Dev Mac app reads the same selected control Home as the `lf`
+process that launched it. A cold launch shows the populated Wave roster and
+roadmap, Activity leaves its loading state, and a failed first read shows the
+subprocess reason without also claiming that the fleet is empty.
+
+Proof must exercise the Mac app's production `RegistryQuery` through the real
+launch environment and selected machine entry gate. Fixture-only Swift decoding
+and a healthy shell `lf` do not count.
+
+## Observations
+
+- The selected control store is
+  `~/.lf-dev/installed/local-04115a69e0c34b198bf110976b32f390/loopflow.db`.
+  `lf ls --all --json` returns five Loopflow Waves; `lf roadmap --all --json`
+  returns populated product planning.
+- The Dev app bundles a validation-only release-provenance `lf`. With the
+  LaunchServices environment produced by `scripts/loopflow-dev.py`, it falls
+  back to `~/.lf/loopflow.db` because `_app_environment` forwards only
+  `LF_HOME` and `LF_DB_PATH`, not the selected `LF_CONTROL_HOME` and
+  `LF_CONTROL_DB_PATH`.
+- Against that fallback store, the bundled helper reproduces both reported
+  failures: `ls --all --json` and `roadmap --all --json` exit nonzero with
+  `no such column: retired_at`. The fallback database is at migration
+  `0.12.12.001_release`; Wave retirement arrives in `0.12.13.001_release`.
+- After forwarding the selected Home, the rebuilt bundled helper reaches the
+  intended database but still cannot read it. The Home is owned by the active
+  installed development `lf` and carries its draft frontier; the bundled
+  release-provenance reader reports incompatible schema and then fails on
+  `work_state` / `work_kind`. The machine entry gate at `~/.local/bin/lf`
+  successfully resolves the matching active binary and reads this store.
+- `LF_CONTROL_BIN` is not usable as the app reader on this machine: it points
+  to a stale pre-command `~/.lf/bin/lf`. The machine entry gate, not this legacy
+  inherited path, is the current install authority.
+- The primary Podium model preserves read failures and their reasons. Its
+  console nevertheless renders `No Waves found.` whenever the failed fleet
+  read has no last-good value, contradicting the adjacent unavailable signal.
+- A stale Xcode-built Loopflow process from 2026-07-21 is also running from
+  DerivedData and has no bundled `lf`. It is evidence of the reported machine
+  state, but changing or deleting that build is not required to restore the
+  separately identified Dev app path.
+
+## Rejected hypothesis
+
+Preserving the complete selected-Home environment across `open --env` will make
+the bundled helper read the populated control store it was launched to operate.
+The first half holds; the second fails because a release-provenance helper is
+not the binary that owns an installed development store.
+
+## Restored model
+
+Resolve `lf` from the GUI-enriched PATH first. `~/.local/bin/lf` is Loopflow's
+machine entry gate, so it dispatches to the binary matching the active install
+and store. Keep the bundled helper only as the no-install fallback. Preserve the
+selected-Home environment so development launches retain their explicit
+authority. Restrict fleet and Activity empty copy to successful reads.
+
+## Restoration proof
+
+- `uv run python scripts/loopflow-dev.py run` rebuilt, signed, and launched
+  `~/Applications/Loopflow Dev.app` with the selected control Home preserved.
+- The installed-bundle capture at `/tmp/loo-274-installed-restored.png` ran
+  `~/Applications/Loopflow Dev.app/Contents/MacOS/Loopflow` with
+  `LOOPFLOW_UI_TEST_MODE=live`, the real `LF_CONTROL_HOME` /
+  `LF_CONTROL_DB_PATH`, and the machine entry gate first on `PATH`. After a
+  40-second settle it showed five Waves and populated Work rows, matching
+  `lf ls --all --json` and `lf roadmap --all --json` from the selected
+  development store. It is byte-identical to the independent source-build
+  proof (`sha256 7c6e6dd98991885511077c7b9d5d193578f037fd508d8e2bd93e5cf07860a714`).
+- Activity left `Reading Activity…`. Its current wire mismatch surfaced as
+  `Activity unavailable` with the exact missing-`run_id` decode reason, and did
+  not render `No Activity in this window`. This distinguishes restoration from
+  the reported indefinitely loading or plausibly empty surface.
+- `/usr/bin/time -p lf activity --since 7d --limit 50 --json` returned 50 items
+  in 6.67 seconds. The command completes with populated JSON; the visible Mac
+  failure is a named DTO mismatch rather than an empty ledger.
+- Focused proof: `uv run pytest python/tests/test_loopflow_dev.py` passed; Swift
+  launcher and Podium model filters passed 24 tests. The documented signed
+  `xcodebuild build-for-testing` gate compiled and signed the app plus
+  `LoopflowUITests`, including `PodiumStateTests`.
+
+## Review
+
+- Reads and controls share `controlLfPath()`; there is no second Mac query
+  implementation. The active machine entry gate owns installed-Home selection,
+  and the validation-only bundle remains the offline fallback.
+- No database migration or user-state edit was needed. The fallback and active
+  stores remain intact, and the stale Xcode process was left untouched.
+- Capture targeting changes only automated capture mode. Ordinary launches
+  still restore the user's repo-scoped Sessions surface.
+- The missing `run_id` Activity DTO mismatch remains deliberately visible and
+  outside this restore. Repairing that wire contract is separate follow-up,
+  not a reason to hide the fleet and roadmap recovery.
+
+## Near-misses
+
+- Migrating, rebuilding, or discarding the fallback `~/.lf` database.
+- Using the bundled release-provenance helper as the peer for a draft
+  development store.
+- Treating authored `wave/*/GOAL.md` placeholders as proof that registry reads
+  recovered.
+- Showing a zero/empty fleet alongside an unavailable read.
+- Capturing before the live reads settle. The legacy nanoseconds sleep returned
+  early for long delays here; the duration-based sleep now holds the declared
+  capture interval and returns on cancellation instead of taking a false frame.

--- a/scratch/restore-wave-fleet-and-roadmap.md
+++ b/scratch/restore-wave-fleet-and-roadmap.md
@@ -94,9 +94,9 @@ consequence and made the broken surface look healthy.
 
 ## Changes to Implement
 
-- [x] Define the install-owned local-control authority: the fixed machine gate
-  reads the active receipt that binds the exact executable and store; an
-  explicit bundled-offline case applies only when no installation exists.
+- [x] Use the install-owned local-control authority: the fixed machine gate
+  reads the active receipt that binds the exact executable and store; the
+  bundled offline path applies only when no installation exists.
 - [x] Make Dev launch and Mac process launch consume that authority, then
   delete the manual `LF_*` forwarding list and arbitrary PATH scan.
 - [ ] Add an installed-Dev-app integration proof using a disposable populated
@@ -169,7 +169,7 @@ not the binary that owns an installed development store.
 Resolve the fixed OS-account gate at `~/.lf-machine/install/gates/1/lf`. Its
 active install receipt selects the compatible executable and store together,
 regardless of PATH or inherited Home variables. Keep the validation-only
-bundled helper as an explicitly typed no-install fallback. Restrict fleet and
+bundled helper as an explicit no-install fallback. Restrict fleet and
 Activity empty copy to successful reads.
 
 ### Restoration proof
@@ -199,8 +199,8 @@ Activity empty copy to successful reads.
 
 ### Review
 
-- Reads and controls share `controlLfPath()`; there is no second Mac query
-  implementation. `LocalControlAuthority` selects either the receipt-backed
+- Reads and controls share `controlLfPath()`; there is no second Mac query or
+  Swift-owned authority type. The function selects either the receipt-backed
   machine gate or the validation-only offline fallback. It never scans PATH,
   and a receipt with a missing or non-executable gate fails rather than falling
   through to another store.

--- a/scratch/restore-wave-fleet-and-roadmap.md
+++ b/scratch/restore-wave-fleet-and-roadmap.md
@@ -1,6 +1,117 @@
-# Restore Wave fleet and roadmap loading
+# 5 Whys: The Mac read a populated Home with an incompatible `lf`
 
-## Finish line
+## The Problem
+
+The configured Dev Mac app kept Wave fleet, roadmap, and Activity reads loading,
+then presented zero or empty Work even though the selected local Home contained
+five Waves and populated planning.
+
+## Chain
+
+Populated Work appeared empty → Mac `lf` reads failed → Dev launch paired a
+selected Home with the wrong helper → bundle location stood in for executable
+identity → Mac and Dev tooling duplicated machine-install authority
+
+**Problem**: The Mac showed a zero Wave fleet, no roadmap, and persistent
+loading despite a populated selected Home.
+
+**Why 1**: Every relevant `RegistryQuery` subprocess failed before producing a
+decodable DTO. With no last-good fleet, the console then treated the absent value
+as an empty array and rendered an empty claim beside the failure signal.
+
+↳ *Could we have caught this earlier?* A configured cold-launch proof that
+requires a nonzero known fleet and a terminal Activity state would have failed
+before the regression reached the desktop. Fixture-only decoding could not.
+
+**Why 2**: LaunchServices receives only explicitly forwarded environment. The
+Dev launcher copied legacy `LF_HOME` / `LF_DB_PATH` but dropped the active
+`LF_CONTROL_HOME` / `LF_CONTROL_DB_PATH`, sending the helper to an older store.
+Preserving those variables was necessary but insufficient because the bundled
+validation-only helper was still not compatible with the selected development
+store.
+
+↳ *What process allowed this?* The launcher maintained one manual list of Home
+routing variables while Swift independently chose an executable. No check
+validated the resulting executable/store pair.
+
+**Why 3**: The Mac policy treated the app's bundled `lf` as its exact wire peer
+and explicitly rejected PATH fallback. That was safe only if bundle provenance
+also guaranteed compatibility with the selected Home. In the Dev app it did
+not: the bundle was release-provenance and validation-only, while the Home was
+owned by an installed development binary carrying draft migrations.
+
+↳ *What assumption was wrong?* "Built beside this Swift app" was assumed to be
+stronger identity than "selected by the Home's machine entry gate." It protects
+against an arbitrary checkout binary, but it cannot prove store compatibility.
+
+**Why 4**: Production activation and Dev assembly evolved different meanings for
+the same helper path. Production rewrites the installed app helper to the
+machine entry gate; Dev assembly embeds a standalone validation helper. Unit
+tests reinforced the bundle-only policy, and the error UI fixture kept Waves
+available even when every other reading was unavailable. Neither test crossed
+Dev launch → executable selection → selected Home → visible terminal state.
+
+↳ *Why was that assumption encoded?* Two valid safety mechanisms were designed
+locally: validation-only helpers prevent a Dev UI from migrating a release Home,
+and installed development Homes pin draft-compatible executables. Their
+composition had no owner, so each layer selected half of the pair.
+
+**Why 5 (Root)**: Executable/store compatibility is durable machine-install
+authority, but the Mac app and Dev launcher duplicated it as bundle-path and
+environment conventions. Because no single contract supplied both the selected
+Home and its compatible entry gate, helper provenance, Home routing, tests, and
+UI truthfulness could drift independently.
+
+### Parallel rendering branch
+
+The read failure became a plausible empty state because views consumed
+`PodiumReading.value` as an optional collection instead of rendering the enum
+exhaustively. The model preserved loading, available, unavailable, last-good,
+and reason; the presentation layer collapsed those facts back into `nil` and
+`[]`. The fixture repeated that collapse by making the fleet available during
+its error state. This did not cause the subprocess failure, but it hid its
+consequence and made the broken surface look healthy.
+
+## Unanswered Whys
+
+| Branch Point | Unexplored Question | Priority |
+|--------------|---------------------|----------|
+| Why 4 | Should Dev assembly make `Contents/MacOS/lf` the machine gate, or should the Mac consume an explicit install-owned authority receipt? | High |
+| Why 5 | What exact helper/store contract should offline app operation use when no machine installation exists? | High |
+| Rendering branch | Which other `PodiumReading` consumers still infer empty state through `value ?? []` instead of switching exhaustively? | High |
+| Why 1 | Why does current `lf activity` JSON omit the Swift-required `run_id` on some items? | High |
+| Proof branch | Why did the legacy nanoseconds sleep return early for long live-capture delays on this host? | Medium |
+| Machine state | Why was a July Xcode-built app still running without a usable helper, and can stale app provenance be named in-product? | Low |
+
+## Fixes
+
+| Level | Fix | Prevents |
+|-------|-----|----------|
+| Immediate | Preserve `LF_CONTROL_HOME` / `LF_CONTROL_DB_PATH`, resolve the active machine `lf` before the offline bundle, and render unavailable fleet/Activity states without empty copy. | This reported instance and its misleading presentation |
+| Structural | Give Dev launch and the Mac one install-owned local-control authority containing the selected Home and exact entry gate; remove independent environment allowlists and executable search rules. | Any helper/store provenance mismatch across release and development Homes |
+| Structural | Render `PodiumReading` exhaustively through one shared state boundary and make fixtures vary fleet, roadmap, and Activity failure independently. | Unavailable or unknown evidence silently becoming healthy empty state |
+| Systemic | Gate the installed Dev app with a disposable populated development Home whose schema is intentionally ahead of the validation-only bundle, and require nonzero fleet/roadmap plus terminal failure presentation. | Future feature combinations that unit and DTO fixture tests cannot see |
+
+## Changes to Implement
+
+- [ ] Define the install-owned local-control authority: selected Home identity,
+  database, exact machine entry gate, and an explicitly typed offline fallback.
+- [ ] Make Dev assembly and Mac process launch consume that authority, then
+  delete the manual `LF_*` forwarding list and arbitrary PATH scan.
+- [ ] Add an installed-Dev-app integration proof using a disposable populated
+  development Home newer than the validation-only bundled helper.
+- [ ] Audit every `PodiumReading` consumer and replace optional/empty inference
+  with exhaustive loading, available, last-good, and unavailable rendering.
+- [ ] Track the missing Activity `run_id` wire mismatch separately; keep its
+  current explicit unavailable state until the shared DTO contract is repaired.
+
+The next prevention should establish the install-owned authority boundary
+before expanding UI coverage. Otherwise tests would only pin the current PATH
+workaround rather than make incompatible executable/store pairs impossible.
+
+## Restoration Record
+
+### Finish line
 
 The configured Dev Mac app reads the same selected control Home as the `lf`
 process that launched it. A cold launch shows the populated Wave roster and
@@ -11,15 +122,15 @@ Proof must exercise the Mac app's production `RegistryQuery` through the real
 launch environment and selected machine entry gate. Fixture-only Swift decoding
 and a healthy shell `lf` do not count.
 
-## Observations
+### Observations
 
 - The selected control store is
   `~/.lf-dev/installed/local-04115a69e0c34b198bf110976b32f390/loopflow.db`.
   `lf ls --all --json` returns five Loopflow Waves; `lf roadmap --all --json`
   returns populated product planning.
-- The Dev app bundles a validation-only release-provenance `lf`. With the
-  LaunchServices environment produced by `scripts/loopflow-dev.py`, it falls
-  back to `~/.lf/loopflow.db` because `_app_environment` forwards only
+- The Dev app bundles a validation-only release-provenance `lf`. Before the
+  restore, the LaunchServices environment produced by `scripts/loopflow-dev.py`
+  fell back to `~/.lf/loopflow.db` because `_app_environment` forwarded only
   `LF_HOME` and `LF_DB_PATH`, not the selected `LF_CONTROL_HOME` and
   `LF_CONTROL_DB_PATH`.
 - Against that fallback store, the bundled helper reproduces both reported
@@ -35,22 +146,23 @@ and a healthy shell `lf` do not count.
 - `LF_CONTROL_BIN` is not usable as the app reader on this machine: it points
   to a stale pre-command `~/.lf/bin/lf`. The machine entry gate, not this legacy
   inherited path, is the current install authority.
-- The primary Podium model preserves read failures and their reasons. Its
-  console nevertheless renders `No Waves found.` whenever the failed fleet
-  read has no last-good value, contradicting the adjacent unavailable signal.
+- The primary Podium model preserved read failures and their reasons. Before the
+  restore, its console nevertheless rendered `No Waves found.` whenever the
+  failed fleet read had no last-good value, contradicting the adjacent
+  unavailable signal.
 - A stale Xcode-built Loopflow process from 2026-07-21 is also running from
   DerivedData and has no bundled `lf`. It is evidence of the reported machine
   state, but changing or deleting that build is not required to restore the
   separately identified Dev app path.
 
-## Rejected hypothesis
+### Rejected hypothesis
 
 Preserving the complete selected-Home environment across `open --env` will make
 the bundled helper read the populated control store it was launched to operate.
 The first half holds; the second fails because a release-provenance helper is
 not the binary that owns an installed development store.
 
-## Restored model
+### Restored model
 
 Resolve `lf` from the GUI-enriched PATH first. `~/.local/bin/lf` is Loopflow's
 machine entry gate, so it dispatches to the binary matching the active install
@@ -58,7 +170,7 @@ and store. Keep the bundled helper only as the no-install fallback. Preserve the
 selected-Home environment so development launches retain their explicit
 authority. Restrict fleet and Activity empty copy to successful reads.
 
-## Restoration proof
+### Restoration proof
 
 - `uv run python scripts/loopflow-dev.py run` rebuilt, signed, and launched
   `~/Applications/Loopflow Dev.app` with the selected control Home preserved.
@@ -82,7 +194,7 @@ authority. Restrict fleet and Activity empty copy to successful reads.
   `xcodebuild build-for-testing` gate compiled and signed the app plus
   `LoopflowUITests`, including `PodiumStateTests`.
 
-## Review
+### Review
 
 - Reads and controls share `controlLfPath()`; there is no second Mac query
   implementation. The active machine entry gate owns installed-Home selection,
@@ -95,7 +207,7 @@ authority. Restrict fleet and Activity empty copy to successful reads.
   outside this restore. Repairing that wire contract is separate follow-up,
   not a reason to hide the fleet and roadmap recovery.
 
-## Near-misses
+### Near-misses
 
 - Migrating, rebuilding, or discarding the fallback `~/.lf` database.
 - Using the bundled release-provenance helper as the peer for a draft

--- a/scratch/restore-wave-fleet-and-roadmap.md
+++ b/scratch/restore-wave-fleet-and-roadmap.md
@@ -177,17 +177,21 @@ Activity empty copy to successful reads.
 - `uv run python scripts/loopflow-dev.py run` rebuilt, signed, and launched
   `~/Applications/Loopflow Dev.app` with only the development repository
   override; the machine install receipt supplied the active Home.
-- The installed-bundle capture at `/tmp/loo-274-installed-authority.png` ran
+- The installed-bundle capture at `/tmp/loo-274-gate-retry.png` ran
   `~/Applications/Loopflow Dev.app/Contents/MacOS/Loopflow` with every `LF_*`
   routing variable removed and `PATH=/usr/bin:/bin`. After a 40-second settle it
   showed the five Loopflow Waves and populated Work rows. The exact machine gate
   under the same hostile environment reported five Loopflow Waves; roadmap
   reported product with three Projects and 88 Tasks. The capture checksum is
-  `0518ce7c1e8a9cc1764049f2f3ef3ed88ef55568a87496f85d31835df99cfe53`.
+  `3e7aab97d12f5ed1aa3bb0635d6e88eeb408fe896863a0f00938b3ac237e5130`.
 - Activity left `Reading Activity…`. Its current wire mismatch surfaced as
   `Activity unavailable` with the exact missing-`run_id` decode reason, and did
   not render `No Activity in this window`. This distinguishes restoration from
   the reported indefinitely loading or plausibly empty surface.
+- A gate capture first caught Activity back in `Reading Activity…`: each
+  same-scope retry reset an unavailable reading to loading before the command
+  finished. Retries now preserve the current terminal reading until new evidence
+  arrives; the second 40-second capture above remained explicitly unavailable.
 - `/usr/bin/time -p lf activity --since 7d --limit 50 --json` returned 50 items
   in 6.67 seconds. The command completes with populated JSON; the visible Mac
   failure is a named DTO mismatch rather than an empty ledger.
@@ -236,14 +240,18 @@ Activity empty copy to successful reads.
 | Populated fleet | A cold launch exposes the real local Wave roster. | `RegistryQuery` receives `lf ls --all --json` through the machine gate. | `/tmp/loo-274-review-settled.png` shows **5 Waves**; the exact gate independently returned the same five Loopflow Waves. | pass |
 | Populated roadmap | Roadmap loading terminates with the selected store's real Work. | `RegistryQuery` receives `lf roadmap --all --json` through the same gate. | The installed-app capture shows populated Work rows; the exact gate returned product with 3 Projects and 88 Tasks. | pass |
 | Terminal Activity state | Activity must leave `Reading Activity…` even when its DTO cannot decode. | A failed first read becomes `Activity unavailable` with the subprocess/decode reason. | The installed-app capture shows the current missing-`run_id` reason and the terminal unavailable state. | pass |
+| Activity retry stability | A periodic retry must not hide the last terminal Activity state while its subprocess is running. | Same-scope refreshes retain the existing reading; a scope change alone resets to loading. | `PodiumModelTests.unavailableActivityStaysVisibleDuringRetry` holds a retry open and observes the prior failure; the 40-second live capture remains unavailable across multiple retries. | pass |
 | Failed reads are not empty | Unavailable fleet, roadmap, or Activity evidence must not claim healthy emptiness. | Empty copy is restricted to successful empty readings; the error fixture makes every affected reading unavailable. | Live capture shows no Activity empty claim; `PodiumStateTests.testUnavailableIsNotRenderedAsEmpty` pins all three surfaces. | pass |
 
 The exact-head capture checksum is
-`0518ce7c1e8a9cc1764049f2f3ef3ed88ef55568a87496f85d31835df99cfe53`.
+`3e7aab97d12f5ed1aa3bb0635d6e88eeb408fe896863a0f00938b3ac237e5130`.
 Focused review proofs passed: `uv run pytest python/tests/test_loopflow_dev.py`,
 `swift test --package-path swift --filter LocalWaveAgentLauncherTests`, and
-`swift test --package-path swift --filter PodiumModelTests` (28 Swift tests
-across the two filters).
+`swift test --package-path swift --filter PodiumModelTests` (14 tests in the
+final focused filter). Before the bounded retry fix, gate also passed 205 Python
+tests and the 230-test full Swift suite; the final tree passed the Swift
+platform-boundary check, Mac package build, eight distinct render proofs, and
+the signed macOS `build-for-testing` check.
 
 Disposition: the restoration slice is coherent and its applicable Done When
 claims hold through the configured installed app. The Activity `run_id` wire

--- a/scratch/restore-wave-fleet-and-roadmap.md
+++ b/scratch/restore-wave-fleet-and-roadmap.md
@@ -87,16 +87,17 @@ consequence and made the broken surface look healthy.
 
 | Level | Fix | Prevents |
 |-------|-----|----------|
-| Immediate | Preserve `LF_CONTROL_HOME` / `LF_CONTROL_DB_PATH`, resolve the active machine `lf` before the offline bundle, and render unavailable fleet/Activity states without empty copy. | This reported instance and its misleading presentation |
+| Immediate | Resolve the fixed OS-account machine gate before the offline bundle, and render unavailable fleet/Activity states without empty copy. | This reported instance and its misleading presentation |
 | Structural | Give Dev launch and the Mac one install-owned local-control authority containing the selected Home and exact entry gate; remove independent environment allowlists and executable search rules. | Any helper/store provenance mismatch across release and development Homes |
 | Structural | Render `PodiumReading` exhaustively through one shared state boundary and make fixtures vary fleet, roadmap, and Activity failure independently. | Unavailable or unknown evidence silently becoming healthy empty state |
 | Systemic | Gate the installed Dev app with a disposable populated development Home whose schema is intentionally ahead of the validation-only bundle, and require nonzero fleet/roadmap plus terminal failure presentation. | Future feature combinations that unit and DTO fixture tests cannot see |
 
 ## Changes to Implement
 
-- [ ] Define the install-owned local-control authority: selected Home identity,
-  database, exact machine entry gate, and an explicitly typed offline fallback.
-- [ ] Make Dev assembly and Mac process launch consume that authority, then
+- [x] Define the install-owned local-control authority: the fixed machine gate
+  reads the active receipt that binds the exact executable and store; an
+  explicit bundled-offline case applies only when no installation exists.
+- [x] Make Dev launch and Mac process launch consume that authority, then
   delete the manual `LF_*` forwarding list and arbitrary PATH scan.
 - [ ] Add an installed-Dev-app integration proof using a disposable populated
   development Home newer than the validation-only bundled helper.
@@ -105,9 +106,10 @@ consequence and made the broken surface look healthy.
 - [ ] Track the missing Activity `run_id` wire mismatch separately; keep its
   current explicit unavailable state until the shared DTO contract is repaired.
 
-The next prevention should establish the install-owned authority boundary
-before expanding UI coverage. Otherwise tests would only pin the current PATH
-workaround rather than make incompatible executable/store pairs impossible.
+With the install-owned authority boundary established, the next prevention is
+the installed-Dev-app integration gate. It should create a disposable populated
+development Home newer than the validation-only helper and require the receipt-
+selected gate to load it without any `LF_*` routing environment.
 
 ## Restoration Record
 
@@ -164,24 +166,24 @@ not the binary that owns an installed development store.
 
 ### Restored model
 
-Resolve `lf` from the GUI-enriched PATH first. `~/.local/bin/lf` is Loopflow's
-machine entry gate, so it dispatches to the binary matching the active install
-and store. Keep the bundled helper only as the no-install fallback. Preserve the
-selected-Home environment so development launches retain their explicit
-authority. Restrict fleet and Activity empty copy to successful reads.
+Resolve the fixed OS-account gate at `~/.lf-machine/install/gates/1/lf`. Its
+active install receipt selects the compatible executable and store together,
+regardless of PATH or inherited Home variables. Keep the validation-only
+bundled helper as an explicitly typed no-install fallback. Restrict fleet and
+Activity empty copy to successful reads.
 
 ### Restoration proof
 
 - `uv run python scripts/loopflow-dev.py run` rebuilt, signed, and launched
-  `~/Applications/Loopflow Dev.app` with the selected control Home preserved.
-- The installed-bundle capture at `/tmp/loo-274-installed-restored.png` ran
-  `~/Applications/Loopflow Dev.app/Contents/MacOS/Loopflow` with
-  `LOOPFLOW_UI_TEST_MODE=live`, the real `LF_CONTROL_HOME` /
-  `LF_CONTROL_DB_PATH`, and the machine entry gate first on `PATH`. After a
-  40-second settle it showed five Waves and populated Work rows, matching
-  `lf ls --all --json` and `lf roadmap --all --json` from the selected
-  development store. It is byte-identical to the independent source-build
-  proof (`sha256 7c6e6dd98991885511077c7b9d5d193578f037fd508d8e2bd93e5cf07860a714`).
+  `~/Applications/Loopflow Dev.app` with only the development repository
+  override; the machine install receipt supplied the active Home.
+- The installed-bundle capture at `/tmp/loo-274-installed-authority.png` ran
+  `~/Applications/Loopflow Dev.app/Contents/MacOS/Loopflow` with every `LF_*`
+  routing variable removed and `PATH=/usr/bin:/bin`. After a 40-second settle it
+  showed the five Loopflow Waves and populated Work rows. The exact machine gate
+  under the same hostile environment reported five Loopflow Waves; roadmap
+  reported product with three Projects and 88 Tasks. The capture checksum is
+  `0518ce7c1e8a9cc1764049f2f3ef3ed88ef55568a87496f85d31835df99cfe53`.
 - Activity left `Reading Activity…`. Its current wire mismatch surfaced as
   `Activity unavailable` with the exact missing-`run_id` decode reason, and did
   not render `No Activity in this window`. This distinguishes restoration from
@@ -189,16 +191,19 @@ authority. Restrict fleet and Activity empty copy to successful reads.
 - `/usr/bin/time -p lf activity --since 7d --limit 50 --json` returned 50 items
   in 6.67 seconds. The command completes with populated JSON; the visible Mac
   failure is a named DTO mismatch rather than an empty ledger.
-- Focused proof: `uv run pytest python/tests/test_loopflow_dev.py` passed; Swift
-  launcher and Podium model filters passed 24 tests. The documented signed
-  `xcodebuild build-for-testing` gate compiled and signed the app plus
-  `LoopflowUITests`, including `PodiumStateTests`.
+- Focused proof: `uv run pytest python/tests/test_loopflow_dev.py` passed, and
+  `swift test --package-path swift --filter LocalWaveAgentLauncherTests` passed
+  14 authority and launcher behaviors. The earlier restoration pass also
+  compiled and signed the app plus `LoopflowUITests`; gate owns rerunning that
+  broader build against the final branch content.
 
 ### Review
 
 - Reads and controls share `controlLfPath()`; there is no second Mac query
-  implementation. The active machine entry gate owns installed-Home selection,
-  and the validation-only bundle remains the offline fallback.
+  implementation. `LocalControlAuthority` selects either the receipt-backed
+  machine gate or the validation-only offline fallback. It never scans PATH,
+  and a receipt with a missing or non-executable gate fails rather than falling
+  through to another store.
 - No database migration or user-state edit was needed. The fallback and active
   stores remain intact, and the stale Xcode process was left untouched.
 - Capture targeting changes only automated capture mode. Ordinary launches

--- a/scratch/restore-wave-fleet-and-roadmap.md
+++ b/scratch/restore-wave-fleet-and-roadmap.md
@@ -223,3 +223,30 @@ Activity empty copy to successful reads.
 - Capturing before the live reads settle. The legacy nanoseconds sleep returned
   early for long delays here; the duration-based sleep now holds the declared
   capture interval and returns on cancellation instead of taking a false frame.
+- Using obsolete capture variable names. The current knobs are
+  `LOOPFLOW_UI_TEST_DELAY`, `LOOPFLOW_UI_TEST_WIDTH`, and
+  `LOOPFLOW_UI_TEST_HEIGHT`; `..._SNAPSHOT_*` names silently use the 2.5-second
+  default and capture the healthy live query while it is still loading.
+
+## Slice Review — 2026-08-27
+
+| Claim | Planned behavior | Implemented behavior | Proof | Result |
+|---|---|---|---|---|
+| Installed authority | The configured app reads the Home selected by the machine installation, independent of inherited routing variables and PATH. | Reads and controls both resolve `~/.lf-machine/install/gates/1/lf`; only a machine with no install receipt uses the bundled validation helper. | Exact installed app launched with all `LF_*` routing removed and `PATH=/usr/bin:/bin`; launcher suite passed 14 authority/control behaviors. | pass |
+| Populated fleet | A cold launch exposes the real local Wave roster. | `RegistryQuery` receives `lf ls --all --json` through the machine gate. | `/tmp/loo-274-review-settled.png` shows **5 Waves**; the exact gate independently returned the same five Loopflow Waves. | pass |
+| Populated roadmap | Roadmap loading terminates with the selected store's real Work. | `RegistryQuery` receives `lf roadmap --all --json` through the same gate. | The installed-app capture shows populated Work rows; the exact gate returned product with 3 Projects and 88 Tasks. | pass |
+| Terminal Activity state | Activity must leave `Reading Activity…` even when its DTO cannot decode. | A failed first read becomes `Activity unavailable` with the subprocess/decode reason. | The installed-app capture shows the current missing-`run_id` reason and the terminal unavailable state. | pass |
+| Failed reads are not empty | Unavailable fleet, roadmap, or Activity evidence must not claim healthy emptiness. | Empty copy is restricted to successful empty readings; the error fixture makes every affected reading unavailable. | Live capture shows no Activity empty claim; `PodiumStateTests.testUnavailableIsNotRenderedAsEmpty` pins all three surfaces. | pass |
+
+The exact-head capture checksum is
+`0518ce7c1e8a9cc1764049f2f3ef3ed88ef55568a87496f85d31835df99cfe53`.
+Focused review proofs passed: `uv run pytest python/tests/test_loopflow_dev.py`,
+`swift test --package-path swift --filter LocalWaveAgentLauncherTests`, and
+`swift test --package-path swift --filter PodiumModelTests` (28 Swift tests
+across the two filters).
+
+Disposition: the restoration slice is coherent and its applicable Done When
+claims hold through the configured installed app. The Activity `run_id` wire
+repair, an unversioned install-authority API, the disposable newer-Home gate,
+and the broader `PodiumReading` audit remain explicit prevention work rather
+than hidden conditions of this repair.

--- a/scripts/loopflow-dev.py
+++ b/scripts/loopflow-dev.py
@@ -207,10 +207,10 @@ def cmd_run_debug(repo: Path = REPO_ROOT) -> int:
     _install_dev_app()
     print("Logs: ~/Library/Logs/Loopflow/")
     print(f"Stream log: {LOOPFLOW_STREAM_LOG}")
-    # The app resolves `lf` from its own bundle before PATH, so the dashboard
-    # reads this branch's ledger surfaces (`lf runs/trace/doctor --json`) rather
-    # than whatever `lf` happens to be installed.
-    print(f"Bundled lf: {DEV_APP}/Contents/MacOS/lf")
+    # The app resolves the active machine `lf` before its validation-only
+    # bundled fallback, so selected development Homes use their compatible
+    # installed binary.
+    print(f"Bundled fallback lf: {DEV_APP}/Contents/MacOS/lf")
     print("Telemetry dashboard: Go → Telemetry (⌘1)")
     _print_run_debug_checklist()
     print("Press Ctrl+C to quit")

--- a/scripts/loopflow-dev.py
+++ b/scripts/loopflow-dev.py
@@ -51,7 +51,7 @@ LOOPFLOW_STREAM_LOG = DEV_LOG_DIR / f"{REPO_ROOT.name}.loopflow-run-debug.log"
 
 def _app_environment(repo: Path) -> dict[str, str]:
     env = {"LOOPFLOW_DEV_WAVE_REPO": str(repo)}
-    for key in ("LF_HOME", "LF_DB_PATH"):
+    for key in ("LF_CONTROL_HOME", "LF_CONTROL_DB_PATH", "LF_HOME", "LF_DB_PATH"):
         if value := os.environ.get(key):
             env[key] = value
     return env

--- a/scripts/loopflow-dev.py
+++ b/scripts/loopflow-dev.py
@@ -25,7 +25,6 @@ Streaming logs (long-running commands):
 from __future__ import annotations
 
 import argparse
-import os
 import shutil
 import subprocess
 import sys
@@ -50,11 +49,7 @@ LOOPFLOW_STREAM_LOG = DEV_LOG_DIR / f"{REPO_ROOT.name}.loopflow-run-debug.log"
 
 
 def _app_environment(repo: Path) -> dict[str, str]:
-    env = {"LOOPFLOW_DEV_WAVE_REPO": str(repo)}
-    for key in ("LF_CONTROL_HOME", "LF_CONTROL_DB_PATH", "LF_HOME", "LF_DB_PATH"):
-        if value := os.environ.get(key):
-            env[key] = value
-    return env
+    return {"LOOPFLOW_DEV_WAVE_REPO": str(repo)}
 
 
 def run(cmd: list[str], cwd: Path | None = None, check: bool = True) -> subprocess.CompletedProcess:
@@ -207,9 +202,8 @@ def cmd_run_debug(repo: Path = REPO_ROOT) -> int:
     _install_dev_app()
     print("Logs: ~/Library/Logs/Loopflow/")
     print(f"Stream log: {LOOPFLOW_STREAM_LOG}")
-    # The app resolves the active machine `lf` before its validation-only
-    # bundled fallback, so selected development Homes use their compatible
-    # installed binary.
+    # The app resolves the install-owned machine gate before its validation-only
+    # bundled fallback, so executable and store selection stay one authority.
     print(f"Bundled fallback lf: {DEV_APP}/Contents/MacOS/lf")
     print("Telemetry dashboard: Go → Telemetry (⌘1)")
     _print_run_debug_checklist()

--- a/swift/Loopflow/Services/RegistryQuery.swift
+++ b/swift/Loopflow/Services/RegistryQuery.swift
@@ -10,8 +10,8 @@
 // This runs `lf ls/status/roadmap/ps/activity --json` as a subprocess and decodes the wire
 // snapshots (mirrors of the Rust types in `lf/commands/waves.rs` and
 // `lf/commands/runs.rs`) into the app models the stores hold. The subprocess
-// runner is injected: on macOS it execs the active machine `lf`, with the app's
-// bundled helper as an offline fallback. There is no HTTP fallback for reads;
+// runner is injected: on macOS it execs the install-owned machine `lf` gate,
+// with the app's bundled helper as an offline fallback. There is no HTTP fallback for reads;
 // remote reads need to become proxied `lf` queries.
 
 import Foundation

--- a/swift/Loopflow/Services/RegistryQuery.swift
+++ b/swift/Loopflow/Services/RegistryQuery.swift
@@ -10,8 +10,9 @@
 // This runs `lf ls/status/roadmap/ps/activity --json` as a subprocess and decodes the wire
 // snapshots (mirrors of the Rust types in `lf/commands/waves.rs` and
 // `lf/commands/runs.rs`) into the app models the stores hold. The subprocess
-// runner is injected: on macOS it execs the `lf` shipped inside the app. There is no
-// HTTP fallback for reads; remote reads need to become proxied `lf` queries.
+// runner is injected: on macOS it execs the active machine `lf`, with the app's
+// bundled helper as an offline fallback. There is no HTTP fallback for reads;
+// remote reads need to become proxied `lf` queries.
 
 import Foundation
 

--- a/swift/LoopflowMac/AppTestMode.swift
+++ b/swift/LoopflowMac/AppTestMode.swift
@@ -133,6 +133,18 @@ enum AppTestMode: String {
         return env["LOOPFLOW_UI_TEST_SNAPSHOT_PATH"] == nil ? nil : .primary
     }
 
+    /// Start primary Wave and roadmap captures on the Work surface even when
+    /// the user's saved scope points at a repository and would normally open
+    /// Sessions. This only drives capture mode; ordinary launches still restore
+    /// the user's last surface.
+    static var startsOnWorkSurface: Bool {
+        guard current() != nil else { return false }
+        switch ProcessInfo.processInfo.environment["LOOPFLOW_UI_TEST_VIEW"] {
+        case "wave", "roadmap": return true
+        default: return false
+        }
+    }
+
     /// Website captures are deliberately light even when the laptop is dark.
     /// Ordinary UI tests and production keep the user's appearance setting.
     static var forcesLightAppearance: Bool {

--- a/swift/LoopflowMac/LoopflowApp.swift
+++ b/swift/LoopflowMac/LoopflowApp.swift
@@ -255,7 +255,11 @@ private extension View {
                             ?? window.frame.height
                         window.setContentSize(NSSize(width: width, height: height))
                     }
-                    try? await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+                    do {
+                        try await Task.sleep(for: .seconds(delay))
+                    } catch {
+                        return
+                    }
                     if window.isVisible {
                         do {
                             _ = try SnapshotService().snapshotWindow(window, to: path)

--- a/swift/LoopflowMac/MacLocalWaveAgentLauncher.swift
+++ b/swift/LoopflowMac/MacLocalWaveAgentLauncher.swift
@@ -17,20 +17,13 @@ struct TaskStartReceipt: Decodable, Sendable, Equatable {
     let wave: String
 }
 
-enum LocalControlAuthority: Equatable {
-    case installedMachine(executable: URL)
-    case bundledOffline(executable: URL)
-
-    var executable: URL {
-        switch self {
-        case .installedMachine(let executable), .bundledOffline(let executable): executable
-        }
-    }
-
-    static func resolve(
+enum LocalWaveAgentLauncher {
+    /// Return the receipt-backed machine control binary, or the offline helper
+    /// when no machine installation exists.
+    static func controlLfPath(
         accountHome: URL = FileManager.default.homeDirectoryForCurrentUser,
         bundled: URL? = Bundle.main.url(forAuxiliaryExecutable: "lf")
-    ) throws -> Self {
+    ) throws -> String {
         let installRoot = accountHome
             .appendingPathComponent(".lf-machine", isDirectory: true)
             .appendingPathComponent("install", isDirectory: true)
@@ -48,7 +41,7 @@ enum LocalControlAuthority: Equatable {
                         + "Repair or reinstall Loopflow."
                 )
             }
-            return .installedMachine(executable: gate)
+            return gate.path
         }
 
         let hasInstallReceipt = ["active.json", "switch.json"].contains { name in
@@ -70,11 +63,9 @@ enum LocalControlAuthority: Equatable {
                     + "Rebuild or reinstall Loopflow."
             )
         }
-        return .bundledOffline(executable: bundled)
+        return bundled.path
     }
-}
 
-enum LocalWaveAgentLauncher {
     /// Stop the listener through the same `lf` lifecycle surface the CLI uses.
     /// The server performs resident, registry, and discovery-file cleanup.
     static func stopWave(repoPath: String, waveName: String) throws {
@@ -182,21 +173,6 @@ enum LocalWaveAgentLauncher {
 
     static func taskInterruptCommand(lfPath: String, issue: String) -> [String] {
         [lfPath, "task", "interrupt", issue]
-    }
-
-    /// Return the active machine control binary, or the bundled offline fallback.
-    ///
-    /// The fixed OS-account gate reads the active install receipt and dispatches
-    /// to the binary that owns its store. PATH and inherited Home variables are
-    /// process configuration, not install authority.
-    static func controlLfPath(
-        accountHome: URL = FileManager.default.homeDirectoryForCurrentUser,
-        bundled: URL? = Bundle.main.url(forAuxiliaryExecutable: "lf")
-    ) throws -> String {
-        try LocalControlAuthority.resolve(
-            accountHome: accountHome,
-            bundled: bundled
-        ).executable.path
     }
 
     /// Run an `lf` query verb (`ls`, `status`, `runs`, …) and return its

--- a/swift/LoopflowMac/MacLocalWaveAgentLauncher.swift
+++ b/swift/LoopflowMac/MacLocalWaveAgentLauncher.swift
@@ -17,6 +17,63 @@ struct TaskStartReceipt: Decodable, Sendable, Equatable {
     let wave: String
 }
 
+enum LocalControlAuthority: Equatable {
+    case installedMachine(executable: URL)
+    case bundledOffline(executable: URL)
+
+    var executable: URL {
+        switch self {
+        case .installedMachine(let executable), .bundledOffline(let executable): executable
+        }
+    }
+
+    static func resolve(
+        accountHome: URL = FileManager.default.homeDirectoryForCurrentUser,
+        bundled: URL? = Bundle.main.url(forAuxiliaryExecutable: "lf")
+    ) throws -> Self {
+        let installRoot = accountHome
+            .appendingPathComponent(".lf-machine", isDirectory: true)
+            .appendingPathComponent("install", isDirectory: true)
+        let gate = installRoot
+            .appendingPathComponent("gates", isDirectory: true)
+            .appendingPathComponent("1", isDirectory: true)
+            .appendingPathComponent("lf", isDirectory: false)
+        var isDirectory = ObjCBool(false)
+        if FileManager.default.fileExists(atPath: gate.path, isDirectory: &isDirectory) {
+            guard !isDirectory.boolValue,
+                  FileManager.default.isExecutableFile(atPath: gate.path)
+            else {
+                throw LocalLfError(
+                    errorDescription: "Loopflow's installed machine entry gate is not executable at \(gate.path). "
+                        + "Repair or reinstall Loopflow."
+                )
+            }
+            return .installedMachine(executable: gate)
+        }
+
+        let hasInstallReceipt = ["active.json", "switch.json"].contains { name in
+            FileManager.default.fileExists(
+                atPath: installRoot.appendingPathComponent(name, isDirectory: false).path
+            )
+        }
+        if hasInstallReceipt {
+            throw LocalLfError(
+                errorDescription: "Loopflow's machine install receipt exists, but its entry gate is missing at "
+                    + "\(gate.path). Repair or reinstall Loopflow."
+            )
+        }
+
+        guard let bundled, FileManager.default.isExecutableFile(atPath: bundled.path) else {
+            throw LocalLfError(
+                errorDescription: "Loopflow has no installed machine entry gate at \(gate.path) "
+                    + "and this app is missing its executable offline lf helper at Contents/MacOS/lf. "
+                    + "Rebuild or reinstall Loopflow."
+            )
+        }
+        return .bundledOffline(executable: bundled)
+    }
+}
+
 enum LocalWaveAgentLauncher {
     /// Stop the listener through the same `lf` lifecycle surface the CLI uses.
     /// The server performs resident, registry, and discovery-file cleanup.
@@ -129,37 +186,17 @@ enum LocalWaveAgentLauncher {
 
     /// Return the active machine control binary, or the bundled offline fallback.
     ///
-    /// Loopflow's enriched GUI PATH leads with `~/.local/bin`, whose `lf` is the
-    /// machine entry gate. It dispatches to the binary that owns the selected
-    /// installed Home, including an installed development store with draft
-    /// migrations a release-provenance helper cannot interpret.
+    /// The fixed OS-account gate reads the active install receipt and dispatches
+    /// to the binary that owns its store. PATH and inherited Home variables are
+    /// process configuration, not install authority.
     static func controlLfPath(
-        searchPath: String = GUIProcessEnvironment.enrichedPath(
-            from: ProcessInfo.processInfo.environment["PATH"]
-        ),
+        accountHome: URL = FileManager.default.homeDirectoryForCurrentUser,
         bundled: URL? = Bundle.main.url(forAuxiliaryExecutable: "lf")
     ) throws -> String {
-        for directory in searchPath.split(separator: ":") {
-            let candidate = URL(fileURLWithPath: String(directory), isDirectory: true)
-                .appendingPathComponent("lf", isDirectory: false)
-            if FileManager.default.isExecutableFile(atPath: candidate.path) {
-                return candidate.path
-            }
-        }
-        return try bundledLfPath(bundled: bundled)
-    }
-
-    /// Return the control binary shipped with this exact Mac client build.
-    static func bundledLfPath(
-        bundled: URL? = Bundle.main.url(forAuxiliaryExecutable: "lf")
-    ) throws -> String {
-        guard let bundled, FileManager.default.isExecutableFile(atPath: bundled.path) else {
-            throw LocalLfError(
-                errorDescription: "Loopflow.app is missing its executable bundled lf helper at Contents/MacOS/lf. "
-                    + "No active machine lf was found; rebuild or reinstall Loopflow."
-            )
-        }
-        return bundled.path
+        try LocalControlAuthority.resolve(
+            accountHome: accountHome,
+            bundled: bundled
+        ).executable.path
     }
 
     /// Run an `lf` query verb (`ls`, `status`, `runs`, …) and return its

--- a/swift/LoopflowMac/MacLocalWaveAgentLauncher.swift
+++ b/swift/LoopflowMac/MacLocalWaveAgentLauncher.swift
@@ -22,7 +22,7 @@ enum LocalWaveAgentLauncher {
     /// The server performs resident, registry, and discovery-file cleanup.
     static func stopWave(repoPath: String, waveName: String) throws {
         let origin = WaveOrigin.resolve(repoPath)
-        let lfPath = try bundledLfPath()
+        let lfPath = try controlLfPath()
         try runChecked(waveStopCommand(lfPath: lfPath, waveName: waveName), cwd: origin)
     }
 
@@ -35,7 +35,7 @@ enum LocalWaveAgentLauncher {
     /// Task process; the app does not reproduce any of those decisions.
     static func runTask(repoPath: String, issue: String) throws {
         let origin = WaveOrigin.resolve(repoPath)
-        let lfPath = try bundledLfPath()
+        let lfPath = try controlLfPath()
         try runChecked(taskRunCommand(lfPath: lfPath, issue: issue), cwd: origin)
     }
 
@@ -47,7 +47,7 @@ enum LocalWaveAgentLauncher {
         directive: String
     ) throws -> TaskStartReceipt {
         let origin = WaveOrigin.resolve(repoPath)
-        let lfPath = try bundledLfPath()
+        let lfPath = try controlLfPath()
         let stdout = try runCheckedOutput(
             taskStartCommand(
                 lfPath: lfPath,
@@ -64,7 +64,7 @@ enum LocalWaveAgentLauncher {
     /// status record.
     static func resumeTask(repoPath: String, issue: String) throws {
         let origin = WaveOrigin.resolve(repoPath)
-        let lfPath = try bundledLfPath()
+        let lfPath = try controlLfPath()
         try runChecked(taskResumeCommand(lfPath: lfPath, issue: issue), cwd: origin)
     }
 
@@ -72,7 +72,7 @@ enum LocalWaveAgentLauncher {
     /// provider turn is stopped and records the receipt in the shared store.
     static func interruptTask(repoPath: String, issue: String) throws {
         let origin = WaveOrigin.resolve(repoPath)
-        let lfPath = try bundledLfPath()
+        let lfPath = try controlLfPath()
         try runChecked(taskInterruptCommand(lfPath: lfPath, issue: issue), cwd: origin)
     }
 
@@ -82,7 +82,7 @@ enum LocalWaveAgentLauncher {
     /// honored in one place. Only an explicit user review action calls this;
     /// background app work publishes with `lf pr publish`.
     static func reviewPullRequest(worktree: String) throws {
-        let lfPath = try bundledLfPath()
+        let lfPath = try controlLfPath()
         try runChecked(pullRequestReviewCommand(lfPath: lfPath), cwd: worktree)
     }
 
@@ -127,17 +127,36 @@ enum LocalWaveAgentLauncher {
         [lfPath, "task", "interrupt", issue]
     }
 
-    /// Return the control binary shipped with this exact Mac client build.
+    /// Return the active machine control binary, or the bundled offline fallback.
     ///
-    /// A missing or stale bundled helper is a malformed app, not permission to
-    /// borrow a different wire contract from PATH or a checkout build.
+    /// Loopflow's enriched GUI PATH leads with `~/.local/bin`, whose `lf` is the
+    /// machine entry gate. It dispatches to the binary that owns the selected
+    /// installed Home, including an installed development store with draft
+    /// migrations a release-provenance helper cannot interpret.
+    static func controlLfPath(
+        searchPath: String = GUIProcessEnvironment.enrichedPath(
+            from: ProcessInfo.processInfo.environment["PATH"]
+        ),
+        bundled: URL? = Bundle.main.url(forAuxiliaryExecutable: "lf")
+    ) throws -> String {
+        for directory in searchPath.split(separator: ":") {
+            let candidate = URL(fileURLWithPath: String(directory), isDirectory: true)
+                .appendingPathComponent("lf", isDirectory: false)
+            if FileManager.default.isExecutableFile(atPath: candidate.path) {
+                return candidate.path
+            }
+        }
+        return try bundledLfPath(bundled: bundled)
+    }
+
+    /// Return the control binary shipped with this exact Mac client build.
     static func bundledLfPath(
         bundled: URL? = Bundle.main.url(forAuxiliaryExecutable: "lf")
     ) throws -> String {
         guard let bundled, FileManager.default.isExecutableFile(atPath: bundled.path) else {
             throw LocalLfError(
                 errorDescription: "Loopflow.app is missing its executable bundled lf helper at Contents/MacOS/lf. "
-                    + "Rebuild or reinstall Loopflow; PATH fallback is disabled."
+                    + "No active machine lf was found; rebuild or reinstall Loopflow."
             )
         }
         return bundled.path
@@ -145,10 +164,10 @@ enum LocalWaveAgentLauncher {
 
     /// Run an `lf` query verb (`ls`, `status`, `runs`, …) and return its
     /// stdout. Backs `RegistryQuery` on macOS: the wave dashboard reads durable
-    /// facts by shelling the daemonless bundled `lf` over the local store, not
-    /// by streaming a center. Throws on a spawn failure or a non-zero exit.
+    /// facts through the machine's active daemonless `lf`, not by streaming a
+    /// center. Throws on a spawn failure or a non-zero exit.
     static func queryLf(_ subargs: [String], cwd: String?) throws -> String {
-        let lfPath = try bundledLfPath()
+        let lfPath = try controlLfPath()
         guard let result = run([lfPath] + subargs, cwd: cwd) else {
             throw LocalLfError(
                 errorDescription: "Failed to spawn: lf \(subargs.joined(separator: " "))"

--- a/swift/LoopflowMac/PodiumFixture.swift
+++ b/swift/LoopflowMac/PodiumFixture.swift
@@ -23,21 +23,28 @@ enum PodiumFixture {
             case .mockWaves:
                 let fixture = try loadRoadmap(sourceFile: sourceFile)
                 let reading: PodiumReading<RoadmapSnapshot>
+                let waves: PodiumReading<[Wave]>
                 let processActivity: PodiumReading<ActivitySnapshot>
                 let workActivity: PodiumReading<WorkActivitySnapshot>
                 switch MockWaveFixture.detailState {
                 case .selected:
                     reading = .available(fixture.roadmap)
+                    waves = .available(fixture.waves)
                     processActivity = .available(try loadProcessActivity(sourceFile: sourceFile))
                     workActivity = .available(try loadWorkActivity(sourceFile: sourceFile))
                 case .loading:
                     reading = .loading
+                    waves = .loading
                     processActivity = .loading
                     workActivity = .loading
                 case .error:
                     reading = .unavailable(
                         lastGood: nil,
                         reason: "the local registry is unreachable"
+                    )
+                    waves = .unavailable(
+                        lastGood: nil,
+                        reason: "the Wave fleet is unavailable"
                     )
                     processActivity = .unavailable(
                         lastGood: nil,
@@ -50,7 +57,7 @@ enum PodiumFixture {
                 }
                 model.applyFixture(
                     roadmap: reading,
-                    waves: .available(fixture.waves),
+                    waves: waves,
                     processActivity: processActivity,
                     workActivity: workActivity,
                     repos: fixture.repos,

--- a/swift/LoopflowMac/PodiumModel.swift
+++ b/swift/LoopflowMac/PodiumModel.swift
@@ -257,9 +257,10 @@ final class PodiumModel {
             return
         }
 
-        let previous = workActivityScope == scope ? workActivity.value : nil
+        let sameScope = workActivityScope == scope
+        let previous = sameScope ? workActivity.value : nil
+        if !sameScope { workActivity = .loading }
         workActivityScope = scope
-        if previous == nil { workActivity = .loading }
 
         let result = await readWorkActivity(scope: scope)
 

--- a/swift/LoopflowMac/Services/ProcessEnvironment.swift
+++ b/swift/LoopflowMac/Services/ProcessEnvironment.swift
@@ -2,8 +2,8 @@
 //
 // GUI-launched apps inherit a minimal PATH (/usr/bin:/bin:/usr/sbin:/sbin) that
 // doesn't include Homebrew, ~/.local/bin, or ~/.cargo/bin. Anything Loopflow
-// shells out to — tmux, git, and the active lf entry gate — inherits that, so
-// execvp can't find user-installed binaries. Pipe child envs through
+// shells out to — tmux, git, and agent CLIs — inherits that, so execvp can't
+// find user-installed binaries. Pipe child envs through
 // `enrichedPath` so they resolve the same binaries the user's shell would.
 
 import Foundation

--- a/swift/LoopflowMac/Services/ProcessEnvironment.swift
+++ b/swift/LoopflowMac/Services/ProcessEnvironment.swift
@@ -2,9 +2,9 @@
 //
 // GUI-launched apps inherit a minimal PATH (/usr/bin:/bin:/usr/sbin:/sbin) that
 // doesn't include Homebrew, ~/.local/bin, or ~/.cargo/bin. Anything Loopflow
-// shells out to — tmux, git, and the bundled lf — inherits that, so execvp can't
-// find user-installed binaries. Pipe child envs through `enrichedPath` so they
-// resolve the same binaries the user's shell would.
+// shells out to — tmux, git, and the active lf entry gate — inherits that, so
+// execvp can't find user-installed binaries. Pipe child envs through
+// `enrichedPath` so they resolve the same binaries the user's shell would.
 
 import Foundation
 

--- a/swift/LoopflowMac/Views/PodiumConsole.swift
+++ b/swift/LoopflowMac/Views/PodiumConsole.swift
@@ -76,7 +76,9 @@ struct PodiumConsole<Content: View>: View {
                     .padding(.trailing, Spacing.lg)
                     .accessibilityIdentifier("podium-console-error")
             }
-            if visibleWaves.isEmpty, !model.waves.isLoading {
+            if visibleWaves.isEmpty,
+               !model.waves.isLoading,
+               model.waves.errorMessage == nil {
                 Text("No Waves found.")
                     .font(Typography.caption())
                     .foregroundStyle(.white.opacity(0.58))

--- a/swift/LoopflowMac/Views/PodiumView.swift
+++ b/swift/LoopflowMac/Views/PodiumView.swift
@@ -31,7 +31,11 @@ struct PodiumView: View {
         let model = PodiumModel(query: query, repoPath: startingRepoPath)
         PodiumFixture.applyIfRequested(to: model)
         _model = State(initialValue: model)
-        _surface = State(initialValue: model.repoPath == nil ? .work : .sessions)
+        _surface = State(
+            initialValue: AppTestMode.startsOnWorkSurface || model.repoPath == nil
+                ? .work
+                : .sessions
+        )
     }
 
     var body: some View {

--- a/swift/LoopflowMac/Views/WorkActivityView.swift
+++ b/swift/LoopflowMac/Views/WorkActivityView.swift
@@ -79,10 +79,19 @@ struct WorkActivityView: View {
 
     @ViewBuilder
     private var content: some View {
-        if model.workActivity.value == nil, model.workActivity.errorMessage == nil {
-            ProgressView("Reading Activity…")
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
-                .accessibilityIdentifier("podium-activity-loading")
+        if model.workActivity.value == nil {
+            if model.workActivity.errorMessage == nil {
+                ProgressView("Reading Activity…")
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .accessibilityIdentifier("podium-activity-loading")
+            } else {
+                ContentUnavailableView(
+                    "Activity unavailable",
+                    systemImage: "exclamationmark.triangle",
+                    description: Text("The latest Activity read failed. The reason is shown above.")
+                )
+                .accessibilityIdentifier("podium-activity-error")
+            }
         } else if let items = model.workActivity.value?.items, !items.isEmpty {
             ScrollView {
                 LazyVStack(alignment: .leading, spacing: 0) {

--- a/swift/LoopflowTests/LocalWaveAgentLauncherTests.swift
+++ b/swift/LoopflowTests/LocalWaveAgentLauncherTests.swift
@@ -125,14 +125,48 @@ struct LocalWaveAgentLauncherTests {
 
     // MARK: - Bundled binary boundary
 
-    @Test("a missing bundled helper never falls through to PATH")
-    func missingBundledHelperFails() {
+    @Test("the active machine lf precedes the bundled fallback")
+    func activeMachineLfPrecedesBundle() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("loopflow-control-lf-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let installed = directory.appendingPathComponent("lf")
+        try Data().write(to: installed)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o755],
+            ofItemAtPath: installed.path
+        )
+
+        let resolved = try LocalWaveAgentLauncher.controlLfPath(
+            searchPath: directory.path,
+            bundled: URL(fileURLWithPath: "/Applications/Loopflow.app/Contents/MacOS/lf")
+        )
+
+        #expect(resolved == installed.path)
+    }
+
+    @Test("a missing machine lf uses the bundled offline fallback")
+    func missingMachineLfUsesBundle() throws {
+        let bundled = URL(fileURLWithPath: "/bin/sh")
+        let resolved = try LocalWaveAgentLauncher.controlLfPath(
+            searchPath: "/path/that/does/not/exist",
+            bundled: bundled
+        )
+
+        #expect(resolved == bundled.path)
+    }
+
+    @Test("a missing machine and bundled helper fails clearly")
+    func missingControlHelpersFail() {
         #expect {
-            try LocalWaveAgentLauncher.bundledLfPath(bundled: nil)
+            try LocalWaveAgentLauncher.controlLfPath(
+                searchPath: "/path/that/does/not/exist",
+                bundled: nil
+            )
         } throws: { error in
             guard error is LocalLfError else { return false }
             return error.localizedDescription.contains("missing its executable bundled lf helper")
-                && error.localizedDescription.contains("PATH fallback is disabled")
         }
     }
 

--- a/swift/LoopflowTests/LocalWaveAgentLauncherTests.swift
+++ b/swift/LoopflowTests/LocalWaveAgentLauncherTests.swift
@@ -125,48 +125,129 @@ struct LocalWaveAgentLauncherTests {
 
     // MARK: - Bundled binary boundary
 
-    @Test("the active machine lf precedes the bundled fallback")
-    func activeMachineLfPrecedesBundle() throws {
-        let directory = FileManager.default.temporaryDirectory
-            .appendingPathComponent("loopflow-control-lf-\(UUID().uuidString)", isDirectory: true)
-        defer { try? FileManager.default.removeItem(at: directory) }
-        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
-        let installed = directory.appendingPathComponent("lf")
+    @Test("the install-owned machine gate supplies executable and store authority")
+    func installedMachineGatePrecedesBundle() throws {
+        let accountHome = FileManager.default.temporaryDirectory
+            .appendingPathComponent("loopflow-control-home-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: accountHome) }
+        let installed = accountHome
+            .appendingPathComponent(".lf-machine/install/gates/1", isDirectory: true)
+            .appendingPathComponent("lf")
+        try FileManager.default.createDirectory(
+            at: installed.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
         try Data().write(to: installed)
         try FileManager.default.setAttributes(
             [.posixPermissions: 0o755],
             ofItemAtPath: installed.path
         )
 
-        let resolved = try LocalWaveAgentLauncher.controlLfPath(
-            searchPath: directory.path,
+        let authority = try LocalControlAuthority.resolve(
+            accountHome: accountHome,
             bundled: URL(fileURLWithPath: "/Applications/Loopflow.app/Contents/MacOS/lf")
         )
 
-        #expect(resolved == installed.path)
+        #expect(authority == .installedMachine(executable: installed))
     }
 
-    @Test("a missing machine lf uses the bundled offline fallback")
-    func missingMachineLfUsesBundle() throws {
+    @Test("an account-local bin cannot replace install authority")
+    func accountLocalBinCannotReplaceInstallAuthority() throws {
+        let accountHome = FileManager.default.temporaryDirectory
+            .appendingPathComponent("loopflow-control-home-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: accountHome) }
+        let unrelatedDirectory = accountHome
+            .appendingPathComponent(".local", isDirectory: true)
+            .appendingPathComponent("bin", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: unrelatedDirectory,
+            withIntermediateDirectories: true
+        )
+        let unrelated = unrelatedDirectory.appendingPathComponent("lf")
+        try Data().write(to: unrelated)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o755],
+            ofItemAtPath: unrelated.path
+        )
         let bundled = URL(fileURLWithPath: "/bin/sh")
-        let resolved = try LocalWaveAgentLauncher.controlLfPath(
-            searchPath: "/path/that/does/not/exist",
+
+        let authority = try LocalControlAuthority.resolve(
+            accountHome: accountHome,
             bundled: bundled
         )
 
-        #expect(resolved == bundled.path)
+        #expect(authority == .bundledOffline(executable: bundled))
+    }
+
+    @Test("a missing machine install uses the typed bundled offline fallback")
+    func missingMachineInstallUsesBundle() throws {
+        let bundled = URL(fileURLWithPath: "/bin/sh")
+        let authority = try LocalControlAuthority.resolve(
+            accountHome: URL(fileURLWithPath: "/path/that/does/not/exist", isDirectory: true),
+            bundled: bundled
+        )
+
+        #expect(authority == .bundledOffline(executable: bundled))
+    }
+
+    @Test("a broken installed gate fails instead of reading a different store")
+    func brokenInstalledGateFails() throws {
+        let accountHome = FileManager.default.temporaryDirectory
+            .appendingPathComponent("loopflow-control-home-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: accountHome) }
+        let gate = accountHome
+            .appendingPathComponent(".lf-machine/install/gates/1", isDirectory: true)
+            .appendingPathComponent("lf")
+        try FileManager.default.createDirectory(
+            at: gate.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try Data().write(to: gate)
+
+        #expect {
+            try LocalControlAuthority.resolve(
+                accountHome: accountHome,
+                bundled: URL(fileURLWithPath: "/bin/sh")
+            )
+        } throws: { error in
+            error.localizedDescription.contains("machine entry gate is not executable")
+        }
+    }
+
+    @Test("a receipt with no machine gate fails instead of reading a different store")
+    func missingInstalledGateFails() throws {
+        let accountHome = FileManager.default.temporaryDirectory
+            .appendingPathComponent("loopflow-control-home-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: accountHome) }
+        let installRoot = accountHome
+            .appendingPathComponent(".lf-machine", isDirectory: true)
+            .appendingPathComponent("install", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: installRoot,
+            withIntermediateDirectories: true
+        )
+        try Data("{}".utf8).write(to: installRoot.appendingPathComponent("active.json"))
+
+        #expect {
+            try LocalControlAuthority.resolve(
+                accountHome: accountHome,
+                bundled: URL(fileURLWithPath: "/bin/sh")
+            )
+        } throws: { error in
+            error.localizedDescription.contains("install receipt exists")
+        }
     }
 
     @Test("a missing machine and bundled helper fails clearly")
     func missingControlHelpersFail() {
         #expect {
-            try LocalWaveAgentLauncher.controlLfPath(
-                searchPath: "/path/that/does/not/exist",
+            try LocalControlAuthority.resolve(
+                accountHome: URL(fileURLWithPath: "/path/that/does/not/exist", isDirectory: true),
                 bundled: nil
             )
         } throws: { error in
             guard error is LocalLfError else { return false }
-            return error.localizedDescription.contains("missing its executable bundled lf helper")
+            return error.localizedDescription.contains("missing its executable offline lf helper")
         }
     }
 

--- a/swift/LoopflowTests/LocalWaveAgentLauncherTests.swift
+++ b/swift/LoopflowTests/LocalWaveAgentLauncherTests.swift
@@ -143,12 +143,12 @@ struct LocalWaveAgentLauncherTests {
             ofItemAtPath: installed.path
         )
 
-        let authority = try LocalControlAuthority.resolve(
+        let resolved = try LocalWaveAgentLauncher.controlLfPath(
             accountHome: accountHome,
             bundled: URL(fileURLWithPath: "/Applications/Loopflow.app/Contents/MacOS/lf")
         )
 
-        #expect(authority == .installedMachine(executable: installed))
+        #expect(resolved == installed.path)
     }
 
     @Test("an account-local bin cannot replace install authority")
@@ -171,23 +171,23 @@ struct LocalWaveAgentLauncherTests {
         )
         let bundled = URL(fileURLWithPath: "/bin/sh")
 
-        let authority = try LocalControlAuthority.resolve(
+        let resolved = try LocalWaveAgentLauncher.controlLfPath(
             accountHome: accountHome,
             bundled: bundled
         )
 
-        #expect(authority == .bundledOffline(executable: bundled))
+        #expect(resolved == bundled.path)
     }
 
-    @Test("a missing machine install uses the typed bundled offline fallback")
+    @Test("a missing machine install uses the bundled offline fallback")
     func missingMachineInstallUsesBundle() throws {
         let bundled = URL(fileURLWithPath: "/bin/sh")
-        let authority = try LocalControlAuthority.resolve(
+        let resolved = try LocalWaveAgentLauncher.controlLfPath(
             accountHome: URL(fileURLWithPath: "/path/that/does/not/exist", isDirectory: true),
             bundled: bundled
         )
 
-        #expect(authority == .bundledOffline(executable: bundled))
+        #expect(resolved == bundled.path)
     }
 
     @Test("a broken installed gate fails instead of reading a different store")
@@ -205,7 +205,7 @@ struct LocalWaveAgentLauncherTests {
         try Data().write(to: gate)
 
         #expect {
-            try LocalControlAuthority.resolve(
+            try LocalWaveAgentLauncher.controlLfPath(
                 accountHome: accountHome,
                 bundled: URL(fileURLWithPath: "/bin/sh")
             )
@@ -229,7 +229,7 @@ struct LocalWaveAgentLauncherTests {
         try Data("{}".utf8).write(to: installRoot.appendingPathComponent("active.json"))
 
         #expect {
-            try LocalControlAuthority.resolve(
+            try LocalWaveAgentLauncher.controlLfPath(
                 accountHome: accountHome,
                 bundled: URL(fileURLWithPath: "/bin/sh")
             )
@@ -241,7 +241,7 @@ struct LocalWaveAgentLauncherTests {
     @Test("a missing machine and bundled helper fails clearly")
     func missingControlHelpersFail() {
         #expect {
-            try LocalControlAuthority.resolve(
+            try LocalWaveAgentLauncher.controlLfPath(
                 accountHome: URL(fileURLWithPath: "/path/that/does/not/exist", isDirectory: true),
                 bundled: nil
             )

--- a/swift/LoopflowTests/PodiumModelTests.swift
+++ b/swift/LoopflowTests/PodiumModelTests.swift
@@ -264,6 +264,34 @@ struct PodiumModelTests {
         ])
     }
 
+    @Test("Unavailable Activity stays visible while the same scope retries")
+    func unavailableActivityStaysVisibleDuringRetry() async throws {
+        let fixture = try PodiumTestFixture.load()
+        let deferred = DeferredActivityResponse()
+        let query = RegistryQuery { args, _ in
+            #expect(args.first == "activity")
+            return await deferred.response()
+        }
+        let model = PodiumModel(query: query)
+
+        let failedRefresh = Task { await model.refreshWorkActivity() }
+        await deferred.waitUntilRequested()
+        await deferred.release("{}")
+        await failedRefresh.value
+        let failure = try #require(model.workActivity.errorMessage)
+
+        let retry = Task { await model.refreshWorkActivity() }
+        await deferred.waitUntilRequested()
+
+        #expect(model.workActivity.errorMessage == failure)
+        #expect(!model.workActivity.isLoading)
+
+        let success = try #require(String(data: fixture.workActivityData, encoding: .utf8))
+        await deferred.release(success)
+        await retry.value
+        #expect(model.workActivity.value?.items.count == fixture.workActivity.items.count)
+    }
+
     @Test("A late Activity query cannot replace evidence for a newer selection")
     func staleActivityQueryDoesNotReplaceNewSelection() async throws {
         let fixture = try PodiumTestFixture.load()

--- a/swift/LoopflowUITests/PodiumStateTests.swift
+++ b/swift/LoopflowUITests/PodiumStateTests.swift
@@ -143,6 +143,9 @@ final class PodiumStateTests: XCTestCase {
         forEachWidth(detailState: "error") { app in
             XCTAssertTrue(waitFor(app, id: "podium-work-unavailable"))
             XCTAssertTrue(exists(app, id: "podium-console-path"))
+            XCTAssertTrue(exists(app, id: "podium-console-error"))
+            XCTAssertTrue(exists(app, id: "podium-activity-error"))
+            XCTAssertFalse(exists(app, id: "podium-console-empty"))
             XCTAssertFalse(exists(app, id: "podium-work-empty"))
             XCTAssertFalse(exists(app, id: "podium-activity-empty"))
         }

--- a/swift/README.md
+++ b/swift/README.md
@@ -88,7 +88,7 @@ codebase tree, and registry health.
   renders its reason, and refresh failures leave the last successful roadmap or
   Activity history visible. The Mac resolves the fixed OS-account `lf` entry
   gate first, so one install receipt supplies the executable and store together;
-  the bundled helper is the typed offline fallback when Loopflow is not installed.
+  the bundled helper is the offline fallback when Loopflow is not installed.
 - **Per-Wave SSE** owns live motion. `WaveChatConnection` first reads
   `lf chat --history --json`, then connects only to the selected Wave's
   `/events` stream and upserts its replay before continuing live.

--- a/swift/README.md
+++ b/swift/README.md
@@ -86,9 +86,9 @@ codebase tree, and registry health.
   `lf ls/status/roadmap/ps/activity/usage/doctor/tokens --json`; the app does not
   maintain a second roadmap or lifecycle database. Unavailable per-Wave evidence
   renders its reason, and refresh failures leave the last successful roadmap or
-  Activity history visible. The Mac resolves the active machine `lf` entry gate
-  first so reads match the selected Home and its schema; the bundled helper is
-  the offline fallback when Loopflow is not installed.
+  Activity history visible. The Mac resolves the fixed OS-account `lf` entry
+  gate first, so one install receipt supplies the executable and store together;
+  the bundled helper is the typed offline fallback when Loopflow is not installed.
 - **Per-Wave SSE** owns live motion. `WaveChatConnection` first reads
   `lf chat --history --json`, then connects only to the selected Wave's
   `/events` stream and upserts its replay before continuing live.
@@ -123,10 +123,12 @@ only the selected Wave's `lf wave` process; it has no machine-wide service or
 remote-connection mode.
 
 The dev app bundles the current source `lf` with release Home selection and
-validation-only migration authority. Its operator views therefore read the
-real Home without allowing an unpromoted build to advance the shared database
-frontier. Ordinary source-built `lf` commands keep their isolated `.lf-dev`
-Home.
+validation-only migration authority. When Loopflow is installed, operator reads
+use the fixed machine entry gate and the exact executable/store pair from its
+active receipt. The Dev launcher forwards only its repository override; ambient
+Home variables cannot split that pair. Without an installation, the bundled
+helper remains a read-only offline fallback. Ordinary source-built `lf` commands
+keep their isolated `.lf-dev` Home.
 
 | Command | What it does |
 | --- | --- |
@@ -153,8 +155,8 @@ xcodebuild -project LoopflowSwift.xcodeproj \
 
 The generated app target builds validation-only `lf` and `lfd` fallback helpers
 from the same checkout into `Loopflow.app/Contents/MacOS`. A runnable app uses
-the active machine entry gate when present so a selected development Home is
-read by its matching binary.
+`~/.lf-machine/install/gates/1/lf` when present, so the active receipt selects
+both the matching binary and store without PATH or inherited Home conventions.
 
 Keep `Package.swift` and `project.yml` in sync.
 

--- a/swift/README.md
+++ b/swift/README.md
@@ -86,7 +86,9 @@ codebase tree, and registry health.
   `lf ls/status/roadmap/ps/activity/usage/doctor/tokens --json`; the app does not
   maintain a second roadmap or lifecycle database. Unavailable per-Wave evidence
   renders its reason, and refresh failures leave the last successful roadmap or
-  Activity history visible.
+  Activity history visible. The Mac resolves the active machine `lf` entry gate
+  first so reads match the selected Home and its schema; the bundled helper is
+  the offline fallback when Loopflow is not installed.
 - **Per-Wave SSE** owns live motion. `WaveChatConnection` first reads
   `lf chat --history --json`, then connects only to the selected Wave's
   `/events` stream and upserts its replay before continuing live.
@@ -149,9 +151,10 @@ xcodebuild -project LoopflowSwift.xcodeproj \
   build
 ```
 
-The generated app target builds validation-only `lf` and `lfd` helpers from
-the same checkout into `Loopflow.app/Contents/MacOS`. A runnable app never
-borrows a different `lf` from PATH.
+The generated app target builds validation-only `lf` and `lfd` fallback helpers
+from the same checkout into `Loopflow.app/Contents/MacOS`. A runnable app uses
+the active machine entry gate when present so a selected development Home is
+read by its matching binary.
 
 Keep `Package.swift` and `project.yml` in sync.
 

--- a/swift/README.md
+++ b/swift/README.md
@@ -127,8 +127,8 @@ validation-only migration authority. When Loopflow is installed, operator reads
 use the fixed machine entry gate and the exact executable/store pair from its
 active receipt. The Dev launcher forwards only its repository override; ambient
 Home variables cannot split that pair. Without an installation, the bundled
-helper remains a read-only offline fallback. Ordinary source-built `lf` commands
-keep their isolated `.lf-dev` Home.
+helper remains the validation-only offline fallback. Ordinary source-built `lf`
+commands keep their isolated `.lf-dev` Home.
 
 | Command | What it does |
 | --- | --- |


### PR DESCRIPTION
<!-- loopflow:task-pr-context:start -->
> [!NOTE]
> **Task:** [LOO-274 — Restore Wave fleet and roadmap loading in the Mac app](https://linear.app/loopflow/issue/LOO-274/restore-wave-fleet-and-roadmap-loading-in-the-mac-app)
> **Task cycle:** fix
> **PR lifecycle:** PR 1 is published for review; no Task settlement is requested.
<!-- loopflow:task-pr-context:end -->

## Evaluate

Build and launch the installed Dev app, then strip every ambient routing hint:

```bash
uv run python scripts/loopflow-dev.py run
env -u LF_HOME -u LF_DB_PATH -u LF_CONTROL_HOME \
  -u LF_CONTROL_DB_PATH -u LF_CONTROL_BIN PATH=/usr/bin:/bin \
  LOOPFLOW_UI_TEST_MODE=live LOOPFLOW_UI_TEST_VIEW=roadmap \
  LOOPFLOW_UI_TEST_DELAY=40 \
  ~/Applications/Loopflow\ Dev.app/Contents/MacOS/Loopflow
```

Observe five Waves and populated Work from the active development installation.
Activity leaves its loading state; the current missing-`run_id` DTO mismatch is
shown as `Activity unavailable` with its exact reason, without a healthy-empty
claim. The settled capture was SHA-256
`3e7aab97d12f5ed1aa3bb0635d6e88eeb408fe896863a0f00938b3ac237e5130`.
The exact gate independently returned five Waves and product planning with three
Projects and 88 Tasks.

Focused checks:

```bash
uv run pytest python/tests/
swift test --package-path swift --filter PodiumModelTests
uv run python scripts/check_swift_multiplatform_boundaries.py
scripts/prove_wave_surface_states.sh
```

The gate passed 205 Python tests, the 230-test Swift suite before the final
bounded correction, its 14-test focused Swift proof afterward, eight distinct
surface-state captures, the Mac package build, and signed macOS
`build-for-testing` on the final tree.

## Why it matters

The configured Mac app was pairing a populated development Home with an
incompatible bundled helper, then presenting read failure as a plausible zero
fleet. The app now consumes the machine installation's executable/store
authority and keeps absent evidence visibly absent.

## What changed

- Resolve the fixed machine gate for both Mac reads and controls; use the
  validation-only bundled helper only without an installation.
- Remove Dev launch's manual Home-variable forwarding contract.
- Render fleet, roadmap, and Activity states exhaustively so unavailable is not
  empty.
- Keep terminal Activity failures visible while same-scope retries run.
- Make live capture timing and target selection deterministic enough to prove
  the configured installed path.

## Risks / Not included

The versioned gate path still needs an unversioned machine API. Activity
`run_id` and the live `lf ps` node-kind mismatch remain explicit follow-ups, as
do the disposable newer-Home integration gate and the broader
`PodiumReading` audit. Sampled long-lived-store reads took 14.40 seconds
(fleet), 10.30 seconds (roadmap), and 6.71 seconds (Activity); production p95
milestones are not yet instrumented.