### PR TITLE
wave: reconcile durable main context

### DIFF
--- a/wave/infrastructure/MEMORY.md
+++ b/wave/infrastructure/MEMORY.md
@@ -41,6 +41,32 @@ Renamed from `systems` in the 2026-07-08 wave/project/task restructure. Steers L
   Linear moves an issue, historical Task Runs retain their evidence but lose
   automated PR and completion authority; fail closed before side effects and
   preserve the full Work, Run, Steer, and PR history for remediation.
+- **A live parent Run is not proof of child-control authority** (learned
+  2026-08-22). A relaunched Project can have a healthy provider process yet
+  lack the durable Turn Basis required to reserve its Task Run. Wave-level
+  Task control then correctly fails because only the immediate parent may act.
+  Preserve the existing Task, Work, and PR; do not retry into duplicate Runs
+  or publications. Wake pursuit only when a basis-bearing immediate-parent Run
+  exists. A Turn without `LF_AGENT_INVOCATION_ID` also cannot open a parent Ask,
+  so report that escalation boundary explicitly rather than silently spinning.
+- **Historical continuity currently short-circuits daily telemetry** (observed
+  2026-08-23). `telemetry-daily` stops in `doctor` on the same eight 2026-08-04
+  through 2026-08-11 gap days before its scorecard runs. LOO-241 owns making
+  continuity obligation-aware. Fresh receipts are new evidence for that Task,
+  not grounds for duplicate daily Tasks; retry its Work only from a Turn with
+  valid Run execution context.
+- **Release orchestration and product publication are separate evidence**
+  (observed 2026-08-23). A cron receipt proves only the scheduled target's
+  terminal state. `lf release status` remained at tag `v0.12.14` with a
+  successful hosted workflow and gate-safe notes but no GitHub Release after
+  both successful and failed `release-run` receipts. Judge the release KR by
+  the product state and keep same-tag recovery singular; LOO-261 owns the known
+  clean-host candidate-validation boundary.
+- **Incomplete release synchronization still consumes caller edits**
+  (reproduced 2026-08-23). The scheduled retry left `main` clean after removing
+  two pre-run Infrastructure memory edits. LOO-266 owns preserving the caller
+  branch, index, and working bytes across every release exit; do not file a
+  second repair Task for later instances of the same failure.
 
 ## Model (design settled)
 

--- a/wave/list/GOAL.md
+++ b/wave/list/GOAL.md
@@ -1,0 +1,29 @@
+---
+pm:
+  linear_initiative: f6d2c0bd-c9bd-490a-a18e-8ed03216e6d4
+---
+
+## Objective
+
+Loopflow's Task control plane keeps work safe, recoverable, and available while
+process ownership, provider sessions, telemetry, and releases change
+independently.
+
+## Projects
+
+Projects and tasks live in Linear and sync into the local SQLite registry.
+Projects do not own memory, cadence, or child projects.
+
+## Bounds
+
+- Resolve control authority and release coexistence semantics before changing
+  Task execution, recovery, or promotion.
+- Keep provider history and telemetry useful without silently granting them
+  operational authority.
+
+## Process
+
+Read the synced Project and its first open Task. Settle architectural forks in
+one explicit design artifact before implementation, then use focused behavioral
+proofs to keep Task control safe under missing processes, provider state, and
+telemetry.

--- a/wave/list/MEMORY.md
+++ b/wave/list/MEMORY.md
@@ -1,0 +1,7 @@
+# Open questions
+
+- Does exact OS-verifiable `ProcessOwner` identity hold sole authority for Task
+  liveness and signaling, or can provider Invocation state authorize or veto
+  control actions?
+- Does release promotion stop and restart the current Task process, or allow
+  adjacent releases to coexist under an explicit ownership boundary?


### PR DESCRIPTION
## Usage

```bash
git show --stat origin/main
```

## Summary

Preserve the release-recovery evidence lost during an earlier main restoration and initialize the list wave from its current Linear-backed context. This reconciles the local canonical branch through the protected merge queue so task worktrees can start from origin/main.