### PR TITLE
LOO-241: Preserve missingness in telemetry health evidence

### DIFF
--- a/docs/waves.md
+++ b/docs/waves.md
@@ -146,6 +146,12 @@ Contracts define no command, query, schedule, secret, or KR copy. Product code
 registered as the named instrument pushes pre-aggregated, revision-bound
 observations into the local store.
 
+Emit an observed value only when durable authority covers the exact source
+window and defines a non-empty eligible population. Mark partial capture
+incomplete so readers report Unknown; report an empty population or failed
+source read as Unavailable with the reason. Never encode an absent denominator
+as zero. Only a complete observation can meet or miss a target.
+
 ```bash
 lf status <wave>            # owner, value, target, window, freshness, reason
 lf status <wave> --json     # the shared metric_portfolio DTO

--- a/python/tests/test_lifecycle_scorecard.py
+++ b/python/tests/test_lifecycle_scorecard.py
@@ -323,6 +323,33 @@ def test_task_loop_trust_emits_one_exact_window_observation(tmp_path: Path) -> N
     }
 
 
+def test_task_loop_trust_without_eligible_tasks_is_unavailable(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "loopflow"
+    repo.mkdir()
+    connection = _task_loop_connection()
+    started = datetime(2026, 7, 15, tzinfo=timezone.utc)
+    ended = datetime(2026, 7, 22, tzinfo=timezone.utc)
+    connection.execute(
+        "INSERT INTO performance_evidence_authority VALUES (1, ?)",
+        (int(started.timestamp()) - 1,),
+    )
+
+    observation = scorecard.task_loop_trust_observation(
+        connection, repo, started, ended
+    )
+
+    assert observation == {
+        "wave": "product",
+        "metric_id": "task-loop-trust",
+        "instrument": "lifecycle-scorecard",
+        "kind": "unavailable",
+        "source_as_of": "2026-07-22T00:00:00Z",
+        "reason": "No eligible settled Tasks in the source window",
+    }
+
+
 def test_task_loop_trust_counts_a_pr_that_settles_after_its_epoch_starts(
     tmp_path: Path,
 ) -> None:

--- a/python/tests/test_lifecycle_scorecard.py
+++ b/python/tests/test_lifecycle_scorecard.py
@@ -318,8 +318,6 @@ def test_task_loop_trust_emits_one_exact_window_observation(tmp_path: Path) -> N
         "source_window_start": "2026-07-15T00:00:00Z",
         "source_window_end": "2026-07-22T00:00:00Z",
         "complete": True,
-        "eligible": 4,
-        "successful": 2,
     }
 
 
@@ -386,8 +384,6 @@ def test_task_loop_trust_counts_a_pr_that_settles_after_its_epoch_starts(
         connection, repo, started, ended
     )
 
-    assert observation["eligible"] == 2
-    assert observation["successful"] == 1
     assert observation["value"] == 0.5
 
 
@@ -425,8 +421,6 @@ def test_task_loop_trust_ignores_manual_repair_from_an_earlier_epoch(
         connection, repo, started, ended
     )
 
-    assert observation["eligible"] == 1
-    assert observation["successful"] == 1
     assert observation["value"] == 1.0
 
 

--- a/rust/loopflow/src/lf/commands/doctor.rs
+++ b/rust/loopflow/src/lf/commands/doctor.rs
@@ -8,7 +8,10 @@
 //! and the old process-grained run view once spliced one process's label onto
 //! another's cost.
 //!
-//! Checks are pure functions of the rows, so they are tested without a store.
+//! A failing check names either a directly violated durable invariant or the
+//! owner, due interval, and evidence query for a missed obligation. Observer
+//! silence without that authority remains non-failing history. Checks are pure
+//! functions of their evidence, so they are tested without a store.
 
 use std::collections::{BTreeSet, HashMap, HashSet};
 use std::path::Path;

--- a/rust/loopflow/src/ops/flow.rs
+++ b/rust/loopflow/src/ops/flow.rs
@@ -414,9 +414,7 @@ print(json.dumps({"report": {"ok": True}, "metric_observations": [], "text": "sc
                     "value":0.5,
                     "source_window_start":"2026-08-14T09:00:00Z",
                     "source_window_end":"2026-08-21T09:00:00Z",
-                    "complete":true,
-                    "eligible":4,
-                    "successful":2
+                    "complete":true
                 }],
                 "text":"Lifecycle scorecard"
             }"#,
@@ -456,9 +454,7 @@ print(json.dumps({
         "value": 1.0,
         "source_window_start": start.isoformat(),
         "source_window_end": end.isoformat(),
-        "complete": True,
-        "eligible": 1,
-        "successful": 1
+        "complete": True
     }],
     "text": "scorecard text\n"
 }))

--- a/rust/loopflow/src/ops/flow.rs
+++ b/rust/loopflow/src/ops/flow.rs
@@ -402,7 +402,7 @@ print(json.dumps({"report": {"ok": True}, "metric_observations": [], "text": "sc
     }
 
     #[test]
-    fn telemetry_envelope_decodes_project_metric_observation() {
+    fn telemetry_envelope_accepts_older_producer_annotations() {
         let envelope: TelemetryScorecardEnvelope = serde_json::from_str(
             r#"{
                 "report":{"schema_version":1},
@@ -414,7 +414,9 @@ print(json.dumps({"report": {"ok": True}, "metric_observations": [], "text": "sc
                     "value":0.5,
                     "source_window_start":"2026-08-14T09:00:00Z",
                     "source_window_end":"2026-08-21T09:00:00Z",
-                    "complete":true
+                    "complete":true,
+                    "eligible":4,
+                    "successful":2
                 }],
                 "text":"Lifecycle scorecard"
             }"#,

--- a/rust/loopflow/src/ops/metrics.rs
+++ b/rust/loopflow/src/ops/metrics.rs
@@ -148,7 +148,7 @@ async fn compose_persisted_portfolio(
 }
 
 #[derive(Debug, Clone, Deserialize)]
-#[serde(tag = "kind", rename_all = "snake_case", deny_unknown_fields)]
+#[serde(tag = "kind", rename_all = "snake_case")]
 pub(crate) enum MetricProducerObservation {
     Observed {
         wave: String,

--- a/rust/loopflow/src/ops/metrics.rs
+++ b/rust/loopflow/src/ops/metrics.rs
@@ -148,7 +148,7 @@ async fn compose_persisted_portfolio(
 }
 
 #[derive(Debug, Clone, Deserialize)]
-#[serde(tag = "kind", rename_all = "snake_case")]
+#[serde(tag = "kind", rename_all = "snake_case", deny_unknown_fields)]
 pub(crate) enum MetricProducerObservation {
     Observed {
         wave: String,

--- a/scratch/make-ledger-continuity-failures-match.md
+++ b/scratch/make-ledger-continuity-failures-match.md
@@ -1,0 +1,113 @@
+# 5 Whys: Historical ledger gaps permanently gated daily telemetry
+
+## The Problem
+
+The 2026-08-20 `telemetry-daily` run stopped in `lf doctor` on eight
+2026-08-04 through 2026-08-11 ledger gap-days even though no durable scheduler
+obligation required a run on those days, so the telemetry scorecard never ran.
+
+## Recorded Evidence
+
+- Before PR #1248, `check_continuity` accepted only `run_events` and the current
+  time. It treated every missing UTC date between the first and last observed
+  event as a failure, and treated more than 24 hours without an event as a
+  warning. It did not read cron installation or receipt evidence.
+- The old unit tests made that proxy normative: a single internal gap-day had
+  to fail, and a 29-hour silence inside two populated days had to warn.
+- `.lf/flows/telemetry-daily.yaml` runs `doctor` before
+  `__telemetry-scorecard`; any doctor failure prevents the scorecard step.
+- The retained Infrastructure launchd jobs were created on
+  2026-08-22T17:23:51Z. They durably name the wave, flow, fixed-daily schedule,
+  and Home `home_39860354aaca640c2ccb50bf6ca609d8`, but the legacy files have no
+  activation field.
+- The earliest exact scheduled receipt for `infrastructure/telemetry-daily`
+  began at 2026-08-22T17:24:01Z on that Home. Its target failed, but the receipt
+  still proves the scheduler launched: `run_cron` persists the running receipt
+  before placement validation or target execution.
+- The eight August 4-11 dates therefore predate the first durable evidence of
+  this Home's cadence by at least ten days. Their missing capture remains real
+  historical evidence, but it is not evidence of a missed cron obligation.
+- PR #1248 now persists or recovers activation, joins installed cron identity
+  to exact scheduled receipts, judges only the latest due interval, and keeps
+  raw gap-days diagnostic. Its copied-production-path test proves
+  `telemetry-daily` reaches the scorecard without altering historical events.
+
+## Chain
+
+Permanent telemetry failure → every calendar gap was a failed continuity check
+→ event presence stood in for expected scheduler execution → the scheduler had
+no durable activation boundary exposed to doctor → tests verified the proxy
+instead of the configured telemetry path → missing evidence was treated as a
+missed obligation without first establishing the denominator
+
+**Problem**: Eight terminal historical ledger gaps caused every later
+`telemetry-daily` run to fail before its scorecard.
+
+**Why 1**: `check_continuity` returned `Fail` for any internal calendar date
+without a `run_events` row, regardless of whether anything was scheduled.
+
+↳ *Could we have caught this earlier?* A test containing events before and
+after a pre-activation gap, plus a current scheduled receipt, would have exposed
+that old history could never recover.
+
+**Why 2**: The check used general ledger activity as a proxy for scheduler
+health. Its input had no installed cron, activation time, Home, schedule, or
+receipt source from which to compute a real obligation.
+
+↳ *What process allowed this?* The continuity check and cron runner were
+reviewed as separate features. No configured-path test joined the cron's
+declared cadence to the doctor gate inside `telemetry-daily`.
+
+**Why 3**: The installed cron metadata described how to launch work but not
+when that obligation began. Receipts described attempts after they happened,
+but doctor never read either surface. There was no domain value corresponding
+to “this Home owed this cron in this interval.”
+
+↳ *What assumption was wrong?* A quiet ledger was assumed to mean the ledger
+was unavailable. It can also mean that no owned work was due, that cadence was
+not active yet, or that unrelated historical capture was lost.
+
+**Why 4**: The original fix was shaped around a real 29.2-hour capture outage.
+It generalized an observer-side symptom—elapsed time between rows—into a health
+policy, and focused unit tests reinforced that heuristic without supplying an
+authoritative denominator.
+
+↳ *Why was that assumption encoded?* At the time, the observable event span
+was the only readily available continuity signal. Cron later gained durable
+receipts, but the monitoring model was not revisited to distinguish history
+from current obligation.
+
+**Why 5 (Root)**: Infrastructure health had no explicit expectedness rule.
+Absence of an observation was allowed to become evidence of an outage before a
+durable authority established the owner, activation boundary, due interval,
+and receipt that should exist. That conflated historical missingness with a
+currently violated obligation.
+
+## Unanswered Whys
+
+| Branch Point | Unexplored Question | Priority |
+|--------------|---------------------|----------|
+| Why 1 | Why were the August 4-11 `run_events` absent? LOO-219 owns capture loss; its answer cannot change the cadence denominator. | High |
+| Why 2 | What launched the 2026-08-20 telemetry run before the retained Home's 2026-08-22 cron activation? | Medium |
+| Why 3 | How should a legacy installed job with neither a scheduled receipt nor trustworthy file birth time establish activation? | Medium |
+| Why 5 | Do any other doctor or scorecard failures infer a missing obligation from observer silence instead of durable authority? | High |
+
+## Fixes
+
+| Level | Fix | Prevents |
+|-------|-----|----------|
+| Immediate | Let terminal historical gaps remain diagnostic once the current due cron interval has an exact scheduled receipt. Shipped in PR #1248. | The August 4-11 gaps permanently blocking `telemetry-daily`. |
+| Structural | Persist activation with the installed cron, preserve it across unchanged syncs, recover legacy activation from exact scheduled receipts, and compare the latest due interval with receipts matching wave, flow, target kind, Home, schedule, and scheduled source. Shipped in PR #1248. | Manual runs, target outcomes, stale identities, or pre-activation history being mistaken for scheduler continuity. |
+| Systemic | Make negative health claims prove their denominator: durable authority, owner, activation, due interval, and evidence query. Without that proof, report history or unknown state rather than an outage. | Future monitoring gates turning absence of unrelated observations into permanent red state. |
+
+## Changes to Implement
+
+- [x] Restore cron continuity through durable activation and exact scheduled
+  receipts while preserving historical events.
+- [x] Prove the real `doctor` → telemetry-scorecard path on a
+  copied-production-shaped store.
+- [ ] Audit remaining absence-based `lf doctor` and lifecycle scorecard gates.
+  For each red state, record the durable authority, owner, expected interval,
+  and evidence query; reclassify any claim without that denominator as history
+  or unknown. Encode this rule in the health-check authoring guidance, without
+  extracting a generic evaluator until a second concrete check needs it.

--- a/scratch/make-ledger-continuity-failures-match.md
+++ b/scratch/make-ledger-continuity-failures-match.md
@@ -106,8 +106,18 @@ currently violated obligation.
   receipts while preserving historical events.
 - [x] Prove the real `doctor` → telemetry-scorecard path on a
   copied-production-shaped store.
-- [ ] Audit remaining absence-based `lf doctor` and lifecycle scorecard gates.
+- [x] Audit remaining absence-based `lf doctor` and lifecycle scorecard gates.
   For each red state, record the durable authority, owner, expected interval,
   and evidence query; reclassify any claim without that denominator as history
   or unknown. Encode this rule in the health-check authoring guidance, without
   extracting a generic evaluator until a second concrete check needs it.
+
+## Audit Result
+
+Every remaining `lf doctor` failure reports either a direct invariant violation
+or an error reading its named authority. Lifecycle scorecard rows already keep
+missing samples and absent authority Unknown. One producer boundary still
+synthesized an incomplete observed `0.0` for the undefined ratio `0 / 0` when
+no settled Task was eligible. Emit the existing Unavailable observation with a
+source-window reason instead; no new metric state or generic evaluator is
+needed.

--- a/scratch/questions.md
+++ b/scratch/questions.md
@@ -1,0 +1,8 @@
+# Open Questions
+
+- 2026-08-28: `lf task status LOO-241` reports merged PR #1248 and recommends
+  `start_next_pr`, but `lf pr next ledger-continuity-5whys` failed with
+  `no Task owns this worktree`. Continue the computable 5 Whys artifact in the
+  retained clean worktree; do not bypass Loopflow with manual branch or
+  worktree operations. The runner must restore Task ownership before this
+  follow-up can be published.

--- a/scratch/questions.md
+++ b/scratch/questions.md
@@ -1,8 +1,8 @@
 # Open Questions
 
 - 2026-08-28: `lf task status LOO-241` reports merged PR #1248 and recommends
-  `start_next_pr`, but `lf pr next ledger-continuity-5whys` failed with
-  `no Task owns this worktree`. Continue the computable 5 Whys artifact in the
-  retained clean worktree; do not bypass Loopflow with manual branch or
-  worktree operations. The runner must restore Task ownership before this
+  `start_next_pr`, but both the 5 Whys and implementation Runs received
+  `no Task owns this worktree` from `lf pr next`. Continue the computable
+  follow-up in the retained worktree; do not bypass Loopflow with manual branch
+  or worktree operations. The runner must restore Task ownership before this
   follow-up can be published.

--- a/scratch/review.md
+++ b/scratch/review.md
@@ -1,0 +1,36 @@
+# Review: Obligation-aware ledger continuity
+
+## Evidence Matrix
+
+| Claim | Planned behavior | Implemented behavior | Proof | Result |
+|---|---|---|---|---|
+| August 4–11 are outside the cadence denominator | Explain each historical gap from durable activation and receipt evidence | The retained job identifies `infrastructure/telemetry-daily`, Home `home_39860354aaca640c2ccb50bf6ca609d8`, and schedule `0 0 9 * * *`; its file birth is 2026-08-22T17:23:51Z and its first exact scheduled receipt starts 2026-08-22T17:24:01Z | Live plist metadata and first retained receipt; `copied_production_history_does_not_block_the_telemetry_scorecard` | pass |
+| A current missed run is actionable | Fail with the owning cron, Home, expected interval, and receipt-history action | Continuity matches scheduled receipts on wave, flow, target kind, Home, schedule, and interval, then prints every named field and the exact `lf cron history` command | `a_missing_due_receipt_names_the_cron_home_interval_and_action` | pass |
+| Pre-activation history is not an outage | Do not create an obligation before activation | A schedule at or before the current time is due only when its interval starts at or after `activated_at` | `a_pre_activation_day_has_no_due_interval` | pass |
+| Scheduler execution is distinct from target success | A scheduled failed target satisfies cadence; a manual run does not | Receipt source participates in the match and receipt outcome does not | `a_scheduled_failure_counts_but_a_manual_trigger_does_not` | pass |
+| New evidence restores the current window without rewriting history | A later receipt makes continuity healthy while old gaps remain immutable diagnostics | Adding the exact scheduled receipt changes Fail to Ok; the event rows remain byte-for-byte equal and the gap detail remains visible | `a_later_receipt_restores_the_current_window_without_rewriting_history` | pass |
+| Telemetry reaches its scorecard | Historical gaps alone cannot stop `telemetry-daily` before `__telemetry-scorecard` | The copied store preserves all August events, doctor reports all eight dates as pre-activation history, and the configured flow writes its scorecard marker | `cargo test -p loopflow --test doctor_tests copied_production_history_does_not_block_the_telemetry_scorecard -- --exact` | pass |
+| Activation survives reconciliation | Preserve activation for the same obligation and recover legacy jobs from exact scheduled evidence | Sync retains activation when identity, target, schedule, and Home match; legacy parsing chooses the earliest matching scheduled receipt before file timestamps | `add_list_remove_round_trips_loaded_launchd_spec`; `legacy_cron_activation_is_recovered_from_its_first_scheduled_receipt` | pass |
+| An empty metric population is missing evidence, not zero | Do not synthesize `0 / 0` after auditing other absence-based health claims | The scorecard emits Unavailable with the exact source time and reason; non-empty observations contain only the durable metric fields | `uv run pytest python/tests/test_lifecycle_scorecard.py -k task_loop_trust -q` (4 passed) | pass |
+
+## Source Review
+
+The core model is one `CronObligation`: cron identity, fixed-daily schedule,
+Home, activation, and retained receipts. `lf doctor` derives the latest due
+interval from that value and makes no writes. Raw ledger events remain a
+separate historical diagnostic. No evaluator, compatibility type, or second
+continuity state was added.
+
+One review finding was fixed. The installed binary executes
+`scripts/lifecycle_scorecard.py` from the selected checkout, so binary and
+checkout revisions can legitimately differ. Strict unknown-field rejection
+would have made the current binary reject the prior script's harmless
+`eligible` and `successful` annotations. The producer no longer emits those
+fields, the durable Rust type does not carry them, and the decoder remains
+liberal across checkout skew. The focused
+`telemetry_envelope_accepts_older_producer_annotations` proof passes.
+
+## Disposition
+
+The behavior and source now match the Task outcome. Publishing remains subject
+to Loopflow restoring Task ownership for this retained post-merge worktree.

--- a/scratch/review.md
+++ b/scratch/review.md
@@ -32,5 +32,5 @@ liberal across checkout skew. The focused
 
 ## Disposition
 
-The behavior and source now match the Task outcome. Publishing remains subject
-to Loopflow restoring Task ownership for this retained post-merge worktree.
+The behavior and source match the Task outcome. Loopflow published the reviewed
+follow-up as PR #1254.

--- a/scripts/lifecycle_scorecard.py
+++ b/scripts/lifecycle_scorecard.py
@@ -344,8 +344,6 @@ def task_loop_trust_observation(
         "source_window_start": source_window_start,
         "source_window_end": source_window_end,
         "complete": True,
-        "eligible": len(eligible),
-        "successful": successful,
     }
 
 

--- a/scripts/lifecycle_scorecard.py
+++ b/scripts/lifecycle_scorecard.py
@@ -321,6 +321,13 @@ def task_loop_trust_observation(
         for row in rows
         if row["worktree"] is not None and belongs_to_repo(row["worktree"], repo)
     ]
+    if not eligible:
+        return {
+            **identity,
+            "kind": "unavailable",
+            "source_as_of": source_window_end,
+            "reason": "No eligible settled Tasks in the source window",
+        }
     successful = sum(
         1
         for row in eligible
@@ -333,10 +340,10 @@ def task_loop_trust_observation(
     return {
         **identity,
         "kind": "observed",
-        "value": successful / len(eligible) if eligible else 0.0,
+        "value": successful / len(eligible),
         "source_window_start": source_window_start,
         "source_window_end": source_window_end,
-        "complete": bool(eligible),
+        "complete": True,
         "eligible": len(eligible),
         "successful": successful,
     }


### PR DESCRIPTION
Treat empty task-loop source populations as unavailable instead of an observed zero, document the authority-backed denominator rule, and keep scorecard producer decoding tolerant across installed-binary and checkout version skew. Includes the completed LOO-241 root-cause analysis and production-path review evidence.