### PR TITLE
release: decouple artifact identity from Home compatibility

### DIFF
--- a/python/tests/test_release_publisher.py
+++ b/python/tests/test_release_publisher.py
@@ -73,6 +73,20 @@ def test_publisher_rejects_validation_only_control_plane(
         publish_release._validate_release_candidate(binary, tmp_path)
 
 
+def test_publisher_accepts_published_identity_when_home_preflight_refuses(tmp_path: Path):
+    binary = tmp_path / "lf"
+    binary.write_text(
+        "#!/bin/sh\n"
+        "echo '{\"candidate\":{\"authority\":\"published\"},"
+        "\"verdict\":{\"kind\":\"reject\"}}'\n"
+        "echo 'Error: promotion preflight refused' >&2\n"
+        "exit 1\n"
+    )
+    binary.chmod(0o755)
+
+    publish_release._validate_release_candidate(binary, tmp_path)
+
+
 def test_publisher_completes_all_stages_before_marking_release_published(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ):
@@ -93,6 +107,7 @@ def test_publisher_completes_all_stages_before_marking_release_published(
         cwd: Path = tmp_path,
         capture: bool = False,
         env: dict[str, str] | None = None,
+        check: bool = True,
     ) -> subprocess.CompletedProcess[str]:
         commands.append(command)
         if command[:3] == ["git", "tag", "--points-at"]:

--- a/scripts/publish_release.py
+++ b/scripts/publish_release.py
@@ -63,12 +63,13 @@ def _run(
     cwd: Path = ROOT,
     capture: bool = False,
     env: dict[str, str] | None = None,
+    check: bool = True,
 ) -> subprocess.CompletedProcess[str]:
     print(f"$ {shlex.join(cmd)}", flush=True)
     return subprocess.run(
         cmd,
         cwd=cwd,
-        check=True,
+        check=check,
         capture_output=capture,
         text=True,
         env=env,
@@ -148,6 +149,7 @@ def _validate_release_candidate(binary: Path, scratch: Path) -> None:
         [str(binary), "install", "preflight", "--json"],
         capture=True,
         env={**os.environ, "LF_CONTROL_DB_PATH": str(scratch / "uninitialized.db")},
+        check=False,
     )
     try:
         candidate = json.loads(result.stdout)["candidate"]


### PR DESCRIPTION
## Why

v0.12.14 emits its candidate identity before refusing promotion against the release host’s live Home. The publisher treated that expected nonzero exit as an invalid artifact and never read the identity.

## Change

- Capture candidate preflight output without requiring a successful Home verdict.
- Continue to require a parseable candidate with published migration authority.
- Cover a published candidate that emits JSON and exits nonzero.

## Proof

- `uv run pytest python/tests/test_release_publisher.py python/tests/test_release_automation.py -q`
- `uv run ruff check scripts/publish_release.py python/tests/test_release_publisher.py`