### PR TITLE
mac release: verify self-contained app resources

### DIFF
--- a/python/tests/test_release_loopflow.py
+++ b/python/tests/test_release_loopflow.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import importlib.util
 import plistlib
+import shlex
 import subprocess
 import sys
 from pathlib import Path
@@ -55,6 +56,62 @@ def test_release_bundle_carries_the_control_plane_pair(
 
     assert (app_macos_dir / "lf").read_bytes() == b"release-lf"
     assert (app_macos_dir / "lfd").read_bytes() == b"release-lfd"
+
+
+def _write_test_app(app_path: Path, script: str) -> None:
+    app_macos_dir = app_path / "Contents" / "MacOS"
+    app_macos_dir.mkdir(parents=True)
+    with (app_path / "Contents" / "Info.plist").open("wb") as file:
+        plistlib.dump({"CFBundleExecutable": "Loopflow"}, file)
+    executable = app_macos_dir / "Loopflow"
+    executable.write_text("#!/bin/sh\nset -eu\n" + script)
+    executable.chmod(0o755)
+
+
+def test_resource_check_hides_then_restores_build_resources(tmp_path: Path) -> None:
+    build_dir = tmp_path / "build"
+    build_bundle = build_dir / "LoopflowSwift_Loopflow.bundle"
+    build_bundle.mkdir(parents=True)
+    app_path = tmp_path / "Loopflow.app"
+    quoted_bundle = shlex.quote(str(build_bundle))
+    _write_test_app(
+        app_path,
+        f'test ! -e {quoted_bundle}\nprintf snapshot > "$LOOPFLOW_UI_TEST_SNAPSHOT_PATH"\n',
+    )
+
+    release_loopflow._verify_app_resource_self_containment(app_path, build_dir)
+
+    assert build_bundle.is_dir()
+
+
+def test_resource_check_rejects_a_build_dependent_app(tmp_path: Path) -> None:
+    build_dir = tmp_path / "build"
+    build_bundle = build_dir / "LoopflowSwift_Loopflow.bundle"
+    build_bundle.mkdir(parents=True)
+    app_path = tmp_path / "Loopflow.app"
+    quoted_bundle = shlex.quote(str(build_bundle))
+    _write_test_app(
+        app_path,
+        f'test -e {quoted_bundle}\nprintf snapshot > "$LOOPFLOW_UI_TEST_SNAPSHOT_PATH"\n',
+    )
+
+    with pytest.raises(RuntimeError, match="failed without SwiftPM build resources"):
+        release_loopflow._verify_app_resource_self_containment(app_path, build_dir)
+
+    assert build_bundle.is_dir()
+
+
+def test_resource_check_requires_a_rendered_snapshot(tmp_path: Path) -> None:
+    build_dir = tmp_path / "build"
+    build_bundle = build_dir / "LoopflowSwift_Loopflow.bundle"
+    build_bundle.mkdir(parents=True)
+    app_path = tmp_path / "Loopflow.app"
+    _write_test_app(app_path, "exit 0\n")
+
+    with pytest.raises(RuntimeError, match="produced no resource-check snapshot"):
+        release_loopflow._verify_app_resource_self_containment(app_path, build_dir)
+
+    assert build_bundle.is_dir()
 
 
 def test_release_command_reports_timeout(

--- a/scripts/release-loopflow.py
+++ b/scripts/release-loopflow.py
@@ -45,10 +45,18 @@ def run_capture(
     cmd: list[str],
     cwd: Path | None = None,
     timeout: int | None = None,
+    env: dict[str, str] | None = None,
 ) -> subprocess.CompletedProcess:
     print(f"$ {' '.join(cmd)}", flush=True)
     try:
-        return subprocess.run(cmd, cwd=cwd, capture_output=True, text=True, timeout=timeout)
+        return subprocess.run(
+            cmd,
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            env=env,
+        )
     except subprocess.TimeoutExpired as exc:
         print(f"Timed out after {timeout}s: {' '.join(cmd)}", flush=True)
         raise RuntimeError(f"command timed out after {timeout}s") from exc
@@ -168,16 +176,75 @@ def _copy_bundled_tools(app_macos_dir: Path) -> None:
         shutil.copy(source, app_macos_dir / binary)
 
 
-def _copy_app_executable(build_dir: Path, info_plist: Path, app_macos_dir: Path) -> None:
+def _bundle_executable(info_plist: Path) -> str:
     with info_plist.open("rb") as file:
         executable = plistlib.load(file).get("CFBundleExecutable")
     if not isinstance(executable, str) or not executable:
         raise RuntimeError(f"Missing CFBundleExecutable in {info_plist}")
+    return executable
+
+
+def _copy_app_executable(build_dir: Path, info_plist: Path, app_macos_dir: Path) -> None:
+    executable = _bundle_executable(info_plist)
 
     source = build_dir / SWIFT_APP_PRODUCT
     if not source.is_file():
         raise RuntimeError(f"Missing built app executable: {source}")
     shutil.copy(source, app_macos_dir / executable)
+
+
+def _verify_app_resource_self_containment(app_path: Path, build_dir: Path) -> None:
+    info_plist = app_path / "Contents" / "Info.plist"
+    executable = app_path / "Contents" / "MacOS" / _bundle_executable(info_plist)
+    resource_bundles = tuple(sorted(build_dir.glob("*.bundle")))
+    if not resource_bundles:
+        raise RuntimeError(f"No SwiftPM resource bundles found in {build_dir}")
+
+    print(
+        "Verifying packaged app without SwiftPM build resources...",
+        flush=True,
+    )
+    with tempfile.TemporaryDirectory(
+        prefix="loopflow-app-resource-check-",
+        dir=build_dir.parent,
+    ) as temp:
+        holding_dir = Path(temp)
+        snapshot = holding_dir / "snapshot.png"
+        moved: list[tuple[Path, Path]] = []
+        try:
+            for bundle in resource_bundles:
+                held = holding_dir / bundle.name
+                bundle.rename(held)
+                moved.append((held, bundle))
+
+            result = run_capture(
+                [str(executable), "-ui-test-mode", "empty-workspaces"],
+                timeout=30,
+                env={
+                    **os.environ,
+                    "LOOPFLOW_UI_TEST_SNAPSHOT_PATH": str(snapshot),
+                    "LOOPFLOW_UI_TEST_DELAY": "0.2",
+                    "LOOPFLOW_UI_TEST_WIDTH": "900",
+                    "LOOPFLOW_UI_TEST_HEIGHT": "600",
+                },
+            )
+        finally:
+            for held, bundle in reversed(moved):
+                held.rename(bundle)
+
+        if result.returncode != 0:
+            diagnostic = (result.stderr.strip() or result.stdout.strip())[-2000:]
+            detail = f": {diagnostic}" if diagnostic else ""
+            raise RuntimeError(
+                "Packaged app failed without SwiftPM build resources "
+                f"(exit {result.returncode}){detail}"
+            )
+        if not snapshot.is_file() or snapshot.stat().st_size == 0:
+            raise RuntimeError("Packaged app produced no resource-check snapshot")
+    print(
+        "Verified packaged app renders without SwiftPM build resources",
+        flush=True,
+    )
 
 
 def release() -> int:
@@ -195,7 +262,8 @@ def release() -> int:
     app_name = "Loopflow"
     version = read_release_version(REPO_ROOT)
     dist_dir = SWIFT_DIR / "dist"
-    app_dir = dist_dir / f"{app_name}.app" / "Contents"
+    app_path = dist_dir / f"{app_name}.app"
+    app_dir = app_path / "Contents"
 
     if dist_dir.exists():
         shutil.rmtree(dist_dir)
@@ -222,7 +290,6 @@ def release() -> int:
     identity = _detect_signing_identity()
     if identity:
         entitlements = SWIFT_DIR / "LoopflowMac" / "Loopflow.entitlements"
-        app_path = dist_dir / f"{app_name}.app"
         rc = _codesign_app(app_path, identity, entitlements)
         if rc != 0:
             print("Codesigning failed")
@@ -234,6 +301,8 @@ def release() -> int:
             flush=True,
         )
         return 1
+
+    _verify_app_resource_self_containment(app_path, build_dir)
 
     # Create DMG
     dmg_path = dist_dir / f"{app_name}.dmg"

--- a/swift/Loopflow/AppBootstrap.swift
+++ b/swift/Loopflow/AppBootstrap.swift
@@ -49,13 +49,26 @@ private final class LoopflowBundleToken {}
 
 extension Bundle {
     /// The bundle holding the library's copied resources (Fonts), resolved for
-    /// both SwiftPM (`.module`) and xcodegen framework (`Bundle(for:)`) builds.
+    /// packaged apps, SwiftPM development, and xcodegen framework builds.
     static var loopflowResources: Bundle {
         #if SWIFT_PACKAGE
+        if let packaged = packagedLoopflowResources(at: Bundle.main.resourceURL) {
+            return packaged
+        }
         return .module
         #else
         return Bundle(for: LoopflowBundleToken.self)
         #endif
+    }
+
+    static func packagedLoopflowResources(at resourcesURL: URL?) -> Bundle? {
+        guard let bundleURL = resourcesURL?.appendingPathComponent(
+            "LoopflowSwift_Loopflow.bundle",
+            isDirectory: true
+        ) else {
+            return nil
+        }
+        return Bundle(url: bundleURL)
     }
 }
 

--- a/swift/LoopflowTests/AppBootstrapResourceTests.swift
+++ b/swift/LoopflowTests/AppBootstrapResourceTests.swift
@@ -1,0 +1,26 @@
+import Foundation
+import Testing
+@testable import Loopflow
+
+@Suite("App Bootstrap Resources")
+struct AppBootstrapResourceTests {
+    @Test("packaged app resolves the SwiftPM bundle from Contents/Resources")
+    func packagedBundleResolvesFromResources() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let resources = root.appendingPathComponent("Contents/Resources", isDirectory: true)
+        let resourceBundle = resources.appendingPathComponent(
+            "LoopflowSwift_Loopflow.bundle",
+            isDirectory: true
+        )
+        try FileManager.default.createDirectory(
+            at: resourceBundle.appendingPathComponent("Fonts", isDirectory: true),
+            withIntermediateDirectories: true
+        )
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let resolved = Bundle.packagedLoopflowResources(at: resources)
+
+        #expect(resolved?.bundleURL.standardizedFileURL == resourceBundle.standardizedFileURL)
+    }
+}

--- a/swift/README.md
+++ b/swift/README.md
@@ -166,6 +166,9 @@ Home.
 | `uv run python scripts/loopflow-dev.py clean` | Remove the development app and reset permissions |
 
 Long-running development commands write logs under `~/.lf/logs/dev/`.
+The release command signs the app, hides SwiftPM's build-time resource bundles,
+and requires the packaged app to render before it creates the DMG. Build
+resources are restored on every verification exit.
 
 `project.yml` generates `LoopflowSwift.xcodeproj`:
 


### PR DESCRIPTION
## Evaluate

```bash
uv run pytest python/tests/test_release_loopflow.py
swift test --package-path swift --filter AppBootstrapResourceTests
```

The Swift test proves packaged apps resolve resources from `Contents/Resources`. The Python tests prove release verification hides build-time bundles, rejects apps that depend on them or fail to render, and restores the bundles on every exit path.

## Why it matters

A packaged app could appear healthy while still loading SwiftPM resources from the local build directory, then fail after installation on another machine. The release now exercises the assembled app without those build artifacts and blocks DMG creation unless it renders successfully.

## What changed

- Prefer the embedded `LoopflowSwift_Loopflow.bundle` for packaged SwiftPM apps while retaining development and framework resource resolution.
- After signing and verification, temporarily move SwiftPM build resource bundles aside, launch the packaged app in UI-test mode, and require a non-empty snapshot within 30 seconds.
- Restore hidden build resources whether verification succeeds or fails, and include launch diagnostics in failures.
- Document the new release gate.

## Risks / Not included

- The gate verifies startup and initial rendering, not broader application interaction.
- Release builds now require the packaged app to render successfully in the build environment before DMG creation.