### PR TITLE
release: recover same-tag publisher worktrees

### DIFF
--- a/rust/loopflow/src/engine/builtins.rs
+++ b/rust/loopflow/src/engine/builtins.rs
@@ -524,6 +524,25 @@ mod tests {
     }
 
     #[test]
+    fn release_run_names_its_durable_restart_contract() {
+        let skill = get_builtin_skill("release-run").expect("release-run skill");
+        let skill = skill.split_whitespace().collect::<Vec<_>>().join(" ");
+
+        for contract in [
+            "Process death does not make generated release state temporary",
+            "release-candidate/<target>/<tag>/<commit>",
+            "prepare-<target>-<tag>-<commit>",
+            "publish-<target>-<tag>",
+            ".lf/releases/<tag>/<commit>-<workflow-run-id>",
+            "observe → classify → converge or refuse",
+            "Mismatched, dirty, differently registered, or live-owned state fails closed",
+            "must not manually remove a stale generated worktree, ref, or artifact directory",
+        ] {
+            assert!(skill.contains(contract), "release-run omits {contract:?}");
+        }
+    }
+
+    #[test]
     fn generic_execution_skills_never_infer_a_wave_or_require_pm() {
         for name in ["implement", "gate", "qa", "research", "rebase-conflicts"] {
             let skill = get_builtin_skill(name).expect("generic skill");

--- a/rust/loopflow/src/engine/builtins/ops/skill/release-run.md
+++ b/rust/loopflow/src/engine/builtins/ops/skill/release-run.md
@@ -45,6 +45,26 @@ publication, deployment, and secret handling in the publisher.
 `lf release run` resumes an existing release PR or incomplete latest tag after
 interruptions.
 
+Process death does not make generated release state temporary. Re-entry owns:
+
+- provisional `release-candidate/<target>/<tag>/<commit>` refs
+- generated `prepare-<target>-<tag>-<commit>` and
+  `publish-<target>-<tag>` branch/worktree pairs
+- exact prepared artifacts at
+  `.lf/releases/<tag>/<commit>-<workflow-run-id>`
+
+Before creating, reusing, or removing one of these intermediates, the command
+must observe its target, tag, source commit, workflow run, generated path/ref,
+Git cleanliness and registration, and current stage lease. It then follows one
+restart rule: **observe → classify → converge or refuse**. Under the exact stage
+lease, reuse or replace only matching inactive state. Mismatched, dirty,
+differently registered, or live-owned state fails closed with the observed
+ownership evidence and no mutation.
+
+The one-shot caller must not manually remove a stale generated worktree, ref, or
+artifact directory as a workaround. A release stage is resumable only when each
+durable intermediate implements this restart rule.
+
 ## Guardrails
 
 - The version comes from the human or wave config. Don't decide it.

--- a/rust/loopflow/src/ops/release.rs
+++ b/rust/loopflow/src/ops/release.rs
@@ -15,11 +15,15 @@ use crate::engine::config::{
     load_config_or_default, Config, ReleaseCompletion, ReleaseTargetConfig,
 };
 use crate::engine::git::{
-    acquire_worktree_lease, delete_local_branch, fetch, get_default_branch, sync_main,
-    worktree_remove, worktree_remove_owned, WorktreeLease,
+    acquire_worktree_lease, current_branch, delete_local_branch, fetch, get_default_branch,
+    is_clean, ref_exists, rev_parse, sync_main, worktree_remove, worktree_remove_owned,
+    WorktreeLease,
 };
 use crate::engine::naming::{git_user, sanitize_for_branch};
-use crate::engine::worktrees::{create_named_worktree, main_repo_root, worktree_path};
+use crate::engine::worktrees::{
+    branch_exists, create_named_worktree, list_porcelain, main_repo_root, worktree_path,
+    CreateWorktreeResult,
+};
 use crate::ops::commit::{commit_workflow, CommitOptions};
 use crate::ops::error::{OpsError, OpsResult};
 use crate::ops::land::{finish_arm_after_rebase, LandOptions};
@@ -893,6 +897,169 @@ fn publish_worktree_name(target: &ReleaseTarget, tag: &str) -> String {
     format!("publish-{target_name}-{tag}")
 }
 
+fn materialize_exact_source_worktree(
+    repo: &Path,
+    worktree_name: &str,
+    revision: &str,
+    lease: &WorktreeLease,
+) -> OpsResult<CreateWorktreeResult> {
+    let path = worktree_path(repo, worktree_name);
+    let branch = release_branch_name(repo, worktree_name)?;
+    let expected_commit = rev_parse(repo, &format!("{revision}^{{commit}}"))?;
+    let registrations = list_porcelain(repo)?;
+    let registered_at_path = registrations
+        .iter()
+        .find(|(registered_path, _)| registered_path == &path)
+        .map(|(_, registered_branch)| registered_branch.clone());
+    let branch_registration = registrations
+        .iter()
+        .find(|(_, registered_branch)| registered_branch.as_deref() == Some(branch.as_str()))
+        .map(|(registered_path, _)| registered_path.clone());
+
+    if let Some(registered_path) = branch_registration.as_deref() {
+        if registered_path != path {
+            return Err(publisher_worktree_refused(
+                &path,
+                &branch,
+                &expected_commit,
+                &format!(
+                    "generated branch is registered at {}",
+                    registered_path.display()
+                ),
+            ));
+        }
+    }
+
+    if let Some(observed_branch) = registered_at_path.as_ref() {
+        if observed_branch.as_deref() != Some(branch.as_str()) {
+            let observed = observed_branch.as_deref().unwrap_or("detached HEAD");
+            return Err(publisher_worktree_refused(
+                &path,
+                &branch,
+                &expected_commit,
+                &format!("path is registered on {observed}"),
+            ));
+        }
+    }
+
+    let local_head = if branch_exists(repo, &branch)? {
+        Some(rev_parse(repo, &format!("refs/heads/{branch}^{{commit}}"))?)
+    } else {
+        None
+    };
+    if let Some(observed) = local_head.as_deref() {
+        if observed != expected_commit {
+            return Err(publisher_worktree_refused(
+                &path,
+                &branch,
+                &expected_commit,
+                &format!("local branch resolves to {observed}"),
+            ));
+        }
+    }
+
+    let remote_ref = format!("refs/remotes/origin/{branch}");
+    if ref_exists(repo, &remote_ref)? {
+        let remote_head = rev_parse(repo, &format!("{remote_ref}^{{commit}}"))?;
+        if remote_head != expected_commit {
+            return Err(publisher_worktree_refused(
+                &path,
+                &branch,
+                &expected_commit,
+                &format!("origin branch resolves to {remote_head}"),
+            ));
+        }
+    }
+
+    if registered_at_path.is_some() && path.exists() {
+        let observed_branch = current_branch(&path)?;
+        if observed_branch.as_deref() != Some(branch.as_str()) {
+            let observed = observed_branch.as_deref().unwrap_or("detached HEAD");
+            return Err(publisher_worktree_refused(
+                &path,
+                &branch,
+                &expected_commit,
+                &format!("worktree reports branch {observed}"),
+            ));
+        }
+        let observed_head = rev_parse(&path, "HEAD^{commit}")?;
+        if observed_head != expected_commit {
+            return Err(publisher_worktree_refused(
+                &path,
+                &branch,
+                &expected_commit,
+                &format!("worktree HEAD resolves to {observed_head}"),
+            ));
+        }
+        if !is_clean(&path)? {
+            let status = run_stdout(&path, "git", &["status", "--short"])?;
+            return Err(publisher_worktree_refused(
+                &path,
+                &branch,
+                &expected_commit,
+                &format!("worktree is dirty: {status}"),
+            ));
+        }
+        return Ok(CreateWorktreeResult {
+            path,
+            branch,
+            base_branch: None,
+            base_commit: Some(expected_commit),
+        });
+    }
+
+    if registered_at_path.is_none() && path.exists() && !publisher_path_is_empty(&path)? {
+        return Err(publisher_worktree_refused(
+            &path,
+            &branch,
+            &expected_commit,
+            "unregistered generated path is not an empty directory",
+        ));
+    }
+
+    if registered_at_path.is_some() {
+        worktree_remove_owned(repo, &path, lease)?;
+    }
+    if local_head.is_some() {
+        delete_local_branch(repo, &branch)?;
+    }
+    if path.exists() {
+        fs::remove_dir(&path)?;
+    }
+
+    let worktree = create_named_worktree(repo, worktree_name, Some(revision), false)?;
+    let observed_head = rev_parse(&worktree.path, "HEAD^{commit}")?;
+    if observed_head != expected_commit {
+        let _ = worktree_remove_owned(repo, &worktree.path, lease);
+        let _ = delete_local_branch(repo, &worktree.branch);
+        return Err(OpsError::Message(format!(
+            "publisher worktree {} materialized branch {branch} at {observed_head}, expected {expected_commit}; cleanup was attempted",
+            path.display()
+        )));
+    }
+    Ok(worktree)
+}
+
+fn publisher_path_is_empty(path: &Path) -> OpsResult<bool> {
+    let metadata = fs::symlink_metadata(path)?;
+    if !metadata.file_type().is_dir() {
+        return Ok(false);
+    }
+    Ok(fs::read_dir(path)?.next().is_none())
+}
+
+fn publisher_worktree_refused(
+    path: &Path,
+    branch: &str,
+    expected_commit: &str,
+    observed: &str,
+) -> OpsError {
+    OpsError::Message(format!(
+        "publisher worktree recovery refused for {}: expected branch {branch} at {expected_commit}; {observed}; no state was changed",
+        path.display()
+    ))
+}
+
 fn prepare_worktree_name(target: &ReleaseTarget, candidate: &ReleaseCandidate) -> String {
     let mut name =
         publish_worktree_name(target, &candidate.tag).replacen("publish-", "prepare-", 1);
@@ -987,7 +1154,7 @@ fn prepare_publisher(
         &format!("release candidate preparation for {}", candidate.tag),
     )?;
     progress.status(&format!("Preparing signed candidate {}...", candidate.tag));
-    let wt = create_named_worktree(repo, &wt_name, Some(&candidate.commit), false)?;
+    let wt = materialize_exact_source_worktree(repo, &wt_name, &candidate.commit, &lease)?;
     let prepare_result = {
         let mut cmd = Command::new(program);
         cmd.args(args)
@@ -1062,7 +1229,7 @@ fn run_publisher(
     progress.status(&format!(
         "Materializing tagged publisher worktree {wt_name}..."
     ));
-    let wt = create_named_worktree(repo, &wt_name, Some(tag), false)?;
+    let wt = materialize_exact_source_worktree(repo, &wt_name, tag, &lease)?;
     let publish_result = {
         let mut cmd = Command::new(program);
         cmd.args(args)

--- a/rust/loopflow/tests/release_tests.rs
+++ b/rust/loopflow/tests/release_tests.rs
@@ -1,6 +1,7 @@
 mod support;
 
 use std::fs;
+use std::path::PathBuf;
 use std::process::Command;
 use std::thread;
 use std::time::{Duration, Instant};
@@ -274,7 +275,7 @@ fn git_output_bare(repo: &TestRepo, args: &[&str]) -> String {
 }
 
 fn wait_for_path(path: &std::path::Path) {
-    let deadline = Instant::now() + Duration::from_secs(10);
+    let deadline = Instant::now() + Duration::from_secs(20);
     while !path.exists() {
         assert!(
             Instant::now() < deadline,
@@ -961,6 +962,163 @@ exit 2
 }
 
 #[test]
+fn release_run_owns_each_interrupted_candidate_preparation_materialization() {
+    for interrupted in [
+        InterruptedWorktree::EmptyPath,
+        InterruptedWorktree::BranchOnly,
+        InterruptedWorktree::MissingPath,
+        InterruptedWorktree::Complete,
+    ] {
+        let repo = TestRepo::new();
+        let state = tempfile::tempdir().expect("release state");
+        let fixture = configure_candidate_publisher(&repo, state.path());
+        let worktree = leave_interrupted_worktree(
+            &repo,
+            interrupted,
+            &fixture.worktree_name,
+            &fixture.branch,
+            &fixture.head,
+        );
+        let _env = EnvGuard::new(&[("gh", fixture.gh_script.as_str())]);
+
+        let outcome = release_run(repo.path(), "patch", None, &NullProgress)
+            .unwrap_or_else(|error| panic!("{interrupted:?} retry failed: {error}"));
+
+        let ReleaseRunOutcome::Released(receipt) = outcome else {
+            panic!("{interrupted:?} should release the prepared candidate");
+        };
+        assert_eq!(receipt.commit, fixture.head);
+        assert_eq!(
+            fs::read_to_string(&fixture.attempts).expect("candidate preparation attempt"),
+            "prepare\n"
+        );
+        assert!(receipt.release_exists);
+        assert!(!worktree.exists());
+    }
+}
+
+#[test]
+fn release_run_preserves_dirty_candidate_preparation_worktree() {
+    let repo = TestRepo::new();
+    let state = tempfile::tempdir().expect("release state");
+    let fixture = configure_candidate_publisher(&repo, state.path());
+    let worktree = leave_interrupted_worktree(
+        &repo,
+        InterruptedWorktree::Complete,
+        &fixture.worktree_name,
+        &fixture.branch,
+        &fixture.head,
+    );
+    fs::write(worktree.join("operator.txt"), "preserve me\n").expect("dirty candidate tree");
+    let branch_head = git_output(&repo, &["rev-parse", &fixture.branch]);
+    let _env = EnvGuard::new(&[("gh", fixture.gh_script.as_str())]);
+
+    let error = release_run(repo.path(), "patch", None, &NullProgress)
+        .expect_err("dirty candidate state must fail closed");
+    let message = error.to_string();
+
+    assert!(message.contains(&worktree.display().to_string()));
+    assert!(message.contains(&fixture.branch));
+    assert!(message.contains(&fixture.head));
+    assert!(message.contains("operator.txt"));
+    assert!(message.contains("no state was changed"));
+    assert_eq!(
+        fs::read_to_string(worktree.join("operator.txt")).expect("preserved file"),
+        "preserve me\n"
+    );
+    assert_eq!(
+        git_output(&repo, &["rev-parse", &fixture.branch]),
+        branch_head
+    );
+    assert!(!fixture.attempts.exists());
+}
+
+#[test]
+fn release_run_preserves_divergent_candidate_preparation_worktree() {
+    let repo = TestRepo::new();
+    let state = tempfile::tempdir().expect("release state");
+    let fixture = configure_candidate_publisher(&repo, state.path());
+    let worktree = leave_interrupted_worktree(
+        &repo,
+        InterruptedWorktree::Complete,
+        &fixture.worktree_name,
+        &fixture.branch,
+        "v0.9.1",
+    );
+    let branch_head = git_output(&repo, &["rev-parse", &fixture.branch]);
+    let _env = EnvGuard::new(&[("gh", fixture.gh_script.as_str())]);
+
+    let error = release_run(repo.path(), "patch", None, &NullProgress)
+        .expect_err("divergent candidate state must fail closed");
+    let message = error.to_string();
+
+    assert!(message.contains(&worktree.display().to_string()));
+    assert!(message.contains(&fixture.branch));
+    assert!(message.contains(&fixture.head));
+    assert!(message.contains(&branch_head));
+    assert!(message.contains("no state was changed"));
+    assert!(worktree.exists());
+    assert_eq!(
+        git_output(&repo, &["rev-parse", &fixture.branch]),
+        branch_head
+    );
+    assert!(!fixture.attempts.exists());
+}
+
+#[test]
+fn active_candidate_preparation_blocks_concurrent_cleanup_until_exit() {
+    let repo = TestRepo::new();
+    let state = tempfile::tempdir().expect("release state");
+    let fixture = configure_candidate_publisher(&repo, state.path());
+    fs::write(&fixture.block, "").expect("block candidate preparation");
+    let _env = EnvGuard::new(&[("gh", fixture.gh_script.as_str())]);
+
+    let release = Command::new(env!("CARGO_BIN_EXE_lf"))
+        .args(["release", "run", "patch"])
+        .current_dir(repo.path())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .expect("start candidate preparation");
+
+    wait_for_path(&fixture.ready);
+    assert!(fixture.worktree.exists());
+    let branch_head = git_output(&repo, &["rev-parse", &fixture.branch]);
+    let removal = Command::new(env!("CARGO_BIN_EXE_lf"))
+        .args(["wt", "remove", fixture.worktree_name.as_str()])
+        .current_dir(repo.path())
+        .output()
+        .expect("attempt concurrent candidate cleanup");
+
+    assert!(!removal.status.success());
+    assert!(
+        String::from_utf8_lossy(&removal.stderr)
+            .contains("release candidate preparation for v0.9.2"),
+        "unexpected cleanup error: {}",
+        String::from_utf8_lossy(&removal.stderr)
+    );
+    assert!(fixture.worktree.exists());
+    assert_eq!(
+        git_output(&repo, &["rev-parse", &fixture.branch]),
+        branch_head
+    );
+    assert_eq!(branch_head, fixture.head);
+
+    fs::write(&fixture.allow, "").expect("allow candidate preparation");
+    let output = release.wait_with_output().expect("wait for release");
+    assert!(
+        output.status.success(),
+        "release failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        fs::read_to_string(&fixture.attempts).expect("candidate preparation attempt"),
+        "prepare\n"
+    );
+    assert!(!fixture.worktree.exists());
+}
+
+#[test]
 fn failed_candidate_build_reuses_the_version_after_a_fix_merges() {
     let repo = TestRepo::new();
     prepare_candidate_release_repo(&repo);
@@ -1388,6 +1546,439 @@ exit 1
     assert!(!publisher_worktree.exists());
     assert!(neighbor.exists());
     assert_eq!(git_output(&repo, &["tag", "--list"]), tags_before);
+}
+
+#[derive(Debug, Clone, Copy)]
+enum InterruptedWorktree {
+    EmptyPath,
+    BranchOnly,
+    MissingPath,
+    Complete,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum PublisherRegistrationConflict {
+    BranchElsewhere,
+    PathOnOtherBranch,
+}
+
+struct CandidatePublisherFixture {
+    head: String,
+    worktree_name: String,
+    worktree: PathBuf,
+    branch: String,
+    gh_script: String,
+    attempts: PathBuf,
+    block: PathBuf,
+    ready: PathBuf,
+    allow: PathBuf,
+}
+
+fn configure_candidate_publisher(
+    repo: &TestRepo,
+    state: &std::path::Path,
+) -> CandidatePublisherFixture {
+    prepare_candidate_release_repo(repo);
+    let log_path = state.join("gh.log");
+    let attempts = state.join("preparation-attempts");
+    let block = state.join("block-preparation");
+    let ready = state.join("preparation-ready");
+    let allow = state.join("allow-preparation");
+    let publisher = repo.path().join("publisher.sh");
+    fs::write(
+        &publisher,
+        format!(
+            r#"#!/bin/sh
+case "$1" in
+  check) exit 0 ;;
+  prepare)
+    shift
+    while [ "$#" -gt 0 ]; do
+      case "$1" in
+        --output) output="$2"; shift 2 ;;
+        *) shift ;;
+      esac
+    done
+    expected="$(git -C "$LF_RELEASE_MAIN_REPO" rev-parse 'HEAD^{{commit}}')"
+    observed="$(git rev-parse 'HEAD^{{commit}}')"
+    prefix="$(printf '%s' "$expected" | cut -c1-9)"
+    branch="$(git symbolic-ref --short HEAD)"
+    [ "$observed" = "$expected" ] || {{ echo "preparation commit mismatch: $observed" >&2; exit 71; }}
+    [ "$branch" = "jack/prepare-default-v0-9-2-$prefix" ] || {{ echo "preparation branch mismatch: $branch" >&2; exit 72; }}
+    printf 'prepare\n' >> '{}'
+    if [ -f '{}' ]; then
+      : > '{}'
+      waits=0
+      while [ ! -f '{}' ] && [ "$waits" -lt 500 ]; do
+        waits=$((waits + 1))
+        sleep 0.02
+      done
+      [ -f '{}' ] || {{ echo 'candidate preparation timed out' >&2; exit 73; }}
+    fi
+    mkdir -p "$output"
+    printf '{{}}\n' > "$output/candidate.json"
+    exit 0 ;;
+  publish)
+    : > '{}.published'
+    exit 0 ;;
+esac
+exit 2
+"#,
+            attempts.display(),
+            block.display(),
+            ready.display(),
+            allow.display(),
+            allow.display(),
+            log_path.display(),
+        ),
+    )
+    .expect("write publisher");
+    fs::write(
+        repo.path().join(".lf/config.yaml"),
+        "release:\n  targets:\n    default:\n      workflow: release.yml\n      publisher: [\"sh\", \"{repo}/publisher.sh\"]\n",
+    )
+    .expect("configure publisher");
+    git(repo, &["add", ".lf/config.yaml", "publisher.sh"]);
+    git(repo, &["commit", "-m", "Configure candidate publisher"]);
+    git(repo, &["push", "origin", "HEAD"]);
+
+    let head = git_output(repo, &["rev-parse", "HEAD"]);
+    let revision = head.get(..9).expect("full commit hash");
+    let worktree_name = format!("prepare-default-v0-9-2-{revision}");
+    let worktree = named_worktree_path(repo, &worktree_name);
+    let branch = format!("jack/{worktree_name}");
+    let gh_script = write_gh_candidate_release_script(&log_path.to_string_lossy(), "success");
+    CandidatePublisherFixture {
+        head,
+        worktree_name,
+        worktree,
+        branch,
+        gh_script,
+        attempts,
+        block,
+        ready,
+        allow,
+    }
+}
+
+fn named_worktree_path(repo: &TestRepo, name: &str) -> PathBuf {
+    let repo_name = repo
+        .path()
+        .file_name()
+        .expect("repo name")
+        .to_string_lossy();
+    repo.path()
+        .parent()
+        .expect("repo parent")
+        .join(format!("{repo_name}.{name}"))
+}
+
+fn publisher_worktree_path(repo: &TestRepo) -> PathBuf {
+    named_worktree_path(repo, "publish-default-v0-9-1")
+}
+
+fn leave_interrupted_worktree(
+    repo: &TestRepo,
+    state: InterruptedWorktree,
+    name: &str,
+    branch: &str,
+    revision: &str,
+) -> PathBuf {
+    let path = named_worktree_path(repo, name);
+    if matches!(state, InterruptedWorktree::EmptyPath) {
+        fs::create_dir(&path).expect("leave empty worktree path");
+        return path;
+    }
+
+    let path_arg = path.to_string_lossy();
+    git(
+        repo,
+        &["worktree", "add", "-b", branch, &path_arg, revision],
+    );
+    match state {
+        InterruptedWorktree::BranchOnly => {
+            git(repo, &["worktree", "remove", "--force", &path_arg]);
+        }
+        InterruptedWorktree::MissingPath => {
+            fs::remove_dir_all(&path).expect("remove interrupted worktree body");
+        }
+        InterruptedWorktree::Complete => {}
+        InterruptedWorktree::EmptyPath => unreachable!(),
+    }
+    path
+}
+
+fn leave_interrupted_publisher_tree(repo: &TestRepo, state: InterruptedWorktree) -> PathBuf {
+    leave_interrupted_worktree(
+        repo,
+        state,
+        "publish-default-v0-9-1",
+        "jack/publish-default-v0-9-1",
+        "v0.9.1",
+    )
+}
+
+fn configure_same_tag_publisher(repo: &TestRepo, state: &std::path::Path) -> String {
+    let published = state.join("published");
+    let attempts = state.join("attempts");
+    let publisher = repo.path().join("publisher.sh");
+    fs::write(
+        &publisher,
+        format!(
+            r#"#!/bin/sh
+case "$1" in
+  check) exit 0 ;;
+  prepare)
+    shift
+    while [ "$#" -gt 0 ]; do
+      case "$1" in
+        --output) output="$2"; shift 2 ;;
+        *) shift ;;
+      esac
+    done
+    mkdir -p "$output"
+    printf '{{}}\n' > "$output/candidate.json"
+    exit 0 ;;
+  publish)
+    shift
+    while [ "$#" -gt 0 ]; do
+      case "$1" in
+        --artifacts) artifacts="$2"; shift 2 ;;
+        *) shift ;;
+      esac
+    done
+    expected="$(git -C "$LF_RELEASE_MAIN_REPO" rev-parse 'v0.9.1^{{commit}}')"
+    observed="$(git rev-parse 'HEAD^{{commit}}')"
+    branch="$(git symbolic-ref --short HEAD)"
+    [ "$observed" = "$expected" ] || {{ echo "publisher commit mismatch: $observed" >&2; exit 71; }}
+    [ "$branch" = jack/publish-default-v0-9-1 ] || {{ echo "publisher branch mismatch: $branch" >&2; exit 72; }}
+    [ -f "$artifacts/candidate.json" ] || {{ echo "verified candidate missing: $artifacts" >&2; exit 73; }}
+    case "$artifacts" in
+      */.lf/releases/v0-9-1/"$expected"-42) ;;
+      *) echo "candidate ownership mismatch: $artifacts" >&2; exit 74 ;;
+    esac
+    printf 'publish\n' >> '{}'
+    : > '{}'
+    exit 0 ;;
+esac
+exit 2
+"#,
+            attempts.display(),
+            published.display(),
+        ),
+    )
+    .expect("write publisher");
+    fs::create_dir_all(repo.path().join(".lf")).expect("config dir");
+    fs::write(
+        repo.path().join(".lf/config.yaml"),
+        "release:\n  targets:\n    default:\n      publisher: [\"sh\", \"{repo}/publisher.sh\"]\n",
+    )
+    .expect("release config");
+    git(repo, &["add", ".lf/config.yaml", "publisher.sh"]);
+    git(repo, &["commit", "-m", "Configure current publisher"]);
+    git(repo, &["push", "origin", "HEAD"]);
+
+    format!(
+        r#"#!/bin/sh
+if [ "$1" = "--version" ]; then exit 0; fi
+case "$1 $2" in
+  'release view')
+    [ -f '{}' ] || exit 1
+    echo '{{"isDraft":false}}'
+    exit 0 ;;
+  'run list')
+    echo '[{{"databaseId":42,"headBranch":"v0.9.1","status":"completed","conclusion":"success"}}]'
+    exit 0 ;;
+  'run download') exit 0 ;;
+esac
+echo "unexpected gh invocation: $*" >&2
+exit 1
+"#,
+        published.display()
+    )
+}
+
+#[test]
+fn same_tag_release_retry_owns_each_interrupted_publisher_materialization() {
+    for interrupted in [
+        InterruptedWorktree::EmptyPath,
+        InterruptedWorktree::BranchOnly,
+        InterruptedWorktree::MissingPath,
+        InterruptedWorktree::Complete,
+    ] {
+        let repo = TestRepo::new();
+        git(&repo, &["tag", "v0.9.1"]);
+        git(&repo, &["push", "origin", "v0.9.1"]);
+        let state = tempfile::tempdir().expect("publisher state");
+        let gh_script = configure_same_tag_publisher(&repo, state.path());
+        let publisher_worktree = leave_interrupted_publisher_tree(&repo, interrupted);
+        let _env = EnvGuard::new(&[("gh", gh_script.as_str())]);
+
+        let outcome = release_run(repo.path(), "patch", None, &NullProgress)
+            .unwrap_or_else(|error| panic!("{interrupted:?} retry failed: {error}"));
+
+        let ReleaseRunOutcome::Resumed(receipt) = outcome else {
+            panic!("{interrupted:?} should resume the tagged release");
+        };
+        assert_eq!(receipt.tag, "v0.9.1");
+        assert_eq!(
+            fs::read_to_string(state.path().join("attempts")).expect("publication attempt"),
+            "publish\n"
+        );
+        assert!(state.path().join("published").exists());
+        assert!(!publisher_worktree.exists());
+    }
+}
+
+#[test]
+fn same_tag_release_retry_preserves_dirty_publisher_worktree() {
+    let repo = TestRepo::new();
+    git(&repo, &["tag", "v0.9.1"]);
+    git(&repo, &["push", "origin", "v0.9.1"]);
+    let state = tempfile::tempdir().expect("publisher state");
+    let gh_script = configure_same_tag_publisher(&repo, state.path());
+    let publisher_worktree = leave_interrupted_publisher_tree(&repo, InterruptedWorktree::Complete);
+    fs::write(publisher_worktree.join("operator.txt"), "preserve me\n")
+        .expect("dirty publisher tree");
+    let tag_commit = git_output(&repo, &["rev-parse", "v0.9.1^{commit}"]);
+    let branch_head = git_output(
+        &repo,
+        &["rev-parse", "jack/publish-default-v0-9-1^{commit}"],
+    );
+    let _env = EnvGuard::new(&[("gh", gh_script.as_str())]);
+
+    let error = release_run(repo.path(), "patch", None, &NullProgress)
+        .expect_err("dirty publisher state must fail closed");
+    let message = error.to_string();
+
+    assert!(message.contains(&publisher_worktree.display().to_string()));
+    assert!(message.contains("jack/publish-default-v0-9-1"));
+    assert!(message.contains(&tag_commit));
+    assert!(message.contains("operator.txt"));
+    assert!(message.contains("no state was changed"));
+    assert_eq!(
+        fs::read_to_string(publisher_worktree.join("operator.txt")).expect("preserved file"),
+        "preserve me\n"
+    );
+    assert_eq!(
+        git_output(
+            &repo,
+            &["rev-parse", "jack/publish-default-v0-9-1^{commit}"],
+        ),
+        branch_head
+    );
+    assert!(!state.path().join("attempts").exists());
+}
+
+#[test]
+fn same_tag_release_retry_preserves_mismatched_publisher_worktree() {
+    let repo = TestRepo::new();
+    git(&repo, &["tag", "v0.9.1"]);
+    git(&repo, &["push", "origin", "v0.9.1"]);
+    let state = tempfile::tempdir().expect("publisher state");
+    let gh_script = configure_same_tag_publisher(&repo, state.path());
+    let publisher_worktree = publisher_worktree_path(&repo);
+    let path_arg = publisher_worktree.to_string_lossy();
+    git(
+        &repo,
+        &[
+            "worktree",
+            "add",
+            "-b",
+            "jack/publish-default-v0-9-1",
+            &path_arg,
+            "main",
+        ],
+    );
+    let tag_commit = git_output(&repo, &["rev-parse", "v0.9.1^{commit}"]);
+    let branch_head = git_output(
+        &repo,
+        &["rev-parse", "jack/publish-default-v0-9-1^{commit}"],
+    );
+    let _env = EnvGuard::new(&[("gh", gh_script.as_str())]);
+
+    let error = release_run(repo.path(), "patch", None, &NullProgress)
+        .expect_err("mismatched publisher state must fail closed");
+    let message = error.to_string();
+
+    assert!(message.contains(&publisher_worktree.display().to_string()));
+    assert!(message.contains(&tag_commit));
+    assert!(message.contains(&branch_head));
+    assert!(message.contains("no state was changed"));
+    assert!(publisher_worktree.exists());
+    assert_eq!(
+        git_output(
+            &repo,
+            &["rev-parse", "jack/publish-default-v0-9-1^{commit}"],
+        ),
+        branch_head
+    );
+    assert!(!state.path().join("attempts").exists());
+}
+
+#[test]
+fn same_tag_release_retry_preserves_differently_registered_publisher_worktrees() {
+    for conflict in [
+        PublisherRegistrationConflict::BranchElsewhere,
+        PublisherRegistrationConflict::PathOnOtherBranch,
+    ] {
+        let repo = TestRepo::new();
+        git(&repo, &["tag", "v0.9.1"]);
+        git(&repo, &["push", "origin", "v0.9.1"]);
+        let state = tempfile::tempdir().expect("publisher state");
+        let gh_script = configure_same_tag_publisher(&repo, state.path());
+        let publisher_worktree = publisher_worktree_path(&repo);
+        let expected_branch = "jack/publish-default-v0-9-1";
+        let (registered_path, registered_branch) = match conflict {
+            PublisherRegistrationConflict::BranchElsewhere => (
+                named_worktree_path(&repo, "publisher-registered-elsewhere"),
+                expected_branch,
+            ),
+            PublisherRegistrationConflict::PathOnOtherBranch => {
+                (publisher_worktree.clone(), "jack/operator-publisher-state")
+            }
+        };
+        let path_arg = registered_path.to_string_lossy();
+        git(
+            &repo,
+            &[
+                "worktree",
+                "add",
+                "-b",
+                registered_branch,
+                &path_arg,
+                "v0.9.1",
+            ],
+        );
+        let tag_commit = git_output(&repo, &["rev-parse", "v0.9.1^{commit}"]);
+        let registered_head = git_output(
+            &repo,
+            &["rev-parse", &format!("{registered_branch}^{{commit}}")],
+        );
+        let _env = EnvGuard::new(&[("gh", gh_script.as_str())]);
+
+        let error = match release_run(repo.path(), "patch", None, &NullProgress) {
+            Err(error) => error,
+            Ok(_) => panic!("{conflict:?} should fail closed"),
+        };
+        let message = error.to_string();
+
+        assert!(message.contains(&publisher_worktree.display().to_string()));
+        assert!(message.contains(expected_branch));
+        assert!(message.contains(&tag_commit));
+        assert!(message.contains(&registered_path.display().to_string()));
+        assert!(message.contains(registered_branch));
+        assert!(message.contains("no state was changed"));
+        assert!(registered_path.exists());
+        assert_eq!(
+            git_output(
+                &repo,
+                &["rev-parse", &format!("{registered_branch}^{{commit}}")],
+            ),
+            registered_head
+        );
+        assert!(!state.path().join("attempts").exists());
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Evaluate

Run:

```bash
cargo test -p loopflow --test release_tests --no-fail-fast
```

All 49 release tests pass. The production-shaped same-tag fixture resumes from
empty-path, branch-only, missing-body, and complete clean worktree states,
observes the exact tag commit and prepared artifact directory, and invokes the
publisher exactly once. Dirty, divergent, differently registered, and
live-owned fixtures make no publication attempt and preserve their bytes and
refs.

The CI-matched local checks also pass:

```bash
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
cargo test -p loopflow release_run_names_its_durable_restart_contract
cargo test -p loopflow golden_prompt
```

Before: an interrupted generated publisher worktree required operator
verification and removal. After: all attributable interruption boundaries
recover with zero operator cleanup.

## Why it matters

An interrupted release should be resumable from durable evidence, not from an
assumption that process-local scaffolding disappeared. This keeps weekly
publication singular and preserves exact-tag, exact-commit, verified-artifact,
and single-publisher gates while deleting the reported manual workaround.

## What changed

- Added one exact-source release worktree materializer under the existing stage
  lease for both candidate preparation and tagged publication.
- Reused complete clean exact worktrees and reconstructed attributable partial
  state; ambiguous ownership now fails with expected and observed evidence and
  no mutation.
- Added interruption matrices and negative fixtures for dirty, divergent,
  differently registered, and live-owned state.
- Made the installed `release-run` skill name generated refs, worktrees, and
  artifact directories as process-durable restart state.

## Durable learning

Invariant: process death does not erase generated release state. Every
immutable-source release stage must inspect the exact generated path and ref,
source commit, cleanliness, Git registration, and current stage lease before it
acts. Matching inactive state may converge; dirty, divergent, differently
registered, or live-owned state preserves its evidence and refuses.

The shared exact-source materializer enforces this for candidate preparation
and tagged publication. The interruption and refusal matrices prove it, and the
installed `release-run` skill carries the rule into future release work.

## Risks / Not included

Corrupt or ambiguous Git metadata intentionally refuses recovery. Mutable
release-PR worktrees can contain unique authored evidence and are not handled by
the immutable-source policy; LOO-277 owns their separate lease and restart
design. The proof uses an isolated production-shaped publisher rather than a
live release.
